### PR TITLE
Add requiresUserPrivacyConsent() getter

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -894,6 +894,14 @@ public class OneSignal {
       requiresUserPrivacyConsent = required;
    }
 
+
+   /**
+    * Indicates if the SDK is still waiting for the user to provide consent
+    */
+   public static boolean requiresUserPrivacyConsent() {
+      return requiresUserPrivacyConsent && !userProvidedPrivacyConsent();
+   }
+
    static boolean shouldLogUserPrivacyConsentErrorMessageForMethodName(String methodName) {
       if (requiresUserPrivacyConsent && !userProvidedPrivacyConsent()) {
          if (methodName != null)

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
@@ -2237,6 +2237,19 @@ public class MainOneSignalClassRunner {
       postNotificationSuccess = postNotificationFailure = null;
    }
 
+   @Test
+   public void shouldReturnCorrectConsentRequiredStatus() throws Exception {
+      OneSignal.setRequiresUserPrivacyConsent(true);
+
+      OneSignalInit();
+
+      assertTrue(OneSignal.requiresUserPrivacyConsent());
+
+      OneSignal.provideUserConsent(true);
+
+      assertFalse(OneSignal.requiresUserPrivacyConsent());
+   }
+
    /*
    // Can't get test to work from a app flow due to the main thread being locked one way or another in a robolectric env.
    // Running ActivityLifecycleListener.focusHandlerThread...advanceToNextPostedRunnable waits on the main thread.


### PR DESCRIPTION
• Since developers can manually require consent by editing the manifest, the wrapper SDK's need a way of knowing if the Android SDK is waiting on the user's privacy consent
• Exposes a public getter that returns TRUE if consent is required but hasn't been provided yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/598)
<!-- Reviewable:end -->
