### PR TITLE
Add Update Handler for Send/Delete Tags

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -143,6 +143,24 @@ public class OneSignal {
       void tagsAvailable(JSONObject tags);
    }
 
+   public interface ChangeTagsUpdateHandler {
+      void onSuccess(JSONObject tags);
+      void onFailure(SendTagsError error);
+   }
+
+   public static class SendTagsError {
+      private String message;
+      private int code;
+
+      SendTagsError(int errorCode, String errorMessage) {
+         this.message = errorMessage;
+         this.code = errorCode;
+      }
+
+      public int getCode() { return code; }
+      public String getMessage() { return message; }
+   }
+
 
    public enum EmailErrorType {
       VALIDATION, REQUIRES_EMAIL_AUTH, INVALID_OPERATION, NETWORK
@@ -869,6 +887,13 @@ public class OneSignal {
 
       unprocessedOpenedNotifis.clear();
    }
+   /**
+    * Please do not use this method for logging, it is meant solely to be
+    * used by our wrapper SDK's.
+    */
+   public static void onesignalLog(LOG_LEVEL level, String message) {
+      OneSignal.Log(level, message);
+   }
 
    public static boolean userProvidedPrivacyConsent() {
       return getSavedUserConsentStatus();
@@ -1414,6 +1439,24 @@ public class OneSignal {
     *
     */
    public static void sendTags(final JSONObject keyValues) {
+      sendTags(keyValues, null);
+   }
+
+   /**
+    * Tag a user based on an app event of your choosing so later you can create
+    * <a href="https://documentation.onesignal.com/docs/segmentation">OneSignal Segments</a>
+    *  to target these users.
+    *
+    *  NOTE: The ChangeTagsUpdateHandler will not be called under all circumstances. It can also take
+    *  more than 5 seconds in some cases to be called, so please do not block any user action
+    *  based on this callback.
+    * @param keyValues Key value pairs of your choosing to create or update. <b>Note:</b>
+    *                  Passing in a blank String as a value deletes a key.
+    *                  You can also call {@link #deleteTag(String)} or {@link #deleteTags(String)}.
+    *
+    */
+   public static void sendTags(final JSONObject keyValues, ChangeTagsUpdateHandler handler) {
+      final ChangeTagsUpdateHandler tagsHandler = handler;
 
       //if applicable, check if the user provided privacy consent
       if (shouldLogUserPrivacyConsentErrorMessageForMethodName("sendTags()"))
@@ -1422,10 +1465,13 @@ public class OneSignal {
       Runnable sendTagsRunnable = new Runnable() {
          @Override
          public void run() {
-            if (keyValues == null) return;
+            if (keyValues == null) {
+               if (tagsHandler != null)
+                  tagsHandler.onFailure(new SendTagsError(-1, "Attempted to send null tags"));
+               return;
+            }
 
             JSONObject existingKeys = OneSignalStateSynchronizer.getTags(false).result;
-
             JSONObject toSend = new JSONObject();
 
             Iterator<String> keys = keyValues.keys();
@@ -1448,8 +1494,11 @@ public class OneSignal {
                catch (Throwable t) {}
             }
 
-            if (!toSend.toString().equals("{}"))
-               OneSignalStateSynchronizer.sendTags(toSend);
+            if (!toSend.toString().equals("{}")) {
+               OneSignalStateSynchronizer.sendTags(toSend, tagsHandler);
+            } else {
+               tagsHandler.onSuccess(existingKeys);
+            }
          }
       };
 
@@ -1457,6 +1506,9 @@ public class OneSignal {
       if (appContext == null || shouldRunTaskThroughQueue()) {
          Log(LOG_LEVEL.ERROR, "You must initialize OneSignal before modifying tags!" +
                  "Moving this operation to a pending task queue.");
+         if (tagsHandler != null)
+            tagsHandler.onFailure(new SendTagsError(-1, "You must initialize OneSignal before modifying tags!" +
+                    "Moving this operation to a pending task queue."));
          addTaskToQueue(new PendingTaskRunnable(sendTagsRunnable));
          return;
       }
@@ -1604,14 +1656,17 @@ public class OneSignal {
     * @param key Key to remove.
     */
    public static void deleteTag(String key) {
+      deleteTag(key, null);
+   }
 
+   public static void deleteTag(String key, ChangeTagsUpdateHandler handler) {
       //if applicable, check if the user provided privacy consent
       if (shouldLogUserPrivacyConsentErrorMessageForMethodName("deleteTag()"))
          return;
 
       Collection<String> tempList = new ArrayList<>(1);
       tempList.add(key);
-      deleteTags(tempList);
+      deleteTags(tempList, handler);
    }
 
    /**
@@ -1620,7 +1675,10 @@ public class OneSignal {
     * @param keys Keys to remove.
     */
    public static void deleteTags(Collection<String> keys) {
+      deleteTags(keys, null);
+   }
 
+   public static void deleteTags(Collection<String> keys, ChangeTagsUpdateHandler handler) {
       //if applicable, check if the user provided privacy consent
       if (shouldLogUserPrivacyConsentErrorMessageForMethodName("deleteTags()"))
          return;
@@ -1630,14 +1688,17 @@ public class OneSignal {
          for (String key : keys)
             jsonTags.put(key, "");
 
-         sendTags(jsonTags);
+         sendTags(jsonTags, handler);
       } catch (Throwable t) {
          Log(LOG_LEVEL.ERROR, "Failed to generate JSON for deleteTags.", t);
       }
    }
 
    public static void deleteTags(String jsonArrayString) {
+      deleteTags(jsonArrayString, null);
+   }
 
+   public static void deleteTags(String jsonArrayString, ChangeTagsUpdateHandler handler) {
       //if applicable, check if the user provided privacy consent
       if (shouldLogUserPrivacyConsentErrorMessageForMethodName("deleteTags()"))
          return;
@@ -1649,7 +1710,7 @@ public class OneSignal {
          for (int i = 0; i < jsonArray.length(); i++)
             jsonTags.put(jsonArray.getString(i), "");
 
-         sendTags(jsonTags);
+         sendTags(jsonTags, handler);
       } catch (Throwable t) {
          Log(LOG_LEVEL.ERROR, "Failed to generate JSON for deleteTags.", t);
       }
@@ -2128,6 +2189,10 @@ public class OneSignal {
    }
    public static void setInFocusDisplaying(int displayOption) {
       setInFocusDisplaying(getInFocusDisplaying(displayOption));
+   }
+
+   public static OSInFocusDisplayOption currentInFocusDisplayOption() {
+      return getCurrentOrNewInitBuilder().mDisplayOption;
    }
 
    private static OSInFocusDisplayOption getInFocusDisplaying(int displayOption) {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalStateSynchronizer.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalStateSynchronizer.java
@@ -29,6 +29,7 @@ package com.onesignal;
 
 import org.json.JSONException;
 import org.json.JSONObject;
+import com.onesignal.OneSignal.ChangeTagsUpdateHandler;
 
 class OneSignalStateSynchronizer {
 
@@ -71,12 +72,13 @@ class OneSignalStateSynchronizer {
       getEmailStateSynchronizer().syncUserState(fromSyncService);
    }
 
-   static void sendTags(JSONObject newTags) {
+   static void sendTags(JSONObject newTags, ChangeTagsUpdateHandler handler) {
       try {
          JSONObject jsonField = new JSONObject().put("tags", newTags);
-         getPushStateSynchronizer().sendTags(jsonField);
-         getEmailStateSynchronizer().sendTags(jsonField);
+         getPushStateSynchronizer().sendTags(jsonField, handler);
+         getEmailStateSynchronizer().sendTags(jsonField, handler);
       } catch (JSONException e) {
+         handler.onFailure(new OneSignal.SendTagsError(-1, "Encountered an error attempting to serialize your tags into JSON: " + e.getMessage() + "\n" + e.getStackTrace()));
          e.printStackTrace();
       }
    }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStateSynchronizer.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStateSynchronizer.java
@@ -189,9 +189,11 @@ abstract class UserStateSynchronizer {
             if (jsonBody == null) {
                 currentUserState.persistStateAfterSync(dependDiff, null);
 
-                for (ChangeTagsUpdateHandler handler : this.sendTagsHandlers)
-                    if (handler != null)
+                for (ChangeTagsUpdateHandler handler : this.sendTagsHandlers) {
+                    if (handler != null) {
                         handler.onSuccess(OneSignalStateSynchronizer.getTags(false).result);
+                    }
+                }
 
                 this.sendTagsHandlers.clear();
                 
@@ -265,9 +267,11 @@ abstract class UserStateSynchronizer {
 
     private void doPutSync(String userId, final JSONObject jsonBody, final JSONObject dependDiff) {
         if (userId == null) {
-            for (ChangeTagsUpdateHandler handler : this.sendTagsHandlers)
-                if (handler != null)
+            for (ChangeTagsUpdateHandler handler : this.sendTagsHandlers) {
+                if (handler != null) {
                     handler.onFailure(new SendTagsError(-1, "Unable to update tags: the current user is not registered with OneSignal"));
+                }
+            }
 
             this.sendTagsHandlers.clear();
 
@@ -289,9 +293,11 @@ abstract class UserStateSynchronizer {
                     handleNetworkFailure();
 
                 if (jsonBody.has("tags"))
-                    for (ChangeTagsUpdateHandler handler : tagsHandlers)
-                        if (handler != null)
+                    for (ChangeTagsUpdateHandler handler : tagsHandlers) {
+                        if (handler != null) {
                             handler.onFailure(new SendTagsError(statusCode, response));
+                        }
+                    }
 
             }
 
@@ -302,9 +308,11 @@ abstract class UserStateSynchronizer {
                 JSONObject tags = OneSignalStateSynchronizer.getTags(false).result;
 
                 if (jsonBody.has("tags") && tags != null)
-                    for (ChangeTagsUpdateHandler handler : tagsHandlers)
-                        if (handler != null)
+                    for (ChangeTagsUpdateHandler handler : tagsHandlers) {
+                        if (handler != null) {
                             handler.onSuccess(tags);
+                        }
+                    }
 
             }
         });

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
@@ -1287,6 +1287,7 @@ public class MainOneSignalClassRunner {
       }
    }
 
+   // Tests to make sure the onSuccess handler works
    @Test
    public void shouldSendNewTagsWithResponse() throws Exception {
       OneSignalInit();
@@ -1312,15 +1313,35 @@ public class MainOneSignalClassRunner {
       assertTrue(handler.getSucceeded());
    }
 
+   // Tests to make sure that the onFailure callback works
    @Test
    public void shouldFailToSendTagsWithResponse() throws Exception {
       TestChangeTagsUpdateHandler handler = new TestChangeTagsUpdateHandler();
 
+      // should fail because there is no OneSignal player ID
       OneSignal.sendTags(new JSONObject("{\"test\" : \"value\"}"), handler);
 
       threadAndTaskWait();
 
       assertTrue(handler.getFailed());
+   }
+
+   // Tests to make sure that the SDK will call both handlers
+   @Test
+   public void shouldCallMultipleHandlers() throws Exception {
+      OneSignalInit();
+      threadAndTaskWait();
+
+      TestChangeTagsUpdateHandler firstHandler = new TestChangeTagsUpdateHandler();
+      TestChangeTagsUpdateHandler secondHandler = new TestChangeTagsUpdateHandler();
+
+      OneSignal.sendTags(new JSONObject("{\"test1\" : \"value1\"}"), firstHandler);
+      OneSignal.sendTags(new JSONObject("{\"test2\" : \"value2\"}"), secondHandler);
+
+      threadAndTaskWait();
+
+      assertTrue(firstHandler.getSucceeded());
+      assertTrue(secondHandler.getSucceeded());
    }
 
    @Test

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
@@ -41,6 +41,7 @@ import android.database.sqlite.SQLiteDatabase;
 import android.location.Location;
 import android.net.ConnectivityManager;
 import android.os.Bundle;
+import android.util.Log;
 
 import com.onesignal.BuildConfig;
 import com.onesignal.OSEmailSubscriptionObserver;
@@ -79,6 +80,7 @@ import com.onesignal.StaticResetHelper;
 import com.onesignal.SyncJobService;
 import com.onesignal.SyncService;
 import com.onesignal.example.BlankActivity;
+import com.onesignal.OneSignal.ChangeTagsUpdateHandler;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -1260,6 +1262,65 @@ public class MainOneSignalClassRunner {
 
       assertEquals(2, ShadowOneSignalRestClient.networkCallCount);
       assertNotNull(callBackUseId);
+   }
+
+   private class TestChangeTagsUpdateHandler implements ChangeTagsUpdateHandler {
+      private AtomicBoolean succeeded = new AtomicBoolean(false);
+      private AtomicBoolean failed = new AtomicBoolean(false);
+
+      @Override
+      public void onSuccess(JSONObject tags) {
+         succeeded.set(true);
+      }
+
+      @Override
+      public void onFailure(OneSignal.SendTagsError error) {
+         failed.set(true);
+      }
+
+      boolean getSucceeded() {
+         return succeeded.get();
+      }
+
+      boolean getFailed() {
+         return failed.get();
+      }
+   }
+
+   @Test
+   public void shouldSendNewTagsWithResponse() throws Exception {
+      OneSignalInit();
+      threadAndTaskWait();
+
+      TestChangeTagsUpdateHandler handler = new TestChangeTagsUpdateHandler();
+
+      OneSignal.sendTags(new JSONObject("{\"test\" : \"value\"}"), handler);
+
+      threadAndTaskWait();
+
+      assertTrue(handler.getSucceeded());
+
+      // now test to make sure the handler still fires for a call to
+      // sendTags() that doesn't modify existing tags (no JSON delta)
+
+      handler = new TestChangeTagsUpdateHandler();
+
+      OneSignal.sendTags(new JSONObject("{\"test\" : \"value\"}"), handler);
+
+      threadAndTaskWait();
+
+      assertTrue(handler.getSucceeded());
+   }
+
+   @Test
+   public void shouldFailToSendTagsWithResponse() throws Exception {
+      TestChangeTagsUpdateHandler handler = new TestChangeTagsUpdateHandler();
+
+      OneSignal.sendTags(new JSONObject("{\"test\" : \"value\"}"), handler);
+
+      threadAndTaskWait();
+
+      assertTrue(handler.getFailed());
    }
 
    @Test


### PR DESCRIPTION
• Adds an update handler to methods that update tags to allow developers to respond when the HTTP request is finished (or fails)
• Adds a new public method oneSignalLog() to allow wrapper SDK's to use OneSignal logging

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/595)
<!-- Reviewable:end -->
