### PR TITLE
NotificationExtenderService Fix Dose Delay

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
@@ -459,11 +459,16 @@ class NotificationBundleProcessor {
       intent.putExtra("json_payload", bundleAsJSONObject(bundle).toString());
       intent.putExtra("timestamp", System.currentTimeMillis() / 1000L);
 
+      boolean isHighPriority = Integer.parseInt(bundle.getString("pri", "0")) > 9;
 
-      if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
-         NotificationExtenderService.enqueueWork(context,
-                 intent.getComponent(), EXTENDER_SERVICE_JOB_ID,
-                 intent);
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
+         NotificationExtenderService.enqueueWork(
+            context,
+            intent.getComponent(),
+            EXTENDER_SERVICE_JOB_ID,
+            intent,
+            isHighPriority
+         );
       else
          context.startService(intent);
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationRestorer.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationRestorer.java
@@ -207,12 +207,13 @@ class NotificationRestorer {
             NotificationExtenderService.enqueueWork(context,
                   intent.getComponent(),
                   NotificationExtenderService.EXTENDER_SERVICE_JOB_ID,
-                  intent);
+                  intent,
+                  false);
          }
          else {
             Intent intent = addRestoreExtras(new Intent(), cursor);
             ComponentName componentName = new ComponentName(context, RestoreJobService.class);
-            RestoreJobService.enqueueWork(context, componentName, RestoreJobService.RESTORE_SERVICE_JOB_ID, intent);
+            RestoreJobService.enqueueWork(context, componentName, RestoreJobService.RESTORE_SERVICE_JOB_ID, intent, false);
          }
 
          if (delay > 0)


### PR DESCRIPTION
### Added useWakefulService option to JobIntetService
* This allows overriding the API 26 check so when we have FCM high priority wakelock we can start a IntentService instead of using a JobService
  - A JobService won't start when doze is active so the job would delayed otherwise

* Updated internal JobIntentService to latest

Fixes #475

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/640)
<!-- Reviewable:end -->
