### PR TITLE
Handling some nullPointer exceptions regarding privacy consent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,3 +29,5 @@ after_failure:
     - pwd
     - ls -la $HOME
     - ls -la $HOME/android-sdk
+
+dist: trusty

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -607,6 +607,7 @@ public class OneSignal {
    }
 
    public static void init(Context context, String googleProjectNumber, String oneSignalAppId, NotificationOpenedHandler notificationOpenedHandler, NotificationReceivedHandler notificationReceivedHandler) {
+      mInitBuilder = createInitBuilder(notificationOpenedHandler, notificationReceivedHandler);
       OneSignal.setAppContext(context);
       setupPrivacyConsent(context);
 
@@ -615,8 +616,6 @@ public class OneSignal {
          delayedInitParams = new DelayedConsentInitializationParameters(context, googleProjectNumber, oneSignalAppId, notificationOpenedHandler, notificationReceivedHandler);
          return;
       }
-
-      mInitBuilder = createInitBuilder(notificationOpenedHandler, notificationReceivedHandler);
 
       if (!isGoogleProjectNumberRemote())
          mGoogleProjectNumber = googleProjectNumber;
@@ -1210,6 +1209,10 @@ public class OneSignal {
       LocationGMS.onFocusChange();
 
       lastTrackedFocusTime = SystemClock.elapsedRealtime();
+
+      // Make sure without privacy consent, onAppFocus returns early
+      if (shouldLogUserPrivacyConsentErrorMessageForMethodName("onAppFocus"))
+         return;
 
       doSessionInit();
 

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
@@ -287,10 +287,6 @@ public class OneSignalPackagePrivateHelper {
       }
    }
 
-   public static void onAppFocus() {
-      OneSignal.onAppFocus();
-   }
-
    public static boolean hasConfigChangeFlag(Activity activity, int configChangeFlag) {
       return OSUtils.hasConfigChangeFlag(activity, configChangeFlag);
    }

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
@@ -287,6 +287,10 @@ public class OneSignalPackagePrivateHelper {
       }
    }
 
+   public static void onAppFocus() {
+      OneSignal.onAppFocus();
+   }
+
    public static boolean hasConfigChangeFlag(Activity activity, int configChangeFlag) {
       return OSUtils.hasConfigChangeFlag(activity, configChangeFlag);
    }

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
@@ -295,7 +295,7 @@ public class MainOneSignalClassRunner {
       threadAndTaskWait();
       ShadowSystemClock.setCurrentTimeMillis(60 * 60 * 1000);
 
-      OneSignalPackagePrivateHelper.onAppFocus();
+      blankActivityController.resume();
       threadAndTaskWait();
 
       // No requests should be made at this point since privacy consent has not been given
@@ -311,7 +311,7 @@ public class MainOneSignalClassRunner {
       ShadowSystemClock.setCurrentTimeMillis(121 * 60 * 1000);
 
       // Call onAppFocus and check that the last url is a on_session request
-      OneSignalPackagePrivateHelper.onAppFocus();
+      blankActivityController.resume();
       threadAndTaskWait();
 
       assertTrue(ShadowOneSignalRestClient.lastUrl.matches("players/.*/on_session"));

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
@@ -285,6 +285,39 @@ public class MainOneSignalClassRunner {
    }
 
    @Test
+   public void testAppFocusWithPrivacyConsent() throws Exception {
+      OneSignal.setRequiresUserPrivacyConsent(true);
+      OneSignalInit();
+      threadAndTaskWait();
+
+      // Make sure onAppFocus does not move past privacy consent check and on_session is not called
+      blankActivityController.pause();
+      threadAndTaskWait();
+      ShadowSystemClock.setCurrentTimeMillis(60 * 60 * 1000);
+
+      OneSignalPackagePrivateHelper.onAppFocus();
+      threadAndTaskWait();
+
+      // No requests should be made at this point since privacy consent has not been given
+      int requestsCount = ShadowOneSignalRestClient.requests.size();
+      assertEquals(requestsCount, 0);
+
+      // Give privacy consent
+      OneSignal.provideUserConsent(true);
+
+      // Pause app and wait enough time to trigger on_session
+      blankActivityController.pause();
+      threadAndTaskWait();
+      ShadowSystemClock.setCurrentTimeMillis(121 * 60 * 1000);
+
+      // Call onAppFocus and check that the last url is a on_session request
+      OneSignalPackagePrivateHelper.onAppFocus();
+      threadAndTaskWait();
+
+      assertTrue(ShadowOneSignalRestClient.lastUrl.matches("players/.*/on_session"));
+   }
+
+   @Test
    public void testOnSessionCalledOnlyOncePer30Sec() throws Exception {
       // Will call create
       ShadowSystemClock.setCurrentTimeMillis(60 * 60 * 1000);


### PR DESCRIPTION
* mInitBuilder now initialized above privacy consent check inside init
* User privacy consent check will force onAppFocus to return early

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/816)
<!-- Reviewable:end -->
