### PR TITLE
ConcurrentModificationException from JSONUtil Fix

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalPrefs.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalPrefs.java
@@ -51,7 +51,7 @@ class OneSignalPrefs {
 
     static ConcurrentHashMap<String,SharedPreferences> preferencesMap = new ConcurrentHashMap<>();
     //use a thread pool executor to execute disk writes
-    private static final ScheduledThreadPoolExecutor prefsExecutor = new ScheduledThreadPoolExecutor(10);
+    private static final ScheduledThreadPoolExecutor prefsExecutor = new ScheduledThreadPoolExecutor(1);
     static {
         prefsExecutor.setThreadFactory(new ThreadFactory() {
             @Override


### PR DESCRIPTION
* Fixes ConcurrentModificationException regression bug reintroduced in 3.8.0
  - Corrected test to mimic more realistic case to prevent another regression
* Resolves #465

Additional history debugging the issue in commit 77b92800c4878054a65ced7fe2b79377ef7b395d

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/478)
<!-- Reviewable:end -->
