### PR TITLE
Added result to GCM broadcast aborts

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/GcmBroadcastReceiver.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/GcmBroadcastReceiver.java
@@ -73,7 +73,7 @@ public class GcmBroadcastReceiver extends WakefulBroadcastReceiver {
       
       // Null means this isn't a GCM / FCM message.
       if (processedResult == null) {
-         setResult(Activity.RESULT_OK);
+         setSuccessfulResultCode();
          return;
       }
       
@@ -95,17 +95,27 @@ public class GcmBroadcastReceiver extends WakefulBroadcastReceiver {
          return;
       }
 
-      setResult(Activity.RESULT_OK);
+      setSuccessfulResultCode();
    }
 
-   private void setResult(int code) {
+   private void setSuccessfulResultCode() {
       if (isOrderedBroadcast())
-         setResultCode(code);
+         setResultCode(Activity.RESULT_OK);
    }
 
    private void setAbort() {
-      if (isOrderedBroadcast())
+      if (isOrderedBroadcast()) {
+         // Prevents other BroadcastReceivers from firing
          abortBroadcast();
+
+         // RESULT_OK prevents the following confusing logcat entry;
+         // W/GCM: broadcast intent callback: result=CANCELLED forIntent {
+         //    act=com.google.android.c2dm.intent.RECEIVE
+         //    flg=0x10000000
+         //    pkg=com.onesignal.example (has extras)
+         // }
+         setResultCode(Activity.RESULT_OK);
+      }
    }
    
    private static ProcessedBundleResult processOrderBroadcast(Context context, Intent intent, Bundle bundle) {

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
@@ -808,7 +808,7 @@ public class GenerateNotificationRunner {
       GcmBroadcastReceiver gcmBroadcastReceiver = new GcmBroadcastReceiver();
       gcmBroadcastReceiver.onReceive(blankActivity, intentGcm);
       
-      assertNull(ShadowGcmBroadcastReceiver.lastResultCode);
+      assertEquals(Activity.RESULT_OK, (int)ShadowGcmBroadcastReceiver.lastResultCode);
       assertTrue(ShadowGcmBroadcastReceiver.calledAbortBroadcast);
    }
    


### PR DESCRIPTION
* Adding a result prevents the GMS  app from putting a confusing CANCELLED entry into the logcat.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/642)
<!-- Reviewable:end -->
