### PR TITLE
Added filterOtherGCMReceivers method

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/ADMMessageHandler.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/ADMMessageHandler.java
@@ -48,8 +48,10 @@ public class ADMMessageHandler extends ADMMessageHandlerBase {
    @Override
    protected void onMessage(Intent intent) {
       Bundle bundle = intent.getExtras();
-
-      if (NotificationBundleProcessor.processBundle(this, bundle))
+   
+      NotificationBundleProcessor.ProcessedBundleResult processedResult = NotificationBundleProcessor.processBundle(this, bundle);
+   
+      if (processedResult.processed())
          return;
    
       NotificationGenerationJob notifJob = new NotificationGenerationJob(this);

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/GcmBroadcastReceiver.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/GcmBroadcastReceiver.java
@@ -1,7 +1,7 @@
 /**
  * Modified MIT License
  * 
- * Copyright 2016 OneSignal
+ * Copyright 2017 OneSignal
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -33,15 +33,17 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.v4.content.WakefulBroadcastReceiver;
+import com.onesignal.NotificationBundleProcessor.ProcessedBundleResult;
 
 public class GcmBroadcastReceiver extends WakefulBroadcastReceiver {
 
-   private static final String GCM_RECEIVE = "com.google.android.c2dm.intent.RECEIVE";
+   private static final String GCM_RECEIVE_ACTION = "com.google.android.c2dm.intent.RECEIVE";
    private static final String GCM_TYPE = "gcm";
+   private static final String MESSAGE_TYPE_EXTRA_KEY = "message_type";
 
    private static boolean isGcmMessage(Intent intent) {
-      if (GCM_RECEIVE.equals(intent.getAction())) {
-         String messageType = intent.getStringExtra("message_type");
+      if (GCM_RECEIVE_ACTION.equals(intent.getAction())) {
+         String messageType = intent.getStringExtra(MESSAGE_TYPE_EXTRA_KEY);
          return (messageType == null || GCM_TYPE.equals(messageType));
       }
       return false;
@@ -55,25 +57,53 @@ public class GcmBroadcastReceiver extends WakefulBroadcastReceiver {
       Bundle bundle = intent.getExtras();
       if (bundle == null || "google.com/iid".equals(bundle.getString("from")))
          return;
-
-      processOrderBroadcast(context, intent, bundle);
+   
+      ProcessedBundleResult processedResult = processOrderBroadcast(context, intent, bundle);
+      
+      // Null means this isn't a GCM / FCM message.
+      if (processedResult == null) {
+         setResultCode(Activity.RESULT_OK);
+         return;
+      }
+      
+      // Prevent other GCM receivers from firing if;
+      //   This is a duplicated GCM message
+      //   OR app developer setup a extender service to handle the notification.
+      if (processedResult.isDup || processedResult.hasExtenderService) {
+         // Abort to prevent other GCM receivers from process this Intent.
+         abortBroadcast();
+         return;
+      }
+   
+      // Prevent other GCM receivers from firing if;
+      //   This is a OneSignal payload
+      //   AND the setting is enabled to allow filtering in this case.
+      if (processedResult.isOneSignalPayload &&
+          OneSignal.getFilterOtherGCMReceivers(context)) {
+         
+         abortBroadcast();
+         return;
+      }
 
       setResultCode(Activity.RESULT_OK);
    }
-
-   private static void processOrderBroadcast(Context context, Intent intent, Bundle bundle) {
+   
+   private static ProcessedBundleResult processOrderBroadcast(Context context, Intent intent, Bundle bundle) {
       if (!isGcmMessage(intent))
-         return;
-
+         return null;
+      
+      ProcessedBundleResult processedResult = NotificationBundleProcessor.processBundle(context, bundle);
+   
       // Return if the notification will NOT be handled by normal GcmIntentService display flow.
-      if (NotificationBundleProcessor.processBundle(context, bundle))
-         return;
+      if (processedResult.processed())
+         return processedResult;
 
       Intent intentForService = new Intent();
       intentForService.putExtra("json_payload", NotificationBundleProcessor.bundleAsJSONObject(bundle).toString());
       intentForService.setComponent(new ComponentName(context.getPackageName(),
-                                    GcmIntentService.class.getName()));
+                                                      GcmIntentService.class.getName()));
       startWakefulService(context, intentForService);
+      
+      return processedResult;
    }
-
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -106,6 +106,7 @@ public class OneSignal {
       boolean mDisableGmsMissingPrompt;
       // Default true in 4.0.0 release.
       boolean mUnsubscribeWhenNotificationsAreDisabled;
+      boolean mFilterOtherGCMReceivers;
 
       // Exists to make wrapper SDKs simpler so they don't need to store their own variable before
       //  calling startInit().init()
@@ -152,6 +153,11 @@ public class OneSignal {
       
       public Builder unsubscribeWhenNotificationsAreDisabled(boolean set) {
          mUnsubscribeWhenNotificationsAreDisabled = set;
+         return this;
+      }
+      
+      public Builder filterOtherGCMReceivers(boolean set) {
+         mFilterOtherGCMReceivers = set;
          return this;
       }
 
@@ -359,6 +365,8 @@ public class OneSignal {
       foreground = contextIsActivity;
       appId = oneSignalAppId;
       appContext = context.getApplicationContext();
+   
+      saveFilterOtherGCMReceivers(mInitBuilder.mFilterOtherGCMReceivers);
 
       if (contextIsActivity) {
          ActivityLifecycleHandler.curActivity = (Activity) context;
@@ -372,7 +380,7 @@ public class OneSignal {
 
       OneSignalStateSynchronizer.initUserState(appContext);
 
-      if (android.os.Build.VERSION.SDK_INT > Build.VERSION_CODES.HONEYCOMB_MR2)
+      if (Build.VERSION.SDK_INT > Build.VERSION_CODES.HONEYCOMB_MR2)
          ((Application)appContext).registerActivityLifecycleCallbacks(new ActivityLifecycleListener());
       else
          ActivityLifecycleListenerCompat.startListener();
@@ -1250,7 +1258,21 @@ public class OneSignal {
       editor.putString("GT_PLAYER_ID", userId);
       editor.commit();
    }
-
+   
+   static boolean getFilterOtherGCMReceivers(Context context) {
+      SharedPreferences prefs = getGcmPreferences(context);
+      return prefs.getBoolean("OS_FILTER_OTHER_GCM_RECEIVERS", false);
+   }
+   
+   static void saveFilterOtherGCMReceivers(boolean set) {
+      if (appContext == null)
+         return;
+      final SharedPreferences prefs = getGcmPreferences(appContext);
+      SharedPreferences.Editor editor = prefs.edit();
+      editor.putBoolean("OS_FILTER_OTHER_GCM_RECEIVERS", set);
+      editor.commit();
+   }
+   
    static void updateUserIdDependents(String userId) {
       saveUserId(userId);
       fireIdsAvailableCallback();

--- a/OneSignalSDK/onesignal/src/release/AndroidManifest.xml
+++ b/OneSignalSDK/onesignal/src/release/AndroidManifest.xml
@@ -6,12 +6,14 @@
 
     <application>
         <meta-data android:name="onesignal_app_id" android:value="${onesignal_app_id}" />
+        <!-- Deprecated - Pulled from OneSignal dashboard. -->
         <meta-data android:name="onesignal_google_project_number" android:value="str:${onesignal_google_project_number}" />
 
         <receiver
             android:name="com.onesignal.GcmBroadcastReceiver"
             android:permission="com.google.android.c2dm.permission.SEND" >
-            <intent-filter>
+            <!-- High priority so OneSignal payloads can be filtered from other GCM receivers if filterOtherGCMReceivers is enabled. -->
+            <intent-filter android:priority="999" >
                 <action android:name="com.google.android.c2dm.intent.RECEIVE" />
                 <category android:name="${applicationId}" />
             </intent-filter>

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
@@ -70,7 +70,8 @@ public class OneSignalPackagePrivateHelper {
    }
 
    public static boolean GcmBroadcastReceiver_processBundle(Context context, Bundle bundle) {
-      return NotificationBundleProcessor.processBundle(context, bundle);
+      NotificationBundleProcessor.ProcessedBundleResult processedResult = NotificationBundleProcessor.processBundle(context, bundle);
+      return processedResult.processed();
    }
 
    public static int NotificationBundleProcessor_Process(Context context, boolean restoring, JSONObject jsonPayload, NotificationExtenderService.OverrideSettings overrideSettings) {

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowGcmBroadcastReceiver.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowGcmBroadcastReceiver.java
@@ -1,0 +1,52 @@
+/**
+ * Modified MIT License
+ *
+ * Copyright 2017 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.onesignal;
+
+import android.content.BroadcastReceiver;
+
+import org.robolectric.annotation.Implements;
+
+@Implements(BroadcastReceiver.class)
+public class ShadowGcmBroadcastReceiver {
+   
+   public static boolean calledAbortBroadcast;
+   public static Integer lastResultCode;
+   
+   public static void resetStatics() {
+      calledAbortBroadcast = false;
+      lastResultCode = null;
+   }
+   
+   public void abortBroadcast() {
+      calledAbortBroadcast = true;
+   }
+   
+   public void setResultCode(int code) {
+      lastResultCode = code;
+   }
+}

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/TestHelpers.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/TestHelpers.java
@@ -2,6 +2,7 @@ package com.test.onesignal;
 
 import com.onesignal.OneSignalPackagePrivateHelper;
 import com.onesignal.ShadowCustomTabsClient;
+import com.onesignal.ShadowGcmBroadcastReceiver;
 import com.onesignal.ShadowNotificationManagerCompat;
 import com.onesignal.ShadowOSUtils;
 import com.onesignal.ShadowOneSignalRestClient;
@@ -31,6 +32,7 @@ class TestHelpers {
       ShadowOSUtils.subscribableStatus = 1;
    
       ShadowCustomTabsClient.resetStatics();
+      ShadowGcmBroadcastReceiver.resetStatics();
 
       // DB seems to be cleaned up on it's own.
       /*


### PR DESCRIPTION
* Enable to prevent other SDKs / Libraries from trying to parse a GCM / FCM payload from OneSignal.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/221)
<!-- Reviewable:end -->
