### PR TITLE
promptLocation after init registration fix

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -720,14 +720,26 @@ public class OneSignal {
    }
 
    private static void startLocationUpdate() {
-      LocationGMS.getLocation(appContext, mInitBuilder.mPromptLocation && !promptedLocation, new LocationGMS.LocationHandler() {
+      LocationGMS.getLocation(
+         appContext,
+         mInitBuilder.mPromptLocation && !promptedLocation,
+         getGetLocationCompleteHandler()
+      );
+   }
+
+   private static LocationGMS.LocationHandler getGetLocationCompleteHandler() {
+      return new LocationGMS.LocationHandler() {
          @Override
          public void complete(LocationGMS.LocationPoint point) {
             lastLocationPoint = point;
             locationFired = true;
+
+            if (point != null)
+               OneSignalStateSynchronizer.updateLocation(point);
+
             registerUser();
          }
-      });
+      };
    }
 
    private static void registerForPushToken() {
@@ -2041,14 +2053,11 @@ public class OneSignal {
       Runnable runPromptLocation = new Runnable() {
          @Override
          public void run() {
-            LocationGMS.getLocation(appContext, true, new LocationGMS.LocationHandler() {
-               @Override
-               public void complete(LocationGMS.LocationPoint point) {
-                  if (point != null)
-                     OneSignalStateSynchronizer.updateLocation(point);
-               }
-            });
-
+            LocationGMS.getLocation(
+               appContext,
+               true,
+               getGetLocationCompleteHandler()
+            );
             promptedLocation = true;
          }
       };

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalSyncServiceUtils.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalSyncServiceUtils.java
@@ -206,6 +206,11 @@ class OneSignalSyncServiceUtils {
 
          LocationGMS.LocationHandler locationHandler = new LocationGMS.LocationHandler() {
             @Override
+            public LocationGMS.CALLBACK_TYPE getType() {
+               return LocationGMS.CALLBACK_TYPE.SYNC_SERVICE;
+            }
+
+            @Override
             public void complete(LocationGMS.LocationPoint point) {
                if (point != null)
                   OneSignalStateSynchronizer.updateLocation(point);

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowGoogleApiClientBuilder.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowGoogleApiClientBuilder.java
@@ -39,7 +39,7 @@ public class ShadowGoogleApiClientBuilder {
    
    @RealObject private GoogleApiClient.Builder realBuilder;
    
-   static GoogleApiClient.ConnectionCallbacks connectionCallback;
+   public static GoogleApiClient.ConnectionCallbacks connectionCallback;
    
    public GoogleApiClient.Builder addConnectionCallbacks(@NonNull GoogleApiClient.ConnectionCallbacks connectionCallback) {
       ShadowGoogleApiClientBuilder.connectionCallback = connectionCallback;


### PR DESCRIPTION
* Fixed issue where calling promptLocation right after init may cause registerUser not to fire
* This was due to a race condition due to promptLocation overriding the internal getLocation callback
* This would cause the device not to register at all or the device would register under device_type 0 with only location set
* Fixed by providing the same callback logic for both getLocation calls

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/484)
<!-- Reviewable:end -->
