### PR TITLE
Fix on getTags nested call

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -382,7 +382,7 @@ public class OneSignal {
    private static Collection<JSONArray> unprocessedOpenedNotifis = new ArrayList<>();
    private static HashSet<String> postedOpenedNotifIds = new HashSet<>();
 
-   private static ArrayList<GetTagsHandler> pendingGetTagsHandlers = new ArrayList<>();
+   private static Vector<GetTagsHandler> pendingGetTagsHandlers = new Vector<>();
    private static boolean getTagsCall;
 
    private static boolean waitingToPostStateSync;

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
@@ -8,11 +8,9 @@ import android.os.Looper;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
-import org.robolectric.shadows.ShadowMessageQueue;
 import org.robolectric.util.Scheduler;
 
 import java.lang.reflect.Field;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 


### PR DESCRIPTION
  * Calling nested getTags cause a ConcurrentModificationException
  * Add new thread to getTags and Vector to handler list

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/756)
<!-- Reviewable:end -->
