### PR TITLE
Catch for SecurityException from JobIntentService

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/JobIntentService.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/JobIntentService.java
@@ -333,17 +333,26 @@ abstract class JobIntentService extends Service {
         public JobIntentService.GenericWorkItem dequeueWork() {
             JobWorkItem work;
             synchronized (mLock) {
-                if (mParams == null) {
+                if (mParams == null)
+                    return null;
+
+                try {
+                    work = mParams.dequeueWork();
+                } catch (SecurityException e) {
+                    // Work around for https://issuetracker.google.com/issues/63622293
+                    // https://github.com/OneSignal/OneSignal-Android-SDK/issues/673
+                    // Caller no longer running, last stopped +###ms because: last work dequeued
+                    Log.e(TAG, "Failed to run mParams.dequeueWork()!", e);
                     return null;
                 }
-                work = mParams.dequeueWork();
             }
+
             if (work != null) {
                 work.getIntent().setExtrasClassLoader(mService.getClassLoader());
                 return new WrapperWorkItem(work);
-            } else {
-                return null;
             }
+            else
+                return null;
         }
     }
 
@@ -489,6 +498,7 @@ abstract class JobIntentService extends Service {
     @Override
     public void onDestroy() {
         super.onDestroy();
+        doStopCurrentWork();
         synchronized (mCompatQueue) {
             mDestroyed = true;
             mCompatWorkEnqueuer.serviceProcessingFinished();


### PR DESCRIPTION
* Thrown in rare cases due to know Android issue
   - https://issuetracker.google.com/issues/63622293
* Added stopping queued work from the `Service.onDestroy ` event.
* Fixes issue #673

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/678)
<!-- Reviewable:end -->
