### PR TITLE
Android support library rev 27 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,8 @@ android:
             # https://github.com/travis-ci/travis-ci/issues/6193
             # Required to get the newest platform-tools.
     - platform-tools
-    - build-tools-26.0.1
-    - android-26
+    - build-tools-27.0.2
+    - android-27
   licenses:
     - '.+'
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ android:
   licenses:
     - '.+'
 before_install:
+    - yes | sdkmanager "platforms;android-27"
     - pwd
     - ls -la
     - cd OneSignalSDK

--- a/OneSignalSDK/app/build.gradle
+++ b/OneSignalSDK/app/build.gradle
@@ -1,15 +1,22 @@
+plugins {
+    id 'com.onesignal.androidsdk.onesignal-gradle-plugin' version '0.8.0'
+}
+apply plugin: 'com.onesignal.androidsdk.onesignal-gradle-plugin'
+
 apply plugin: 'com.android.application'
 
+//apply plugin: com.onesignal.androidsdk.GradleProjectPlugin
+
 android {
-    compileSdkVersion 26
-    buildToolsVersion '26.0.1'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.2'
     defaultConfig {
         applicationId "com.onesignal.example"
         manifestPlaceholders = [onesignal_app_id: "b2f7f966-d8cc-11e4-bed1-df8f05be55ba",
                                 // Project number pulled from dashboard, local value is ignored.
                                 onesignal_google_project_number: "REMOTE"]
         minSdkVersion 15
-        targetSdkVersion 26
+        targetSdkVersion 27
         versionCode 1
         versionName "1.0"
     }
@@ -31,20 +38,21 @@ repositories {
 }
 
 dependencies {
-    compile fileTree(include: ['*.jar'], dir: 'libs')
-    compile 'com.android.support:appcompat-v7:26.1.0'
+    implementation fileTree(include: ['*.jar'], dir: 'libs')
+    implementation 'com.android.support:appcompat-v7:27.0.2'
 
     // Use for SDK Development
-    compile(project(':onesignal')) {
-        exclude group: 'com.android.support', module: 'support-v4'
-        exclude group: 'com.android.support', module: 'customtabs'
-        exclude group: 'com.google.android.gms', module: 'play-services-gcm'
-        exclude group: 'com.google.android.gms', module: 'play-services-analytics'
-        exclude group: 'com.google.android.gms', module: 'play-services-location'
+    implementation(project(':onesignal')) {
+//        exclude group: 'com.android.support', module: 'support-v4'
+//        exclude group: 'com.android.support', module: 'customtabs'
+//        exclude group: 'com.google.android.gms', module: 'play-services-gcm'
+//        exclude group: 'com.google.android.gms', module: 'play-services-analytics'
+//        exclude group: 'com.google.android.gms', module: 'play-services-location'
     }
 
     // Use snapshot
     // compile 'com.onesignal:OneSignal:4.0.0-SNAPSHOT'
+    // compile 'com.onesignal:OneSignal:4.0.0-20171206.043726-5'
 
     // Use to run local .aar file
     // compile(name: 'OneSignal-release', ext: 'aar')
@@ -55,9 +63,11 @@ dependencies {
     // Old Instructions - Use for released SDK
     // compile 'com.onesignal:OneSignal:3.+@aar'
 
-    compile 'com.google.android.gms:play-services-gcm:11.2.2'
-    compile 'com.google.android.gms:play-services-location:11.2.2'
+    //implementation 'com.google.android.gms:play-services-gcm:11.2.2'
+    //implementation 'com.google.android.gms:play-services-location:11.2.2'
 
     // For Chrome tabs
-    compile 'com.android.support:customtabs:26.1.0'
+   // compile 'com.android.support:customtabs:26.1.0'
 }
+
+//apply plugin: 'com.google.gms.google-services'

--- a/OneSignalSDK/gradle/wrapper/gradle-wrapper.properties
+++ b/OneSignalSDK/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-bin.zip

--- a/OneSignalSDK/onesignal/build.gradle
+++ b/OneSignalSDK/onesignal/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion '26.0.1'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.2'
 
     defaultConfig {
         minSdkVersion 15
@@ -28,11 +28,11 @@ android {
 dependencies {
     provided fileTree(dir: 'libs', include: ['*.jar'])
 
-    compile 'com.google.android.gms:play-services-gcm:11.2.2'
-    compile 'com.google.android.gms:play-services-location:11.2.2'
+    implementation 'com.google.android.gms:play-services-gcm:11.6.2'
+    implementation 'com.google.android.gms:play-services-location:11.6.2'
 
-    compile 'com.android.support:support-v4:26.1.0'
-    compile 'com.android.support:customtabs:26.1.0'
+    implementation 'com.android.support:support-v4:27.0.2'
+    implementation 'com.android.support:customtabs:27.0.2'
 }
 
 apply from: 'maven-push.gradle'

--- a/OneSignalSDK/onesignal/maven-push.gradle
+++ b/OneSignalSDK/onesignal/maven-push.gradle
@@ -28,8 +28,8 @@ class Global {
 
     // Limit upper number (exclusive) to prevent untested versions
     static def versionGroupOverrides = [
-        'com.google.android.gms': '[10.2.1,11.3.0)',
-        'com.android.support': '[26.0.0,26.2.0)'
+        'com.google.android.gms': '[10.2.1,11.7.0)',
+        'com.android.support': '[26.0.0,27.1.0)'
     ]
 
     static def GROUP_ID = 'com.onesignal'

--- a/OneSignalSDK/unittest/build.gradle
+++ b/OneSignalSDK/unittest/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion '26.0.1'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.2'
 
     defaultConfig {
         applicationId "com.onesignal.example"
@@ -10,7 +10,7 @@ android {
                                 // Project number pulled from dashboard, local value is ignored.
                                 onesignal_google_project_number: "REMOTE"]
         minSdkVersion 15
-        targetSdkVersion 26
+        targetSdkVersion 27
         versionCode 1
         versionName '1.0'
     }
@@ -40,7 +40,7 @@ repositories {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
 
-    compile 'com.android.support:support-v4:26.1.0'
+    compile 'com.android.support:support-v4:27.0.2'
 
 //    compile 'com.android.support:support-compat:26.0.0'
 //    compile 'com.android.support:support-media-compat:26.0.0'
@@ -66,17 +66,17 @@ dependencies {
 
     // Test with 7.0.0 to make sure there are no breaking changes in Google's libraries.
     // This insure that the SDK will work if an app developer is using an older version of GMS.
-    compile "com.google.android.gms:play-services-gcm:11.2.2"
+    compile "com.google.android.gms:play-services-gcm:11.6.2"
 
     // play-services-analytics is required for AdvertisingIdClient when using GMS 8.1.0 or lower.
     // 8.3.0 it is included in 'basement' which is required by 'base'.
     //compile "com.google.android.gms:play-services-analytics:7.0.0"
-    compile "com.google.android.gms:play-services-location:11.2.2"
+    compile "com.google.android.gms:play-services-location:11.6.2"
 
     // compile 'com.google.android.gms:play-services-analytics:7.0.0'
 
-    compile 'com.android.support:customtabs:26.1.0'
+    compile 'com.android.support:customtabs:27.0.2'
 
     testCompile 'junit:junit:4.12'
-    testCompile 'org.robolectric:robolectric:3.4.2'
+    testCompile 'org.robolectric:robolectric:3.5.1'
 }

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
@@ -95,6 +95,7 @@ import org.robolectric.shadows.ShadowSystemClock;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.android.controller.ServiceController;
 
+import java.lang.reflect.Field;
 import java.math.BigInteger;
 import java.util.Iterator;
 import java.util.Map;
@@ -1062,8 +1063,16 @@ public class GenerateNotificationRunner {
             @Override
             public NotificationCompat.Builder extend(NotificationCompat.Builder builder) {
                // Must disable the default sound when setting a custom one
-               builder.mNotification.flags &= ~Notification.DEFAULT_SOUND;
-               builder.setDefaults(builder.mNotification.flags);
+               try {
+                  Field mNotificationField = NotificationCompat.Builder.class.getDeclaredField("mNotification");
+                  mNotificationField.setAccessible(true);
+                  Notification mNotification = (Notification) mNotificationField.get(builder);
+
+                  mNotification.flags &= ~Notification.DEFAULT_SOUND;
+                  builder.setDefaults(mNotification.flags);
+               } catch (Throwable t) {
+                  t.printStackTrace();
+               }
                
                return builder.setSound(Uri.parse("content://media/internal/audio/media/32"))
                    .setColor(new BigInteger("FF00FF00", 16).intValue())


### PR DESCRIPTION
* Some NotificationCompat fields were marked private in the rev 27 update
* Since the new library updated didn't provide new APIs as a replacement reflection was added to keep the same logic
* Updated to Gradle 4.4
* Updated all dev gradle files to use the latest Google Play services and the Android Support libraries
  - Updated max dependency range as well for the public maven POM file

* Resolves #352

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/392)
<!-- Reviewable:end -->
