### PR TITLE
Handle Multiple GetTags Handlers

### DIFF
--- a/OneSignalSDK/app/src/main/java/com/onesignal/example/MainActivity.java
+++ b/OneSignalSDK/app/src/main/java/com/onesignal/example/MainActivity.java
@@ -86,14 +86,14 @@ public class MainActivity extends Activity implements OSEmailSubscriptionObserve
          consentButton.setText("Revoke Consent");
 
          this.addObservers();
+
+         OSPermissionSubscriptionState state = OneSignal.getPermissionSubscriptionState();
+
+         this.didGetEmailStatus(state.getEmailSubscriptionStatus().getSubscribed());
       }
 
       this.debugTextView = this.findViewById(R.id.debugTextView);
       this.emailTextView = this.findViewById(R.id.emailTextView);
-
-      OSPermissionSubscriptionState state = OneSignal.getPermissionSubscriptionState();
-
-      this.didGetEmailStatus(state.getEmailSubscriptionStatus().getSubscribed());
 
       // compute your public key and store it in base64EncodedPublicKey
       mHelper = new IabHelper(this, "sdafsfds");

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -382,7 +382,7 @@ public class OneSignal {
    private static Collection<JSONArray> unprocessedOpenedNotifis = new ArrayList<>();
    private static HashSet<String> postedOpenedNotifIds = new HashSet<>();
 
-   private static GetTagsHandler pendingGetTagsHandler;
+   private static ArrayList<GetTagsHandler> pendingGetTagsHandlers = new ArrayList<>();
    private static boolean getTagsCall;
 
    private static boolean waitingToPostStateSync;
@@ -1656,7 +1656,13 @@ public class OneSignal {
       if (shouldLogUserPrivacyConsentErrorMessageForMethodName("getTags()"))
          return;
 
-      pendingGetTagsHandler = getTagsHandler;
+      synchronized (pendingGetTagsHandlers) {
+         pendingGetTagsHandlers.add(getTagsHandler);
+
+         // if there is an existing in-flight request, we should return
+         // since there's no point in making a duplicate runnable
+         if (pendingGetTagsHandlers.size() > 1) return;
+      }
 
       Runnable getTagsRunnable = new Runnable() {
          @Override
@@ -1669,7 +1675,8 @@ public class OneSignal {
             if (getUserId() == null) {
                return;
             }
-            internalFireGetTagsCallback(pendingGetTagsHandler);
+
+            internalFireGetTagsCallbacks();
          }
       };
 
@@ -1683,18 +1690,27 @@ public class OneSignal {
       getTagsRunnable.run();
    }
 
-   private static void internalFireGetTagsCallback(final GetTagsHandler getTagsHandler) {
-      if (getTagsHandler == null) return;
+   private static void internalFireGetTagsCallbacks() {
+      synchronized (pendingGetTagsHandlers) {
+         if (pendingGetTagsHandlers.size() == 0) return;
+      }
 
       new Thread(new Runnable() {
          @Override
          public void run() {
             final UserStateSynchronizer.GetTagsResult tags = OneSignalStateSynchronizer.getTags(!getTagsCall);
             if (tags.serverSuccess) getTagsCall = true;
-            if (tags.result == null || tags.toString().equals("{}"))
-               getTagsHandler.tagsAvailable(null);
-            else
-               getTagsHandler.tagsAvailable(tags.result);
+
+            synchronized (pendingGetTagsHandlers) {
+               for (GetTagsHandler handler : pendingGetTagsHandlers) {
+                  if (tags.result == null || tags.toString().equals("{}"))
+                     handler.tagsAvailable(null);
+                  else
+                     handler.tagsAvailable(tags.result);
+               }
+
+               pendingGetTagsHandlers.clear();
+            }
          }
       }, "OS_GETTAGS_CALLBACK").start();
    }
@@ -2130,7 +2146,7 @@ public class OneSignal {
    static void updateUserIdDependents(String userId) {
       saveUserId(userId);
       fireIdsAvailableCallback();
-      internalFireGetTagsCallback(pendingGetTagsHandler);
+      internalFireGetTagsCallbacks();
    
       getCurrentSubscriptionState(appContext).setUserId(userId);
       

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
@@ -3338,6 +3338,36 @@ public class MainOneSignalClassRunner {
       assertEquals(externalIdRequests, 2);
    }
 
+   @Test
+   public void testGetTagsQueuesCallbacks() throws Exception {
+
+      // Allows us to validate that both handlers get executed independently
+      class DebugGetTagsHandler implements OneSignal.GetTagsHandler {
+         boolean executed = false;
+
+         @Override
+         public void tagsAvailable(JSONObject tags) {
+            executed = true;
+         }
+      }
+
+      OneSignalInit();
+      threadAndTaskWait();
+
+      OneSignal.sendTag("test", "value");
+      threadAndTaskWait();
+
+      DebugGetTagsHandler first = new DebugGetTagsHandler();
+      DebugGetTagsHandler second = new DebugGetTagsHandler();
+
+      OneSignal.getTags(first);
+      OneSignal.getTags(second);
+      threadAndTaskWait();
+
+      assertTrue(first.executed);
+      assertTrue(second.executed);
+   }
+
    // ####### Unit test helper methods ########
 
    private static OSNotification createTestOSNotification() throws Exception {


### PR DESCRIPTION
• This PR changes the SDK so that it maintains an array of `getTags` handlers instead of only retaining a reference to the most recent handler.
• So in the past, if `getTags()` was called multiple times, only the handler for the most recent call would get executed.
• Makes a small change to the example project to fix a crash when GDPR consent was not granted

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/703)
<!-- Reviewable:end -->
