### PR TITLE
Unity Proxy setLocationShared

### DIFF
--- a/OneSignalSDK/onesignal/src/unity/java/com/onesignal/OneSignalUnityProxy.java
+++ b/OneSignalSDK/onesignal/src/unity/java/com/onesignal/OneSignalUnityProxy.java
@@ -213,6 +213,8 @@ public class OneSignalUnityProxy implements NotificationOpenedHandler, Notificat
    public String getPermissionSubscriptionState() {
       return OneSignal.getPermissionSubscriptionState().toJSONObject().toString();
    }
+
+   public void setLocationShared(boolean shared) { OneSignal.setLocationShared(shared); }
    
    @Override
    public void onOSPermissionChanged(OSPermissionStateChanges stateChanges) {


### PR DESCRIPTION
• Adds setLocationShared(bool) to the Unity proxy

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/529)
<!-- Reviewable:end -->
