### PR TITLE
Fixed NPE with the Builder on app focus

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSUtils.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSUtils.java
@@ -62,6 +62,8 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 
+import static com.onesignal.OneSignal.Log;
+
 class OSUtils {
 
    static final int UNINITIALIZABLE_STATUS = -999;
@@ -95,13 +97,13 @@ class OSUtils {
          //noinspection ResultOfMethodCallIgnored
          UUID.fromString(oneSignalAppId);
       } catch (Throwable t) {
-         OneSignal.Log(OneSignal.LOG_LEVEL.FATAL, "OneSignal AppId format is invalid.\nExample: 'b2f7f966-d8cc-11e4-bed1-df8f05be55ba'\n", t);
+         Log(OneSignal.LOG_LEVEL.FATAL, "OneSignal AppId format is invalid.\nExample: 'b2f7f966-d8cc-11e4-bed1-df8f05be55ba'\n", t);
          return UNINITIALIZABLE_STATUS;
       }
 
       if ("b2f7f966-d8cc-11e4-bed1-df8f05be55ba".equals(oneSignalAppId) ||
           "5eb5a37e-b458-11e3-ac11-000c2940e62c".equals(oneSignalAppId))
-         OneSignal.Log(OneSignal.LOG_LEVEL.ERROR, "OneSignal Example AppID detected, please update to your app's id found on OneSignal.com");
+         Log(OneSignal.LOG_LEVEL.ERROR, "OneSignal Example AppID detected, please update to your app's id found on OneSignal.com");
 
       if (deviceType == UserState.DEVICE_TYPE_ANDROID) {
          Integer pushErrorType = checkForGooglePushLibrary();
@@ -140,15 +142,15 @@ class OSUtils {
       boolean hasGCMLibrary = hasGCMLibrary();
 
       if (!hasFCMLibrary && !hasGCMLibrary) {
-         OneSignal.Log(OneSignal.LOG_LEVEL.FATAL, "The Firebase FCM library is missing! Please make sure to include it in your project.");
+         Log(OneSignal.LOG_LEVEL.FATAL, "The Firebase FCM library is missing! Please make sure to include it in your project.");
          return UserState.PUSH_STATUS_MISSING_FIREBASE_FCM_LIBRARY;
       }
 
       if (hasGCMLibrary && !hasFCMLibrary)
-         OneSignal.Log(OneSignal.LOG_LEVEL.WARN, "GCM Library detected, please upgrade to Firebase FCM library as GCM is deprecated!");
+         Log(OneSignal.LOG_LEVEL.WARN, "GCM Library detected, please upgrade to Firebase FCM library as GCM is deprecated!");
 
       if (hasGCMLibrary && hasFCMLibrary)
-         OneSignal.Log(OneSignal.LOG_LEVEL.WARN, "Both GCM & FCM Libraries detected! Please remove the deprecated GCM library.");
+         Log(OneSignal.LOG_LEVEL.WARN, "Both GCM & FCM Libraries detected! Please remove the deprecated GCM library.");
 
       return null;
    }
@@ -185,12 +187,12 @@ class OSUtils {
       boolean hasNotificationManagerCompat = hasNotificationManagerCompat();
 
       if (!hasWakefulBroadcastReceiver && !hasNotificationManagerCompat) {
-         OneSignal.Log(OneSignal.LOG_LEVEL.FATAL, "Could not find the Android Support Library. Please make sure it has been correctly added to your project.");
+         Log(OneSignal.LOG_LEVEL.FATAL, "Could not find the Android Support Library. Please make sure it has been correctly added to your project.");
          return UserState.PUSH_STATUS_MISSING_ANDROID_SUPPORT_LIBRARY;
       }
 
       if (!hasWakefulBroadcastReceiver || !hasNotificationManagerCompat) {
-         OneSignal.Log(OneSignal.LOG_LEVEL.FATAL, "The included Android Support Library is to old or incomplete. Please update to the 26.0.0 revision or newer.");
+         Log(OneSignal.LOG_LEVEL.FATAL, "The included Android Support Library is to old or incomplete. Please update to the 26.0.0 revision or newer.");
          return UserState.PUSH_STATUS_OUTDATED_ANDROID_SUPPORT_LIBRARY;
       }
 
@@ -200,7 +202,7 @@ class OSUtils {
          && getTargetSdkVersion(context) >= Build.VERSION_CODES.O) {
          // Class was added in 26.0.0-beta2
          if (!hasJobIntentService()) {
-            OneSignal.Log(OneSignal.LOG_LEVEL.FATAL, "The included Android Support Library is to old or incomplete. Please update to the 26.0.0 revision or newer.");
+            Log(OneSignal.LOG_LEVEL.FATAL, "The included Android Support Library is to old or incomplete. Please update to the 26.0.0 revision or newer.");
             return UserState.PUSH_STATUS_OUTDATED_ANDROID_SUPPORT_LIBRARY;
          }
       }
@@ -252,7 +254,7 @@ class OSUtils {
          Bundle bundle = ai.metaData;
          return bundle.getString(metaName);
       } catch (Throwable t) {
-         OneSignal.Log(OneSignal.LOG_LEVEL.ERROR, "", t);
+         Log(OneSignal.LOG_LEVEL.ERROR, "", t);
       }
 
       return null;
@@ -454,5 +456,15 @@ class OSUtils {
             result.add((String) value);
       }
       return result;
+   }
+
+   static boolean shouldLogMissingAppIdError(@Nullable String appId) {
+      if (appId != null)
+         return false;
+
+      // Wrapper SDKs can't normally call on Application.onCreate so just count this as informational.
+      Log(OneSignal.LOG_LEVEL.INFO, "OneSignal was not initialized, " +
+         "ensure to always initialize OneSignal from the onCreate of your Application class.");
+      return true;
    }
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserState.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserState.java
@@ -11,8 +11,9 @@ import java.util.Set;
 
 abstract class UserState {
 
-    static final int DEVICE_TYPE_ANDROID = 1;
-    static final int DEVICE_TYPE_FIREOS = 2;
+    public static final int DEVICE_TYPE_ANDROID = 1;
+    public static final int DEVICE_TYPE_FIREOS = 2;
+    public static final int DEVICE_TYPE_EMAIL = 11;
 
     static final int PUSH_STATUS_SUBSCRIBED = 1;
     static final int PUSH_STATUS_NO_PERMISSION = 0;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStateEmailSynchronizer.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStateEmailSynchronizer.java
@@ -104,7 +104,7 @@ class UserStateEmailSynchronizer extends UserStateSynchronizer {
     @Override
     protected void addOnSessionOrCreateExtras(JSONObject jsonBody) {
         try {
-            jsonBody.put("device_type", 11);
+            jsonBody.put("device_type", UserState.DEVICE_TYPE_EMAIL);
             jsonBody.putOpt("device_player_id", OneSignal.getUserId());
         } catch (JSONException e) {
             e.printStackTrace();

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
@@ -290,4 +290,10 @@ public class OneSignalPackagePrivateHelper {
    public static boolean hasConfigChangeFlag(Activity activity, int configChangeFlag) {
       return OSUtils.hasConfigChangeFlag(activity, configChangeFlag);
    }
+
+   public abstract class UserState extends com.onesignal.UserState {
+      UserState(String inPersistKey, boolean load) {
+         super(inPersistKey, load);
+      }
+   }
 }

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowOneSignalRestClient.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowOneSignalRestClient.java
@@ -27,6 +27,8 @@
 
 package com.onesignal;
 
+import com.test.onesignal.RestClientValidator;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.robolectric.annotation.Implements;
@@ -170,13 +172,16 @@ public class ShadowOneSignalRestClient {
       }
    }
 
-   private static void trackRequest(REST_METHOD method, JSONObject payload, String url) {
+   private static void trackRequest(REST_METHOD method, JSONObject payload, String url) throws JSONException {
       if (method == REST_METHOD.POST || method == REST_METHOD.PUT)
          lastPost = payload;
       lastUrl = url;
       networkCallCount++;
 
-      requests.add(new Request(method, payload, url));
+      Request request = new Request(method, payload, url);
+      requests.add(request);
+
+      RestClientValidator.validateRequest(request);
 
       System.out.println(networkCallCount + ":" + method + "@URL:" + url + "\nBODY: " + payload);
    }
@@ -237,18 +242,18 @@ public class ShadowOneSignalRestClient {
       }
    }
 
-   public static void post(String url, JSONObject jsonBody, OneSignalRestClient.ResponseHandler responseHandler) {
+   public static void post(String url, JSONObject jsonBody, OneSignalRestClient.ResponseHandler responseHandler) throws JSONException {
       trackRequest(REST_METHOD.POST, jsonBody, url);
       mockPost(url, jsonBody, responseHandler);
    }
 
-   public static void postSync(String url, JSONObject jsonBody, OneSignalRestClient.ResponseHandler responseHandler) {
+   public static void postSync(String url, JSONObject jsonBody, OneSignalRestClient.ResponseHandler responseHandler) throws JSONException {
       trackRequest(REST_METHOD.POST, jsonBody, url);
       freezeSyncCall();
       mockPost(url, jsonBody, responseHandler);
    }
 
-   public static void putSync(String url, JSONObject jsonBody, OneSignalRestClient.ResponseHandler responseHandler) {
+   public static void putSync(String url, JSONObject jsonBody, OneSignalRestClient.ResponseHandler responseHandler) throws JSONException {
       trackRequest(REST_METHOD.PUT, jsonBody, url);
 
       freezeSyncCall();
@@ -260,7 +265,7 @@ public class ShadowOneSignalRestClient {
          responseHandler.onSuccess(response);
    }
 
-   public static void put(String url, JSONObject jsonBody, OneSignalRestClient.ResponseHandler responseHandler) {
+   public static void put(String url, JSONObject jsonBody, OneSignalRestClient.ResponseHandler responseHandler) throws JSONException {
       trackRequest(REST_METHOD.PUT, jsonBody, url);
 
       if (doFail(responseHandler, failNextPut)) return;
@@ -268,7 +273,7 @@ public class ShadowOneSignalRestClient {
       responseHandler.onSuccess("{}");
    }
 
-   public static void get(final String url, final OneSignalRestClient.ResponseHandler responseHandler, String cacheKey) {
+   public static void get(final String url, final OneSignalRestClient.ResponseHandler responseHandler, String cacheKey) throws JSONException {
       trackRequest(REST_METHOD.GET, null, url);
       if (failGetParams && doFail(responseHandler, true)) return;
 
@@ -297,7 +302,7 @@ public class ShadowOneSignalRestClient {
       }
    }
 
-   public static void getSync(final String url, final OneSignalRestClient.ResponseHandler responseHandler, String cacheKey) {
+   public static void getSync(final String url, final OneSignalRestClient.ResponseHandler responseHandler, String cacheKey) throws JSONException {
       trackRequest(REST_METHOD.GET, null, url);
 
       if (doFail(responseHandler)) return;

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/RestClientAsserts.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/RestClientAsserts.java
@@ -1,0 +1,117 @@
+package com.test.onesignal;
+
+import android.support.annotation.NonNull;
+
+import com.onesignal.OneSignalPackagePrivateHelper.UserState;
+import com.onesignal.ShadowOneSignalRestClient;
+import com.onesignal.ShadowOneSignalRestClient.Request;
+import com.onesignal.ShadowOneSignalRestClient.REST_METHOD;
+
+import org.hamcrest.core.AnyOf;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import static com.test.onesignal.RestClientValidator.GET_REMOTE_PARAMS_ENDPOINT;
+import static com.test.onesignal.TypeAsserts.assertIsUUID;
+import static org.hamcrest.CoreMatchers.anyOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+class RestClientAsserts {
+
+   private static final AnyOf<Integer> ANY_OF_VALID_DEVICE_TYPES = anyOf(
+      is(UserState.DEVICE_TYPE_ANDROID),
+      is(UserState.DEVICE_TYPE_FIREOS),
+      is(UserState.DEVICE_TYPE_EMAIL)
+   );
+
+   private static final AnyOf<Integer> ANY_OF_PUSH_DEVICE_TYPES = anyOf(
+      is(UserState.DEVICE_TYPE_ANDROID),
+      is(UserState.DEVICE_TYPE_FIREOS)
+   );
+
+   static void assertPlayerCreateAnyAtIndex(int index) throws JSONException {
+      assertPlayerCreateAny(ShadowOneSignalRestClient.requests.get(index));
+   }
+
+   static void assertPlayerCreateAny(Request request) throws JSONException {
+      assertPlayerCreateMethodAndUrl(request);
+      assertValidDeviceType(request.payload);
+   }
+
+   static void assertPlayerCreatePush(Request request) throws JSONException {
+      assertPlayerCreateMethodAndUrl(request);
+      assertDeviceTypeIsPush(request.payload);
+   }
+
+   static void assertPlayerCreatePushAtIndex(int index) throws JSONException {
+      assertPlayerCreatePush(ShadowOneSignalRestClient.requests.get(index));
+   }
+
+   private static void assertPlayerCreateMethodAndUrl(@NonNull Request request) {
+      assertEquals(REST_METHOD.POST, request.method);
+      assertEquals(request.url, "players");
+   }
+
+   private static void assertDeviceTypeIsPush(@NonNull JSONObject payload) throws JSONException {
+      assertThat(payload.getInt("device_type"), ANY_OF_PUSH_DEVICE_TYPES);
+   }
+
+   private static void assertValidDeviceType(@NonNull JSONObject payload) throws JSONException {
+      assertThat(payload.getInt("device_type"), ANY_OF_VALID_DEVICE_TYPES);
+   }
+
+   static void assertRemoteParamsAtIndex(int index) {
+      Request request = ShadowOneSignalRestClient.requests.get(index);
+
+      assertEquals(REST_METHOD.GET, request.method);
+      assertRemoteParamsUrl(request.url);
+   }
+
+   // Assert that URL matches the format apps/{UUID}/android_params.js
+   static void assertRemoteParamsUrl(@NonNull String url) {
+      String[] parts = url.split("/");
+
+      assertEquals("apps", parts[0]);
+      assertIsUUID(parts[1]);
+
+      String[] playerIdParts = parts[2].split("\\?player_id=");
+      assertEquals(GET_REMOTE_PARAMS_ENDPOINT, playerIdParts[0]);
+      if (playerIdParts.length == 2)
+         assertIsUUID( playerIdParts[1]);
+      else if (playerIdParts.length > 2)
+         fail("Invalid format");
+
+      assertEquals(3, parts.length);
+   }
+
+   static void assertRestCalls(int calls) {
+      assertEquals(calls, ShadowOneSignalRestClient.networkCallCount);
+   }
+
+   static void assertHasAppId(@NonNull Request request) {
+      if (request.method == REST_METHOD.GET) {
+         assertAppIdInUrl(request.url);
+         return;
+      }
+
+      assertIsUUID(request.payload.optString("app_id"));
+   }
+
+   private static void assertAppIdInUrl(@NonNull String url) {
+      String[] appsPath = url.split("apps/");
+      if (appsPath.length == 2) {
+         String[] appIdPart = appsPath[1].split("/");
+         assertIsUUID(appIdPart[0]);
+      }
+      else if (appsPath.length == 1) {
+         // Check for "?app_id=" or "&app_id="
+         String[] appsQueryParam = url.split("\\?app_id=|&app_id=");
+         assertIsUUID(appsQueryParam[1]);
+      }
+      else
+         fail("Invalid format");
+   }
+}

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/RestClientValidator.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/RestClientValidator.java
@@ -1,0 +1,34 @@
+package com.test.onesignal;
+
+import android.support.annotation.NonNull;
+
+import com.onesignal.ShadowOneSignalRestClient.Request;
+
+import org.json.JSONException;
+
+import static com.test.onesignal.RestClientAsserts.assertHasAppId;
+import static com.test.onesignal.RestClientAsserts.assertPlayerCreateAny;
+import static com.test.onesignal.RestClientAsserts.assertRemoteParamsUrl;
+
+// Validator runs on each mock REST API call on All tests to ensure the correct fields are sent
+public class RestClientValidator {
+
+   static final String GET_REMOTE_PARAMS_ENDPOINT = "android_params.js";
+
+   public static void validateRequest(@NonNull Request request) throws JSONException {
+      switch (request.method) {
+         case GET:
+            if (request.url.contains(GET_REMOTE_PARAMS_ENDPOINT))
+               assertRemoteParamsUrl(request.url);
+            break;
+         case POST:
+            if (request.url.endsWith("players"))
+               assertPlayerCreateAny(request);
+      }
+
+      assertHasAppId(request);
+
+      // TODO: Add rest of the REST API calls here
+   }
+
+}

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/TypeAsserts.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/TypeAsserts.java
@@ -1,0 +1,12 @@
+package com.test.onesignal;
+
+import android.support.annotation.Nullable;
+
+import java.util.UUID;
+
+class TypeAsserts {
+
+   static void assertIsUUID(@Nullable String value) {
+      UUID.fromString(value);
+   }
+}


### PR DESCRIPTION
* Fixed issue where postNotification could be called before an app_id is set.
* Fixed a bug where player created could have been called before an app_id is set.
   - Would have only happened in the specific focus case without initializing the SDK.
* Fixed case where the builder would be null when the app comes into focus if OneSignal.init was not called but a Context was set.
* This could happen if a push was received and later the app is opened but OneSignal was not initialized in Application.onCreate.
* Added validation for app_id to all REST API calls durning tests via a new RestClientValidator class.
* Added new RestClientAsserts to make checking if REST API calls were made much simpler.