### PR TITLE
Added proguard entry to fix crash on Oreo devices

### DIFF
--- a/OneSignalSDK/onesignal/consumer-proguard-rules.pro
+++ b/OneSignalSDK/onesignal/consumer-proguard-rules.pro
@@ -53,3 +53,5 @@
 
 # Proguard ends up removing this class even if it is used in AndroidManifest.xml so force keeping it.
 -keep public class com.onesignal.ADMMessageHandler {*;}
+
+-keep class com.onesignal.JobIntentService$* {*;}


### PR DESCRIPTION
* com.onesignal.JobIntentService$* entries would get obfuscated which would cause crashes on Oreo devices
* Resolves issue #424

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/429)
<!-- Reviewable:end -->
