### PR TITLE
No longer default title for Android N and newer

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotification.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotification.java
@@ -223,10 +223,13 @@ class GenerateNotification {
       notifBuilder
          .setAutoCancel(true)
          .setSmallIcon(getSmallIconId(gcmBundle))
-         .setContentTitle(getTitle(gcmBundle))
          .setStyle(new NotificationCompat.BigTextStyle().bigText(message))
          .setContentText(message)
          .setTicker(message);
+
+      if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N ||
+          !gcmBundle.optString("title").equals(""))
+         notifBuilder.setContentTitle(getTitle(gcmBundle));
       
       int notificationDefaults = 0;
       


### PR DESCRIPTION
Defaulting the notification title to the app name is no longer needed on Android N+
The app name is already shown in it's own section as part of the notification itself or the group.
Resolves #452

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/471)
<!-- Reviewable:end -->
