### PR TITLE
Bundle NPE in RestoreJobService.onHandleWork

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/RestoreJobService.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/RestoreJobService.java
@@ -38,7 +38,10 @@ public class RestoreJobService extends JobIntentService {
       if (intent == null)
          return;
 
-      final Bundle extras = new Bundle(intent.getExtras());
+      // Null check for https://github.com/OneSignal/OneSignal-Android-SDK/issues/591
+      final Bundle extras = intent.getExtras();
+      if (extras == null)
+         return;
 
       NotificationBundleProcessor.ProcessFromGCMIntentService(
             getApplicationContext(),


### PR DESCRIPTION
* Fixes reported NPE from RestoreJobService.onHandleWork. Issue #591
* Issue maybe related to bug in Android 6.0.1 with BaseBundle.java:127
   - This works around any possible issue here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/634)
<!-- Reviewable:end -->
