### PR TITLE
ConcurrentModificationException, backgrounding app

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStateSynchronizer.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStateSynchronizer.java
@@ -135,9 +135,11 @@ abstract class UserStateSynchronizer {
 
     boolean persist() {
         if (toSyncUserState != null) {
-            boolean unSynced = currentUserState.generateJsonDiff(toSyncUserState, isSessionCall()) != null;
-            toSyncUserState.persistState();
-            return unSynced;
+            synchronized (syncLock) {
+                boolean unSynced = currentUserState.generateJsonDiff(toSyncUserState, isSessionCall()) != null;
+                toSyncUserState.persistState();
+                return unSynced;
+            }
         }
         return false;
     }

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
@@ -168,4 +168,8 @@ public class OneSignalPackagePrivateHelper {
    }
 
    public class OneSignalPrefs extends com.onesignal.OneSignalPrefs {}
+
+   public static void OneSignal_onAppLostFocus() {
+      OneSignal.onAppLostFocus();
+   }
 }

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
@@ -1556,6 +1556,33 @@ public class MainOneSignalClassRunner {
       }
    }
 
+   @Test
+   @Config(sdk = 26)
+   public void testFocusConcurrentModificationException() throws Exception {
+      OneSignalInit();
+      threadAndTaskWait();
+
+      final int TOTAL_RUNS = 75, CONCURRENT_THREADS = 15;
+      for(int a = 0; a < TOTAL_RUNS; a++) {
+         List<Thread> threadList = new ArrayList<>(CONCURRENT_THREADS);
+         for (int i = 0; i < CONCURRENT_THREADS; i++) {
+            OneSignalPackagePrivateHelper.OneSignal_onAppLostFocus();
+            Thread lastThread = newSendTagTestThread(Thread.currentThread(), a * i);
+            lastThread.start();
+            threadList.add(lastThread);
+            assertFalse(failedCurModTest);
+         }
+
+         OneSignalPackagePrivateHelper.runAllNetworkRunnables();
+
+         for(Thread thread : threadList)
+            thread.join();
+
+         assertFalse(failedCurModTest);
+         System.out.println("Pass " + a + " out of " + TOTAL_RUNS);
+      }
+   }
+
    private static Thread newSendTagTestThread(final Thread mainThread, final int id) {
       return new Thread(new Runnable() {
          @Override


### PR DESCRIPTION
* Fixes ConcurrentModificationException error when backgrounding in rare cases
* Noted in issue #465

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/497)
<!-- Reviewable:end -->
