### PR TITLE
Removed "click_name" from JSONObject click endpoint payload

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageController.java
@@ -275,7 +275,6 @@ class OSInAppMessageController implements OSDynamicTriggerControllerObserver, OS
                 put("device_type", new OSUtils().getDeviceType());
                 put("player_id", OneSignal.getUserId());
                 put("click_id", action.clickId);
-                put("click_name", action.clickName);
                 put("variant_id", variantId);
                 if (action.firstClick)
                     put("first_click", true);


### PR DESCRIPTION
* When action name is null, JSONObject was preventing "click_name" from going through
* In the case where action name is not null, the JSONObject payload is sent to backend and "click_name" is invalid param
* This is fixed on the backend now and also removed from Android SDK and not included in iOS SDK