### PR TITLE
Crashes seen around OneSignalNotificationManager

### DIFF
--- a/OneSignalSDK/app/src/main/java/com/onesignal/Toaster.java
+++ b/OneSignalSDK/app/src/main/java/com/onesignal/Toaster.java
@@ -1,0 +1,12 @@
+package com.onesignal;
+
+import android.content.Context;
+import android.widget.Toast;
+
+public class Toaster {
+
+    static public void makeToast(Context context, String message, int time) {
+        Toast.makeText(context, message, time).show();
+    }
+
+}

--- a/OneSignalSDK/app/src/main/java/com/onesignal/example/OneSignalExampleApp.java
+++ b/OneSignalSDK/app/src/main/java/com/onesignal/example/OneSignalExampleApp.java
@@ -47,10 +47,17 @@ public class OneSignalExampleApp extends Application {
    public void onCreate() {
       super.onCreate();
 
-      StrictMode.setThreadPolicy(new StrictMode.ThreadPolicy.Builder().detectAll().build());
-      StrictMode.setVmPolicy(new StrictMode.VmPolicy.Builder().detectAll().build());
+      StrictMode.setThreadPolicy(new StrictMode.ThreadPolicy.Builder()
+              .detectAll()
+              .penaltyLog()
+              .build());
 
-      OneSignal.setLogLevel(OneSignal.LOG_LEVEL.VERBOSE, OneSignal.LOG_LEVEL.ERROR);
+      StrictMode.setVmPolicy(new StrictMode.VmPolicy.Builder()
+              .detectAll()
+              .penaltyLog()
+              .build());
+
+      OneSignal.setLogLevel(OneSignal.LOG_LEVEL.VERBOSE, OneSignal.LOG_LEVEL.NONE);
 
       String currentAppId = getOneSignalAppId(this);
       if (currentAppId == null)

--- a/OneSignalSDK/app/src/main/res/layout/activity_main.xml
+++ b/OneSignalSDK/app/src/main/res/layout/activity_main.xml
@@ -1,9 +1,7 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools" android:layout_width="match_parent"
-    android:layout_height="match_parent" android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
-    android:paddingTop="@dimen/activity_vertical_margin"
-    android:paddingBottom="@dimen/activity_vertical_margin" tools:context="com.onesignal.MainActivity">
+    android:layout_height="match_parent"
+    tools:context="com.onesignal.MainActivity">
 
     <ScrollView
         android:layout_width="match_parent"
@@ -15,6 +13,7 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:padding="16dp"
             android:orientation="vertical" >
 
             <Button
@@ -135,6 +134,54 @@
                 android:layout_below="@+id/setEmail"
                 android:onClick="onLogoutEmailClicked"
                 android:text="Logout Email" />
+
+            <RelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
+
+                <CheckBox
+                    android:id="@+id/postNotificationGroupCheckBox"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_alignParentEnd="true"
+                    android:layout_centerVertical="true"/>
+
+                <Button
+                    android:id="@+id/postNotification"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_alignParentStart="true"
+                    android:layout_centerVertical="true"
+                    android:layout_toStartOf="@id/postNotificationGroupCheckBox"
+                    android:onClick="onPostNotifClicked"
+                    android:text="Post Notification" />
+
+            </RelativeLayout>
+
+            <RelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
+
+                <CheckBox
+                    android:id="@+id/postNotificationAsyncGroupCheckBox"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_alignParentEnd="true"
+                    android:layout_centerVertical="true"/>
+
+                <Button
+                    android:id="@+id/postNotificationAsync"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_alignParentStart="true"
+                    android:layout_centerVertical="true"
+                    android:layout_toStartOf="@id/postNotificationAsyncGroupCheckBox"
+                    android:onClick="onPostNotifAsyncClicked"
+                    android:text="Post Notification Async" />
+
+                </RelativeLayout>
 
             <TextView
                 android:id="@+id/debugTextView"

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/BadgeCountUpdater.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/BadgeCountUpdater.java
@@ -86,8 +86,7 @@ class BadgeCountUpdater {
 
    @RequiresApi(api = Build.VERSION_CODES.M)
    private static void updateStandard(Context context) {
-      NotificationManager notifManager = OneSignalNotificationManager.getNotificationManager(context);
-      StatusBarNotification[] activeNotifs = notifManager.getActiveNotifications();
+      StatusBarNotification[] activeNotifs = OneSignalNotificationManager.getActiveNotifications(context);
 
       int runningCount = 0;
       for (StatusBarNotification activeNotif : activeNotifs) {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotification.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotification.java
@@ -374,7 +374,7 @@ class GenerateNotification {
          // Create PendingIntents for notifications in a groupless or defined summary
          if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N &&
                  group.equals(OneSignalNotificationManager.getGrouplessSummaryKey()))
-            createGrouplessSummaryNotification(notifJob, oneSignalNotificationBuilder, grouplessNotifs.size() + 1);
+            createGrouplessSummaryNotification(notifJob, grouplessNotifs.size() + 1);
          else
             createSummaryNotification(notifJob, oneSignalNotificationBuilder);
       }
@@ -389,7 +389,7 @@ class GenerateNotification {
       //     created by Android itself.
       if (group == null || Build.VERSION.SDK_INT > Build.VERSION_CODES.JELLY_BEAN_MR1) {
          addXiaomiSettings(oneSignalNotificationBuilder, notification);
-         NotificationManagerCompat.from(currentContext).notify(notificationId, notification);
+         OneSignalNotificationManager.notifyNotificationUpdate(currentContext, notificationId, notification);
       }
    }
 
@@ -702,11 +702,11 @@ class GenerateNotification {
          addXiaomiSettings(notifBuilder, summaryNotification);
       }
 
-      NotificationManagerCompat.from(currentContext).notify(summaryNotificationId, summaryNotification);
+      OneSignalNotificationManager.notifyNotificationUpdate(currentContext, summaryNotificationId, summaryNotification);
    }
 
    @RequiresApi(api = Build.VERSION_CODES.M)
-   private static void createGrouplessSummaryNotification(NotificationGenerationJob notifJob, OneSignalNotificationBuilder notifBuilder, int grouplessNotifCount) {
+   private static void createGrouplessSummaryNotification(NotificationGenerationJob notifJob, int grouplessNotifCount) {
       JSONObject gcmBundle = notifJob.jsonPayload;
 
       Notification summaryNotification;
@@ -744,7 +744,7 @@ class GenerateNotification {
         summaryBuilder.setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_SUMMARY);
       }
       catch (Throwable t) {
-        //do nothing in this case...Android support lib 26 isn't in the project
+        // Do nothing in this case... Android support lib 26 isn't in the project
       }
 
       NotificationCompat.InboxStyle inboxStyle = new NotificationCompat.InboxStyle();
@@ -753,7 +753,7 @@ class GenerateNotification {
       summaryBuilder.setStyle(inboxStyle);
       summaryNotification = summaryBuilder.build();
 
-      NotificationManagerCompat.from(currentContext).notify(summaryNotificationId, summaryNotification);
+      OneSignalNotificationManager.notifyNotificationUpdate(currentContext, summaryNotificationId, summaryNotification);
    }
    
    private static Intent createBaseSummaryIntent(int summaryNotificationId, JSONObject gcmBundle, String group) {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotification.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotification.java
@@ -389,7 +389,7 @@ class GenerateNotification {
       //     created by Android itself.
       if (group == null || Build.VERSION.SDK_INT > Build.VERSION_CODES.JELLY_BEAN_MR1) {
          addXiaomiSettings(oneSignalNotificationBuilder, notification);
-         OneSignalNotificationManager.notifyNotificationUpdate(currentContext, notificationId, notification);
+         NotificationManagerCompat.from(currentContext).notify(notificationId, notification);
       }
    }
 
@@ -702,7 +702,7 @@ class GenerateNotification {
          addXiaomiSettings(notifBuilder, summaryNotification);
       }
 
-      OneSignalNotificationManager.notifyNotificationUpdate(currentContext, summaryNotificationId, summaryNotification);
+      NotificationManagerCompat.from(currentContext).notify(summaryNotificationId, summaryNotification);
    }
 
    @RequiresApi(api = Build.VERSION_CODES.M)
@@ -753,7 +753,7 @@ class GenerateNotification {
       summaryBuilder.setStyle(inboxStyle);
       summaryNotification = summaryBuilder.build();
 
-      OneSignalNotificationManager.notifyNotificationUpdate(currentContext, summaryNotificationId, summaryNotification);
+      NotificationManagerCompat.from(currentContext).notify(summaryNotificationId, summaryNotification);
    }
    
    private static Intent createBaseSummaryIntent(int summaryNotificationId, JSONObject gcmBundle, String group) {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationLimitManager.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationLimitManager.java
@@ -46,7 +46,7 @@ class NotificationLimitManager {
          else
             clearOldestOverLimitFallback(context, notifsToMakeRoomFor);
       } catch(Throwable t) {
-         // try-catch for Android 6.0.X bug work around, getActiveNotifications bug
+         // try-catch for Android 6.0.X and possibly 8.0.0 bug work around, getActiveNotifications bug
          clearOldestOverLimitFallback(context, notifsToMakeRoomFor);
       }
    }
@@ -55,8 +55,7 @@ class NotificationLimitManager {
    // This could be any notification, not just a OneSignal notification
    @RequiresApi(api = Build.VERSION_CODES.M)
    static void clearOldestOverLimitStandard(Context context, int notifsToMakeRoomFor) throws Throwable {
-      NotificationManager notifManager = OneSignalNotificationManager.getNotificationManager(context);
-      StatusBarNotification[] activeNotifs = notifManager.getActiveNotifications();
+      StatusBarNotification[] activeNotifs = OneSignalNotificationManager.getActiveNotifications(context);
 
       int notifsToClear = (activeNotifs.length - getMaxNumberOfNotificationsInt()) + notifsToMakeRoomFor;
       // We have enough room in the notification shade, no need to clear any notifications

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationRestorer.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationRestorer.java
@@ -190,27 +190,18 @@ class NotificationRestorer {
       if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M)
          return;
 
-      NotificationManager notifManager = OneSignalNotificationManager.getNotificationManager(context);
+      StatusBarNotification[] activeNotifs = OneSignalNotificationManager.getActiveNotifications(context);
+      if (activeNotifs.length == 0)
+         return;
 
-      try {
-         StatusBarNotification[] activeNotifs = notifManager.getActiveNotifications();
-         if (activeNotifs.length == 0)
-            return;
+      ArrayList<Integer> activeNotifIds = new ArrayList<>();
+      for (StatusBarNotification activeNotif : activeNotifs)
+         activeNotifIds.add(activeNotif.getId());
 
-         ArrayList<Integer> activeNotifIds = new ArrayList<>();
-         for (StatusBarNotification activeNotif : activeNotifs)
-            activeNotifIds.add(activeNotif.getId());
-
-         dbQuerySelection
-                 .append(" AND " + NotificationTable.COLUMN_NAME_ANDROID_NOTIFICATION_ID + " NOT IN (")
-                 .append(TextUtils.join(",", activeNotifIds))
-                 .append(")");
-      } catch(Throwable t) {
-         // try-catch for Android 6.0.X bug work around,
-         //    getActiveNotifications sometimes throws an exception.
-         // Seem to be related to what Android's internal method getAppActiveNotifications returns.
-         // Issue #422
-      }
+      dbQuerySelection
+              .append(" AND " + NotificationTable.COLUMN_NAME_ANDROID_NOTIFICATION_ID + " NOT IN (")
+              .append(TextUtils.join(",", activeNotifIds))
+              .append(")");
    }
 
    /**

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalNotificationManager.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalNotificationManager.java
@@ -91,7 +91,6 @@ public class OneSignalNotificationManager {
             if (!isGroupSummary && isGroupless)
                 grouplessStatusBarNotifications.add(statusBarNotification);
         }
-
         return grouplessStatusBarNotifications;
     }
 
@@ -113,22 +112,7 @@ public class OneSignalNotificationManager {
                     .setGroup(GROUPLESS_SUMMARY_KEY)
                     .build();
 
-            notifyNotificationUpdate(context, grouplessNotif.getId(), notif);
-        }
-    }
-
-    /**
-     * Separated notify() calls with NotificationManagerCompat to help various places consolidate
-     * to a single method call, which will help catching any fatal exceptions and prevent crashes
-     */
-    static void notifyNotificationUpdate(Context context, int notifId, Notification notification) {
-        try {
-            NotificationManagerCompat.from(context).notify(notifId, notification);
-        } catch(Throwable e) {
-            // try-catch for Android 6.0.X and possibly 8.0.0 bug work around,
-            //    notify sometimes throws a fatal exception similar to getActiveNotifications.
-            // Seem to be related to what Android's internal method getAppActiveNotifications returns.
-            // Suspected to be related to Issue #422
+            NotificationManagerCompat.from(context).notify(grouplessNotif.getId(), notif);
         }
     }
 


### PR DESCRIPTION
* Removed all places where we use NotificationManager and NotificationManagerCompat and made static helper methods
* getActiveNotifications() and notify() causing issues with Android 6.0.X previously and now with new groupless notifs handling Android 8.0.0 is having some trouble
* try-catch implemented similar to Issue #422 reported/fixed in Jan/Feb 2018 for Android 6.0.X

Minor additions to demo app for posting notifications with and without groups, also on main thread and async

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/839)
<!-- Reviewable:end -->
