### PR TITLE
Synchronize State

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStateSynchronizer.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStateSynchronizer.java
@@ -119,8 +119,10 @@ abstract class UserStateSynchronizer {
     }
 
     void initUserState() {
-        if (currentUserState == null)
-            currentUserState = newUserState("CURRENT_STATE", true);
+        synchronized (syncLock) {
+            if (currentUserState == null)
+                currentUserState = newUserState("CURRENT_STATE", true);
+        }
 
         getToSyncUserState();
     }
@@ -166,6 +168,9 @@ abstract class UserStateSynchronizer {
             doEmailLogout(userId);
             return;
         }
+
+        if (currentUserState == null)
+            initUserState();
 
         final boolean isSessionCall = isSessionCall();
         JSONObject jsonBody, dependDiff;


### PR DESCRIPTION
• Fixes a crash where the generateJsonDiff() method of the currentUserState property in UserStateSynchronizer is called before the currentUserState is initialized, by adding a synchronization step to the initUserState() method
• Adds a check to make sure the user state is initialized before internalSyncUserState() attempts to access it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/532)
<!-- Reviewable:end -->
