### PR TITLE
Allow setting provideUserConsent before init

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -2024,19 +2024,12 @@ public class OneSignal {
               OneSignalPrefs.PREFS_GT_APP_ID,null);
    }
 
-   static boolean getSavedUserConsentStatus() { return getSavedUserConsentStatus(appContext); }
-
-   private static boolean getSavedUserConsentStatus(Context inContext) {
-      if (inContext == null)
-         return false;
-
+   static boolean getSavedUserConsentStatus() {
       return OneSignalPrefs.getBool(OneSignalPrefs.PREFS_ONESIGNAL, OneSignalPrefs.PREFS_ONESIGNAL_USER_PROVIDED_CONSENT, false);
    }
 
    static void saveUserConsentStatus(boolean consent) {
-      if (appContext == null)
-         return;
-
+      
       OneSignalPrefs.saveBool(OneSignalPrefs.PREFS_ONESIGNAL, OneSignalPrefs.PREFS_ONESIGNAL_USER_PROVIDED_CONSENT, consent);
    }
 

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
@@ -2336,6 +2336,22 @@ public class MainOneSignalClassRunner {
       assertFalse(OneSignal.requiresUserPrivacyConsent());
    }
 
+   @Test
+   public void shouldReturnCorrectConsentRequiredStatusWhenSetBeforeInit() throws Exception {
+      OneSignal.setRequiresUserPrivacyConsent(true);
+      OneSignal.provideUserConsent(true);
+      OneSignalInit();
+      threadAndTaskWait();
+
+      assertTrue(OneSignal.userProvidedPrivacyConsent());
+
+      fastAppRestart();
+      OneSignalInit();
+      threadAndTaskWait();
+
+      assertTrue(OneSignal.userProvidedPrivacyConsent());
+   }
+
    /*
    // Can't get test to work from a app flow due to the main thread being locked one way or another in a robolectric env.
    // Running ActivityLifecycleListener.focusHandlerThread...advanceToNextPostedRunnable waits on the main thread.


### PR DESCRIPTION
* This is safe as OneSignalPrefs will cache the value if the context is not set yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/648)
<!-- Reviewable:end -->
