### PR TITLE
Added removeTriggersForKeysFromJsonArrayString

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/JSONUtils.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/JSONUtils.java
@@ -170,8 +170,15 @@ class JSONUtils {
         return map;
     }
 
-    // Converts a JSONArray into a List
-    private static @NonNull List<Object> jsonArrayToList(@NonNull JSONArray array) throws JSONException {
+    // Converts a JSONArray into a List, returns null if a null value is passed in.
+    static @Nullable List<Object> jsonArrayToList(@Nullable JSONArray array) throws JSONException {
+        if (array == null)
+            return null;
+        return jsonArrayToListNonNull(array);
+    }
+
+    // Converts a JSONArray into a List, same as above however does NOT accept null values
+    private static @NonNull List<Object> jsonArrayToListNonNull(@NonNull JSONArray array) throws JSONException {
         List<Object> list = new ArrayList<>();
         for(int i = 0; i < array.length(); i++) {
             Object value = array.get(i);
@@ -186,7 +193,7 @@ class JSONUtils {
         if (value instanceof JSONObject)
             return jsonObjectToMapNonNull((JSONObject)value);
         if (value instanceof JSONArray)
-            return jsonArrayToList((JSONArray)value);
+            return jsonArrayToListNonNull((JSONArray)value);
         return value;
     }
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSUtils.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSUtils.java
@@ -43,6 +43,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.v4.app.NotificationManagerCompat;
 import android.telephony.TelephonyManager;
 
@@ -51,7 +52,10 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.security.MessageDigest;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.Locale;
 import java.util.Set;
 import java.util.UUID;
@@ -438,5 +442,17 @@ class OSUtils {
          e.printStackTrace();
       }
       return hasFlag;
+   }
+
+   static @NonNull Collection<String> extractStringsFromCollection(@Nullable Collection<Object> collection) {
+      Collection<String> result = new ArrayList<>();
+      if (collection == null)
+         return result;
+
+      for (Object value : collection) {
+         if (value instanceof String)
+            result.add((String) value);
+      }
+      return result;
    }
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -2823,9 +2823,23 @@ public class OneSignal {
    }
 
 
-   /** Removes a list/collection of triggers from their keys  */
+   /** Removes a list/collection of triggers from their keys with a Collection of Strings */
    public static void removeTriggersForKeys(Collection<String> keys) {
       OSInAppMessageController.getController().removeTriggersForKeys(keys);
+   }
+
+   /** Removes a list/collection of triggers from their keys with a JSONArray String.
+    *  Only String types are used, other types in the array will be ignored. */
+   public static void removeTriggersForKeysFromJsonArrayString(@NonNull String keys) {
+      try {
+         JSONArray jsonArray = new JSONArray(keys);
+         Collection<String> keysCollection = OSUtils.extractStringsFromCollection(
+            JSONUtils.jsonArrayToList(jsonArray)
+         );
+         OSInAppMessageController.getController().removeTriggersForKeys(keysCollection);
+      } catch (JSONException e) {
+         OneSignal.Log(LOG_LEVEL.ERROR, "removeTriggersForKeysFromJsonArrayString, invalid json", e);
+      }
    }
 
    /** Removes a single trigger for the given key */

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -2836,6 +2836,9 @@ public class OneSignal {
          Collection<String> keysCollection = OSUtils.extractStringsFromCollection(
             JSONUtils.jsonArrayToList(jsonArray)
          );
+         // Some keys were filtered, log as warning
+         if (jsonArray.length() != keysCollection.size())
+            OneSignal.Log(LOG_LEVEL.WARN, "removeTriggersForKeysFromJsonArrayString: Skipped removing non-String type keys ");
          OSInAppMessageController.getController().removeTriggersForKeys(keysCollection);
       } catch (JSONException e) {
          OneSignal.Log(LOG_LEVEL.ERROR, "removeTriggersForKeysFromJsonArrayString, invalid json", e);

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/InAppMessagingUnitTests.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/InAppMessagingUnitTests.java
@@ -265,6 +265,33 @@ public class InAppMessagingUnitTests {
     }
 
     @Test
+    public void testRemoveTriggersForKeysFromJsonArray_SingleKey() {
+        OneSignal.addTrigger("key", "value");
+
+        OneSignal.removeTriggersForKeysFromJsonArrayString(new JSONArray() {{
+            put("key");
+        }}.toString());
+
+        assertNull(OneSignal.getTriggerValueForKey("key"));
+    }
+
+    @Test
+    public void testRemoveTriggersForKeysFromJsonArray_KeysWithNonStringTypes() {
+        OneSignal.addTrigger("key", "value");
+
+        // Ensure NonString types are ignored and does not throw
+        OneSignal.removeTriggersForKeysFromJsonArrayString(new JSONArray() {{
+            put(1);
+            put(false);
+            put(new JSONObject());
+            put(new JSONArray());
+            put("key");
+        }}.toString());
+
+        assertNull(OneSignal.getTriggerValueForKey("key"));
+    }
+
+    @Test
     public void testGreaterThanOperator() throws JSONException {
         assertTrue(comparativeOperatorTest(OSTriggerOperator.GREATER_THAN, 1, 2));
         assertFalse(comparativeOperatorTest(OSTriggerOperator.GREATER_THAN, 5, 3));


### PR DESCRIPTION
* Added removeTriggersForKeysFromJsonArrayString method to make it easy for triggers to be removed from any wrapper SDK via a JSONArray String.
   - JSON is a common serialization for most OneSignal's wrappers SDKs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/803)
<!-- Reviewable:end -->
