### PR TITLE
Set External User ID

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -1445,7 +1445,7 @@ public class OneSignal {
             }
          };
 
-         OneSignalRestClient.post("players/" + currentSubscriptionState.getUserId(), jsonBody, responseHandler);
+         OneSignalRestClient.put("players/" + currentSubscriptionState.getUserId(), jsonBody, responseHandler);
       } catch (JSONException exception) {
          onesignalLog(LOG_LEVEL.ERROR, "Attempted to set external ID but encountered a JSON exception");
       }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalStateSynchronizer.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalStateSynchronizer.java
@@ -165,4 +165,9 @@ class OneSignalStateSynchronizer {
       getPushStateSynchronizer().logoutEmail();
       getEmailStateSynchronizer().logoutEmail();
    }
+
+   static void setExternalUserId(String externalId) throws JSONException {
+      getPushStateSynchronizer().setExternalUserId(externalId);
+      getEmailStateSynchronizer().setExternalUserId(externalId);
+   }
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStateSynchronizer.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStateSynchronizer.java
@@ -454,6 +454,10 @@ abstract class UserStateSynchronizer {
         generateJsonDiff(syncValues, emailFields, syncValues, null);
     }
 
+    void setExternalUserId(final String externalId) throws JSONException {
+        getUserStateForModification().syncValues.put("external_user_id", externalId);
+    }
+
     abstract void setSubscription(boolean enable);
 
     private void handlePlayerDeletedFromServer() {

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
@@ -3236,6 +3236,57 @@ public class MainOneSignalClassRunner {
       assertNull(ShadowFirebaseAnalytics.lastEventString);
    }
 
+   @Test
+   public void shouldSendExternalUserIdAfterRegistration() throws Exception {
+      OneSignalInit();
+      threadAndTaskWait();
+
+      String testExternalId = "test_ext_id";
+
+      OneSignal.setExternalUserId(testExternalId);
+
+      threadAndTaskWait();
+
+      assertEquals(3, ShadowOneSignalRestClient.networkCallCount);
+
+      ShadowOneSignalRestClient.Request externalIdRequest = ShadowOneSignalRestClient.requests.get(2);
+      assertEquals(ShadowOneSignalRestClient.REST_METHOD.PUT, externalIdRequest.method);
+      assertEquals(testExternalId, externalIdRequest.payload.getString("external_user_id"));
+   }
+
+   @Test
+   public void shouldSendExternalUserIdBeforeRegistration() throws Exception {
+      String testExternalId = "test_ext_id";
+
+      OneSignal.setExternalUserId(testExternalId);
+
+      OneSignalInit();
+      threadAndTaskWait();
+
+      assertEquals(2, ShadowOneSignalRestClient.networkCallCount);
+
+      ShadowOneSignalRestClient.Request registrationRequest = ShadowOneSignalRestClient.requests.get(1);
+      assertEquals(ShadowOneSignalRestClient.REST_METHOD.POST, registrationRequest.method);
+      assertEquals(testExternalId, registrationRequest.payload.getString("external_user_id"));
+   }
+
+   @Test
+   public void shouldRemoveExternalUserId() throws Exception {
+      OneSignal.setExternalUserId("test_ext_id");
+
+      OneSignalInit();
+      threadAndTaskWait();
+
+      OneSignal.removeExternalUserId();
+      threadAndTaskWait();
+
+      assertEquals(3, ShadowOneSignalRestClient.networkCallCount);
+
+      ShadowOneSignalRestClient.Request removeIdRequest = ShadowOneSignalRestClient.requests.get(2);
+      assertEquals(ShadowOneSignalRestClient.REST_METHOD.PUT, removeIdRequest.method);
+      assertEquals(removeIdRequest.payload.getString("external_user_id"), "");
+   }
+
    // ####### Unit test helper methods ########
 
    private static OSNotification createTestOSNotification() throws Exception {

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
@@ -3287,6 +3287,25 @@ public class MainOneSignalClassRunner {
       assertEquals(removeIdRequest.payload.getString("external_user_id"), "");
    }
 
+   @Test
+   public void doesNotSendSameExternalId() throws Exception {
+      String testExternalId = "test_ext_id";
+
+      OneSignal.setExternalUserId(testExternalId);
+
+      OneSignalInit();
+      threadAndTaskWait();
+
+      assertEquals(2, ShadowOneSignalRestClient.networkCallCount);
+
+      OneSignal.setExternalUserId(testExternalId);
+      threadAndTaskWait();
+
+      // Setting the same ID again should not generate a duplicate API request
+      // The SDK should detect it is the same and not generate a request
+      assertEquals(2, ShadowOneSignalRestClient.networkCallCount);
+   }
+
    // ####### Unit test helper methods ########
 
    private static OSNotification createTestOSNotification() throws Exception {

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
@@ -3306,6 +3306,38 @@ public class MainOneSignalClassRunner {
       assertEquals(2, ShadowOneSignalRestClient.networkCallCount);
    }
 
+   @Test
+   public void sendsExternalIdOnEmailPlayers() throws Exception {
+      String testExternalId = "test_ext_id";
+
+      OneSignalInit();
+      threadAndTaskWait();
+
+      OneSignal.setEmail("brad@onesignal.com");
+      threadAndTaskWait();
+
+      int currentRequestCount = ShadowOneSignalRestClient.networkCallCount;
+
+      OneSignal.setExternalUserId(testExternalId);
+      threadAndTaskWait();
+
+      // the SDK should have made two additional API calls
+      // One to set extID on the push player record,
+      // and another for the email player record
+      assertEquals(ShadowOneSignalRestClient.networkCallCount, currentRequestCount + 2);
+
+      int externalIdRequests = 0;
+
+      for (ShadowOneSignalRestClient.Request request : ShadowOneSignalRestClient.requests) {
+         if (request.payload != null && request.payload.has("external_user_id")) {
+            externalIdRequests += 1;
+            assertEquals(request.payload.getString("external_user_id"), testExternalId);
+         }
+      }
+
+      assertEquals(externalIdRequests, 2);
+   }
+
    // ####### Unit test helper methods ########
 
    private static OSNotification createTestOSNotification() throws Exception {


### PR DESCRIPTION
• Adds SDK support to allow developers to map their own system's user identifiers to OneSignal users, this way they don't have to save the user's OneSignal user ID
• This PR adds two new methods: 

`setExternalUserId(String)`: Sets the external ID for the current user. OneSignal maintains separate account records internally for both Email and Push accounts, so if a device has a Push subscription and has also set an Email subscription, this method will generate two API requests.

`removeExternalUserId`: This method is actually just a wrapper on top of `setExternalUserId` except that it sends an empty string as the external user ID. This is because our API requires an empty string instead of null to remove the external ID

• Adds tests to verify that the external ID methods generate correctly formatted API requests for both Push and Email players