### PR TITLE
Catch completeWork exceptions when state is invalid

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/JobIntentService.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/JobIntentService.java
@@ -289,7 +289,21 @@ abstract class JobIntentService extends Service {
             public void complete() {
                 synchronized (mLock) {
                     if (mParams != null) {
-                        mParams.completeWork(mJobWork);
+                        try {
+                            mParams.completeWork(mJobWork);
+                            // The following catches are to prevent errors completely work that
+                            //    is done or hasn't started.
+                            // Example:
+                            // Caused by java.lang.IllegalArgumentException:
+                            //     Given work is not active: JobWorkItem {
+                            //       id=4 intent=Intent { (has extras) } dcount=1
+                            //     }
+                            // Issue: https://github.com/OneSignal/OneSignal-Android-SDK/issues/644
+                        } catch (SecurityException e) {
+                            Log.e(TAG, "SecurityException: Failed to run mParams.completeWork(mJobWork)!", e);
+                        } catch(IllegalArgumentException e) {
+                            Log.e(TAG, "IllegalArgumentException: Failed to run mParams.completeWork(mJobWork)!", e);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
* Fixes #644
  - Details of the issue this fixes are in the issue link above
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/730)
<!-- Reviewable:end -->
