### PR TITLE
Removed manifestApplicationId requirement

### DIFF
--- a/Examples/AndroidStudio/app/build.gradle
+++ b/Examples/AndroidStudio/app/build.gradle
@@ -8,8 +8,7 @@ android {
         applicationId "com.onesignal.example"
 
         // TODO: Please update the Google Project number and OneSignal Id below to yours.
-        manifestPlaceholders = [manifestApplicationId: "${applicationId}",
-                                onesignal_app_id: "b2f7f966-d8cc-11e4-bed1-df8f05be55ba",
+        manifestPlaceholders = [onesignal_app_id: "b2f7f966-d8cc-11e4-bed1-df8f05be55ba",
                                 onesignal_google_project_number: "703322744261"]
 
         minSdkVersion 10

--- a/Examples/AndroidStudioAmazon/app/build.gradle
+++ b/Examples/AndroidStudioAmazon/app/build.gradle
@@ -8,8 +8,7 @@ android {
         applicationId "com.onesignal.example"
 
         // TODO: Please update the Google Project number and OneSignal Id below to yours.
-        manifestPlaceholders = [manifestApplicationId: "${applicationId}",
-                                onesignal_app_id: "b2f7f966-d8cc-11e4-bed1-df8f05be55ba",
+        manifestPlaceholders = [onesignal_app_id: "b2f7f966-d8cc-11e4-bed1-df8f05be55ba",
                                 onesignal_google_project_number: "703322744261"]
 
         minSdkVersion 10

--- a/OneSignalSDK/app/build.gradle
+++ b/OneSignalSDK/app/build.gradle
@@ -6,9 +6,7 @@ android {
 
     defaultConfig {
         applicationId "com.onesignal.example"
-        manifestPlaceholders = [manifestApplicationId: "${applicationId}",
-//                              onesignal_app_id: "5eb5a37e-b458-11e3-ac11-000c2940e62c",
-                                onesignal_app_id: "b2f7f966-d8cc-11e4-bed1-df8f05be55ba",
+        manifestPlaceholders = [onesignal_app_id: "b2f7f966-d8cc-11e4-bed1-df8f05be55ba",
                                 onesignal_google_project_number: "703322744261"]
         minSdkVersion 9
         targetSdkVersion 24

--- a/OneSignalSDK/onesignal/src/release/AndroidManifest.xml
+++ b/OneSignalSDK/onesignal/src/release/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.onesignal">
 
     <!-- Create a unique permission for your app and use it so only your app can receive your OneSignal messages. -->
-    <permission android:name="${manifestApplicationId}.permission.C2D_MESSAGE" android:protectionLevel="signature" />
-    <uses-permission android:name="${manifestApplicationId}.permission.C2D_MESSAGE" />
+    <permission android:name="${applicationId}.permission.C2D_MESSAGE" android:protectionLevel="signature" />
+    <uses-permission android:name="${applicationId}.permission.C2D_MESSAGE" />
 
     <application>
         <meta-data android:name="onesignal_app_id" android:value="${onesignal_app_id}" />
@@ -13,7 +13,7 @@
             android:permission="com.google.android.c2dm.permission.SEND" >
             <intent-filter>
                 <action android:name="com.google.android.c2dm.intent.RECEIVE" />
-                <category android:name="${manifestApplicationId}" />
+                <category android:name="${applicationId}" />
             </intent-filter>
         </receiver>
     </application>


### PR DESCRIPTION
* applicationId is now used in included aar AndroidManifest.xml which is always set in gradle projects.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/114)
<!-- Reviewable:end -->
