### PR TITLE
Fix idsAvailable not firing a 2nd time

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -1683,7 +1683,7 @@ public class OneSignal {
       runIdsAvailable.run();
    }
 
-   private static void fireIdsAvailableCallback() {
+   static void fireIdsAvailableCallback() {
       if (idsAvailableHandler != null) {
          OSUtils.runOnMainUIThread(new Runnable() {
             @Override

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStatePushSynchronizer.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStatePushSynchronizer.java
@@ -157,5 +157,7 @@ class UserStatePushSynchronizer extends UserStateSynchronizer {
     protected void onSuccessfulSync(JSONObject jsonFields) {
         if (jsonFields.has("email"))
             OneSignal.fireEmailUpdateSuccess();
+        if (jsonFields.has("identifier"))
+            OneSignal.fireIdsAvailableCallback();
     }
 }

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
@@ -591,13 +591,19 @@ public class MainOneSignalClassRunner {
       //   and is testing the same logic.
       ShadowPushRegistratorGCM.fail = true;
       OneSignalInitWithBadProjectNum();
-
       threadAndTaskWait();
       Robolectric.getForegroundThreadScheduler().runOneTask();
-      assertEquals(-7, ShadowOneSignalRestClient.lastPost.getInt("notification_types"));
 
+      assertEquals(-7, ShadowOneSignalRestClient.lastPost.getInt("notification_types"));
       // Test that idsAvailable still fires
       assertEquals(ShadowOneSignalRestClient.pushUserId, callBackUseId);
+      assertNull(getCallBackRegId); // Since GCM registration failed, this should be null
+
+      // We now get a push token after the device registers with Onesignal,
+      //    the idsAvailable callback should fire a 2nd time with a registrationId automatically
+      ShadowPushRegistratorGCM.manualFireRegisterForPush();
+      threadAndTaskWait();
+      assertEquals(ShadowPushRegistratorGCM.regId, getCallBackRegId);
    }
 
    @Test


### PR DESCRIPTION
* Fixed issue where idsAvailable would not fire a 2nd time if registrationId the first time
* resolves #558

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/563)
<!-- Reviewable:end -->
