### PR TITLE
Registration fix if restarted before finishing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
 before_script:
     - chmod +x gradlew
 script:
-    - ./gradlew unittest:testReleaseUnitTest
+    - ./gradlew unittest:testReleaseUnitTest --console=plain
 after_failure:
     - cat build/reports/lint-results.xml
     - cat build/outputs/lint-results-debug.xml

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalStateSynchronizer.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalStateSynchronizer.java
@@ -152,13 +152,18 @@ class OneSignalStateSynchronizer {
       getEmailStateSynchronizer().refresh();
    }
 
-   static void setSyncAsNewSession() {
-      getPushStateSynchronizer().setSyncAsNewSession();
-      getEmailStateSynchronizer().setSyncAsNewSession();
+   static void setNewSession() {
+      getPushStateSynchronizer().setNewSession();
+      getEmailStateSynchronizer().setNewSession();
    }
 
-   static void setSyncAsNewSessionForEmail() {
-      getEmailStateSynchronizer().setSyncAsNewSession();
+   static boolean getSyncAsNewSession() {
+      return getPushStateSynchronizer().getSyncAsNewSession() ||
+             getEmailStateSynchronizer().getSyncAsNewSession();
+   }
+
+   static void setNewSessionForEmail() {
+      getEmailStateSynchronizer().setNewSession();
    }
 
    static void logoutEmail() {
@@ -169,5 +174,13 @@ class OneSignalStateSynchronizer {
    static void setExternalUserId(String externalId) throws JSONException {
       getPushStateSynchronizer().setExternalUserId(externalId);
       getEmailStateSynchronizer().setExternalUserId(externalId);
+   }
+
+   // This is to indicate that StateSynchronizer can start making REST API calls
+   // We do this to roll up as many field updates in a single create / on_session call to
+   //   optimize the number of api calls that are made
+   static void readyToUpdate(boolean canMakeUpdates) {
+      getPushStateSynchronizer().readyToUpdate(canMakeUpdates);
+      getEmailStateSynchronizer().readyToUpdate(canMakeUpdates);
    }
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStateEmailSynchronizer.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStateEmailSynchronizer.java
@@ -64,8 +64,9 @@ class UserStateEmailSynchronizer extends UserStateSynchronizer {
         }
 
         String existingEmail = syncValues.optString("identifier", null);
+
         if (existingEmail == null)
-            setSyncAsNewSession();
+            setNewSession();
 
         try {
             JSONObject emailJSON = new JSONObject();
@@ -78,7 +79,7 @@ class UserStateEmailSynchronizer extends UserStateSynchronizer {
                 if (existingEmail != null && !existingEmail.equals(email)) {
                     OneSignal.saveEmailId("");
                     resetCurrentState();
-                    setSyncAsNewSession();
+                    setNewSession();
                 }
             }
 

--- a/OneSignalSDK/unittest/build.gradle
+++ b/OneSignalSDK/unittest/build.gradle
@@ -31,6 +31,14 @@ android {
     }
 }
 
+tasks.withType(Test) {
+    testLogging {
+        exceptionFormat "full"
+        events "started", "skipped", "passed", "failed"
+        showStandardStreams false // Enable to have logging print
+    }
+}
+
 dependencies {
     compileOnly fileTree(dir: 'libs', include: ['*.jar'])
 

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
@@ -134,14 +134,14 @@ public class GenerateNotificationRunner {
    private static final String notifMessage = "Robo test message";
    
    @BeforeClass // Runs only once, before any tests
-   public static void setUpClass() throws Exception {
+   public static void setUpClass() {
       ShadowLog.stream = System.out;
       TestHelpers.beforeTestSuite();
       StaticResetHelper.saveStaticValues();
    }
    
    @Before // Before each test
-   public void beforeEachTest() throws Exception {
+   public void beforeEachTest() {
       // Robolectric mocks System.currentTimeMillis() to 0, we need the current real time to match our SQL records.
       ShadowSystemClock.setCurrentTimeMillis(System.currentTimeMillis());
    

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
@@ -119,6 +119,7 @@ import static com.test.onesignal.GenerateNotificationRunner.getBaseNotifBundle;
 import static com.test.onesignal.TestHelpers.afterTestCleanup;
 import static com.test.onesignal.TestHelpers.fastAppRestart;
 import static com.test.onesignal.TestHelpers.flushBufferedSharedPrefs;
+import static com.test.onesignal.TestHelpers.stopAllOSThreads;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertNotNull;
@@ -344,6 +345,69 @@ public class MainOneSignalClassRunner {
       assertEquals("{\"carrier\":\"test2\",\"app_id\":\"b2f7f966-d8cc-11e4-bed1-df8f05be55ba\"}", ShadowOneSignalRestClient.lastPost.toString());
    }
 
+   @Test
+   public void testCreatesEvenIfAppIsQuicklyForceKilledOnFirstLaunch() throws Exception {
+      // 1. App cold restarted before the device has a chance to create a player
+      OneSignalInit();
+      fastAppRestart();
+
+      // 2. 2nd cold start of the app.
+      OneSignalInit();
+      threadAndTaskWait();
+
+      // 3. Ensure we made 3 network calls. (2 to android_params and 1 create player call)
+      assertEquals(3, ShadowOneSignalRestClient.networkCallCount);
+      assertEquals("players", ShadowOneSignalRestClient.lastUrl);
+      assertEquals(REST_METHOD.POST, ShadowOneSignalRestClient.requests.get(2).method);
+   }
+
+   @Test
+   public void testOnSessionEvenIfQuickAppRestart() throws Exception {
+      // 1. Do app first start and register the device for a player id
+      OneSignalInit();
+      threadAndTaskWait();
+
+      restartAppAndElapseTimeToNextSession();
+
+      // 2. App is restarted before it can make it's on_session call
+      OneSignalInit();
+      stopAllOSThreads();
+      fastAppRestart();
+
+      // 3. 3rd start of the app, we should make an on_session call since the last one did not go through
+      OneSignalInit();
+      threadAndTaskWait();
+
+      // 4. Ensure we made 4 network calls. (2 to android_params and 1 create player call)
+      assertEquals(5, ShadowOneSignalRestClient.networkCallCount);
+      GetIdsAvailable();
+      assertEquals("players/" + callBackUseId + "/on_session", ShadowOneSignalRestClient.lastUrl);
+      assertEquals(REST_METHOD.POST, ShadowOneSignalRestClient.requests.get(4).method);
+   }
+
+   @Test
+   public void testOnSessionFlagIsClearedAfterSuccessfullySynced() throws Exception {
+      // 1. App cold restarted before the device has a chance to create a player
+      OneSignalInit();
+      fastAppRestart();
+
+      // 2. 2nd cold start of the app, waiting to make sure device gets registered
+      OneSignalInit();
+      threadAndTaskWait();
+
+      // 3. Restart the app without wating.
+      fastAppRestart();
+
+      // 4. 3rd cold start of the app.
+      OneSignalInit();
+      threadAndTaskWait();
+
+      // 4. Ensure we made 4 network calls. (3 to android_params and 1 create player call)
+      //    We are making sure we are only making on create call and NO on_session calls
+      assertEquals(4, ShadowOneSignalRestClient.networkCallCount);
+      assertEquals("players", ShadowOneSignalRestClient.requests.get(2).url);
+      assertEquals(REST_METHOD.POST, ShadowOneSignalRestClient.requests.get(2).method);
+   }
 
    @Test
    public void testPutCallsMadeWhenUserStateChangesOnAppResume() throws Exception {
@@ -2676,11 +2740,10 @@ public class MainOneSignalClassRunner {
       restartAppAndElapseTimeToNextSession();
       ShadowGoogleApiClientCompatProxy.skipOnConnected = true;
       OneSignalInit();
-
-      // TODO: Other, this sync seems to not omit PUT when there isn't anything to change....
+      
       SyncJobService syncJobService = Robolectric.buildService(SyncJobService.class).create().get();
       syncJobService.onStartJob(null);
-      Thread.sleep(1_000); // Short sleep to wait for the Thread in the job to run
+      TestHelpers.getThreadByName("OS_SYNCSRV_BG_SYNC").join();
       OneSignalPackagePrivateHelper.runAllNetworkRunnables();
       ShadowGoogleApiClientBuilder.connectionCallback.onConnected(null);
       threadAndTaskWait();

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/NotificationLimitManagerRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/NotificationLimitManagerRunner.java
@@ -8,10 +8,14 @@ import android.support.v4.app.NotificationManagerCompat;
 import com.onesignal.BuildConfig;
 import com.onesignal.OneSignal;
 import com.onesignal.OneSignalPackagePrivateHelper.NotificationLimitManager;
+import com.onesignal.ShadowAdvertisingIdProviderGPS;
 import com.onesignal.ShadowNotificationLimitManager;
+import com.onesignal.ShadowOSUtils;
+import com.onesignal.ShadowPushRegistratorGCM;
 import com.onesignal.StaticResetHelper;
 import com.onesignal.example.BlankActivity;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -24,13 +28,19 @@ import org.robolectric.shadows.ShadowLog;
 
 import static com.onesignal.OneSignalPackagePrivateHelper.NotificationBundleProcessor_ProcessFromGCMIntentService;
 import static com.test.onesignal.GenerateNotificationRunner.getBaseNotifBundle;
+import static com.test.onesignal.TestHelpers.afterTestCleanup;
 import static com.test.onesignal.TestHelpers.threadAndTaskWait;
 import static junit.framework.Assert.assertEquals;
 
 @Config(packageName = "com.onesignal.example",
    constants = BuildConfig.class,
    instrumentedPackages = { "com.onesignal" },
-   shadows = { ShadowNotificationLimitManager.class },
+   shadows = {
+      ShadowNotificationLimitManager.class,
+      ShadowPushRegistratorGCM.class,
+      ShadowOSUtils.class,
+      ShadowAdvertisingIdProviderGPS.class
+   },
    sdk = 26)
 @RunWith(RobolectricTestRunner.class)
 public class NotificationLimitManagerRunner {
@@ -55,6 +65,11 @@ public class NotificationLimitManagerRunner {
       OneSignal.init(blankActivity, "123456789", "b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
       OneSignal.setInFocusDisplaying(OneSignal.OSInFocusDisplayOption.Notification);
       threadAndTaskWait();
+   }
+
+   @After
+   public void afterEachTest() {
+      afterTestCleanup();
    }
 
    @Test


### PR DESCRIPTION
* Fixes issue where if app was cold restarted before the device registered it would not register until the next session
   - This applies to both first time registration as well as on_sessions calls
   - A new session is only counted if you leave the app for 30+ seconds and open or refocus the app.
* Refactored session logic into the StateSynchronizer moving logic out of the OneSignal class
   - State is saved into dependValues so it persists between app restarts
* Removed internal updateOnSessionDependents()

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/718)
<!-- Reviewable:end -->
