### PR TITLE
project number error detection and service error handling fixes

### DIFF
--- a/OneSignalSDK/app/src/test/java/com/onesignal/ShadowPushRegistratorGPS.java
+++ b/OneSignalSDK/app/src/test/java/com/onesignal/ShadowPushRegistratorGPS.java
@@ -50,10 +50,10 @@ public class ShadowPushRegistratorGPS {
       lastCallback = callback;
 
       if (!skipComplete)
-         callback.complete(fail ? null : regId, 1);
+         callback.complete(fail ? null : regId, fail ? -7 : 1);
    }
 
    public static void fireLastCallback() {
-      lastCallback.complete(fail ? null : regId, 1);
+      lastCallback.complete(fail ? null : regId, fail ? -7 : 1);
    }
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
@@ -51,7 +51,14 @@ class NotificationBundleProcessor {
    static void ProcessFromGCMIntentService(Context context, Bundle bundle, NotificationExtenderService.OverrideSettings overrideSettings) {
       try {
          boolean restoring = bundle.getBoolean("restoring", false);
-         JSONObject jsonPayload = new JSONObject(bundle.getString("json_payload"));
+         String jsonStrPayload = bundle.getString("json_payload");
+
+         if (jsonStrPayload == null) {
+            OneSignal.Log(OneSignal.LOG_LEVEL.ERROR, "json_payload key is nonexistent from bundle passed to ProcessFromGCMIntentService: " + bundle);
+            return;
+         }
+
+         JSONObject jsonPayload = new JSONObject(jsonStrPayload);
          if (!restoring && OneSignal.notValidOrDuplicated(context, jsonPayload))
             return;
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationRestoreService.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationRestoreService.java
@@ -35,6 +35,7 @@ public class NotificationRestoreService extends IntentService {
 
    public NotificationRestoreService() {
       super("NotificationRestoreService");
+      setIntentRedelivery(true);
    }
 
    @Override

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationOpenResult.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationOpenResult.java
@@ -35,17 +35,16 @@ public class OSNotificationOpenResult {
    public OSNotificationAction action;
 
    public String stringify() {
-
       JSONObject mainObj = new JSONObject();
-
       try {
-        JSONObject ac = new JSONObject();
-		ac.put("actionID", action.actionID);
-		ac.put("type", action.type);
-		mainObj.put("action", ac);
+         JSONObject ac = new JSONObject();
+         ac.put("actionID", action.actionID);
+         ac.put("type", action.type);
 
-        JSONObject notifObject = new JSONObject(notification.stringify());
-        mainObj.put("notification", notifObject);
+         mainObj.put("action", ac);
+
+         JSONObject notifObject = new JSONObject(notification.stringify());
+         mainObj.put("notification", notifObject);
       }
       catch(JSONException e) {e.printStackTrace();}
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -321,10 +321,14 @@ public class OneSignal {
          @Override
          public void complete(String id, int status) {
             if (status < 1) {
-               if (OneSignalStateSynchronizer.getRegistrationId() == null || subscribableStatus < -6)
+               // Only allow errored subscribableStatuses if we have never gotten a token.
+               //   This ensures the device will not later be marked unsubscribed due to a
+               //   any inconsistencies returned by Google Play services.
+               // Also do not override other types of errors status ( > -6).
+               if (OneSignalStateSynchronizer.getRegistrationId() == null &&
+                   (subscribableStatus == 1 || subscribableStatus < -6))
                   subscribableStatus = status;
             }
-            // Allow the pushRegistrator to replace it's invalid status.
             else if (subscribableStatus < -6)
                subscribableStatus = status;
 


### PR DESCRIPTION
* Added null checks around intent extras and missing bundle keys on services.
   - Rare unreproducible occurrences of these were reported.
* Fixed subscription error priority to prevent GMS errors from overriding other specific error codes.
   - Example fixes case were unknown error GMS error would override a Google project number format error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/106)
<!-- Reviewable:end -->
