### PR TITLE
Fixes OneSignalPrefs reads that may use old values

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalPrefs.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalPrefs.java
@@ -194,7 +194,7 @@ class OneSignalPrefs {
                 return true;
 
             Object cachedValue = pref.get(key);
-            if (cachedValue != null)
+            if (cachedValue != null || pref.containsKey(key))
                 return cachedValue;
         }
 
@@ -215,22 +215,6 @@ class OneSignalPrefs {
         }
 
         return defValue;
-    }
-
-    // TODO: Removes could be optimized as well.
-    //        running applying here for safely for now.
-    static void remove(String prefsName, String key) {
-        HashMap<String, Object> pref = prefsToApply.get(prefsName);
-        synchronized (pref) {
-            pref.remove(key);
-        }
-
-        SharedPreferences prefs = getSharedPrefsByName(prefsName);
-        if (prefs != null) {
-            SharedPreferences.Editor editor = prefs.edit();
-            editor.remove(key);
-            editor.apply();
-        }
     }
 
     private static synchronized SharedPreferences getSharedPrefsByName(String prefsName) {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/PushRegistratorGPS.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/PushRegistratorGPS.java
@@ -35,7 +35,6 @@ import android.app.AlertDialog;
 import android.app.PendingIntent.CanceledException;
 import android.content.Context;
 import android.content.DialogInterface;
-import android.content.SharedPreferences;
 import android.content.DialogInterface.OnClickListener;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/TrackGooglePurchase.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/TrackGooglePurchase.java
@@ -231,7 +231,8 @@ class TrackGooglePurchase {
 
                      OneSignalPrefs.saveString(OneSignalPrefs.PREFS_PLAYER_PURCHASES,
                              OneSignalPrefs.PREFS_PURCHASE_TOKENS, purchaseTokens.toString());
-                     OneSignalPrefs.remove(OneSignalPrefs.PREFS_PLAYER_PURCHASES, OneSignalPrefs.PREFS_EXISTING_PURCHASES);
+                     OneSignalPrefs.saveBool(OneSignalPrefs.PREFS_PLAYER_PURCHASES,
+                              OneSignalPrefs.PREFS_EXISTING_PURCHASES, true);
 
                      newAsExisting = false;
                      isWaitingForPurchasesRequest = false;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/TrackGooglePurchase.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/TrackGooglePurchase.java
@@ -37,14 +37,10 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import com.onesignal.OneSignal;
-import com.onesignal.OneSignal.IdsAvailableHandler;
-
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.ServiceConnection;
-import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.os.IBinder;

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
@@ -96,22 +96,6 @@ public class OneSignalPackagePrivateHelper {
       return true;
    }
 
-   public static void resetRunnables() throws Exception {
-      RunnableArg runnable = new RunnableArg<UserStateSynchronizer.NetworkHandlerThread>() {
-         @Override
-         void run(UserStateSynchronizer.NetworkHandlerThread handlerThread) {
-            handlerThread.stopScheduledRunnable();
-         }
-      };
-
-      processNetworkHandles(runnable);
-
-      Looper looper = ActivityLifecycleHandler.focusHandlerThread.getHandlerLooper();
-      if (looper == null) return;
-
-      shadowOf(looper).reset();
-   }
-
    public static void OneSignal_sendPurchases(JSONArray purchases, boolean newAsExisting, OneSignalRestClient.ResponseHandler responseHandler) {
       OneSignal.sendPurchases(purchases, newAsExisting, responseHandler);
    }
@@ -182,4 +166,6 @@ public class OneSignalPackagePrivateHelper {
    public static void NotificationSummaryManager_updateSummaryNotificationAfterChildRemoved(Context context, SQLiteDatabase writableDb, String group, boolean dismissed) {
       NotificationSummaryManager.updateSummaryNotificationAfterChildRemoved(context, writableDb, group, dismissed);
    }
+
+   public class OneSignalPrefs extends com.onesignal.OneSignalPrefs {}
 }

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
@@ -151,7 +151,7 @@ public class GenerateNotificationRunner {
    
       overrideNotificationId = -1;
       
-      TestHelpers.betweenTestsCleanup();
+      TestHelpers.beforeTestInitAndCleanup();
 
       NotificationManager notificationManager = (NotificationManager) blankActivity.getSystemService(Context.NOTIFICATION_SERVICE);
       notificationManager.cancelAll();


### PR DESCRIPTION
* OneSignalPrefs uses a different thread to write,
   if a read is done before the write thread finishes the read would use old value
  - This may have resulted in some vary rare race condition issues
  - Reads are now done from the pending write cache now to prevent any possible issue
  - This should improve test stability as we did not wait for writes between tests before
* OneSignalPrefs now uses a HandlerThread instead of an overkill ScheduledThreadPoolExecutor
  - This results in only using 1 thread instead of up to 10 as it was configured
  - Writes are now buffer with a short 200ms delay to prevent extra write I/O

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/479)
<!-- Reviewable:end -->
