### PR TITLE
Null alert handling with displayNotification

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
@@ -87,7 +87,12 @@ class NotificationBundleProcessor {
       notifJob.showAsAlert = OneSignal.getInAppAlertNotificationEnabled() && OneSignal.isAppActive();
       processCollapseKey(notifJob);
 
-      if (shouldDisplay(notifJob.jsonPayload.optString("alert")))
+      boolean doDisplay =
+         notifJob.hasExtender()
+         || shouldDisplay(notifJob.jsonPayload.optString("alert"));
+
+
+      if (doDisplay)
          GenerateNotification.fromJsonPayload(notifJob);
 
       if (!notifJob.restoring) {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationGenerationJob.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationGenerationJob.java
@@ -79,7 +79,10 @@ class NotificationGenerationJob {
    }
 
    int getAndroidIdWithoutCreate() {
-      return overrideSettings == null ? -1 : overrideSettings.androidNotificationId;
+      if (overrideSettings == null || overrideSettings.androidNotificationId == null)
+         return -1;
+
+      return overrideSettings.androidNotificationId;
    }
 
    void setAndroidIdWithOutOverriding(Integer id) {
@@ -92,5 +95,9 @@ class NotificationGenerationJob {
       if (overrideSettings == null)
          overrideSettings = new NotificationExtenderService.OverrideSettings();
       overrideSettings.androidNotificationId = id;
+   }
+
+   boolean hasExtender() {
+      return overrideSettings != null && overrideSettings.extender != null;
    }
 }


### PR DESCRIPTION
Fixed issues with displayNotification when receiving a notification with alert was missing from the payload;
 - Getting saved into the SQL lite DB which voids notification duplicate prevention and prints logcat errors.
 - Fixed issue with notification not displaying even if an extender was used.
Resolves #396

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/472)
<!-- Reviewable:end -->
