### PR TITLE
Fix ANR

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStateSynchronizer.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStateSynchronizer.java
@@ -119,9 +119,11 @@ abstract class UserStateSynchronizer {
         }
     }
 
-    protected synchronized UserState getToSyncUserState() {
-        if (toSyncUserState == null)
-            toSyncUserState = newUserState("TOSYNC_STATE", true);
+    protected UserState getToSyncUserState() {
+        synchronized (syncLock) {
+            if (toSyncUserState == null)
+                toSyncUserState = newUserState("TOSYNC_STATE", true);
+        }
 
         return toSyncUserState;
     }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStateSynchronizer.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStateSynchronizer.java
@@ -163,7 +163,7 @@ abstract class UserStateSynchronizer {
         return getToSyncUserState().dependValues.optBoolean("logoutEmail", false);
     }
 
-    synchronized void syncUserState(boolean fromSyncService) {
+    void syncUserState(boolean fromSyncService) {
         runningSyncUserState.set(true);
         internalSyncUserState(fromSyncService);
         runningSyncUserState.set(false);
@@ -287,10 +287,12 @@ abstract class UserStateSynchronizer {
             void onFailure(int statusCode, String response, Throwable throwable) {
                 OneSignal.Log(OneSignal.LOG_LEVEL.WARN, "Failed last request. statusCode: " + statusCode + "\nresponse: " + response);
 
-                if (response400WithErrorsContaining(statusCode, response, "No user with this id found"))
-                    handlePlayerDeletedFromServer();
-                else
-                    handleNetworkFailure();
+                synchronized (syncLock) {
+                    if (response400WithErrorsContaining(statusCode, response, "No user with this id found"))
+                        handlePlayerDeletedFromServer();
+                    else
+                        handleNetworkFailure();
+                }
 
                 if (jsonBody.has("tags"))
                     for (ChangeTagsUpdateHandler handler : tagsHandlers) {
@@ -303,8 +305,11 @@ abstract class UserStateSynchronizer {
 
             @Override
             void onSuccess(String response) {
-                currentUserState.persistStateAfterSync(dependDiff, jsonBody);
-                onSuccessfulSync(jsonBody);
+                synchronized (syncLock) {
+                    currentUserState.persistStateAfterSync(dependDiff, jsonBody);
+                    onSuccessfulSync(jsonBody);
+                }
+
                 JSONObject tags = OneSignalStateSynchronizer.getTags(false).result;
 
                 if (jsonBody.has("tags") && tags != null)
@@ -330,36 +335,40 @@ abstract class UserStateSynchronizer {
         OneSignalRestClient.postSync(urlStr, jsonBody, new OneSignalRestClient.ResponseHandler() {
             @Override
             void onFailure(int statusCode, String response, Throwable throwable) {
-                waitingForSessionResponse = false;
-                OneSignal.Log(OneSignal.LOG_LEVEL.WARN, "Failed last request. statusCode: " + statusCode + "\nresponse: " + response);
+                synchronized (syncLock) {
+                    waitingForSessionResponse = false;
+                    OneSignal.Log(OneSignal.LOG_LEVEL.WARN, "Failed last request. statusCode: " + statusCode + "\nresponse: " + response);
 
-                if (response400WithErrorsContaining(statusCode, response, "not a valid device_type"))
-                    handlePlayerDeletedFromServer();
-                else
-                    handleNetworkFailure();
+                    if (response400WithErrorsContaining(statusCode, response, "not a valid device_type"))
+                        handlePlayerDeletedFromServer();
+                    else
+                        handleNetworkFailure();
+                }
             }
 
             @Override
             void onSuccess(String response) {
-                nextSyncIsSession = waitingForSessionResponse = false;
-                currentUserState.persistStateAfterSync(dependDiff, jsonBody);
+                synchronized (syncLock) {
+                    nextSyncIsSession = waitingForSessionResponse = false;
+                    currentUserState.persistStateAfterSync(dependDiff, jsonBody);
 
-                try {
-                    JSONObject jsonResponse = new JSONObject(response);
+                    try {
+                        JSONObject jsonResponse = new JSONObject(response);
 
-                    if (jsonResponse.has("id")) {
-                        String newUserId = jsonResponse.optString("id");
-                        updateIdDependents(newUserId);
+                        if (jsonResponse.has("id")) {
+                            String newUserId = jsonResponse.optString("id");
+                            updateIdDependents(newUserId);
 
-                        OneSignal.Log(OneSignal.LOG_LEVEL.INFO, "Device registered, UserId = " + newUserId);
+                            OneSignal.Log(OneSignal.LOG_LEVEL.INFO, "Device registered, UserId = " + newUserId);
+                        }
+                        else
+                            OneSignal.Log(OneSignal.LOG_LEVEL.INFO, "session sent, UserId = " + userId);
+
+                        OneSignal.updateOnSessionDependents();
+                        onSuccessfulSync(jsonBody);
+                    } catch (Throwable t) {
+                        OneSignal.Log(OneSignal.LOG_LEVEL.ERROR, "ERROR parsing on_session or create JSON Response.", t);
                     }
-                    else
-                        OneSignal.Log(OneSignal.LOG_LEVEL.INFO, "session sent, UserId = " + userId);
-
-                    OneSignal.updateOnSessionDependents();
-                    onSuccessfulSync(jsonBody);
-                } catch (Throwable t) {
-                    OneSignal.Log(OneSignal.LOG_LEVEL.ERROR, "ERROR parsing on_session or create JSON Response.", t);
                 }
             }
         });


### PR DESCRIPTION
• In rare situations, the main UI thread can block on the user state synchronization making a potentially very long running HTTP request, causing ANR reports (app not responding)
• The user state synchronization model of the Android SDK needs to be significantly refactored & simplified
• In the mean time, this commit makes a minor change so that the user state synchronizer never blocks/holds locks while making HTTP requests
• Fixes #589, #590, #599, and react-native [#587](https://github.com/geektimecoil/react-native-onesignal/issues/587)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/607)
<!-- Reviewable:end -->