### PR TITLE
Work around for HttpURLConnection hangs

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -408,12 +408,18 @@ public class OneSignal {
             new Thread(new Runnable() {
                public void run() {
                   try {
-                     Thread.sleep(30000 + androidParamsReties * 10000);
+                     int sleepTime = 30000 + androidParamsReties * 10000;
+                     
+                     if (sleepTime > 90000)
+                        sleepTime = 90000;
+                     
+                     OneSignal.Log(LOG_LEVEL.INFO, "Failed to get Android parameters, trying again in " + (sleepTime / 1000) +  " seconds.");
+                     Thread.sleep(sleepTime);
                   } catch (Throwable t) {}
                   androidParamsReties++;
                   makeAndroidParamsRequest();
                }
-            }, "OS_PARAMS_REQUEST");
+            }, "OS_PARAMS_REQUEST").start();
          }
 
          @Override
@@ -437,6 +443,8 @@ public class OneSignal {
       String userId = getUserId();
       if (userId != null)
          awl_url += "?player_id=" + userId;
+   
+      OneSignal.Log(LOG_LEVEL.DEBUG, "Starting request to get Android parameters.");
       OneSignalRestClient.get(awl_url, responseHandler);
    }
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalRestClient.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalRestClient.java
@@ -1,7 +1,7 @@
 /**
  * Modified MIT License
  * 
- * Copyright 2016 OneSignal
+ * Copyright 2017 OneSignal
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -43,12 +43,17 @@ class OneSignalRestClient {
 
    private static final String BASE_URL = "https://onesignal.com/api/v1/";
    private static final int TIMEOUT = 120000;
+   private static final int GET_TIMEOUT = 60000;
+   
+   private static int getThreadTimeout(int timeout) {
+      return timeout + 5000;
+   }
 
    static void put(final String url, final JSONObject jsonBody, final ResponseHandler responseHandler) {
 
       new Thread(new Runnable() {
          public void run() {
-            makeRequest(url, "PUT", jsonBody, responseHandler);
+            makeRequest(url, "PUT", jsonBody, responseHandler, TIMEOUT);
          }
       }).start();
    }
@@ -56,7 +61,7 @@ class OneSignalRestClient {
    static void post(final String url, final JSONObject jsonBody, final ResponseHandler responseHandler) {
       new Thread(new Runnable() {
          public void run() {
-            makeRequest(url, "POST", jsonBody, responseHandler);
+            makeRequest(url, "POST", jsonBody, responseHandler, TIMEOUT);
          }
       }).start();
    }
@@ -64,98 +69,144 @@ class OneSignalRestClient {
    static void get(final String url, final ResponseHandler responseHandler) {
       new Thread(new Runnable() {
          public void run() {
-            makeRequest(url, null, null, responseHandler);
+            makeRequest(url, null, null, responseHandler, GET_TIMEOUT);
          }
       }).start();
    }
 
    static void getSync(final String url, final ResponseHandler responseHandler) {
-      makeRequest(url, null, null, responseHandler);
+      makeRequest(url, null, null, responseHandler, GET_TIMEOUT);
    }
 
    static void putSync(String url, JSONObject jsonBody, ResponseHandler responseHandler) {
-      makeRequest(url, "PUT", jsonBody, responseHandler);
+      makeRequest(url, "PUT", jsonBody, responseHandler, TIMEOUT);
    }
 
    static void postSync(String url, JSONObject jsonBody, ResponseHandler responseHandler) {
-      makeRequest(url, "POST", jsonBody, responseHandler);
+      makeRequest(url, "POST", jsonBody, responseHandler, TIMEOUT);
    }
-
-   private static void makeRequest(String url, String method, JSONObject jsonBody, ResponseHandler responseHandler) {
+   
+   private static void makeRequest(final String url, final String method, final JSONObject jsonBody, final ResponseHandler responseHandler, final int timeout) {
+      Thread connectionThread = new Thread(new Runnable() {
+         public void run() {
+            startHTTPConnection(url, method, jsonBody, responseHandler, timeout);
+         }
+      }, "OS_HTTPConnection");
+      
+      connectionThread.start();
+      
+      // getResponseCode() can hang past it's timeout setting so join it's thread to ensure it is timing out.
+      try {
+         connectionThread.join(getThreadTimeout(timeout));
+         if (connectionThread.getState() != Thread.State.TERMINATED)
+            connectionThread.interrupt();
+      } catch (InterruptedException e) {
+         e.printStackTrace();
+      }
+   }
+   
+   private static void startHTTPConnection(String url, String method, JSONObject jsonBody, ResponseHandler responseHandler, int timeout) {
       HttpURLConnection con = null;
       int httpResponse = -1;
       String json = null;
-
+   
       try {
-         OneSignal.Log(OneSignal.LOG_LEVEL.DEBUG, BASE_URL + url);
+         OneSignal.Log(OneSignal.LOG_LEVEL.DEBUG, "OneSignalRestClient: Making request to: " + BASE_URL + url);
          con = (HttpURLConnection)new URL(BASE_URL + url).openConnection();
+         
          con.setUseCaches(false);
-         con.setConnectTimeout(TIMEOUT);
-         con.setReadTimeout(TIMEOUT);
-
+         con.setConnectTimeout(timeout);
+         con.setReadTimeout(timeout);
+         
          if (jsonBody != null)
             con.setDoInput(true);
-
+      
          if (method != null) {
             con.setRequestProperty("Content-Type", "application/json; charset=UTF-8");
             con.setRequestMethod(method);
             con.setDoOutput(true);
          }
-
+      
          if (jsonBody != null) {
             String strJsonBody = jsonBody.toString();
-            OneSignal.Log(OneSignal.LOG_LEVEL.DEBUG, method + " SEND JSON: " + strJsonBody);
-
+            OneSignal.Log(OneSignal.LOG_LEVEL.DEBUG, "OneSignalRestClient: " + method + " SEND JSON: " + strJsonBody);
+         
             byte[] sendBytes = strJsonBody.getBytes("UTF-8");
             con.setFixedLengthStreamingMode(sendBytes.length);
-
+         
             OutputStream outputStream = con.getOutputStream();
             outputStream.write(sendBytes);
          }
-
+      
          httpResponse = con.getResponseCode();
-
+         OneSignal.Log(OneSignal.LOG_LEVEL.VERBOSE, "OneSignalRestClient: After con.getResponseCode  to: " + BASE_URL + url);
+      
          InputStream inputStream;
          Scanner scanner;
          if (httpResponse == HttpURLConnection.HTTP_OK) {
+            OneSignal.Log(OneSignal.LOG_LEVEL.DEBUG, "OneSignalRestClient: Successfully finished request to: " + BASE_URL + url);
+         
             inputStream = con.getInputStream();
             scanner = new Scanner(inputStream, "UTF-8");
             json = scanner.useDelimiter("\\A").hasNext() ? scanner.next() : "";
             scanner.close();
             OneSignal.Log(OneSignal.LOG_LEVEL.DEBUG, method + " RECEIVED JSON: " + json);
-
-            if (responseHandler != null)
-               responseHandler.onSuccess(json);
+            
+            callResponseHandlerOnSuccess(responseHandler, json);
          }
          else {
+            OneSignal.Log(OneSignal.LOG_LEVEL.DEBUG, "OneSignalRestClient: Failed request to: " + BASE_URL + url);
             inputStream = con.getErrorStream();
             if (inputStream == null)
                inputStream = con.getInputStream();
-
+         
             if (inputStream != null) {
                scanner = new Scanner(inputStream, "UTF-8");
                json = scanner.useDelimiter("\\A").hasNext() ? scanner.next() : "";
                scanner.close();
-               OneSignal.Log(OneSignal.LOG_LEVEL.WARN, method + " RECEIVED JSON: " + json);
+               OneSignal.Log(OneSignal.LOG_LEVEL.WARN, "OneSignalRestClient: " + method + " RECEIVED JSON: " + json);
             }
             else
-               OneSignal.Log(OneSignal.LOG_LEVEL.WARN, method + " HTTP Code: " + httpResponse + " No response body!");
-
-            if (responseHandler != null)
-               responseHandler.onFailure(httpResponse, json, null);
+               OneSignal.Log(OneSignal.LOG_LEVEL.WARN, "OneSignalRestClient: " + method + " HTTP Code: " + httpResponse + " No response body!");
+            
+            callResponseHandlerOnFailure(responseHandler, httpResponse, json, null);
          }
       } catch (Throwable t) {
          if (t instanceof java.net.ConnectException || t instanceof java.net.UnknownHostException)
-            OneSignal.Log(OneSignal.LOG_LEVEL.INFO, "Could not send last request, device is offline. Throwable: " + t.getClass().getName());
+            OneSignal.Log(OneSignal.LOG_LEVEL.INFO, "OneSignalRestClient: Could not send last request, device is offline. Throwable: " + t.getClass().getName());
          else
-            OneSignal.Log(OneSignal.LOG_LEVEL.WARN, method + " Error thrown from network stack. ", t);
-
-         if (responseHandler != null)
-            responseHandler.onFailure(httpResponse, null, t);
+            OneSignal.Log(OneSignal.LOG_LEVEL.WARN, "OneSignalRestClient: " + method + " Error thrown from network stack. ", t);
+   
+         callResponseHandlerOnFailure(responseHandler, httpResponse, null, t);
       }
       finally {
          if (con != null)
             con.disconnect();
       }
+   }
+   
+   
+   // These helper methods run the callback a new thread so they don't count towards the fallback thread join timer.
+   
+   private static void callResponseHandlerOnSuccess(final ResponseHandler handler, final String response) {
+      if (handler == null)
+         return;
+      
+      new Thread(new Runnable() {
+         public void run() {
+            handler.onSuccess(response);
+         }
+      }).start();
+   }
+   
+   private static void callResponseHandlerOnFailure(final ResponseHandler handler, final int statusCode, final String response, final Throwable throwable) {
+      if (handler == null)
+         return;
+      
+      new Thread(new Runnable() {
+         public void run() {
+            handler.onFailure(statusCode, response, throwable);
+         }
+      }).start();
    }
 }

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
@@ -76,4 +76,9 @@ public class OneSignalPackagePrivateHelper {
 
    public class NotificationTable extends OneSignalDbContract.NotificationTable { }
    public class NotificationRestorer extends com.onesignal.NotificationRestorer { }
+   
+   
+   public static void OneSignalRestClientPublic_getSync(final String url, final OneSignalRestClient.ResponseHandler responseHandler) {
+      OneSignalRestClient.getSync(url, responseHandler);
+   }
 }

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowOneSignalRestClientForTimeouts.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowOneSignalRestClientForTimeouts.java
@@ -1,0 +1,22 @@
+package com.onesignal;
+
+import org.json.JSONObject;
+import org.robolectric.annotation.Implements;
+
+@Implements(OneSignalRestClient.class)
+public class ShadowOneSignalRestClientForTimeouts {
+   
+   public static boolean threadInterrupted;
+   
+   public static int getThreadTimeout(int timeout) {
+      return 1;
+   }
+   
+   public static void startHTTPConnection(String url, String method, JSONObject jsonBody, OneSignalRestClient.ResponseHandler responseHandler, int timeout) {
+      try {
+         Thread.sleep(120000);
+      } catch (InterruptedException e) {
+         threadInterrupted = true;
+      }
+   }
+}

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
@@ -86,7 +86,6 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import static com.onesignal.OneSignalPackagePrivateHelper.GcmBroadcastReceiver_processBundle;
 import static com.onesignal.OneSignalPackagePrivateHelper.NotificationBundleProcessor_Process;
@@ -1489,45 +1488,7 @@ public class MainOneSignalClassRunner {
    }
 
    private static void threadAndTaskWait() throws Exception {
-      boolean createdNewThread;
-      do {
-         createdNewThread = false;
-         boolean joinedAThread;
-         do {
-            joinedAThread = false;
-//            try {Thread.sleep(testSleepTime);} catch (Throwable t) {}
-
-            Set<Thread> threadSet = Thread.getAllStackTraces().keySet();
-
-            for (Thread thread : threadSet) {
-//               if (thread.equals(Thread.currentThread()))
-//                  continue;
-
-               if (thread.getName().startsWith("OS_")) {
-                  //          && (thread.getState().equals(Thread.State.RUNNABLE) || thread.getState().equals(Thread.State.WAITING)))
-                 // System.out.println("thread: " + thread);
-                 // System.out.println("   state: " + thread.getState());
-                  thread.join();
-                  joinedAThread = createdNewThread = true;
-               }
-//               else if (thread.getName().startsWith("OSH_") && !thread.getState().equals(Thread.State.WAITING))
-//                  noRunningThreads = noNewThreads = false;
-
-//               System.out.println("thread: " + thread);
-//               System.out.println("   state: " + thread.getState());
-            }
-         } while (joinedAThread);
-
-         boolean advancedRunnables = OneSignalPackagePrivateHelper.runAllNetworkRunnables();
-         advancedRunnables = OneSignalPackagePrivateHelper.runFocusRunnables() || advancedRunnables;
-
-//         Scheduler scheduler = Robolectric.getForegroundThreadScheduler();
-//         if (scheduler != null)
-//            advancedRunnables = scheduler.advanceToLastPostedRunnable() || advancedRunnables;
-
-         if (advancedRunnables)
-            createdNewThread = true;
-      } while (createdNewThread);
+      TestHelpers.threadAndTaskWait();
    }
 
    private void OneSignalInit() {

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/RESTClientRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/RESTClientRunner.java
@@ -1,0 +1,44 @@
+package com.test.onesignal;
+
+import com.onesignal.BuildConfig;
+import com.onesignal.OneSignalPackagePrivateHelper;
+import com.onesignal.ShadowOneSignalRestClientForTimeouts;
+
+import junit.framework.Assert;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowLog;
+import org.robolectric.shadows.ShadowSystemClock;
+
+@Config(packageName = "com.onesignal.example",
+    constants = BuildConfig.class,
+    instrumentedPackages = {"com.onesignal"},
+    shadows = { ShadowOneSignalRestClientForTimeouts.class },
+    sdk = 21)
+@RunWith(RobolectricTestRunner.class)
+public class RESTClientRunner {
+   
+   @BeforeClass // Runs only once, before any tests
+   public static void setUpClass() throws Exception {
+      ShadowLog.stream = System.out;
+   }
+   
+   @Before // Before each test
+   public void beforeEachTest() throws Exception {
+      ShadowOneSignalRestClientForTimeouts.threadInterrupted = false;
+   }
+   
+   @Test
+   public void testRESTClientFallbackTimeout() throws Exception {
+      OneSignalPackagePrivateHelper.OneSignalRestClientPublic_getSync("URL", null);
+      ShadowSystemClock.setCurrentTimeMillis(120000);
+      TestHelpers.threadAndTaskWait();
+      Assert.assertTrue(ShadowOneSignalRestClientForTimeouts.threadInterrupted);
+   }
+   
+}

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/TestHelpers.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/TestHelpers.java
@@ -1,0 +1,33 @@
+package com.test.onesignal;
+
+import com.onesignal.OneSignalPackagePrivateHelper;
+
+import java.util.Set;
+
+class TestHelpers {
+   
+   static void threadAndTaskWait() throws Exception {
+      boolean createdNewThread;
+      do {
+         createdNewThread = false;
+         boolean joinedAThread;
+         do {
+            joinedAThread = false;
+            Set<Thread> threadSet = Thread.getAllStackTraces().keySet();
+            
+            for (Thread thread : threadSet) {
+               if (thread.getName().startsWith("OS_")) {
+                  thread.join();
+                  joinedAThread = createdNewThread = true;
+               }
+            }
+         } while (joinedAThread);
+         
+         boolean advancedRunnables = OneSignalPackagePrivateHelper.runAllNetworkRunnables();
+         advancedRunnables = OneSignalPackagePrivateHelper.runFocusRunnables() || advancedRunnables;
+         
+         if (advancedRunnables)
+            createdNewThread = true;
+      } while (createdNewThread);
+   }
+}


### PR DESCRIPTION
* HttpURLConnection.getResponseCode on some devices and networks won't respect it's timeout settings.
  - Wrapped this call in it's own thread so it can be interrupted, disconnected, and then a new connection can be made.
* Fixed issue where getting Android parameters from OneSignal was not retrying.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/201)
<!-- Reviewable:end -->
