### PR TITLE
Fix notification datetime stamp resetting on app cold start

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/ADMMessageHandler.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/ADMMessageHandler.java
@@ -51,8 +51,11 @@ public class ADMMessageHandler extends ADMMessageHandlerBase {
 
       if (NotificationBundleProcessor.processBundle(this, bundle))
          return;
-
-      NotificationBundleProcessor.Process(this, false, NotificationBundleProcessor.bundleAsJSONObject(bundle), null);
+   
+      NotificationGenerationJob notifJob = new NotificationGenerationJob(this);
+      notifJob.jsonPayload = NotificationBundleProcessor.bundleAsJSONObject(bundle);
+   
+      NotificationBundleProcessor.Process(notifJob);
    }
 
    @Override

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationExtenderService.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationExtenderService.java
@@ -91,7 +91,11 @@ public abstract class NotificationExtenderService extends IntentService {
 
       overrideSettings.override(currentBaseOverrideSettings);
       osNotificationDisplayedResult = new OSNotificationDisplayedResult();
-      osNotificationDisplayedResult.androidNotificationId = NotificationBundleProcessor.Process(this, currentlyRestoring, currentJsonPayload, overrideSettings);
+      
+      NotificationGenerationJob notifJob = createNotifJobFromCurrent();
+      notifJob.overrideSettings = overrideSettings;
+      
+      osNotificationDisplayedResult.androidNotificationId = NotificationBundleProcessor.Process(notifJob);
       return osNotificationDisplayedResult;
    }
 
@@ -169,7 +173,7 @@ public abstract class NotificationExtenderService extends IntentService {
                NotificationBundleProcessor.saveNotification(this, currentJsonPayload, true, -1);
          }
          else
-            NotificationBundleProcessor.Process(this, currentlyRestoring, currentJsonPayload, currentBaseOverrideSettings);
+            NotificationBundleProcessor.Process(createNotifJobFromCurrent());
       }
    }
 
@@ -181,5 +185,14 @@ public abstract class NotificationExtenderService extends IntentService {
          return null;
 
       return intent;
+   }
+   
+   private NotificationGenerationJob createNotifJobFromCurrent() {
+      NotificationGenerationJob notifJob = new NotificationGenerationJob(this);
+      notifJob.restoring = currentlyRestoring;
+      notifJob.jsonPayload = currentJsonPayload;
+      notifJob.overrideSettings = currentBaseOverrideSettings;
+      
+      return notifJob;
    }
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationGenerationJob.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationGenerationJob.java
@@ -1,0 +1,60 @@
+/**
+ * Modified MIT License
+ *
+ * Copyright 2017 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.onesignal;
+
+
+import android.content.Context;
+
+import org.json.JSONObject;
+
+import java.util.Random;
+
+class NotificationGenerationJob {
+   Context context;
+   JSONObject jsonPayload;
+   boolean restoring;
+   
+   boolean showAsAlert;
+   
+   Long shownTimeStamp;
+   
+   NotificationGenerationJob(Context context) {
+      this.context = context;
+   }
+   
+   NotificationExtenderService.OverrideSettings overrideSettings;
+   
+   Integer getAndroidId() {
+      if (overrideSettings == null)
+         overrideSettings = new NotificationExtenderService.OverrideSettings();
+      if (overrideSettings.androidNotificationId == null)
+         overrideSettings.androidNotificationId = new Random().nextInt();
+      
+      return overrideSettings.androidNotificationId;
+   }
+}

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationOpenedProcessor.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationOpenedProcessor.java
@@ -172,7 +172,10 @@ class NotificationOpenedProcessor {
          writableDb.update(NotificationTable.TABLE_NAME, newContentValuesWithConsumed(intent), NotificationTable.COLUMN_NAME_GROUP_ID + " = ?", new String[] {grpId });
       else {
          try {
-            GenerateNotification.createSummaryNotification(context, true, new JSONObject("{\"grp\": \"" + grpId + "\"}"));
+            NotificationGenerationJob notifJob = new NotificationGenerationJob(context);
+            notifJob.restoring = true;
+            notifJob.jsonPayload = new JSONObject("{\"grp\": \"" + grpId + "\"}");
+            GenerateNotification.createSummaryNotification(notifJob);
          } catch (JSONException e) {}
       }
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationRestorer.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationRestorer.java
@@ -71,7 +71,8 @@ class NotificationRestorer {
       }
 
       String[] retColumn = { NotificationTable.COLUMN_NAME_ANDROID_NOTIFICATION_ID,
-                             NotificationTable.COLUMN_NAME_FULL_DATA };
+                             NotificationTable.COLUMN_NAME_FULL_DATA,
+                             NotificationTable.COLUMN_NAME_CREATED_TIME};
    
    
       Cursor cursor = null;
@@ -98,6 +99,7 @@ class NotificationRestorer {
             do {
                int existingId = cursor.getInt(cursor.getColumnIndex(NotificationTable.COLUMN_NAME_ANDROID_NOTIFICATION_ID));
                String fullData = cursor.getString(cursor.getColumnIndex(NotificationTable.COLUMN_NAME_FULL_DATA));
+               Long datetime = cursor.getLong(cursor.getColumnIndex(NotificationTable.COLUMN_NAME_CREATED_TIME));
 
                Intent serviceIntent;
 
@@ -109,6 +111,8 @@ class NotificationRestorer {
                serviceIntent.putExtra("json_payload", fullData);
                serviceIntent.putExtra("android_notif_id", existingId);
                serviceIntent.putExtra("restoring", true);
+               serviceIntent.putExtra("timestamp", datetime);
+               
                context.startService(serviceIntent);
             } while (cursor.moveToNext());
          }

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
@@ -73,11 +73,19 @@ public class OneSignalPackagePrivateHelper {
    }
 
    public static int NotificationBundleProcessor_Process(Context context, boolean restoring, JSONObject jsonPayload, NotificationExtenderService.OverrideSettings overrideSettings) {
-      return NotificationBundleProcessor.Process(context, restoring, jsonPayload, overrideSettings);
+      NotificationGenerationJob notifJob = new NotificationGenerationJob(context);
+      notifJob.jsonPayload = jsonPayload;
+      notifJob.overrideSettings = overrideSettings;
+      return NotificationBundleProcessor.Process(notifJob);
    }
 
-   public class NotificationTable extends OneSignalDbContract.NotificationTable { }
-   public class NotificationRestorer extends com.onesignal.NotificationRestorer { }
+   public static class NotificationTable extends OneSignalDbContract.NotificationTable { }
+   public static class NotificationRestorer extends com.onesignal.NotificationRestorer { }
+   public static class NotificationGenerationJob extends com.onesignal.NotificationGenerationJob {
+      NotificationGenerationJob(Context context) {
+         super(context);
+      }
+   }
    
    
    public static void OneSignalRestClientPublic_getSync(final String url, final OneSignalRestClient.ResponseHandler responseHandler) {


### PR DESCRIPTION
* Each time the app was cold started the notification time stamps would update to now.
   - Issue also happens when updating the app or restarting the device.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/209)
<!-- Reviewable:end -->
