### PR TITLE
Added app id pre-check for changing app id during runtime

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -627,6 +627,11 @@ public class OneSignal {
       if (isSubscriptionStatusUninitializable())
          return;
 
+      // Pre-check on app id to make sure init of SDK is performed properly
+      //    Usually when the app id is changed during runtime so that SDK is reinitialized properly
+      if (appId != null && !appId.equals(oneSignalAppId))
+         initDone = false;
+
       if (initDone) {
          if (mInitBuilder.mNotificationOpenedHandler != null)
             fireCallbackForOpenedNotifications();
@@ -638,8 +643,6 @@ public class OneSignal {
 
       saveFilterOtherGCMReceivers(mInitBuilder.mFilterOtherGCMReceivers);
 
-      // NOTE: This must be called here, something above conflicts with the handlers internals
-      //  causing a crash at OneSignal.deepClone()
       handleActivityLifecycleHandler(context);
 
       lastTrackedFocusTime = SystemClock.elapsedRealtime();
@@ -704,6 +707,7 @@ public class OneSignal {
             Log(LOG_LEVEL.DEBUG, "APP ID changed, clearing user id as it is no longer valid.");
             SaveAppId(appId);
             OneSignalStateSynchronizer.resetCurrentState();
+            remoteParams = null;
          }
       }
       else {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalRemoteParams.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalRemoteParams.java
@@ -23,7 +23,7 @@ class OneSignalRemoteParams {
       void complete(Params params);
    }
 
-   private static int androidParamsReties = 0;
+   private static int androidParamsRetries = 0;
 
    private static final int INCREASE_BETWEEN_RETRIES = 10_000;
    private static final int MIN_WAIT_BETWEEN_RETRIES = 30_000;
@@ -40,13 +40,13 @@ class OneSignalRemoteParams {
 
             new Thread(new Runnable() {
                public void run() {
-                  int sleepTime = MIN_WAIT_BETWEEN_RETRIES + androidParamsReties * INCREASE_BETWEEN_RETRIES;
+                  int sleepTime = MIN_WAIT_BETWEEN_RETRIES + androidParamsRetries * INCREASE_BETWEEN_RETRIES;
                   if (sleepTime > MAX_WAIT_BETWEEN_RETRIES)
                      sleepTime = MAX_WAIT_BETWEEN_RETRIES;
 
                   OneSignal.Log(OneSignal.LOG_LEVEL.INFO, "Failed to get Android parameters, trying again in " + (sleepTime / 1_000) +  " seconds.");
                   OSUtils.sleep(sleepTime);
-                  androidParamsReties++;
+                  androidParamsRetries++;
                   makeAndroidParamsRequest(callBack);
                }
             }, "OS_PARAMS_REQUEST").start();

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
@@ -890,12 +890,28 @@ public class MainOneSignalClassRunner {
    }
 
    @Test
-   public void testChangeAppId() throws Exception {
+   public void testChangeAppId_fromColdStart() throws Exception {
       OneSignalInit();
       threadAndTaskWait();
 
       int normalCreateFieldCount = ShadowOneSignalRestClient.lastPost.length();
       fastColdRestartApp();
+      OneSignal.init(blankActivity, "123456789", "99f7f966-d8cc-11e4-bed1-df8f05be55b2");
+      threadAndTaskWait();
+
+      assertEquals(normalCreateFieldCount, ShadowOneSignalRestClient.lastPost.length());
+   }
+
+   /**
+    * Similar to testChangeAppId_fromColdStart test
+    */
+   @Test
+   public void testChangeAppId_duringRuntime() throws Exception {
+      OneSignalInit();
+      threadAndTaskWait();
+
+      int normalCreateFieldCount = ShadowOneSignalRestClient.lastPost.length();
+      ShadowOneSignalRestClient.resetStatics();
       OneSignal.init(blankActivity, "123456789", "99f7f966-d8cc-11e4-bed1-df8f05be55b2");
       threadAndTaskWait();
 


### PR DESCRIPTION
* remoteParams is set null when a app id change occurs
* Unit test written to test app id change during runtime
* Fixed a spelling mistake in OneSignalRemoteParams

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/798)
<!-- Reviewable:end -->
