### PR TITLE
Setting Group Alert Behavior for Summary Notifications

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotification.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotification.java
@@ -349,8 +349,14 @@ class GenerateNotification {
          PendingIntent deleteIntent = getNewActionPendingIntent(random.nextInt(), getNewBaseDeleteIntent(notificationId).putExtra("grp", group));
          notifBuilder.setDeleteIntent(deleteIntent);
          notifBuilder.setGroup(group);
-         notifBuilder.setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_SUMMARY);
-   
+
+         try{
+            notifBuilder.setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_SUMMARY);
+         }
+         catch (Throwable t) {
+            //do nothing in this case...Android support lib 26 isn't in the project
+         }
+
          notification = createSingleNotificationBeforeSummaryBuilder(notifJob, notifBuilder);
          
          createSummaryNotification(notifJob, oneSignalNotificationBuilder);
@@ -602,8 +608,14 @@ class GenerateNotification {
                        .setDeleteIntent(summaryDeleteIntent)
                        .setOnlyAlertOnce(updateSummary)
                        .setGroup(group)
-                       .setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_SUMMARY)
                        .setGroupSummary(true);
+
+         try{
+            summaryBuilder.setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_SUMMARY);
+         }
+         catch (Throwable t) {
+            //do nothing in this case...Android support lib 26 isn't in the project
+         }
 
          summaryNotification = summaryBuilder.build();
          addXiaomiSettings(notifBuilder, summaryNotification);

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotification.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotification.java
@@ -349,6 +349,7 @@ class GenerateNotification {
          PendingIntent deleteIntent = getNewActionPendingIntent(random.nextInt(), getNewBaseDeleteIntent(notificationId).putExtra("grp", group));
          notifBuilder.setDeleteIntent(deleteIntent);
          notifBuilder.setGroup(group);
+         notifBuilder.setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_SUMMARY);
    
          notification = createSingleNotificationBeforeSummaryBuilder(notifJob, notifBuilder);
          
@@ -379,19 +380,19 @@ class GenerateNotification {
    private static Notification createSingleNotificationBeforeSummaryBuilder(NotificationGenerationJob notifJob, NotificationCompat.Builder notifBuilder) {
       // Includes Android 4.3 through 6.0.1. Android 7.1 handles this correctly without this.
       // Android 4.2 and older just post the summary only.
-      boolean singleNotifWorkArounds = Build.VERSION.SDK_INT > Build.VERSION_CODES.JELLY_BEAN_MR1 && Build.VERSION.SDK_INT <Build.VERSION_CODES.N
+      boolean singleNotifWorkArounds = Build.VERSION.SDK_INT > Build.VERSION_CODES.JELLY_BEAN_MR1 && Build.VERSION.SDK_INT < Build.VERSION_CODES.N
                                        && !notifJob.restoring;
       
       if (singleNotifWorkArounds) {
          if (notifJob.overriddenSound != null && !notifJob.overriddenSound.equals(notifJob.orgSound))
             notifBuilder.setSound(null);
       }
-   
+
       Notification notification = notifBuilder.build();
-      
+
       if (singleNotifWorkArounds)
          notifBuilder.setSound(notifJob.overriddenSound);
-      
+
       return notification;
    }
 
@@ -552,6 +553,7 @@ class GenerateNotification {
               .setLargeIcon(getDefaultLargeIcon())
               .setOnlyAlertOnce(updateSummary)
               .setGroup(group)
+              .setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_SUMMARY)
               .setGroupSummary(true);
 
          if (!updateSummary)
@@ -600,6 +602,7 @@ class GenerateNotification {
                        .setDeleteIntent(summaryDeleteIntent)
                        .setOnlyAlertOnce(updateSummary)
                        .setGroup(group)
+                       .setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_SUMMARY)
                        .setGroupSummary(true);
 
          summaryNotification = summaryBuilder.build();

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotification.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotification.java
@@ -350,7 +350,7 @@ class GenerateNotification {
          notifBuilder.setDeleteIntent(deleteIntent);
          notifBuilder.setGroup(group);
 
-         try{
+         try {
             notifBuilder.setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_SUMMARY);
          }
          catch (Throwable t) {
@@ -559,8 +559,14 @@ class GenerateNotification {
               .setLargeIcon(getDefaultLargeIcon())
               .setOnlyAlertOnce(updateSummary)
               .setGroup(group)
-              .setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_SUMMARY)
               .setGroupSummary(true);
+
+         try {
+            summaryBuilder.setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_SUMMARY);
+         }
+         catch (Throwable t) {
+            //do nothing in this case...Android support lib 26 isn't in the project
+         }
 
          if (!updateSummary)
             summaryBuilder.setTicker(summaryMessage);
@@ -610,7 +616,7 @@ class GenerateNotification {
                        .setGroup(group)
                        .setGroupSummary(true);
 
-         try{
+         try {
             summaryBuilder.setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_SUMMARY);
          }
          catch (Throwable t) {


### PR DESCRIPTION
- added groupAlertBehavior on summary notifications to alert only for the entire group, gets rid of double notifications and sound
- resolves issue #318

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/320)
<!-- Reviewable:end -->
