### PR TITLE
Removed ACTION_BOOT_COMPLETED for BOOT_COMPLETED

### DIFF
--- a/OneSignalSDK/onesignal/src/main/AndroidManifest.xml
+++ b/OneSignalSDK/onesignal/src/main/AndroidManifest.xml
@@ -85,7 +85,6 @@
 
         <receiver android:name="com.onesignal.BootUpReceiver">
             <intent-filter>
-                <action android:name="android.intent.action.ACTION_BOOT_COMPLETED" />
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
                 <action android:name="android.intent.action.QUICKBOOT_POWERON" />
             </intent-filter>


### PR DESCRIPTION
* ACTION_BOOT_COMPLETED is invalid, BOOT_COMPLETED is the correct intent action
* Fixes #675

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/677)
<!-- Reviewable:end -->
