### PR TITLE
Introduced a 10 second delay to restoration after app upgrade

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/UpgradeReceiver.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/UpgradeReceiver.java
@@ -35,7 +35,12 @@ import android.support.v4.content.WakefulBroadcastReceiver;
 public class UpgradeReceiver extends WakefulBroadcastReceiver {
 
    @Override
-   public void onReceive(Context context, Intent intent) {
-      NotificationRestorer.startRestoreTaskFromReceiver(context);
+   public void onReceive(final Context context, Intent intent) {
+      new Handler().postDelayed(new Runnable() {
+         @Override
+         public void run() {
+            NotificationRestorer.startRestoreTaskFromReceiver(context);
+         }
+      }, 1000*10);
    }
 }


### PR DESCRIPTION
- trying to address a possible mismatch of resource IDs referenced in #263

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/323)
<!-- Reviewable:end -->
