### PR TITLE
LocationGMS Synchronization ANR Fix

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/LocationGMS.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/LocationGMS.java
@@ -69,6 +69,7 @@ class LocationGMS {
    private static GoogleApiClientCompatProxy mGoogleApiClient;
    private static Location mLastLocation;
    static String requestPermission;
+   static LocationUpdateListener locationUpdateListener;
    private static Context classContext;
    
    protected static final Object syncLock = new Object() {};


### PR DESCRIPTION
Fixes #650

Example ANR:
```
"main" prio=5 tid=1 Blocked
  | group="main" sCount=1 dsCount=0 flags=1 obj=0x755a3990 self=0x7a02c14c00
  | sysTid=31450 nice=0 cgrp=default sched=0/0 handle=0x7a885d3548
  | state=S schedstat=( 4649674210 849715033 8919 ) utm=374 stm=89 core=5 HZ=100
  | stack=0x7fce76e000-0x7fce770000 stackSize=8MB
  | held mutexes=
  at com.onesignal.LocationGMS.onFocusChange (LocationGMS.java:293)
- waiting to lock <0x0dae9bbb> (a com.onesignal.r$1) held by thread 137
  at com.onesignal.OneSignal.onAppFocus (OneSignal.java:1214)
  at com.onesignal.ActivityLifecycleHandler.handleFocus (ActivityLifecycleHandler.java:207)
  at com.onesignal.ActivityLifecycleHandler.onActivityResumed (ActivityLifecycleHandler.java:121)
  at com.onesignal.ActivityLifecycleListener.safedk_b_onActivityResumed_acbc0dc91aa13497e98499eccf6a11f2 (ActivityLifecycleListener.java:78)
  at com.onesignal.ActivityLifecycleListener.onActivityResumed (ActivityLifecycleListener.java)
  at android.app.Application.dispatchActivityResumed (Application.java:239)
  at android.app.Activity.onResume (Activity.java:1351)
  at androidx.fragment.app.FragmentActivity.onResume (FragmentActivity.java:441)
  at com.audiomack.activities.HomeActivity.onResume (HomeActivity.java:1470)
  at android.app.Instrumentation.callActivityOnResume (Instrumentation.java:1434)
  at android.app.Activity.performResume (Activity.java:7304)
  at android.app.ActivityThread.performResumeActivity (ActivityThread.java:3993)
  at android.app.ActivityThread.handleResumeActivity (ActivityThread.java:4033)
  at android.app.servertransaction.ResumeActivityItem.execute (ResumeActivityItem.java:51)
  at android.app.servertransaction.TransactionExecutor.executeLifecycleState (TransactionExecutor.java:145)
  at android.app.servertransaction.TransactionExecutor.execute (TransactionExecutor.java:70)
  at android.app.ActivityThread$H.handleMessage (ActivityThread.java:1977)
  at android.os.Handler.dispatchMessage (Handler.java:106)
  at android.os.Looper.loop (Looper.java:193)
  at android.app.ActivityThread.main (ActivityThread.java:6936)
  at java.lang.reflect.Method.invoke (Method.java)
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:493)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:870)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/836)
<!-- Reviewable:end -->
