### PR TITLE
Firebase events fire without OneSignal handlers

### DIFF
--- a/OneSignalSDK/onesignal/build.gradle
+++ b/OneSignalSDK/onesignal/build.gradle
@@ -28,11 +28,11 @@ android {
 dependencies {
     provided fileTree(dir: 'libs', include: ['*.jar'])
 
-    implementation 'com.google.android.gms:play-services-gcm:11.8.0'
+    api 'com.google.android.gms:play-services-gcm:11.8.0'
     implementation 'com.google.android.gms:play-services-location:11.8.0'
 
-    implementation 'com.android.support:support-v4:27.1.0'
-    implementation 'com.android.support:customtabs:27.1.0'
+    api 'com.android.support:support-v4:27.1.0'
+    api 'com.android.support:customtabs:27.1.0'
 }
 
 apply from: 'maven-push.gradle'

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -1679,29 +1679,28 @@ public class OneSignal {
             mInitBuilder.mNotificationOpenedHandler.notificationOpened(openedResult);
          }
       });
-
-      if(trackFirebaseAnalytics != null && getFirebaseAnalyticsEnabled(appContext))
-         trackFirebaseAnalytics.trackOpenedEvent(openedResult);
    }
 
    // Called when receiving GCM/ADM message after it has been displayed.
    // Or right when it is received if it is a silent one
    //   If a NotificationExtenderService is present in the developers app this will not fire for silent notifications.
    static void handleNotificationReceived(JSONArray data, boolean displayed, boolean fromAlert) {
-      if (mInitBuilder == null || mInitBuilder.mNotificationReceivedHandler == null)
-         return;
-
       OSNotificationOpenResult openResult = generateOsNotificationOpenResult(data, displayed, fromAlert);
-      mInitBuilder.mNotificationReceivedHandler.notificationReceived(openResult.notification);
-
       if(trackFirebaseAnalytics != null && getFirebaseAnalyticsEnabled(appContext))
          trackFirebaseAnalytics.trackReceivedEvent(openResult);
 
+      if (mInitBuilder == null || mInitBuilder.mNotificationReceivedHandler == null)
+         return;
+
+      mInitBuilder.mNotificationReceivedHandler.notificationReceived(openResult.notification);
    }
 
    // Called when opening a notification
    public static void handleNotificationOpen(Context inContext, JSONArray data, boolean fromAlert) {
       notificationOpenedRESTCall(inContext, data);
+
+      if (trackFirebaseAnalytics != null && getFirebaseAnalyticsEnabled(appContext))
+         trackFirebaseAnalytics.trackOpenedEvent(generateOsNotificationOpenResult(data, true, fromAlert));
 
       boolean urlOpened = false;
       boolean defaultOpenActionDisabled = "DISABLE".equals(OSUtils.getManifestMeta(inContext, "com.onesignal.NotificationOpened.DEFAULT"));

--- a/OneSignalSDK/unittest/build.gradle
+++ b/OneSignalSDK/unittest/build.gradle
@@ -5,10 +5,10 @@ android {
     buildToolsVersion '27.0.3'
 
     defaultConfig {
-        applicationId "com.onesignal.example"
-        manifestPlaceholders = [onesignal_app_id: "b2f7f966-d8cc-11e4-bed1-df8f05be55ba",
+        applicationId 'com.onesignal.example'
+        manifestPlaceholders = [onesignal_app_id: 'b2f7f966-d8cc-11e4-bed1-df8f05be55ba',
                                 // Project number pulled from dashboard, local value is ignored.
-                                onesignal_google_project_number: "REMOTE"]
+                                onesignal_google_project_number: 'REMOTE']
         minSdkVersion 15
         targetSdkVersion 27
         versionCode 1
@@ -25,7 +25,7 @@ android {
     testOptions {
         unitTests.all {
             maxParallelForks 1
-            maxHeapSize "2048m"
+            maxHeapSize '2048m'
         }
         unitTests {
             includeAndroidResources = true
@@ -33,50 +33,15 @@ android {
     }
 }
 
-repositories {
-    maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
-}
-
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-
-    compile 'com.android.support:support-v4:27.0.2'
-
-//    compile 'com.android.support:support-compat:26.0.0'
-//    compile 'com.android.support:support-media-compat:26.0.0'
-//    compile 'com.android.support:support-fragment:26.0.0'
-//    compile 'com.android.support:support-core-ui:26.0.0'
-//    compile 'com.android.support:support-core-utils:26.0.0'
-
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
 
     // Use for SDK Development
-    compile(project(':onesignal')) {
-        exclude group: 'com.android.support', module: 'support-v4'
-        exclude group: 'com.android.support', module: 'customtabs'
-        exclude group: 'com.google.android.gms', module: 'play-services-gcm'
-        exclude group: 'com.google.android.gms', module: 'play-services-analytics'
-        exclude group: 'com.google.android.gms', module: 'play-services-location'
-    }
+    implementation(project(':onesignal'))
 
-    // Use to run local .aar file
-    // compile(name: 'OneSignal-release', ext: 'aar')
+    implementation 'com.google.firebase:firebase-core:11.8.0'
+    implementation 'com.google.android.gms:play-services-location:11.8.0'
 
-    // Use for released SDK
-    // compile 'com.onesignal:OneSignal:3.+@aar'
-
-    // Test with 7.0.0 to make sure there are no breaking changes in Google's libraries.
-    // This insure that the SDK will work if an app developer is using an older version of GMS.
-    compile 'com.google.android.gms:play-services-gcm:11.8.0'
-
-    // play-services-analytics is required for AdvertisingIdClient when using GMS 8.1.0 or lower.
-    // 8.3.0 it is included in 'basement' which is required by 'base'.
-    //compile "com.google.android.gms:play-services-analytics:7.0.0"
-    compile 'com.google.android.gms:play-services-location:11.8.0'
-
-    // compile 'com.google.android.gms:play-services-analytics:7.0.0'
-
-    compile 'com.android.support:customtabs:27.1.0'
-
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.robolectric:robolectric:3.7.1'
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.robolectric:robolectric:3.7.1'
 }

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowFirebaseAnalytics.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowFirebaseAnalytics.java
@@ -1,0 +1,49 @@
+/**
+ * Modified MIT License
+ *
+ * Copyright 2018 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.onesignal;
+
+import android.os.Bundle;
+
+import org.robolectric.annotation.Implements;
+
+@Implements(com.google.firebase.analytics.FirebaseAnalytics.class)
+public class ShadowFirebaseAnalytics {
+
+   public static String lastEventString;
+   public static Bundle lastEventBundle;
+
+   public static void resetStatics() {
+      lastEventString = null;
+      lastEventBundle = null;
+   }
+
+   public void logEvent(String event, Bundle bundle) {
+      lastEventString = event;
+      lastEventBundle = bundle;
+   }
+}

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowOneSignalRestClient.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowOneSignalRestClient.java
@@ -1,7 +1,7 @@
 /**
  * Modified MIT License
  *
- * Copyright 2016 OneSignal
+ * Copyright 2018 OneSignal
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -27,10 +27,12 @@
 
 package com.onesignal;
 
+import org.json.JSONException;
 import org.json.JSONObject;
 import org.robolectric.annotation.Implements;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 
 @Implements(OneSignalRestClient.class)
 public class ShadowOneSignalRestClient {
@@ -60,6 +62,8 @@ public class ShadowOneSignalRestClient {
 
    public static String pushUserId, emailUserId;
 
+   public static JSONObject paramExtras;
+
    public static void resetStatics() {
       pushUserId = "a2f7f967-e8cc-11e4-bed1-118f05be4511";
       emailUserId = "b007f967-98cc-11e4-bed1-118f05be4522";
@@ -76,6 +80,8 @@ public class ShadowOneSignalRestClient {
       failNextPut = false;
       failAll = false;
       failPosts = false;
+
+      paramExtras = null;
    }
 
    private static void trackRequest(REST_METHOD method, JSONObject payload, String url) {
@@ -157,11 +163,24 @@ public class ShadowOneSignalRestClient {
          responseHandler.onSuccess(nextSuccessResponse);
          nextSuccessResponse = null;
       }
-      else
-         responseHandler.onSuccess("{\"awl_list\": {" +
-                                    "\"IlIfoQBT5jXgkgn6nBsIrGJn5t0Yd91GqKAGoApIYzk=\": 1," +
-                                    "\"Q3zjDf/4NxXU1QpN9WKp/iwVYNPQZ0js2EDDNO+eo0o=\": 1" +
-                                "}, \"android_sender_id\": \"87654321\"}");
+      else {
+         try {
+            JSONObject getResponseJson = new JSONObject("{\"awl_list\": {" +
+                  "\"IlIfoQBT5jXgkgn6nBsIrGJn5t0Yd91GqKAGoApIYzk=\": 1," +
+                  "\"Q3zjDf/4NxXU1QpN9WKp/iwVYNPQZ0js2EDDNO+eo0o=\": 1" +
+                  "}, \"android_sender_id\": \"87654321\"}");
+            if (paramExtras != null) {
+               Iterator<String> keys = paramExtras.keys();
+               while(keys.hasNext()) {
+                  String key = keys.next();
+                  getResponseJson.put(key, paramExtras.get(key));
+               }
+            }
+            responseHandler.onSuccess(getResponseJson.toString());
+         } catch (JSONException e) {
+            e.printStackTrace();
+         }
+      }
    }
 
    public static void getSync(final String url, final OneSignalRestClient.ResponseHandler responseHandler) {

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/TestHelpers.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/TestHelpers.java
@@ -2,6 +2,7 @@ package com.test.onesignal;
 
 import com.onesignal.OneSignalPackagePrivateHelper;
 import com.onesignal.ShadowCustomTabsClient;
+import com.onesignal.ShadowFirebaseAnalytics;
 import com.onesignal.ShadowFusedLocationApiWrapper;
 import com.onesignal.ShadowGcmBroadcastReceiver;
 import com.onesignal.ShadowLocationGMS;
@@ -31,6 +32,8 @@ class TestHelpers {
 
       ShadowFusedLocationApiWrapper.resetStatics();
       ShadowLocationGMS.resetStatics();
+
+      ShadowFirebaseAnalytics.resetStatics();
 
       // DB seems to be cleaned up on it's own.
       /*


### PR DESCRIPTION
* Firebase open and received events were not firing unless there was also OneSignal handlers setup during init.
* Resolves #454

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/466)
<!-- Reviewable:end -->
