### PR TITLE
Preventing multiple impressions on IAMs

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalPrefs.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalPrefs.java
@@ -216,7 +216,7 @@ class OneSignalPrefs {
         return (Long)get(prefsName, key, Long.class, defValue);
     }
 
-    static @Nullable Set<String> getStringSet(@NonNull String prefsName, @NonNull String key, @Nullable Set<String> defValue) {
+    public static @Nullable Set<String> getStringSet(@NonNull String prefsName, @NonNull String key, @Nullable Set<String> defValue) {
         return (Set<String>)get(prefsName, key, Set.class, defValue);
     }
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalPrefs.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalPrefs.java
@@ -76,6 +76,7 @@ class OneSignalPrefs {
     public static final String PREFS_OS_HTTP_CACHE_PREFIX = "PREFS_OS_HTTP_CACHE_PREFIX_";
     public static final String PREFS_OS_CACHED_IAMS = "PREFS_OS_CACHED_IAMS";
     public static final String PREFS_OS_DISPLAYED_IAMS = "PREFS_OS_DISPLAYED_IAMS";
+    public static final String PREFS_OS_IMPRESSIONED_IAMS = "PREFS_OS_IMPRESSIONED_IAMS";
 
     // PLAYER PURCHASE KEYS
     static final String PREFS_PURCHASE_TOKENS = "purchaseTokens";

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/WebViewManager.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/WebViewManager.java
@@ -285,7 +285,6 @@ class WebViewManager extends ActivityLifecycleHandler.ActivityAvailableListener 
             messageView.updateHeight(newHeight);
         messageView.showView(activity);
         messageView.checkIfShouldDismiss();
-        firstShow = false;
     }
 
     // TODO: Test with chrome://crash
@@ -334,7 +333,8 @@ class WebViewManager extends ActivityLifecycleHandler.ActivityAvailableListener 
         messageView.setMessageController(new InAppMessageView.InAppMessageViewListener() {
             @Override
             public void onMessageWasShown() {
-                OSInAppMessageController.onMessageWasShown(message);
+                firstShow = false;
+                OSInAppMessageController.getController().onMessageWasShown(message);
             }
 
             @Override

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
@@ -275,8 +275,8 @@ public class OneSignalPackagePrivateHelper {
          super.onMessageActionOccurredOnMessage(message, actionJson);
       }
 
-      public static void onMessageWasShown(@NonNull com.onesignal.OSInAppMessage message) {
-         com.onesignal.OSInAppMessageController.onMessageWasShown(message);
+      public void onMessageWasShown(@NonNull com.onesignal.OSInAppMessage message) {
+         com.onesignal.OSInAppMessageController.getController().onMessageWasShown(message);
       }
    }
 

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/InAppMessagingUnitTests.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/InAppMessagingUnitTests.java
@@ -391,9 +391,9 @@ public class InAppMessagingUnitTests {
 
     @Test
     public void testOnMessageWasShown() throws Exception {
-       threadAndTaskWait();
+        threadAndTaskWait();
 
-        OSInAppMessageController.onMessageWasShown(message);
+        OSInAppMessageController.getController().onMessageWasShown(message);
 
         ShadowOneSignalRestClient.Request iamImpressionRequest = ShadowOneSignalRestClient.requests.get(2);
 


### PR DESCRIPTION
* Storing all successfully impressioned messageIds to disk and preventing another impression from being counted on dashboard

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/790)
<!-- Reviewable:end -->
