### PR TITLE
Notification restore now uses JobIntentService

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/JobIntentService.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/JobIntentService.java
@@ -87,7 +87,7 @@ import java.util.HashMap;
  * {@sample frameworks/support/samples/Support4Demos/src/com/example/android/supportv4/app/SimpleJobIntentService.java
  *      complete}
  */
-public abstract class JobIntentService extends Service {
+abstract class JobIntentService extends Service {
     static final String TAG = "JobIntentService";
 
     static final boolean DEBUG = false;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
@@ -33,8 +33,6 @@ import org.json.JSONObject;
 
 import com.onesignal.OneSignalDbContract.NotificationTable;
 
-import android.app.AlarmManager;
-import android.app.PendingIntent;
 import android.content.ContentValues;
 import android.content.Context;
 import android.content.Intent;
@@ -44,7 +42,6 @@ import android.os.Build;
 import android.os.Bundle;
 
 import java.util.ArrayList;
-import java.util.Random;
 import java.util.Set;
 import static com.onesignal.NotificationExtenderService.EXTENDER_SERVICE_JOB_ID;
 
@@ -79,18 +76,6 @@ class NotificationBundleProcessor {
       } catch (JSONException e) {
          e.printStackTrace();
       }
-   }
-
-   /**
-    * Android O - Process the restoration of notifications from a JobService
-    * This branch of logic differs from pre-O in that it is not coming through the GcmIntentService
-    * and doesn't accommodate the developer's NotificationExtenderService. This is preferred to otherwise
-    * not getting any notifications restored on Oreo at all.
-    * @param context
-    * @param bundle
-    */
-   static void ProcessFromRestorerJobService(Context context, BundleCompat bundle) {
-      ProcessFromGCMIntentService(context, bundle, null); // re-use the GCM method
    }
 
    static int ProcessJobForDisplay(NotificationGenerationJob notifJob) {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
@@ -1,7 +1,7 @@
 /**
  * Modified MIT License
  * 
- * Copyright 2017 OneSignal
+ * Copyright 2018 OneSignal
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -73,6 +73,11 @@ class NotificationBundleProcessor {
          
          notifJob.overrideSettings = overrideSettings;
          ProcessJobForDisplay(notifJob);
+
+         // Delay to prevent CPU spikes.
+         //    Normally more than one notification is restored at a time.
+         if (notifJob.restoring)
+            OSUtils.sleep(100);
       } catch (JSONException e) {
          e.printStackTrace();
       }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationExtenderService.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationExtenderService.java
@@ -168,8 +168,7 @@ public abstract class NotificationExtenderService extends JobIntentService {
       boolean developerProcessed = false;
       try {
          developerProcessed = onNotificationProcessing(receivedResult);
-      }
-      catch (Throwable t) {
+      } catch (Throwable t) {
          //noinspection ConstantConditions - displayNotification might have been called by the developer
          if (osNotificationDisplayedResult == null)
             OneSignal.Log(OneSignal.LOG_LEVEL.ERROR, "onNotificationProcessing throw an exception. Displaying normal OneSignal notification.", t);
@@ -201,6 +200,11 @@ public abstract class NotificationExtenderService extends JobIntentService {
          }
          else
             NotificationBundleProcessor.ProcessJobForDisplay(createNotifJobFromCurrent());
+
+         // Delay to prevent CPU spikes.
+         //    Normally more than one notification is restored at a time.
+         if (restoring)
+            OSUtils.sleep(100);
       }
    }
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationRestoreService.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationRestoreService.java
@@ -1,7 +1,7 @@
 /**
  * Modified MIT License
  *
- * Copyright 2016 OneSignal
+ * Copyright 2018 OneSignal
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -35,11 +35,11 @@ public class NotificationRestoreService extends IntentService {
 
    public NotificationRestoreService() {
       super("NotificationRestoreService");
-      setIntentRedelivery(true);
    }
 
    @Override
    protected void onHandleIntent(Intent intent) {
+      Thread.currentThread().setPriority(android.os.Process.THREAD_PRIORITY_BACKGROUND);
       NotificationRestorer.restore(this);
       WakefulBroadcastReceiver.completeWakefulIntent(intent);
    }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationRestorer.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationRestorer.java
@@ -1,7 +1,7 @@
 /**
  * Modified MIT License
  *
- * Copyright 2017 OneSignal
+ * Copyright 2018 OneSignal
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -38,19 +38,32 @@ import android.content.Intent;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.os.Build;
-import android.os.Bundle;
-import android.os.PersistableBundle;
+import android.os.Process;
 import android.service.notification.StatusBarNotification;
-import android.support.annotation.RequiresApi;
-import android.support.v4.app.NotificationManagerCompat;
-import android.support.v4.content.WakefulBroadcastReceiver;
+import android.support.annotation.WorkerThread;
 import android.text.TextUtils;
 
 import com.onesignal.OneSignalDbContract.NotificationTable;
 
 import java.util.ArrayList;
-import java.util.Random;
-import static com.onesignal.NotificationExtenderService.EXTENDER_SERVICE_JOB_ID;
+
+// Purpose:
+// Restore any notifications not interacted by the user back into the notification shade.
+// We consider "not interacted" with if it wasn't swiped away or opened by the user.
+// Android removes all the app's notifications in the following three cases.
+//   1. App was force stopped (AKA forced killed). Different than the app being swiped away.
+//   2. App is updated.
+//   3. Device is rebooted.
+// Restoring is done to ensure notifications are not missed by the user.
+//
+// Restoring cutoff:
+// Notifications received older than 7 days are not restored.
+//
+// Notes:
+// Android 8+ Oreo - Restored notifications will be generated under a "Restored" channel.
+//                   The channel has a low priority so the user is not interrupted again.
+// Android 6+ Marshmallow - We check the notification shade if the notification is already there
+//                            we skip generating it again.
 
 class NotificationRestorer {
 
@@ -69,11 +82,13 @@ class NotificationRestorer {
       new Thread(new Runnable() {
          @Override
          public void run() {
+            Thread.currentThread().setPriority(Process.THREAD_PRIORITY_BACKGROUND);
             restore(context);
          }
       }, "OS_RESTORE_NOTIFS").start();
    }
 
+   @WorkerThread
    public static void restore(Context context) {
       if (restored)
          return;
@@ -103,12 +118,13 @@ class NotificationRestorer {
          }
       }
 
+      long created_at_cutoff = (System.currentTimeMillis() / 1_000L) - 604_800L; // 1 Week back
       StringBuilder dbQuerySelection = new StringBuilder(
-              // 1 Week back.
-              NotificationTable.COLUMN_NAME_CREATED_TIME + " > " + ((System.currentTimeMillis() / 1000L) - 604800L) + " AND " +
-              NotificationTable.COLUMN_NAME_DISMISSED + " = 0 AND " +
-              NotificationTable.COLUMN_NAME_OPENED + " = 0 AND " +
-              NotificationTable.COLUMN_NAME_IS_SUMMARY + " = 0");
+        NotificationTable.COLUMN_NAME_CREATED_TIME + " > " + created_at_cutoff + " AND " +
+        NotificationTable.COLUMN_NAME_DISMISSED + " = 0 AND " +
+        NotificationTable.COLUMN_NAME_OPENED + " = 0 AND " +
+        NotificationTable.COLUMN_NAME_IS_SUMMARY + " = 0"
+      );
 
       skipVisibleNotifications(context, dbQuerySelection);
 
@@ -121,14 +137,14 @@ class NotificationRestorer {
          cursor = readableDb.query(
              NotificationTable.TABLE_NAME,
              COLUMNS_FOR_RESTORE,
-                 dbQuerySelection.toString(),
-             null,
-             null,                            // group by
-             null,                            // filter by row groups
-             NotificationTable._ID + " ASC"   // sort order, old to new
+             dbQuerySelection.toString(),
+            null,
+            null,                           // group by
+            null,                            // filter by row groups
+            NotificationTable._ID + " ASC"  // sort order, old to new
          );
    
-         showNotifications(context, cursor);
+         showNotifications(context, cursor, 100);
          
       } catch (Throwable t) {
          OneSignal.Log(OneSignal.LOG_LEVEL.ERROR, "Error restoring notification records! ", t);
@@ -172,80 +188,62 @@ class NotificationRestorer {
       }
    }
 
-   
-   // NOTE: This can be running from a Application, Service, or JobService context.
-   static void showNotifications(Context context, Cursor cursor) {
-      if (cursor.moveToFirst()) {
-         boolean useExtender = (NotificationExtenderService.getIntent(context) != null);
-      
-         do {
-            int existingId = cursor.getInt(cursor.getColumnIndex(NotificationTable.COLUMN_NAME_ANDROID_NOTIFICATION_ID));
-            String fullData = cursor.getString(cursor.getColumnIndex(NotificationTable.COLUMN_NAME_FULL_DATA));
-            Long datetime = cursor.getLong(cursor.getColumnIndex(NotificationTable.COLUMN_NAME_CREATED_TIME));
-         
-            Intent serviceIntent;
-            if (useExtender)
-               serviceIntent = NotificationExtenderService.getIntent(context);
-            else
-               serviceIntent = new Intent().setComponent(new ComponentName(context.getPackageName(), GcmIntentService.class.getName()));
+   static void showNotifications(Context context, Cursor cursor, int delay) {
+      if (!cursor.moveToFirst())
+         return;
 
-            serviceIntent.putExtra("json_payload", fullData);
-            serviceIntent.putExtra("android_notif_id", existingId);
-            serviceIntent.putExtra("restoring", true);
-            serviceIntent.putExtra("timestamp", datetime);
+      boolean useExtender = (NotificationExtenderService.getIntent(context) != null);
 
-            //Using API 22 as the cutoff due to PersistableBundle#putBoolean being 22+
-            if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1) {
-               //use the job intent service...
-               if (useExtender) {
-                  NotificationExtenderService.enqueueWork(context,
-                          serviceIntent.getComponent(), EXTENDER_SERVICE_JOB_ID,
-                          serviceIntent);
-               } else {
-                  //use a job scheduler...
-                  OneSignal.Log(OneSignal.LOG_LEVEL.INFO, "scheduleRestoreNotif:" + existingId);
+      do {
+         if (useExtender) {
+            Intent intent = NotificationExtenderService.getIntent(context);
+            addRestoreExtras(intent, cursor);
+            NotificationExtenderService.enqueueWork(context,
+                  intent.getComponent(),
+                  NotificationExtenderService.EXTENDER_SERVICE_JOB_ID,
+                  intent);
+         }
+         else {
+            Intent intent = addRestoreExtras(new Intent(), cursor);
+            ComponentName componentName = new ComponentName(context, RestoreJobService.class);
+            RestoreJobService.enqueueWork(context, componentName, RestoreJobService.RESTORE_SERVICE_JOB_ID, intent);
+         }
 
-                  //schedule the job with the job service here...
-                  PersistableBundle restoreBundle = new PersistableBundle();
-                  restoreBundle.putString("json_payload",fullData);
-                  restoreBundle.putInt("android_notif_id", existingId);
-                  restoreBundle.putBoolean("restoring", true);
-                  restoreBundle.putLong("timestamp", datetime);
-
-                  //set the job id to android notif id - that way we don't restore any notif twice
-                  JobInfo.Builder jobBuilder = new JobInfo.Builder(existingId,
-                          new ComponentName(context, RestoreJobService.class));
-                  JobInfo job = jobBuilder.setOverrideDeadline(0)
-                          .setExtras(restoreBundle)
-                          .build();
-
-                  JobScheduler jobScheduler = (JobScheduler)context.getSystemService(Context.JOB_SCHEDULER_SERVICE);
-                  jobScheduler.schedule(job);
-               }
-            }
-            else {
-               startService(context, serviceIntent);
-            }
-
-         } while (cursor.moveToNext());
-      }
+         try {
+            if (delay > 0)
+               Thread.sleep(delay);
+         } catch (InterruptedException e) {
+            e.printStackTrace();
+         }
+      } while (cursor.moveToNext());
    }
 
-   private static void startService(Context context, Intent intent) {
-      context.startService(intent);
+   private static Intent addRestoreExtras(Intent intent, Cursor cursor) {
+      int existingId = cursor.getInt(cursor.getColumnIndex(NotificationTable.COLUMN_NAME_ANDROID_NOTIFICATION_ID));
+      String fullData = cursor.getString(cursor.getColumnIndex(NotificationTable.COLUMN_NAME_FULL_DATA));
+      Long datetime = cursor.getLong(cursor.getColumnIndex(NotificationTable.COLUMN_NAME_CREATED_TIME));
+
+      intent.putExtra("json_payload", fullData)
+            .putExtra("android_notif_id", existingId)
+            .putExtra("restoring", true)
+            .putExtra("timestamp", datetime);
+
+      return intent;
    }
 
+   private static final int RESTORE_NOTIFICATIONS_DELAY_MS = 15_000;
    static void startDelayedRestoreTaskFromReceiver(Context context) {
       if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
          // NotificationRestorer#restore is Code-sensitive to Android O
          OneSignal.Log(OneSignal.LOG_LEVEL.INFO, "scheduleRestoreKickoffJob");
 
-         //set the job id to android notif id - that way we don't restore any notif twice
+         // set the job id to android notif id - that way we don't restore any notif twice
          JobInfo.Builder jobBuilder = new JobInfo.Builder(RESTORE_KICKOFF_REQUEST_CODE,
                  new ComponentName(context, RestoreKickoffJobService.class));
-         JobInfo job = jobBuilder.setOverrideDeadline(15*1000)
-                 .setMinimumLatency(15*1000)
-                 .build();
+         JobInfo job = jobBuilder
+               .setOverrideDeadline(RESTORE_NOTIFICATIONS_DELAY_MS)
+               .setMinimumLatency(RESTORE_NOTIFICATIONS_DELAY_MS)
+               .build();
          JobScheduler jobScheduler = (JobScheduler)context.getSystemService(Context.JOB_SCHEDULER_SERVICE);
          jobScheduler.schedule(job);
       }
@@ -259,9 +257,9 @@ class NotificationRestorer {
          PendingIntent pendingIntent = PendingIntent.getService(context,
                  RESTORE_KICKOFF_REQUEST_CODE, intentForService, PendingIntent.FLAG_CANCEL_CURRENT);
 
-         long scheduleTime = System.currentTimeMillis()+(15*1000);
+         long scheduleTime = System.currentTimeMillis() + RESTORE_NOTIFICATIONS_DELAY_MS;
          AlarmManager alarm = (AlarmManager)context.getSystemService(Context.ALARM_SERVICE);
-         alarm.set(AlarmManager.RTC_WAKEUP, scheduleTime, pendingIntent);
+         alarm.set(AlarmManager.RTC, scheduleTime, pendingIntent);
       }
    }
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationRestorer.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationRestorer.java
@@ -188,6 +188,12 @@ class NotificationRestorer {
       }
    }
 
+   /**
+    * Restores a set of notifications back to the notification shade based on an SQL cursor.
+    * @param context - Context required to start JobIntentService
+    * @param cursor - Source cursor to generate notifications from
+    * @param delay - Delay to slow down process to ensure we don't spike CPU and I/O on the device.
+    */
    static void showNotifications(Context context, Cursor cursor, int delay) {
       if (!cursor.moveToFirst())
          return;
@@ -209,12 +215,8 @@ class NotificationRestorer {
             RestoreJobService.enqueueWork(context, componentName, RestoreJobService.RESTORE_SERVICE_JOB_ID, intent);
          }
 
-         try {
-            if (delay > 0)
-               Thread.sleep(delay);
-         } catch (InterruptedException e) {
-            e.printStackTrace();
-         }
+         if (delay > 0)
+            OSUtils.sleep(delay);
       } while (cursor.moveToNext());
    }
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationSummaryManager.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationSummaryManager.java
@@ -3,7 +3,6 @@ package com.onesignal;
 import android.app.NotificationManager;
 import android.content.ContentValues;
 import android.content.Context;
-import android.content.Intent;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 
@@ -136,17 +135,17 @@ class NotificationSummaryManager {
          cursor = readableDb.query(
              NotificationTable.TABLE_NAME,
              NotificationRestorer.COLUMNS_FOR_RESTORE,
-             NotificationTable.COLUMN_NAME_GROUP_ID + " = ? AND " +
-                 NotificationTable.COLUMN_NAME_DISMISSED + " = 0 AND " +
-                 NotificationTable.COLUMN_NAME_OPENED + " = 0 AND " +
-                 NotificationTable.COLUMN_NAME_IS_SUMMARY + " = 0",
+            NotificationTable.COLUMN_NAME_GROUP_ID + " = ? AND " +
+             NotificationTable.COLUMN_NAME_DISMISSED + " = 0 AND " +
+             NotificationTable.COLUMN_NAME_OPENED + " = 0 AND " +
+             NotificationTable.COLUMN_NAME_IS_SUMMARY + " = 0",
              whereArgs,
-             null,                            // group by
+             null,                           // group by
              null,                            // filter by row groups
              null
          );
    
-         NotificationRestorer.showNotifications(context, cursor);
+         NotificationRestorer.showNotifications(context, cursor, 0);
       } catch (Throwable t) {
          OneSignal.Log(OneSignal.LOG_LEVEL.ERROR, "Error restoring notification records! ", t);
       } finally {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSUtils.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSUtils.java
@@ -284,4 +284,12 @@ class OSUtils {
       }
       return hexString.toString();
    }
+
+   static void sleep(int ms) {
+      try {
+         Thread.sleep(ms);
+      } catch (InterruptedException e) {
+         e.printStackTrace();
+      }
+   }
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/RestoreJobService.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/RestoreJobService.java
@@ -1,38 +1,50 @@
+/**
+ * Modified MIT License
+ *
+ * Copyright 2018 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 package com.onesignal;
 
-import android.app.job.JobParameters;
-import android.app.job.JobService;
-import android.os.Build;
+import android.content.Intent;
 import android.os.Bundle;
-import android.os.PersistableBundle;
-import android.support.annotation.RequiresApi;
 
-/**
- * Copyright 2017 OneSignal
- * Created by alamgir on 9/22/17.
- */
-@RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
-public class RestoreJobService extends JobService {
+public class RestoreJobService extends JobIntentService {
 
-    @Override
-    public boolean onStartJob(final JobParameters jobParameters) {
-        final Bundle extras = new Bundle(jobParameters.getExtras());
-        if(extras == null)
-            return false;
+   static final int RESTORE_SERVICE_JOB_ID = 2071862122;
 
-        new Thread(new Runnable() {
-            public void run() {
-                NotificationBundleProcessor.ProcessFromRestorerJobService(getApplicationContext(),
-                        new BundleCompatBundle(extras));
-                jobFinished(jobParameters, false);
-            }
-        }, "OS_RESTORE_JOB_SERVICE").start();
+   protected final void onHandleWork(Intent intent) {
+      if (intent == null)
+         return;
 
-        return true;
-    }
+      final Bundle extras = new Bundle(intent.getExtras());
 
-    @Override
-    public boolean onStopJob(JobParameters jobParameters) {
-        return false;
-    }
+      NotificationBundleProcessor.ProcessFromGCMIntentService(
+            getApplicationContext(),
+            new BundleCompatBundle(extras),
+            null
+      );
+   }
+
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/RestoreKickoffJobService.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/RestoreKickoffJobService.java
@@ -3,24 +3,15 @@ package com.onesignal;
 import android.app.job.JobParameters;
 import android.app.job.JobService;
 import android.os.Build;
+import android.os.Process;
 import android.support.annotation.RequiresApi;
 
-/**
- * Copyright 2017 OneSignal
- * Created by alamgir on 9/22/17.
- */
 @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
-public class RestoreKickoffJobService extends JobService {
+public class RestoreKickoffJobService extends OneSignalJobServiceBase {
 
     @Override
-    public boolean onStartJob(JobParameters jobParameters) {
+    void startProcessing(JobService jobService, JobParameters jobParameters) {
+        Thread.currentThread().setPriority(Process.THREAD_PRIORITY_BACKGROUND);
         NotificationRestorer.restore(getApplicationContext());
-        jobFinished(jobParameters, false);
-        return true;
-    }
-
-    @Override
-    public boolean onStopJob(JobParameters jobParameters) {
-        return false;
     }
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/UpgradeReceiver.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/UpgradeReceiver.java
@@ -34,7 +34,7 @@ import android.content.Intent;
 public class UpgradeReceiver extends BroadcastReceiver {
 
    @Override
-   public void onReceive(final Context context, Intent intent) {
+   public void onReceive(Context context, Intent intent) {
       NotificationRestorer.startDelayedRestoreTaskFromReceiver(context);
    }
 }


### PR DESCRIPTION
* This makes restoring notification sequential for all version of Android.
   - Restore jobs were parallel on Android 5+, when a notification service was also not setup.
* Set background Thread priority on the NotificationRestoreService
   - Ensures restoring notifications doesn't slow down app start up.
   - Also added a delay of 100ms between each notification being restored to prevent any CPU spikes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/462)
<!-- Reviewable:end -->
