### PR TITLE
Collapse key / id now overrides existing notifications

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotification.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotification.java
@@ -381,7 +381,7 @@ class GenerateNotification {
       createSummaryNotification(notifJob, null);
    }
    
-   // This summary notification will be used visible instead of the normal one on pre-Android 7.0 devices.
+   // This summary notification will be visible instead of the normal one on pre-Android 7.0 devices.
    static void createSummaryNotification(NotificationGenerationJob notifJob, OneSignalNotificationBuilder notifBuilder) {
       boolean updateSummary = notifJob.restoring;
       JSONObject gcmBundle = notifJob.jsonPayload;
@@ -472,8 +472,11 @@ class GenerateNotification {
       
       PendingIntent summaryContentIntent = getNewActionPendingIntent(random.nextInt(),createBaseSummaryIntent(summaryNotificationId, gcmBundle, group));
       
+      
       // 2 or more notifications with a group received, group them together as a single notification.
-      if (summaryList != null && (!updateSummary || summaryList.size() > 1)) {
+      if (summaryList != null &&
+          ((updateSummary && summaryList.size() > 1) ||
+           (!updateSummary && summaryList.size() > 0))) {
          int notificationCount = summaryList.size() + (updateSummary ? 0 : 1);
 
          String summaryMessage = gcmBundle.optString("grp_msg", null);

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationExtenderService.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationExtenderService.java
@@ -85,8 +85,9 @@ public abstract class NotificationExtenderService extends IntentService {
    private OverrideSettings currentBaseOverrideSettings = null;
 
    // Developer may call to override some notification settings.
-   //   - If called the normal SDK notification will not be displayed regardless of what is returned from onNotificationProcessing.
+   // If this method is called the SDK will omit it's notification regardless of what is returned from onNotificationProcessing.
    protected final OSNotificationDisplayedResult displayNotification(OverrideSettings overrideSettings) {
+      // Check if this method has been called already or if no override was set.
       if (osNotificationDisplayedResult != null || overrideSettings == null)
          return null;
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationGenerationJob.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationGenerationJob.java
@@ -57,4 +57,16 @@ class NotificationGenerationJob {
       
       return overrideSettings.androidNotificationId;
    }
+
+   void setAndroidIdWithOutOverriding(Integer id) {
+      if (id == null)
+         return;
+
+      if (overrideSettings != null && overrideSettings.androidNotificationId != null)
+         return;
+
+      if (overrideSettings == null)
+         overrideSettings = new NotificationExtenderService.OverrideSettings();
+      overrideSettings.androidNotificationId = id;
+   }
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalDbContract.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalDbContract.java
@@ -37,6 +37,7 @@ class OneSignalDbContract {
       public static final String COLUMN_NAME_NOTIFICATION_ID = "notification_id"; // OneSignal Notification Id
       public static final String COLUMN_NAME_ANDROID_NOTIFICATION_ID = "android_notification_id";
       public static final String COLUMN_NAME_GROUP_ID = "group_id";
+      public static final String COLUMN_NAME_COLLAPSE_ID = "collapse_id";
       public static final String COLUMN_NAME_IS_SUMMARY = "is_summary";
       public static final String COLUMN_NAME_OPENED = "opened";
       public static final String COLUMN_NAME_DISMISSED = "dismissed";
@@ -51,6 +52,7 @@ class OneSignalDbContract {
       public static final String INDEX_CREATE_NOTIFICATION_ID = "CREATE INDEX notification_notification_id_idx ON notification(notification_id); ";
       public static final String INDEX_CREATE_ANDROID_NOTIFICATION_ID = "CREATE INDEX notification_android_notification_id_idx ON notification(android_notification_id); ";
       public static final String INDEX_CREATE_GROUP_ID = "CREATE INDEX notification_group_id_idx ON notification(group_id); ";
+      public static final String INDEX_CREATE_COLLAPSE_ID = "CREATE INDEX notification_collapse_id_idx ON notification(collapse_id); ";
       public static final String INDEX_CREATE_CREATED_TIME = "CREATE INDEX notification_created_time_idx ON notification(created_time); ";
    }
 }


### PR DESCRIPTION
* Also fixed summary notifications showing "1 new message"
  - Issue would happen when replacing a notification with a group set with only 1 notification in the group.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/211)
<!-- Reviewable:end -->
