### PR TITLE
Fix Notification Restoration Crash for Android 7.0

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/UpgradeReceiver.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/UpgradeReceiver.java
@@ -37,7 +37,7 @@ public class UpgradeReceiver extends BroadcastReceiver {
    @Override
    public void onReceive(Context context, Intent intent) {
 
-      // Return early if using Android 7.0 or earlier due to upgrade restore crash (#263)
+      // Return early if using Android 7.0 due to upgrade restore crash (#263)
       if (Build.VERSION.SDK_INT == Build.VERSION_CODES.N)
          return;
       

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/UpgradeReceiver.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/UpgradeReceiver.java
@@ -30,11 +30,17 @@ package com.onesignal;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
 
 public class UpgradeReceiver extends BroadcastReceiver {
 
    @Override
    public void onReceive(Context context, Intent intent) {
+
+      // Return early if using Android 7.0 or earlier due to upgrade restore crash (#263)
+      if (Build.VERSION.SDK_INT == Build.VERSION_CODES.N)
+         return;
+      
       NotificationRestorer.startDelayedRestoreTaskFromReceiver(context);
    }
 }


### PR DESCRIPTION
• Fixes a crash (#263) by disabling notification restoration after app upgrades for Android 7.0 devices.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/544)
<!-- Reviewable:end -->
