### PR TITLE
Added retries to opening SQL lite DB and catches

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
@@ -116,12 +116,15 @@ class NotificationBundleProcessor {
    static void saveNotification(Context context, JSONObject jsonPayload, boolean opened, int notificationId) {
       try {
          JSONObject customJSON = new JSONObject(jsonPayload.optString("custom"));
-
+   
          OneSignalDbHelper dbHelper = OneSignalDbHelper.getInstance(context);
-         SQLiteDatabase writableDb = dbHelper.getWritableDatabase();
+         SQLiteDatabase writableDb = null;
 
-         writableDb.beginTransaction();
          try {
+            writableDb = dbHelper.getWritableDbWithRetries();
+   
+            writableDb.beginTransaction();
+            
             deleteOldNotifications(writableDb);
 
             ContentValues values = new ContentValues();
@@ -147,7 +150,8 @@ class NotificationBundleProcessor {
          } catch (Exception e) {
             OneSignal.Log(OneSignal.LOG_LEVEL.ERROR, "Error saving notification record! ", e);
          } finally {
-            writableDb.endTransaction();
+            if (writableDb != null)
+               writableDb.endTransaction();
          }
       } catch (JSONException e) {
          e.printStackTrace();

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationOpenedProcessor.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationOpenedProcessor.java
@@ -76,11 +76,14 @@ public class NotificationOpenedProcessor {
             t.printStackTrace();
          }
       }
-
+   
       OneSignalDbHelper dbHelper = OneSignalDbHelper.getInstance(context);
-      SQLiteDatabase writableDb = dbHelper.getWritableDatabase();
-      writableDb.beginTransaction();
+      SQLiteDatabase writableDb = null;
+      
       try {
+         writableDb = dbHelper.getWritableDbWithRetries();
+         writableDb.beginTransaction();
+         
          // We just opened a summary notification.
          if (!dismissed && summaryGroup != null)
             addChildNotifications(dataArray, summaryGroup, writableDb);
@@ -94,7 +97,8 @@ public class NotificationOpenedProcessor {
       } catch (Exception e) {
          OneSignal.Log(OneSignal.LOG_LEVEL.ERROR, "Error processing notification open or dismiss record! ", e);
       } finally {
-         writableDb.endTransaction();
+         if (writableDb != null)
+            writableDb.endTransaction();
       }
 
       if (!dismissed)

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationRestorer.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationRestorer.java
@@ -53,38 +53,45 @@ class NotificationRestorer {
          return;
       restored = true;
 
-      OneSignalDbHelper dbHelper = OneSignalDbHelper.getInstance(context);
-      SQLiteDatabase writableDb = dbHelper.getWritableDatabase();
-
-      writableDb.beginTransaction();
+      OneSignalDbHelper dbHelper = OneSignalDbHelper.getInstance(context);;
+      SQLiteDatabase writableDb = null;
+      
       try {
+         writableDb = dbHelper.getWritableDbWithRetries();
+         
+         writableDb.beginTransaction();
+         
          NotificationBundleProcessor.deleteOldNotifications(writableDb);
          writableDb.setTransactionSuccessful();
       } catch (Throwable t) {
          OneSignal.Log(OneSignal.LOG_LEVEL.ERROR, "Error deleting old notification records! ", t);
       } finally {
-         writableDb.endTransaction();
+         if (writableDb != null)
+            writableDb.endTransaction();
       }
 
       String[] retColumn = { NotificationTable.COLUMN_NAME_ANDROID_NOTIFICATION_ID,
                              NotificationTable.COLUMN_NAME_FULL_DATA };
-
-      SQLiteDatabase readableDb = dbHelper.getReadableDatabase();
-      Cursor cursor = readableDb.query(
-          NotificationTable.TABLE_NAME,
-          retColumn,
-          // 1 Week back.
-          NotificationTable.COLUMN_NAME_CREATED_TIME + " > " + ((System.currentTimeMillis() / 1000L) - 604800L) + " AND " +
-            NotificationTable.COLUMN_NAME_DISMISSED + " = 0 AND " +
-            NotificationTable.COLUMN_NAME_OPENED + " = 0 AND " +
-            NotificationTable.COLUMN_NAME_IS_SUMMARY + " = 0",
-          null,
-          null,                            // group by
-          null,                            // filter by row groups
-          NotificationTable._ID + " ASC"   // sort order, old to new
-      );
-
+   
+   
+      Cursor cursor = null;
       try {
+         SQLiteDatabase readableDb = dbHelper.getReadableDbWithRetries();
+         cursor = readableDb.query(
+             NotificationTable.TABLE_NAME,
+             retColumn,
+             // 1 Week back.
+             NotificationTable.COLUMN_NAME_CREATED_TIME + " > " + ((System.currentTimeMillis() / 1000L) - 604800L) + " AND " +
+                 NotificationTable.COLUMN_NAME_DISMISSED + " = 0 AND " +
+                 NotificationTable.COLUMN_NAME_OPENED + " = 0 AND " +
+                 NotificationTable.COLUMN_NAME_IS_SUMMARY + " = 0",
+             null,
+             null,                            // group by
+             null,                            // filter by row groups
+             NotificationTable._ID + " ASC"   // sort order, old to new
+         );
+         
+         
          if (cursor.moveToFirst()) {
             boolean useExtender = (NotificationExtenderService.getIntent(context) != null);
 


### PR DESCRIPTION
* Added retries to opening a database connection as it could fail in some rare cases.
  - In one case this was due to "compiling: PRAGMA journal_mode".
* All open database opens are now handled with a try catch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/203)
<!-- Reviewable:end -->
