### PR TITLE
Making setAppContext public

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -517,7 +517,12 @@ public class OneSignal {
    // Sets the global shared ApplicationContext for OneSignal
    // This is set from all OneSignal entry points
    //   - BroadcastReceivers, Services, and Activities
-   static void setAppContext(Context context) {
+   public static void setAppContext(@NonNull Context context) {
+      if (context == null) {
+         Log(LOG_LEVEL.WARN, "setAppContext(null) is not valid, ignoring!");
+         return;
+      }
+
       boolean wasAppContextNull = (appContext == null);
       appContext = context.getApplicationContext();
 


### PR DESCRIPTION
* Wont't be commonly used, however it is valid if you need to call provideUserConsent before OneSignal.init

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/705)
<!-- Reviewable:end -->
