### PR TITLE
Misuse of multiple SQL statements in execSQL().

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalDbHelper.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalDbHelper.java
@@ -66,12 +66,11 @@ public class OneSignalDbHelper extends SQLiteOpenHelper {
            NotificationTable.COLUMN_NAME_CREATED_TIME + " TIMESTAMP DEFAULT (strftime('%s', 'now'))" +
            ");";
 
-   private static final String SQL_INDEX_ENTRIES =
-           NotificationTable.INDEX_CREATE_NOTIFICATION_ID +
-           NotificationTable.INDEX_CREATE_ANDROID_NOTIFICATION_ID +
-           NotificationTable.INDEX_CREATE_GROUP_ID +
-           NotificationTable.INDEX_CREATE_COLLAPSE_ID +
-           NotificationTable.INDEX_CREATE_CREATED_TIME;
+   private static final String[] SQL_INDEX_ENTRIES = { NotificationTable.INDEX_CREATE_NOTIFICATION_ID,
+           NotificationTable.INDEX_CREATE_ANDROID_NOTIFICATION_ID,
+           NotificationTable.INDEX_CREATE_GROUP_ID,
+           NotificationTable.INDEX_CREATE_COLLAPSE_ID,
+           NotificationTable.INDEX_CREATE_CREATED_TIME };
 
    private static OneSignalDbHelper sInstance;
 
@@ -116,7 +115,9 @@ public class OneSignalDbHelper extends SQLiteOpenHelper {
    @Override
    public void onCreate(SQLiteDatabase db) {
       db.execSQL(SQL_CREATE_ENTRIES);
-      db.execSQL(SQL_INDEX_ENTRIES);
+      for (String ind : SQL_INDEX_ENTRIES) {
+         db.execSQL(ind);
+      }
    }
 
    @Override


### PR DESCRIPTION
Hello,
I've spotted a misuse of multiple SQL statements in an execSQL(). In fact, after the first index, the others do not get created by SQLite like this. Please consider reviewing and fixing it.
Best,
Csaba

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/554)
<!-- Reviewable:end -->
