### PR TITLE
Update proguard configuration

### DIFF
--- a/OneSignalSDK/onesignal/consumer-proguard-rules.pro
+++ b/OneSignalSDK/onesignal/consumer-proguard-rules.pro
@@ -33,7 +33,7 @@
 
 -keep class com.onesignal.shortcutbadger.impl.AdwHomeBadger { <init>(...); }
 -keep class com.onesignal.shortcutbadger.impl.ApexHomeBadger { <init>(...); }
--keep class com.onesignal.shortcutbadger.impl.AsusHomeLauncher { <init>(...); }
+-keep class com.onesignal.shortcutbadger.impl.AsusHomeBadger { <init>(...); }
 -keep class com.onesignal.shortcutbadger.impl.DefaultBadger { <init>(...); }
 -keep class com.onesignal.shortcutbadger.impl.EverythingMeHomeBadger { <init>(...); }
 -keep class com.onesignal.shortcutbadger.impl.HuaweiHomeBadger { <init>(...); }
@@ -54,5 +54,3 @@
 -keep public class com.onesignal.ADMMessageHandler {*;}
 
 -keep class com.onesignal.JobIntentService$* {*;}
-
--keep class com.onesignal.OneSignalUnityProxy {*;}


### PR DESCRIPTION
If R8 is disabled, the build fails because of proguard errors :

```
Note: the configuration refers to the unknown class 'com.onesignal.shortcutbadger.impl.AsusHomeLauncher'
Note: the configuration refers to the unknown class 'com.onesignal.OneSignalUnityProxy'
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/812)
<!-- Reviewable:end -->
