### PR TITLE
Fixed local notification database concurrency issues

### DIFF
--- a/OneSignalSDK/app/src/test/java/com/onesignal/StaticResetHelper.java
+++ b/OneSignalSDK/app/src/test/java/com/onesignal/StaticResetHelper.java
@@ -37,6 +37,13 @@ public class StaticResetHelper {
             return false;
          }
       }));
+
+      classes.add(new StaticResetHelper().new ClassState(OneSignalDbHelper.class, new OtherFieldHandler() {
+         @Override
+         public boolean onOtherField(Field field) {
+            return false;
+         }
+      }));
    }
 
    private interface OtherFieldHandler {

--- a/OneSignalSDK/app/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
+++ b/OneSignalSDK/app/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
@@ -132,7 +132,7 @@ public class MainOneSignalClassRunner {
       });
    }
 
-   private static void cleanUp() {
+   static void cleanUp() {
       callBackUseId = getCallBackRegId = null;
       StaticResetHelper.restSetStaticFields();
 
@@ -1259,7 +1259,7 @@ public class MainOneSignalClassRunner {
       Assert.assertEquals(0, ShadowRoboNotificationManager.notifications.size());
 
       // Make sure they are marked dismissed.
-      SQLiteDatabase readableDb = new OneSignalDbHelper(blankActivity).getReadableDatabase();
+      SQLiteDatabase readableDb = OneSignalDbHelper.getInstance(blankActivity).getReadableDatabase();
       Cursor cursor = readableDb.query(OneSignalPackagePrivateHelper.NotificationTable.TABLE_NAME, new String[] { "created_time" },
           OneSignalPackagePrivateHelper.NotificationTable.COLUMN_NAME_DISMISSED + " = 1", null, null, null, null);
       Assert.assertEquals(2, cursor.getCount());

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationRestorer.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationRestorer.java
@@ -53,10 +53,18 @@ class NotificationRestorer {
          return;
       restored = true;
 
-      OneSignalDbHelper dbHelper = new OneSignalDbHelper(context);
+      OneSignalDbHelper dbHelper = OneSignalDbHelper.getInstance(context);
       SQLiteDatabase writableDb = dbHelper.getWritableDatabase();
 
-      NotificationBundleProcessor.deleteOldNotifications(writableDb);
+      writableDb.beginTransaction();
+      try {
+         NotificationBundleProcessor.deleteOldNotifications(writableDb);
+         writableDb.setTransactionSuccessful();
+      } catch (Exception e) {
+         OneSignal.Log(OneSignal.LOG_LEVEL.ERROR, "Error deleting old notification records! ", e);
+      } finally {
+         writableDb.endTransaction();
+      }
 
       String[] retColumn = { NotificationTable.COLUMN_NAME_ANDROID_NOTIFICATION_ID,
                              NotificationTable.COLUMN_NAME_FULL_DATA };
@@ -97,6 +105,5 @@ class NotificationRestorer {
       }
 
       cursor.close();
-      writableDb.close();
    }
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalDbHelper.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalDbHelper.java
@@ -62,9 +62,21 @@ public class OneSignalDbHelper extends SQLiteOpenHelper {
            NotificationTable.INDEX_CREATE_GROUP_ID +
            NotificationTable.INDEX_CREATE_CREATED_TIME;
 
-   public OneSignalDbHelper(Context context) {
+
+   private static OneSignalDbHelper sInstance;
+
+   private OneSignalDbHelper(Context context) {
       super(context, DATABASE_NAME, null, DATABASE_VERSION);
    }
+
+   public static synchronized OneSignalDbHelper getInstance(Context context) {
+      if (sInstance == null)
+         sInstance = new OneSignalDbHelper(context.getApplicationContext());
+      return sInstance;
+   }
+
+
+   @Override
    public void onCreate(SQLiteDatabase db) {
       db.execSQL(SQL_CREATE_ENTRIES);
       db.execSQL(SQL_INDEX_ENTRIES);


### PR DESCRIPTION
* Fixes `SQLiteDatabaseLockedException` and other possible database errors.
   - OneSignalDbHelper is now a singleton for improved performance.
   - Writes are done within a transaction to prevent concurrency issues between threads.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/91)
<!-- Reviewable:end -->
