### PR TITLE
Null notification.payload fix due to opening an old summary

### DIFF
--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
@@ -1469,8 +1469,7 @@ public class MainOneSignalClassRunner {
 
       JSONObject additionalData = testJsonObj.optJSONObject("notification").optJSONObject("payload").optJSONObject("additionalData");
       Assert.assertEquals("bar", additionalData.optString("foo"));
-
-      System.out.println(testJsonObj.optJSONObject("notification"));
+      
       JSONObject firstGroupedNotification = (JSONObject)testJsonObj.optJSONObject("notification").optJSONArray("groupedNotifications").get(0);
       Assert.assertEquals("collapseId1", firstGroupedNotification.optString("collapseId"));
    }


### PR DESCRIPTION
* Fixed issue where opening a 4 week+ old summary notification would result in a null notification.payload.
   - The summary notification now contains a onesignal_data key from the most recent notification as a fallback.
* Now ensures the a notification can't be tracked as being opening more than once.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/205)
<!-- Reviewable:end -->
