### PR TITLE
Added use of etags on android_params and get tags

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationChannelManager.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationChannelManager.java
@@ -34,6 +34,8 @@ import android.app.NotificationManager;
 import android.content.Context;
 import android.net.Uri;
 import android.os.Build;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.annotation.RequiresApi;
 import android.support.v4.app.NotificationManagerCompat;
 
@@ -185,22 +187,21 @@ class NotificationChannelManager {
       return RESTORE_CHANNEL_ID;
    }
    
-   static void processChannelList(Context context, JSONObject payload) {
+   static void processChannelList(@NonNull Context context, @Nullable JSONArray list) {
       if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O)
          return;
 
-      if (!payload.has("chnl_lst"))
+      if (list == null)
          return;
 
       NotificationManager notificationManager =
          (NotificationManager)context.getSystemService(Context.NOTIFICATION_SERVICE);
       
-      Set<String> sycnedChannelSet = new HashSet<>();
-      JSONArray chnlList = payload.optJSONArray("chnl_lst");
-      int jsonArraySize = chnlList.length();
+      Set<String> syncedChannelSet = new HashSet<>();
+      int jsonArraySize = list.length();
       for (int i = 0; i < jsonArraySize; i++) {
          try {
-            sycnedChannelSet.add(createChannel(context, notificationManager, chnlList.getJSONObject(i)));
+            syncedChannelSet.add(createChannel(context, notificationManager, list.getJSONObject(i)));
          } catch (JSONException e) {
             OneSignal.Log(OneSignal.LOG_LEVEL.ERROR, "Could not create notification channel due to JSON payload error!", e);
          }
@@ -211,7 +212,7 @@ class NotificationChannelManager {
       List<NotificationChannel> existingChannels = notificationManager.getNotificationChannels();
       for(NotificationChannel existingChannel : existingChannels) {
          String id = existingChannel.getId();
-         if (id.startsWith("OS_") && !sycnedChannelSet.contains(id))
+         if (id.startsWith("OS_") && !syncedChannelSet.contains(id))
             notificationManager.deleteNotificationChannel(id);
       }
    }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalChromeTab.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalChromeTab.java
@@ -45,8 +45,8 @@ class OneSignalChromeTab {
    static void setup(Context context, String appId, String userId, String adId) {
       if (opened)
          return;
-      
-      if (OneSignal.mEnterp)
+
+      if (OneSignal.remoteParams.enterprise)
          return;
       
       if (userId == null)

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalPrefs.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalPrefs.java
@@ -67,6 +67,8 @@ class OneSignalPrefs {
     public static final String PREFS_ONESIGNAL_SYNCED_SUBSCRIPTION = "ONESIGNAL_SYNCED_SUBSCRIPTION";
     public static final String PREFS_GT_REGISTRATION_ID = "GT_REGISTRATION_ID";
     public static final String PREFS_ONESIGNAL_USER_PROVIDED_CONSENT = "ONESIGNAL_USER_PROVIDED_CONSENT";
+    public static final String PREFS_OS_ETAG_PREFIX = "PREFS_OS_ETAG_PREFIX_";
+    public static final String PREFS_OS_HTTP_CACHE_PREFIX = "PREFS_OS_HTTP_CACHE_PREFIX_";
 
     // PLAYER PURCHASE KEYS
     static final String PREFS_PURCHASE_TOKENS = "purchaseTokens";

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalRemoteParams.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalRemoteParams.java
@@ -1,0 +1,87 @@
+package com.onesignal;
+
+import android.support.annotation.NonNull;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+class OneSignalRemoteParams {
+
+   static class Params {
+      String googleProjectNumber;
+      boolean enterprise;
+      boolean useEmailAuth;
+      JSONObject awl;
+      JSONArray notificationChannels;
+      boolean firebaseAnalytics;
+      boolean restoreTTLFilter;
+   }
+
+   interface CallBack {
+      void complete(Params params);
+   }
+
+   private static int androidParamsReties = 0;
+
+   private static final int INCREASE_BETWEEN_RETRIES = 10_000;
+   private static final int MIN_WAIT_BETWEEN_RETRIES = 30_000;
+   private static final int MAX_WAIT_BETWEEN_RETRIES = 90_000;
+
+   static void makeAndroidParamsRequest(final @NonNull CallBack callBack) {
+      OneSignalRestClient.ResponseHandler responseHandler = new OneSignalRestClient.ResponseHandler() {
+         @Override
+         void onFailure(int statusCode, String response, Throwable throwable) {
+            new Thread(new Runnable() {
+               public void run() {
+                  int sleepTime = MIN_WAIT_BETWEEN_RETRIES + androidParamsReties * INCREASE_BETWEEN_RETRIES;
+                  if (sleepTime > MAX_WAIT_BETWEEN_RETRIES)
+                     sleepTime = MAX_WAIT_BETWEEN_RETRIES;
+
+                  OneSignal.Log(OneSignal.LOG_LEVEL.INFO, "Failed to get Android parameters, trying again in " + (sleepTime / 1_000) +  " seconds.");
+                  OSUtils.sleep(sleepTime);
+                  androidParamsReties++;
+                  makeAndroidParamsRequest(callBack);
+               }
+            }, "OS_PARAMS_REQUEST").start();
+         }
+
+         @Override
+         void onSuccess(String response) {
+            processJson(response, callBack);
+         }
+      };
+
+      String awl_url = "apps/" + OneSignal.appId + "/android_params.js";
+      String userId = OneSignal.getUserId();
+      if (userId != null)
+         awl_url += "?player_id=" + userId;
+
+      OneSignal.Log(OneSignal.LOG_LEVEL.DEBUG, "Starting request to get Android parameters.");
+      OneSignalRestClient.get(awl_url, responseHandler, OneSignalRestClient.CACHE_KEY_REMOTE_PARAMS);
+   }
+
+   static private void processJson(String json, final @NonNull CallBack callBack) {
+      final JSONObject responseJson;
+      try {
+         responseJson = new JSONObject(json);
+      }
+      catch (JSONException t) {
+         OneSignal.Log(OneSignal.LOG_LEVEL.FATAL, "Error parsing android_params!: ", t);
+         OneSignal.Log(OneSignal.LOG_LEVEL.FATAL, "Response that errored from android_params!: " + json);
+         return;
+      }
+
+      Params params = new Params() {{
+         enterprise = responseJson.optBoolean("enterp", false);
+         useEmailAuth = responseJson.optBoolean("use_email_auth", false);
+         awl = responseJson.optJSONObject("awl_list");
+         notificationChannels = responseJson.optJSONArray("chnl_lst");
+         firebaseAnalytics = responseJson.optBoolean("fba", false);
+         restoreTTLFilter = responseJson.optBoolean("restore_ttl_filter", true);
+         googleProjectNumber = responseJson.optString("android_sender_id", null);
+      }};
+
+      callBack.complete(params);
+   }
+}

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStatePushSynchronizer.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStatePushSynchronizer.java
@@ -48,7 +48,7 @@ class UserStatePushSynchronizer extends UserStateSynchronizer {
                         e.printStackTrace();
                     }
                 }
-            });
+            }, OneSignalRestClient.CACHE_KEY_GET_TAGS);
         }
 
         synchronized(syncLock) {

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/MockHttpURLConnection.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/MockHttpURLConnection.java
@@ -33,6 +33,8 @@ import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
 
 public class MockHttpURLConnection extends HttpURLConnection {
    private boolean didInterruptMockHang;
@@ -45,6 +47,7 @@ public class MockHttpURLConnection extends HttpURLConnection {
       public String responseBody;
       public boolean mockThreadHang;
       public int status;
+      public Map<String, String> mockProps = new HashMap<>();
    }
 
    private MockResponse mockResponse;
@@ -67,6 +70,11 @@ public class MockHttpURLConnection extends HttpURLConnection {
    @Override
    public void connect() throws IOException {
 
+   }
+
+   @Override
+   public String getHeaderField(String name) {
+      return mockResponse.mockProps.get(name);
    }
 
    @Override

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/MockHttpURLConnection.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/MockHttpURLConnection.java
@@ -93,6 +93,6 @@ public class MockHttpURLConnection extends HttpURLConnection {
 
    @Override
    public InputStream getInputStream() throws IOException {
-      return new ByteArrayInputStream(StandardCharsets.UTF_16.encode(mockResponse.responseBody).array());
+      return new ByteArrayInputStream(StandardCharsets.UTF_8.encode(mockResponse.responseBody).array());
    }
 }

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
@@ -146,7 +146,14 @@ public class OneSignalPackagePrivateHelper {
 
    public static class PushRegistratorGCM extends com.onesignal.PushRegistratorGCM {}
 
-   public class OneSignalRestClient extends com.onesignal.OneSignalRestClient {}
+   public static class OneSignalRestClient extends com.onesignal.OneSignalRestClient {
+      public static abstract class ResponseHandler extends com.onesignal.OneSignalRestClient.ResponseHandler {
+         @Override
+         public void onSuccess(String response) {}
+         @Override
+         public void onFailure(int statusCode, String response, Throwable throwable) {}
+      }
+   }
 
    public static String NotificationChannelManager_createNotificationChannel(Context context, JSONObject payload) {
       NotificationGenerationJob notifJob = new NotificationGenerationJob(context);
@@ -154,8 +161,8 @@ public class OneSignalPackagePrivateHelper {
       return NotificationChannelManager.createNotificationChannel(notifJob);
    }
    
-   public static void NotificationChannelManager_processChannelList(Context context, JSONObject jsonObject) {
-      NotificationChannelManager.processChannelList(context, jsonObject);
+   public static void NotificationChannelManager_processChannelList(Context context, JSONArray jsonArray) {
+      NotificationChannelManager.processChannelList(context, jsonArray);
    }
    
    public static void NotificationOpenedProcessor_processFromContext(Context context, Intent intent) {

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowOneSignalRestClient.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowOneSignalRestClient.java
@@ -240,7 +240,7 @@ public class ShadowOneSignalRestClient {
       responseHandler.onSuccess("{}");
    }
 
-   public static void get(final String url, final OneSignalRestClient.ResponseHandler responseHandler) {
+   public static void get(final String url, final OneSignalRestClient.ResponseHandler responseHandler, String cacheKey) {
       trackRequest(REST_METHOD.GET, null, url);
    
       if (nextSuccessResponse != null) {
@@ -267,7 +267,7 @@ public class ShadowOneSignalRestClient {
       }
    }
 
-   public static void getSync(final String url, final OneSignalRestClient.ResponseHandler responseHandler) {
+   public static void getSync(final String url, final OneSignalRestClient.ResponseHandler responseHandler, String cacheKey) {
       trackRequest(REST_METHOD.GET, null, url);
 
       if (doFail(responseHandler)) return;

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/NotificationChannelManagerRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/NotificationChannelManagerRunner.java
@@ -167,7 +167,7 @@ public class NotificationChannelManagerRunner {
       createChannel("local_existing_id");
       createChannel("OS_existing_id");
    
-      NotificationChannelManager_processChannelList(blankActivity, new JSONObject());
+      NotificationChannelManager_processChannelList(blankActivity, null);
       
       assertNotNull(getChannel("local_existing_id"));
       assertNotNull(getChannel("OS_existing_id"));
@@ -185,10 +185,8 @@ public class NotificationChannelManagerRunner {
       channelItem.put("chnl", channelItemChnl);
    
       channelList.put(channelItem);
-      JSONObject payload = new JSONObject();
-      payload.put("chnl_lst", channelList);
       
-      NotificationChannelManager_processChannelList(blankActivity, payload);
+      NotificationChannelManager_processChannelList(blankActivity, channelList);
       
       assertNotNull(getChannel("local_existing_id"));
       assertNotNull(getChannel("OS_id1"));
@@ -196,7 +194,7 @@ public class NotificationChannelManagerRunner {
    
    @Test
    public void processPayloadDeletingOldChannel() throws Exception {
-      NotificationChannelManager_processChannelList(blankActivity, createBasicChannelListPayload());
+      NotificationChannelManager_processChannelList(blankActivity, createBasicChannelListPayload().optJSONArray("chnl_lst"));
       assertChannelsForBasicChannelList();
    }
    
@@ -221,7 +219,7 @@ public class NotificationChannelManagerRunner {
       
       channelProperties.put("grp_id", "grp_id1");
    
-      NotificationChannelManager_processChannelList(blankActivity, payload);
+      NotificationChannelManager_processChannelList(blankActivity, payload.optJSONArray("chnl_lst"));
       
       NotificationChannel channel = getChannel("OS_id1");
       assertEquals("en_nm", channel.getName());


### PR DESCRIPTION
* Refactored android_params call from OneSignal into a new OneSignalRemoteParms class
* etag storing, caching, and passing if-none-match was implemented in this PR.
  - setUseCaches didn't give back an expected 304 and didn't see an Android built in option specifically for these
  - For now don't want to include a 3rd party library to handle caching

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/723)
<!-- Reviewable:end -->
