### PR TITLE
Fixes background getting cut off in immersive mode

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/InAppMessageView.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/InAppMessageView.java
@@ -231,8 +231,9 @@ class InAppMessageView {
         WindowManager.LayoutParams layoutParams = new WindowManager.LayoutParams(
             hasBackground ? WindowManager.LayoutParams.MATCH_PARENT : pageWidth,
             hasBackground ? WindowManager.LayoutParams.MATCH_PARENT : WindowManager.LayoutParams.WRAP_CONTENT,
-            // Display it on top of other application windows
-            WindowManager.LayoutParams.TYPE_APPLICATION_PANEL,
+            // Using this instead of TYPE_APPLICATION_PANEL so the layout background does not get
+            //  cut off in immersive mode.
+           WindowManager.LayoutParams.TYPE_APPLICATION_ATTACHED_DIALOG,
             // Don't let it grab the input focus
             WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE,
             PixelFormat.TRANSLUCENT


### PR DESCRIPTION
### Before
![image](https://user-images.githubusercontent.com/645861/60788111-c4835200-a110-11e9-93ef-ddacf9194841.png)


### After
![image](https://user-images.githubusercontent.com/645861/60788093-b6353600-a110-11e9-9451-d4cb6f220b25.png)


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/794)
<!-- Reviewable:end -->
