### PR TITLE
Fixed runtime issue when firebase-auth is added

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/PushRegistratorFCM.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/PushRegistratorFCM.java
@@ -60,6 +60,7 @@ class PushRegistratorFCM extends PushRegistratorAbstractGoogle {
          new FirebaseOptions.Builder()
             .setGcmSenderId(senderId)
             .setApplicationId("OMIT_ID")
+            .setApiKey("OMIT_KEY")
             .build();
       firebaseApp = FirebaseApp.initializeApp(OneSignal.appContext, firebaseOptions, FCM_APP_NAME);
    }


### PR DESCRIPTION
* Specific when com.google.firebase:firebase-auth:15.1.0 is used the following error would throw
   - java.lang.IllegalArgumentException: Given String is empty or null
   - at com.google.android.gms.common.internal.Preconditions.checkNotEmpty(Unknown Source)
   - at com.google.firebase.auth.api.internal.zzcq.<init>(Unknown Source)
   - ...
   - at com.google.firebase.FirebaseApp.initializeApp(Unknown Source)
   - at com.onesignal.PushRegistratorFCM.initFirebaseApp(PushRegistratorFCM.java:64)