### PR TITLE
Correct height fallback calculations for webview

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/InAppMessageView.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/InAppMessageView.java
@@ -177,7 +177,7 @@ class InAppMessageView {
     }
 
     private int getDisplayYSize() {
-        return OSViewUtils.getUsableWindowRect(currentActivity).height();
+        return OSViewUtils.getWindowHeight(currentActivity);
     }
 
     private LinearLayout.LayoutParams createParentLinearLayoutParams() {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSViewUtils.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSViewUtils.java
@@ -1,9 +1,12 @@
 package com.onesignal;
 
+import android.annotation.TargetApi;
 import android.app.Activity;
 import android.content.res.Configuration;
 import android.content.res.Resources;
+import android.graphics.Point;
 import android.graphics.Rect;
+import android.os.Build;
 import android.support.annotation.NonNull;
 import android.util.DisplayMetrics;
 import android.view.View;
@@ -40,16 +43,57 @@ class OSViewUtils {
         return isOpen;
     }
 
-    static boolean isScreenRotated(@NonNull Activity activity, int previousOrientation) {
-        int currentOrientation = activity.getResources().getConfiguration().orientation;
-        return previousOrientation == Configuration.ORIENTATION_LANDSCAPE && currentOrientation == Configuration.ORIENTATION_PORTRAIT ||
-                previousOrientation == Configuration.ORIENTATION_PORTRAIT && currentOrientation == Configuration.ORIENTATION_LANDSCAPE;
+
+    static void decorViewReady(@NonNull Activity activity, @NonNull Runnable runnable) {
+        activity.getWindow().getDecorView().post(runnable);
     }
 
-    static @NonNull Rect getUsableWindowRect(@NonNull Activity activity) {
+    private static @NonNull Rect getWindowVisibleDisplayFrame(@NonNull Activity activity) {
        Rect rect = new Rect();
        activity.getWindow().getDecorView().getWindowVisibleDisplayFrame(rect);
        return rect;
+    }
+
+    static int getWindowWidth(@NonNull Activity activity) {
+        return getWindowVisibleDisplayFrame(activity).width();
+    }
+
+    // Due to differences in accounting for keyboard, navigation bar, and status bar between
+    //   Android versions have different implementation here
+    static int getWindowHeight(@NonNull Activity activity) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
+            return getWindowHeightAPI23Plus(activity);
+        else  if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
+            return getWindowHeightLollipop(activity);
+        else
+            return getDisplaySizeY(activity);
+    }
+
+    // Requirement: Ensure DecorView is ready by using OSViewUtils.decorViewReady
+    @TargetApi(Build.VERSION_CODES.M)
+    private static int getWindowHeightAPI23Plus(@NonNull Activity activity) {
+        View decorView = activity.getWindow().getDecorView();
+        // Use use stable heights as SystemWindowInset subtracts the keyboard
+        int heightWithoutKeyboard =
+           decorView.getHeight() -
+           decorView.getRootWindowInsets().getStableInsetBottom() -
+           decorView.getRootWindowInsets().getStableInsetTop();
+        return heightWithoutKeyboard;
+    }
+
+    private static int getWindowHeightLollipop(@NonNull Activity activity) {
+        // getDisplaySizeY - works correctly expect for landscape due to a bug.
+        if (activity.getResources().getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE)
+            return getWindowVisibleDisplayFrame(activity).height();
+        //  getWindowVisibleDisplayFrame - Doesn't work for portrait as it subtracts the keyboard height.
+
+        return getDisplaySizeY(activity);
+    }
+
+    private static int getDisplaySizeY(@NonNull Activity activity) {
+        Point point = new Point();
+        activity.getWindowManager().getDefaultDisplay().getSize(point);
+        return point.y;
     }
 
     static int dpToPx(int dp) {


### PR DESCRIPTION
* Added OSViewUtil.getWindowHeight method that correctly gets the window height no matter the Android version
   - There are different APIs for Android Kitkat, Lollipop, and API 23+
* Removed JS reszie event
   - It fires more often than needed which was creating jitter and inconsistencies

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/793)
<!-- Reviewable:end -->
