### PR TITLE
Fix Null User State Issue

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStateEmailSynchronizer.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStateEmailSynchronizer.java
@@ -57,7 +57,7 @@ class UserStateEmailSynchronizer extends UserStateSynchronizer {
         JSONObject syncValues = getUserStateForModification().syncValues;
 
         boolean noChange = email.equals(syncValues.optString("identifier")) &&
-                               syncValues.optString("email_auth_hash").equals(emailAuthHash == null ? "" : emailAuthHash);
+                syncValues.optString("email_auth_hash").equals(emailAuthHash == null ? "" : emailAuthHash);
         if (noChange) {
             OneSignal.fireEmailUpdateSuccess();
             return;
@@ -115,7 +115,7 @@ class UserStateEmailSynchronizer extends UserStateSynchronizer {
         OneSignal.saveEmailId("");
 
         resetCurrentState();
-        toSyncUserState.syncValues.remove("identifier");
+        getToSyncUserState().syncValues.remove("identifier");
         toSyncUserState.syncValues.remove("email_auth_hash");
         toSyncUserState.syncValues.remove("device_player_id");
         toSyncUserState.persistState();

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStatePushSynchronizer.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStatePushSynchronizer.java
@@ -52,7 +52,7 @@ class UserStatePushSynchronizer extends UserStateSynchronizer {
         }
 
         synchronized(syncLock) {
-            return new GetTagsResult(serverSuccess, JSONUtils.getJSONObjectWithoutBlankValues(getToSyncUserState().syncValues, "tags"));
+            return new GetTagsResult(serverSuccess, JSONUtils.getJSONObjectWithoutBlankValues(toSyncUserState.syncValues, "tags"));
         }
     }
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStatePushSynchronizer.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStatePushSynchronizer.java
@@ -32,7 +32,7 @@ class UserStatePushSynchronizer extends UserStateSynchronizer {
                         if (lastGetTagsResponse.has("tags")) {
                             synchronized(syncLock) {
                                 JSONObject dependDiff = generateJsonDiff(currentUserState.syncValues.optJSONObject("tags"),
-                                        toSyncUserState.syncValues.optJSONObject("tags"),
+                                        getToSyncUserState().syncValues.optJSONObject("tags"),
                                         null, null);
 
                                 currentUserState.syncValues.put("tags", lastGetTagsResponse.optJSONObject("tags"));
@@ -40,8 +40,8 @@ class UserStatePushSynchronizer extends UserStateSynchronizer {
 
                                 // Allow server side tags to overwrite local tags expect for any pending changes
                                 //  that haven't been successfully posted.
-                                toSyncUserState.mergeTags(lastGetTagsResponse, dependDiff);
-                                toSyncUserState.persistState();
+                                getToSyncUserState().mergeTags(lastGetTagsResponse, dependDiff);
+                                getToSyncUserState().persistState();
                             }
                         }
                     } catch (JSONException e) {


### PR DESCRIPTION
• Fixes a relatively rare crash (#503) caused by a race condition where a sync state variable was accessed before it was initialized
• Resolved by synchronizing the accessor method

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/517)
<!-- Reviewable:end -->
