### PR TITLE
Notif restore delay fix

### DIFF
--- a/OneSignalSDK/onesignal/src/main/AndroidManifest.xml
+++ b/OneSignalSDK/onesignal/src/main/AndroidManifest.xml
@@ -72,14 +72,18 @@
         <service android:name="com.onesignal.SyncJobService"
                  android:permission="android.permission.BIND_JOB_SERVICE" />
 
+        <service android:name="com.onesignal.RestoreJobService"
+            android:permission="android.permission.BIND_JOB_SERVICE" />
+
+        <service android:name="com.onesignal.RestoreKickoffJobService"
+            android:permission="android.permission.BIND_JOB_SERVICE" />
+        <!-- END - For Android O -->
+
         <service android:name="com.onesignal.SyncService" />
         <activity android:name="com.onesignal.PermissionsActivity"
                   android:theme="@android:style/Theme.Translucent.NoTitleBar" />
 
         <service android:name="com.onesignal.NotificationRestoreService" />
-        <!-- For Android O -->
-        <service android:name="com.onesignal.RestoreJobService"
-                 android:permission="android.permission.BIND_JOB_SERVICE" />
 
         <receiver android:name="com.onesignal.BootUpReceiver">
             <intent-filter>

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationRestorer.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationRestorer.java
@@ -48,7 +48,7 @@ import java.util.Random;
 
 class NotificationRestorer {
 
-   private static final int RESTORE_KICKOFF_REQUEST_CODE = 2071862119;
+   private static final int RESTORE_KICKOFF_REQUEST_CODE = 2071862120;
 
    static final String[] COLUMNS_FOR_RESTORE = {
        NotificationTable.COLUMN_NAME_ANDROID_NOTIFICATION_ID,

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/RestoreKickoffJobService.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/RestoreKickoffJobService.java
@@ -1,0 +1,26 @@
+package com.onesignal;
+
+import android.app.job.JobParameters;
+import android.app.job.JobService;
+import android.os.Build;
+import android.support.annotation.RequiresApi;
+
+/**
+ * Copyright 2017 OneSignal
+ * Created by alamgir on 9/22/17.
+ */
+@RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+public class RestoreKickoffJobService extends JobService {
+
+    @Override
+    public boolean onStartJob(JobParameters jobParameters) {
+        NotificationRestorer.restore(getApplicationContext());
+        jobFinished(jobParameters, false);
+        return true;
+    }
+
+    @Override
+    public boolean onStopJob(JobParameters jobParameters) {
+        return false;
+    }
+}

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/UpgradeReceiver.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/UpgradeReceiver.java
@@ -36,11 +36,6 @@ public class UpgradeReceiver extends WakefulBroadcastReceiver {
 
    @Override
    public void onReceive(final Context context, Intent intent) {
-      new Handler().postDelayed(new Runnable() {
-         @Override
-         public void run() {
-            NotificationRestorer.startRestoreTaskFromReceiver(context);
-         }
-      }, 1000*10);
+      NotificationRestorer.startDelayedRestoreTaskFromReceiver(context);
    }
 }


### PR DESCRIPTION
- now using a Job/Alarm task to schedule a kickoff the restoration process
- protects from the chance that a long-standing upgrade receiver will get cleaned up before the 10 second handler fires

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/335)
<!-- Reviewable:end -->
