### PR TITLE
Fix for Lenovo Yoga crash due to NullPointerException inside RootToolsInternalMethods.isRooted()

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -1303,7 +1303,9 @@ public class OneSignal {
 
       deviceInfo.put("net_type", osUtils.getNetType());
       deviceInfo.put("carrier", osUtils.getCarrierName());
-      deviceInfo.put("rooted", RootToolsInternalMethods.isRooted());
+      try {
+         deviceInfo.put("rooted", RootToolsInternalMethods.isRooted());
+      } catch (Throwable t) {}
 
       OneSignalStateSynchronizer.updateDeviceInfo(deviceInfo);
 


### PR DESCRIPTION
Fixes the crash below, affecting all Lenovo Yoga devices running Android 6. Crash hasn't occurred anymore since deploying this fix.
![image](https://user-images.githubusercontent.com/26101312/66368430-977a6000-e9db-11e9-802e-b78c80450ac3.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/857)
<!-- Reviewable:end -->
