### PR TITLE
Synchronize LocationGMS

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/LocationGMS.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/LocationGMS.java
@@ -337,6 +337,7 @@ class LocationGMS {
       
       private GoogleApiClient mGoogleApiClient;
 
+      // this initializer method is already synchronized from LocationGMS with respect to the GoogleApiClient lock
       LocationUpdateListener(GoogleApiClient googleApiClient) {
          mGoogleApiClient = googleApiClient;
 
@@ -364,8 +365,10 @@ class LocationGMS {
       @SuppressWarnings("MissingPermission")
       static void requestLocationUpdates(GoogleApiClient googleApiClient, LocationRequest locationRequest, LocationListener locationListener) {
          try {
-            if (googleApiClient.isConnected())
-               LocationServices.FusedLocationApi.requestLocationUpdates(googleApiClient, locationRequest, locationListener);
+            synchronized (LocationGMS.syncLock) {
+               if (googleApiClient.isConnected())
+                  LocationServices.FusedLocationApi.requestLocationUpdates(googleApiClient, locationRequest, locationListener);
+            }
          } catch(Throwable t) {
             OneSignal.Log(OneSignal.LOG_LEVEL.WARN, "FusedLocationApi.requestLocationUpdates failed!", t);
          }
@@ -373,8 +376,10 @@ class LocationGMS {
    
       @SuppressWarnings("MissingPermission")
       static Location getLastLocation(GoogleApiClient googleApiClient) {
-         if (googleApiClient.isConnected())
-            return LocationServices.FusedLocationApi.getLastLocation(googleApiClient);
+         synchronized(LocationGMS.syncLock) {
+            if (googleApiClient.isConnected())
+               return LocationServices.FusedLocationApi.getLastLocation(googleApiClient);
+         }
          return null;
       }
    }


### PR DESCRIPTION
• The GoogleAPIClient instance in LocationGMS (accessed through a proxy via reflection) was being accessed before it was being connected due to a race condition
• Introduces synchronization to ensure access to the instance only occurs after it is initialized & connected.
• Fixes #509

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/536)
<!-- Reviewable:end -->
