### PR TITLE
Fixes disabling sound & vibration in some configs

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/GcmBroadcastReceiver.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/GcmBroadcastReceiver.java
@@ -66,6 +66,8 @@ public class GcmBroadcastReceiver extends WakefulBroadcastReceiver {
       Bundle bundle = intent.getExtras();
       if (bundle == null || "google.com/iid".equals(bundle.getString("from")))
          return;
+
+      OneSignal.setAppContext(context);
       
       ProcessedBundleResult processedResult = processOrderBroadcast(context, intent, bundle);
       

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
@@ -50,6 +50,7 @@ class NotificationBundleProcessor {
    static final String DEFAULT_ACTION = "__DEFAULT__";
 
    static void ProcessFromGCMIntentService(Context context, BundleCompat bundle, NotificationExtenderService.OverrideSettings overrideSettings) {
+      OneSignal.setAppContext(context);
       try {
          String jsonStrPayload = bundle.getString("json_payload");
          if (jsonStrPayload == null) {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationOpenedProcessor.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationOpenedProcessor.java
@@ -45,6 +45,8 @@ class NotificationOpenedProcessor {
    static void processFromContext(Context context, Intent intent) {
       if (!isOneSignalIntent(intent))
          return;
+
+      OneSignal.setAppContext(context);
       
       handleDismissFromActionButtonPress(context, intent);
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationRestoreService.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationRestoreService.java
@@ -43,6 +43,8 @@ public class NotificationRestoreService extends IntentService {
          return;
       
       Thread.currentThread().setPriority(android.os.Process.THREAD_PRIORITY_BACKGROUND);
+      OneSignal.setAppContext(this);
+
       NotificationRestorer.restore(this);
       WakefulBroadcastReceiver.completeWakefulIntent(intent);
    }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSPermissionState.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSPermissionState.java
@@ -29,8 +29,6 @@ package com.onesignal;
 
 import org.json.JSONObject;
 
-import static com.onesignal.OneSignal.appContext;
-
 public class OSPermissionState implements Cloneable {
    
    OSObservable<Object, OSPermissionState> observable;
@@ -51,7 +49,7 @@ public class OSPermissionState implements Cloneable {
    private boolean enabled;
    
    void refreshAsTo() {
-      setEnabled(OSUtils.areNotificationsEnabled(appContext));
+      setEnabled(OSUtils.areNotificationsEnabled(OneSignal.appContext));
    }
    
    public boolean getEnabled() {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -514,9 +514,16 @@ public class OneSignal {
       return mInitBuilder;
    }
 
+   // Sets the global shared ApplicationContext for OneSignal
+   // This is set from all OneSignal entry points
+   //   - BroadcastReceivers, Services, and Activities
    static void setAppContext(Context context) {
+      boolean wasAppContextNull = (appContext == null);
       appContext = context.getApplicationContext();
-      OneSignalPrefs.startDelayedWrite();
+
+      // Prefs require a context to save, kick off write in-case it was waiting.
+      if (wasAppContextNull)
+         OneSignalPrefs.startDelayedWrite();
    }
 
    /**

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalPrefs.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalPrefs.java
@@ -113,7 +113,7 @@ class OneSignalPrefs {
         }
 
         private void flushBufferToDisk() {
-            // A flush will be triggered later once a context via OneSignal.setAppContext(...)
+            // A flush will be triggered later once a context is set via OneSignal.setAppContext(...)
             if (OneSignal.appContext == null)
                 return;
 
@@ -227,8 +227,11 @@ class OneSignalPrefs {
     }
 
     private static synchronized SharedPreferences getSharedPrefsByName(String prefsName) {
-        if (OneSignal.appContext == null)
+        if (OneSignal.appContext == null) {
+            String msg = "OneSignal.appContext null, could not read " + prefsName + " from getSharedPreferences.";
+            OneSignal.Log(OneSignal.LOG_LEVEL.WARN, msg, new Throwable());
             return null;
+        }
 
         return OneSignal.appContext.getSharedPreferences(prefsName, Context.MODE_PRIVATE);
     }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/PermissionsActivity.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/PermissionsActivity.java
@@ -47,6 +47,8 @@ public class PermissionsActivity extends Activity {
    protected void onCreate(Bundle savedInstanceState) {
       super.onCreate(savedInstanceState);
 
+      OneSignal.setAppContext(this);
+
       // Android sets android:hasCurrentPermissionsRequest if the Activity was recreated while
       //  the permission prompt is showing to the user.
       // This can happen if the task is cold resumed from the Recent Apps list.

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/RestoreKickoffJobService.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/RestoreKickoffJobService.java
@@ -12,6 +12,7 @@ public class RestoreKickoffJobService extends OneSignalJobServiceBase {
     @Override
     void startProcessing(JobService jobService, JobParameters jobParameters) {
         Thread.currentThread().setPriority(Process.THREAD_PRIORITY_BACKGROUND);
+        OneSignal.setAppContext(this);
         NotificationRestorer.restore(getApplicationContext());
     }
 }


### PR DESCRIPTION
* If OneSignal was not initialized from onCreate of the application class on Android 7 and older.
* This was due to the appContext not being set before trying to read from shared preferences.
* All entry points now set the appContext to avoid any future issue with dependencies on this.
   - Includes OneSignal BroadcastReceivers, Services, and Activities.
* Fixes #618