### PR TITLE
Fixes Issue 733: unvalidated BigInteger for LED hex value

### DIFF
--- a/OneSignalSDK/app/build.gradle
+++ b/OneSignalSDK/app/build.gradle
@@ -67,7 +67,7 @@ dependencies {
     implementation 'com.google.android.gms:play-services-location:12.0.0'
 
     // For Chrome tabs
-    compile 'com.android.support:customtabs:27.1.0'
+    implementation 'com.android.support:customtabs:27.1.0'
 }
 
 //apply plugin: 'com.google.gms.google-services'

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationChannelManager.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationChannelManager.java
@@ -58,7 +58,7 @@ class NotificationChannelManager {
 
    private static final String DEFAULT_CHANNEL_ID = "fcm_fallback_notification_channel";
    private static final String RESTORE_CHANNEL_ID = "restored_OS_notifications";
-   private static final String HEX_PATTERN = "^([A-Fa-f0-9]{8})$";
+   private static final Pattern pattern = Pattern.compile("^([A-Fa-f0-9]{8})$");
    
    static String createNotificationChannel(NotificationGenerationJob notifJob) {
       if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O)
@@ -133,13 +133,11 @@ class NotificationChannelManager {
       }
 
       if (payload.has("ledc")){
-         Pattern pattern = Pattern.compile(HEX_PATTERN);
-
          String ledc = payload.optString("ledc");
          Matcher matcher = pattern.matcher(ledc);
          BigInteger ledColor;
 
-         if ( !matcher.matches() ) {
+         if (!matcher.matches()) {
             OneSignal.Log(OneSignal.LOG_LEVEL.WARN, "ARGB Hex value incorrect format (E.g: FF9900FF)");
             ledc = "FFFFFFFF";
          }
@@ -147,7 +145,7 @@ class NotificationChannelManager {
          try {
             ledColor = new BigInteger(ledc, 16);
             channel.setLightColor(ledColor.intValue());
-         } catch (Throwable t){
+         } catch (Throwable t) {
             OneSignal.Log(OneSignal.LOG_LEVEL.ERROR, "Couldn't convert ARGB Hex value to BigInteger:", t);
          }
       }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationChannelManager.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationChannelManager.java
@@ -58,7 +58,7 @@ class NotificationChannelManager {
 
    private static final String DEFAULT_CHANNEL_ID = "fcm_fallback_notification_channel";
    private static final String RESTORE_CHANNEL_ID = "restored_OS_notifications";
-   private static final Pattern pattern = Pattern.compile("^([A-Fa-f0-9]{8})$");
+   private static final Pattern hexPattern = Pattern.compile("^([A-Fa-f0-9]{8})$");
    
    static String createNotificationChannel(NotificationGenerationJob notifJob) {
       if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O)
@@ -132,13 +132,13 @@ class NotificationChannelManager {
          channel.setGroup(group_id);
       }
 
-      if (payload.has("ledc")){
+      if (payload.has("ledc")) {
          String ledc = payload.optString("ledc");
-         Matcher matcher = pattern.matcher(ledc);
+         Matcher matcher = hexPattern.matcher(ledc);
          BigInteger ledColor;
 
          if (!matcher.matches()) {
-            OneSignal.Log(OneSignal.LOG_LEVEL.WARN, "ARGB Hex value incorrect format (E.g: FF9900FF)");
+            OneSignal.Log(OneSignal.LOG_LEVEL.WARN, "OneSignal LED Color Settings: ARGB Hex value incorrect format (E.g: FF9900FF)");
             ledc = "FFFFFFFF";
          }
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationChannelManager.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationChannelManager.java
@@ -129,8 +129,16 @@ class NotificationChannelManager {
          channel.setGroup(group_id);
       }
 
-      if (payload.has("ledc")) {
-         BigInteger ledColor = new BigInteger(payload.optString("ledc"), 16);
+      if (payload.has("ledc")){
+         String ledc = payload.optString("ledc");
+         BigInteger ledColor = new BigInteger("FFFFFFFF", 16);
+
+         // validate string
+         try {
+            ledColor = new BigInteger(ledc, 16);
+         } catch (Throwable t){
+            OneSignal.Log(OneSignal.LOG_LEVEL.ERROR, "ARGB Hex value incorrect format (E.g: FF9900FF", t);
+         }
          channel.setLightColor(ledColor.intValue());
       }
       channel.enableLights(payload.optInt("led", 1) == 1);

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/NotificationChannelManagerRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/NotificationChannelManagerRunner.java
@@ -7,8 +7,11 @@ import android.app.NotificationManager;
 import android.content.Context;
 
 import com.onesignal.ShadowOSUtils;
+import com.onesignal.ShadowOneSignal;
 import com.onesignal.ShadowRoboNotificationManager;
 import com.onesignal.example.BlankActivity;
+
+import junit.framework.Assert;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -22,6 +25,8 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowLog;
+
+import java.math.BigInteger;
 
 import static com.onesignal.OneSignalPackagePrivateHelper.NotificationChannelManager_createNotificationChannel;
 import static com.onesignal.OneSignalPackagePrivateHelper.NotificationChannelManager_processChannelList;
@@ -227,19 +232,24 @@ public class NotificationChannelManagerRunner {
       assertEquals("en_grp_nm", ShadowRoboNotificationManager.lastChannelGroup.getName());
    }
 
-   @Test(expected = IllegalArgumentException.class)
+   @Test
+   @Config(shadows = {ShadowOneSignal.class})
    public void handleInvalidColorCode() throws Exception {
       JSONObject payload = new JSONObject();
       JSONObject chnl = new JSONObject();
 
       chnl.put("id", "test_id");
       chnl.put("nm", "Test Name");
-
-      payload.put("ledc", "FFFF00000");
+      payload.put("ledc", "FFFFFFFFY");
       payload.put("chnl", chnl.toString());
 
       NotificationChannelManager_createNotificationChannel(blankActivity, payload);
 
+      // check default to white
+      NotificationChannel channel = ShadowRoboNotificationManager.lastChannel;
+      BigInteger ledColor = new BigInteger("FFFFFFFF", 16);
+      assertEquals(ledColor.intValue(), channel.getLightColor());
+      assertTrue(ShadowOneSignal.messages.contains("ARGB Hex value incorrect format (E.g: FF9900FF)"));
    }
    
    // Starting helper methods

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/NotificationChannelManagerRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/NotificationChannelManagerRunner.java
@@ -249,7 +249,7 @@ public class NotificationChannelManagerRunner {
       NotificationChannel channel = ShadowRoboNotificationManager.lastChannel;
       BigInteger ledColor = new BigInteger("FFFFFFFF", 16);
       assertEquals(ledColor.intValue(), channel.getLightColor());
-      assertTrue(ShadowOneSignal.messages.contains("ARGB Hex value incorrect format (E.g: FF9900FF)"));
+      assertTrue(ShadowOneSignal.messages.contains("OneSignal LED Color Settings: ARGB Hex value incorrect format (E.g: FF9900FF)"));
    }
    
    // Starting helper methods

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/NotificationChannelManagerRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/NotificationChannelManagerRunner.java
@@ -226,6 +226,21 @@ public class NotificationChannelManagerRunner {
       assertEquals("en_dscr", channel.getDescription());
       assertEquals("en_grp_nm", ShadowRoboNotificationManager.lastChannelGroup.getName());
    }
+
+   @Test(expected = IllegalArgumentException.class)
+   public void handleInvalidColorCode() throws Exception {
+      JSONObject payload = new JSONObject();
+      JSONObject chnl = new JSONObject();
+
+      chnl.put("id", "test_id");
+      chnl.put("nm", "Test Name");
+
+      payload.put("ledc", "FFFF00000");
+      payload.put("chnl", chnl.toString());
+
+      NotificationChannelManager_createNotificationChannel(blankActivity, payload);
+
+   }
    
    // Starting helper methods
    


### PR DESCRIPTION
- Handles incorrect ledColor hex value, sets default, throws warning
- Unit test checks that the hex value is set to the default and warning was shown

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/775)
<!-- Reviewable:end -->
