### PR TITLE
Fixed proguard compatibility

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSUtils.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSUtils.java
@@ -150,11 +150,10 @@ class OSUtils {
    }
 
    private Integer checkAndroidSupportLibrary(Context context) {
-      String version = getAndroidSupporVersionFromMetaFile();
       boolean hasWakefulBroadcastReceiver = hasWakefulBroadcastReceiver();
       boolean hasNotificationManagerCompat = hasNotificationManagerCompat();
 
-      if (version == null && !hasWakefulBroadcastReceiver && !hasNotificationManagerCompat) {
+      if (!hasWakefulBroadcastReceiver && !hasNotificationManagerCompat) {
          OneSignal.Log(OneSignal.LOG_LEVEL.FATAL, "Could not find the Android Support Library. Please make sure it has been correctly added to your project.");
          return UserState.PUSH_STATUS_MISSING_ANDROID_SUPPORT_LIBRARY;
       }
@@ -176,17 +175,6 @@ class OSUtils {
       }
 
       return null;
-   }
-
-   private static String getAndroidSupporVersionFromMetaFile() {
-      InputStream inputStream = Object.class.getClassLoader().getResourceAsStream("META-INF/com.android.support_support-v4.version");
-      if (inputStream == null)
-         return null;
-
-      Scanner scanner = new Scanner(inputStream, "UTF-8");
-      String version = scanner.useDelimiter("\\A").hasNext() ? scanner.next() : null;
-      scanner.close();
-      return version;
    }
 
    int getDeviceType() {


### PR DESCRIPTION
* Proguard is now renaming public classes so changed to static class based checks.
  - This way when Proguard renames the public class name it will be updated in OSUtils.
  - This is better then adding a proguard rule to keep class as allows renaming which means a smaller APK.
* Resolves #533

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/541)
<!-- Reviewable:end -->
