### PR TITLE
Public methods executorservice

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -565,7 +565,7 @@ public class OneSignal {
 
    private static void onTaskRan(long taskId) {
       if(lastTaskId.get() == taskId) {
-         OneSignal.Log(LOG_LEVEL.INFO,"Last Pending Task has been ran, shutting down");
+         OneSignal.Log(LOG_LEVEL.INFO,"Last Pending Task has ran, shutting down");
          pendingTaskExecutor.shutdown();
       }
    }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -1059,7 +1059,7 @@ public class OneSignal {
          return;
       }
 
-      OSUtils.runOnMainUIThread(runSyncHashedEmail);
+      runSyncHashedEmail.run();
    }
 
    /**
@@ -1139,7 +1139,7 @@ public class OneSignal {
          return;
       }
 
-      OSUtils.runOnMainUIThread(sendTagsRunnable);
+      sendTagsRunnable.run();
    }
 
    public static void postNotification(String json, final PostNotificationResponseHandler handler) {
@@ -1246,7 +1246,7 @@ public class OneSignal {
          return;
       }
 
-      OSUtils.runOnMainUIThread(getTagsRunnable);
+      getTagsRunnable.run();
    }
 
    private static void internalFireGetTagsCallback(final WeakReference<GetTagsHandler> getTagsHandler) {
@@ -1331,8 +1331,7 @@ public class OneSignal {
          return;
       }
 
-      OSUtils.runOnMainUIThread(runIdsAvailable);
-
+      runIdsAvailable.run();
    }
 
    private static void fireIdsAvailableCallback() {
@@ -1742,7 +1741,7 @@ public class OneSignal {
          return;
       }
 
-      OSUtils.runOnMainUIThread(runSetSubscription);
+      runSetSubscription.run();
    }
 
    public static void setLocationShared(boolean enable) {
@@ -1793,7 +1792,7 @@ public class OneSignal {
          return;
       }
 
-      osUtils.runOnMainUIThread(runPromptLocation);
+      runPromptLocation.run();
    }
 
    /**
@@ -1874,7 +1873,7 @@ public class OneSignal {
          return;
       }
 
-      OSUtils.runOnMainUIThread(runClearOneSignalNotifications);
+      runClearOneSignalNotifications.run();
    }
 
    /**
@@ -1930,7 +1929,7 @@ public class OneSignal {
          return;
       }
 
-      OSUtils.runOnMainUIThread(runCancelNotification);
+      runCancelNotification.run();
 
       NotificationManager notificationManager = (NotificationManager)appContext.getSystemService(Context.NOTIFICATION_SERVICE);
       notificationManager.cancel(id);
@@ -2016,7 +2015,7 @@ public class OneSignal {
          return;
       }
 
-      OSUtils.runOnMainUIThread(runCancelGroupedNotifications);
+      runCancelGroupedNotifications.run();
    }
 
    public static void removeNotificationOpenedHandler() {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -300,7 +300,7 @@ public class OneSignal {
    // the concurrent queue in which we pin pending tasks upon finishing initialization
    public static ConcurrentLinkedQueue<Runnable> taskQueueWaitingForInit = new ConcurrentLinkedQueue<>();
 
-   private static WeakReference<IdsAvailableHandler> idsAvailableHandler;
+   private static WeakReference<IdsAvailableHandler> idsAvailableHandler  = new WeakReference<>(null);
 
    private static long lastTrackedFocusTime = 1, unSentActiveTime = -1;
 
@@ -328,7 +328,7 @@ public class OneSignal {
    private static Collection<JSONArray> unprocessedOpenedNotifis = new ArrayList<>();
    private static HashSet<String> postedOpenedNotifIds = new HashSet<>();
 
-   private static WeakReference<GetTagsHandler> pendingGetTagsHandler;
+   private static WeakReference<GetTagsHandler> pendingGetTagsHandler = new WeakReference<>(null);
    private static boolean getTagsCall;
 
    private static boolean waitingToPostStateSync;
@@ -1194,7 +1194,7 @@ public class OneSignal {
    }
 
    private static void internalFireGetTagsCallback(final WeakReference<GetTagsHandler> getTagsHandler) {
-      if (getTagsHandler == null || getTagsHandler.get() == null) return;
+      if (getTagsHandler.get() == null) return;
 
       new Thread(new Runnable() {
          @Override
@@ -1280,8 +1280,7 @@ public class OneSignal {
    }
 
    private static void fireIdsAvailableCallback() {
-      if (idsAvailableHandler != null &&
-              idsAvailableHandler.get() != null) {
+      if (idsAvailableHandler.get() != null) {
          OSUtils.runOnMainUIThread(new Runnable() {
             @Override
             public void run() {
@@ -1292,8 +1291,7 @@ public class OneSignal {
    }
 
    private synchronized static void internalFireIdsAvailableCallback() {
-      if (idsAvailableHandler == null ||
-              idsAvailableHandler.get() == null)
+      if (idsAvailableHandler.get() == null)
          return;
 
       String regId = OneSignalStateSynchronizer.getRegistrationId();
@@ -1307,7 +1305,7 @@ public class OneSignal {
       idsAvailableHandler.get().idsAvailable(userId, regId);
 
       if (regId != null)
-         idsAvailableHandler = null;
+         idsAvailableHandler = new WeakReference<>(null);
    }
 
    static void sendPurchases(JSONArray purchases, boolean newAsExisting, OneSignalRestClient.ResponseHandler responseHandler) {

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
@@ -1049,9 +1049,10 @@ public class MainOneSignalClassRunner {
          }
       });
 
+
       // ----- END QUEUE ------
 
-      //there should be 8 pending operations in the queue
+      //there should be 503 pending operations in the queue
       Assert.assertEquals(503, OneSignal.taskQueueWaitingForInit.size());
 
       OneSignalInit(); //starts the pending tasks executor
@@ -1160,6 +1161,28 @@ public class MainOneSignalClassRunner {
       Assert.assertEquals("2",tags.getString("a2"));
       Assert.assertEquals("3",tags.getString("a3"));
       Assert.assertEquals("4",tags.getString("a4"));
+   }
+
+   @Test
+   public void testIdsHandlerWeakReference() throws Exception {
+      // test a nullified/collected IdsAvailableHandler - test the WeakReference
+      OneSignal.IdsAvailableHandler nullableHandler = new OneSignal.IdsAvailableHandler() {
+         @Override
+         public void idsAvailable(String userId, String registrationId) {
+            //if we reach here...then fail
+            Assert.assertTrue(false);
+         }
+      };
+      OneSignal.idsAvailable(nullableHandler);
+      nullableHandler = null;
+      System.gc();
+
+      OneSignalInit(); //starts the pending tasks executor
+
+      threadAndTaskWait();
+
+      Assert.assertTrue(nullableHandler == null);
+
    }
 
    private static boolean failedCurModTest;

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
@@ -41,6 +41,7 @@ import android.database.sqlite.SQLiteDatabase;
 import android.location.Location;
 import android.net.ConnectivityManager;
 import android.os.Bundle;
+import android.util.Log;
 
 import com.onesignal.BuildConfig;
 import com.onesignal.OSNotification;
@@ -944,6 +945,41 @@ public class MainOneSignalClassRunner {
 
       Assert.assertFalse(lastGetTags.has("array"));
       Assert.assertFalse(lastGetTags.has("object"));
+   }
+
+   @Test
+   public void testOneSignalMethodsBeforeInit() throws Exception {
+      //queue up a bunch of actions and check that the queue gains size before init
+      OneSignal.syncHashedEmail("test@test.com");
+
+      for(int a = 0; a < 10; a++) {
+         OneSignal.sendTag("a"+a,String.valueOf(a));
+      }
+
+      OneSignal.getTags(new OneSignal.GetTagsHandler() {
+         @Override
+         public void tagsAvailable(JSONObject tags) {
+            Assert.assertTrue(true);
+         }
+      });
+//
+      OneSignal.idsAvailable(new OneSignal.IdsAvailableHandler() {
+         @Override
+         public void idsAvailable(String userId, String registrationId) {
+            Assert.assertTrue(true);
+         }
+      });
+//
+//      OneSignal.setSubscription(true);
+
+      Assert.assertEquals(13, OneSignal.taskQueueWaitingForInit.size());
+
+      OneSignalInit();
+
+      Assert.assertEquals(0, OneSignal.taskQueueWaitingForInit.size());
+
+      threadAndTaskWait();
+
    }
 
    private static boolean failedCurModTest;

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
@@ -1163,28 +1163,6 @@ public class MainOneSignalClassRunner {
       Assert.assertEquals("4",tags.getString("a4"));
    }
 
-   @Test
-   public void testIdsHandlerWeakReference() throws Exception {
-      // test a nullified/collected IdsAvailableHandler - test the WeakReference
-      OneSignal.IdsAvailableHandler nullableHandler = new OneSignal.IdsAvailableHandler() {
-         @Override
-         public void idsAvailable(String userId, String registrationId) {
-            //if we reach here...then fail
-            Assert.assertTrue(false);
-         }
-      };
-      OneSignal.idsAvailable(nullableHandler);
-      nullableHandler = null;
-      System.gc();
-
-      OneSignalInit(); //starts the pending tasks executor
-
-      threadAndTaskWait();
-
-      Assert.assertTrue(nullableHandler == null);
-
-   }
-
    private static boolean failedCurModTest;
    @Test
    public void testSendTagsConcurrentModificationException() throws Exception {

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
@@ -192,7 +192,7 @@ public class MainOneSignalClassRunner {
 
    @After
    public void afterEachTest() throws Exception {
-      Thread.sleep(1000*5);
+      Thread.sleep(1000*2);
    }
 
    @AfterClass

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
@@ -192,7 +192,7 @@ public class MainOneSignalClassRunner {
 
    @After
    public void afterEachTest() throws Exception {
-      Thread.sleep(1000*2);
+      Thread.sleep(1000*5);
    }
 
    @AfterClass

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
@@ -952,16 +952,16 @@ public class MainOneSignalClassRunner {
       //queue up a bunch of actions and check that the queue gains size before init
       OneSignal.syncHashedEmail("test@test.com");
 
-      for(int a = 0; a < 5; a++) {
+      for(int a = 0; a < 500; a++) {
          OneSignal.sendTag("a"+a,String.valueOf(a));
       }
 
       OneSignal.getTags(new OneSignal.GetTagsHandler() {
          @Override
          public void tagsAvailable(JSONObject tags) {
-            //assert that the tags sent were available
+            //assert that the first 10 tags sent were available
             try {
-               for(int a = 0; a < 5; a++) {
+               for(int a = 0; a < 10; a++) {
                   Assert.assertEquals(String.valueOf(a),tags.get("a"+a));
                }
             }
@@ -983,9 +983,11 @@ public class MainOneSignalClassRunner {
 //      OneSignal.setSubscription(true);
 
       //there should be 8 pending operations in the queue
-      Assert.assertEquals(8, OneSignal.taskQueueWaitingForInit.size());
+      Assert.assertEquals(503, OneSignal.taskQueueWaitingForInit.size());
 
       OneSignalInit();
+
+      OneSignal.sendTag("a499","5"); //this operation should be sent to the executor queue
 
       //after init, the queue should be empty...
       Assert.assertEquals(0, OneSignal.taskQueueWaitingForInit.size());
@@ -1006,6 +1008,8 @@ public class MainOneSignalClassRunner {
       Assert.assertEquals("2",tags.getString("a2"));
       Assert.assertEquals("3",tags.getString("a3"));
       Assert.assertEquals("4",tags.getString("a4"));
+      Assert.assertEquals("5",tags.getString("a499"));
+
    }
 
    private static boolean failedCurModTest;


### PR DESCRIPTION
Allows developers to call OneSignal methods before init. 

This could happen through the following example scenarios:
- Manifest-declared receivers/intent-filters that call OneSignal before the `Application` class is created
- Multiple calls to OneSignal from various threads with some of them running before the init has finished

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/322)
<!-- Reviewable:end -->
