### PR TITLE
Proguard keep for OneSignalUnityProxy class

### DIFF
--- a/OneSignalSDK/onesignal/consumer-proguard-rules.pro
+++ b/OneSignalSDK/onesignal/consumer-proguard-rules.pro
@@ -7,7 +7,6 @@
 }
 
 
--keep public interface android.app.OnActivityPausedListener {*;}
 -keep class com.onesignal.ActivityLifecycleListenerCompat** {*;}
 
 
@@ -55,3 +54,5 @@
 -keep public class com.onesignal.ADMMessageHandler {*;}
 
 -keep class com.onesignal.JobIntentService$* {*;}
+
+-keep class com.onesignal.OneSignalUnityProxy {*;}


### PR DESCRIPTION
* Also removed OnActivityPausedListener class that was removed in the 3.6.0 update

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/483)
<!-- Reviewable:end -->
