### PR TITLE
Fix Flaky Tests

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalRestClient.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalRestClient.java
@@ -66,7 +66,7 @@ class OneSignalRestClient {
          public void run() {
             makeRequest(url, "PUT", jsonBody, responseHandler, TIMEOUT, null);
          }
-      }).start();
+      }, "OS_REST_ASYNC_PUT").start();
    }
 
    public static void post(final String url, final JSONObject jsonBody, final ResponseHandler responseHandler) {
@@ -74,7 +74,7 @@ class OneSignalRestClient {
          public void run() {
             makeRequest(url, "POST", jsonBody, responseHandler, TIMEOUT, null);
          }
-      }).start();
+      }, "OS_REST_ASYNC_POST").start();
    }
 
    public static void get(final String url, final ResponseHandler responseHandler, @NonNull final String cacheKey) {
@@ -82,7 +82,7 @@ class OneSignalRestClient {
          public void run() {
             makeRequest(url, null, null, responseHandler, GET_TIMEOUT, cacheKey);
          }
-      }).start();
+      }, "OS_REST_ASYNC_GET").start();
    }
 
    public static void getSync(final String url, final ResponseHandler responseHandler, @NonNull String cacheKey) {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalRestClient.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalRestClient.java
@@ -261,7 +261,7 @@ class OneSignalRestClient {
          public void run() {
             handler.onSuccess(response);
          }
-      });
+      }, "OS_REST_SUCCESS_CALLBACK");
       thread.start();
       
       return thread;
@@ -275,7 +275,7 @@ class OneSignalRestClient {
          public void run() {
             handler.onFailure(statusCode, response, throwable);
          }
-      });
+      }, "OS_REST_FAILURE_CALLBACK");
       thread.start();
       
       return thread;

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowRoboNotificationManager.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowRoboNotificationManager.java
@@ -31,12 +31,16 @@ import android.app.NotificationChannel;
 import android.app.Notification;
 import android.app.NotificationChannelGroup;
 import android.app.NotificationManager;
+import android.support.annotation.NonNull;
+import android.support.v4.app.NotificationCompat;
 
 import org.robolectric.annotation.Implements;
 import org.robolectric.shadows.ShadowNotification;
 import org.robolectric.shadows.ShadowNotificationManager;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 
 import static org.robolectric.Shadows.shadowOf;
 
@@ -69,6 +73,11 @@ public class ShadowRoboNotificationManager extends ShadowNotificationManager {
    public static int lastNotifId;
 
    public static LinkedHashMap<Integer, PostedNotification> notifications = new LinkedHashMap<>();
+
+   private static ShadowRoboNotificationManager mInstance;
+   ShadowRoboNotificationManager() {
+      mInstance = this;
+   }
    
    @Override
    public void cancelAll() {
@@ -94,6 +103,18 @@ public class ShadowRoboNotificationManager extends ShadowNotificationManager {
       lastNotifId = id;
       notifications.put(id, new PostedNotification(id, lastNotif));
       super.notify(tag, id, notification);
+   }
+
+   public static @NonNull List<Notification> getNotificationsInGroup(@NonNull String group) {
+      List<Notification> notifications = new ArrayList<>();
+      for (Notification notification : mInstance.getAllNotifications()) {
+         if (NotificationCompat.isGroupSummary(notification))
+            continue;
+         if (!group.equals(notification.getGroup()))
+            continue;
+         notifications.add(notification);
+      }
+      return notifications;
    }
 
    public static NotificationChannel lastChannel;

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
@@ -94,7 +94,6 @@ import org.robolectric.android.controller.ServiceController;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowAlertDialog;
 import org.robolectric.shadows.ShadowLog;
-import org.robolectric.shadows.ShadowSystemClock;
 
 import java.lang.reflect.Field;
 import java.math.BigInteger;
@@ -107,6 +106,7 @@ import static com.onesignal.OneSignalPackagePrivateHelper.NotificationBundleProc
 import static com.onesignal.OneSignalPackagePrivateHelper.NotificationOpenedProcessor_processFromContext;
 import static com.onesignal.OneSignalPackagePrivateHelper.NotificationSummaryManager_updateSummaryNotificationAfterChildRemoved;
 import static com.onesignal.OneSignalPackagePrivateHelper.createInternalPayloadBundle;
+import static com.onesignal.ShadowRoboNotificationManager.getNotificationsInGroup;
 import static com.test.onesignal.RestClientAsserts.assertReportReceivedAtIndex;
 import static com.test.onesignal.RestClientAsserts.assertRestCalls;
 import static com.test.onesignal.TestHelpers.advanceSystemTimeBy;
@@ -327,51 +327,26 @@ public class GenerateNotificationRunner {
 
    @Test
    @Config(sdk = Build.VERSION_CODES.N)
-   public void testGetMostRecentNotifIdFromGroup() throws Exception {
-      OneSignal.setInFocusDisplaying(OneSignal.OSInFocusDisplayOption.Notification);
-      OneSignal.init(blankActivity, "123456789", "b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
+   public void testFourNotificationsUseProvidedGroup() throws Exception {
+      OneSignal.init(blankActivity.getApplicationContext(), "123456789", "b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
       threadAndTaskWait();
 
       // Add 4 grouped notifications
       postNotificationWithOptionalGroup(4, "test1");
 
-      SQLiteDatabase readableDb = OneSignalDbHelper.getInstance(blankActivity).getReadableDatabase();
-      // Grab the most recent timestamped notification from local DB
-      Integer mostRecentId = OneSignalNotificationManagerPackageHelper.getMostRecentNotifIdFromGroup(readableDb, "test1", false);
-
-      Map<Integer, PostedNotification> postedNotifs = ShadowRoboNotificationManager.notifications;
-      // Iterator is ordered by notification post (0 index is most recent)
-      Iterator<Map.Entry<Integer, PostedNotification>> postedNotifsIterator = postedNotifs.entrySet().iterator();
-      // First notification is the summary so we skip it and move on to the first normal notif
-      postedNotifsIterator.next();
-      Integer expectedId = postedNotifsIterator.next().getKey();
-
-      // Assert our id equals the first real notif id (most recent posted)
-      assertEquals(expectedId, mostRecentId);
+      assertEquals(4, getNotificationsInGroup("test1").size());
    }
 
    @Test
    @Config(sdk = Build.VERSION_CODES.N)
-   public void testGetMostRecentNotifIdFromGroupless() throws Exception {
-      OneSignal.setInFocusDisplaying(OneSignal.OSInFocusDisplayOption.Notification);
-      OneSignal.init(blankActivity, "123456789", "b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
+   public void testFourGrouplessNotificationsUseDefaultGroup() throws Exception {
+      OneSignal.init(blankActivity.getApplicationContext(), "123456789", "b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
       threadAndTaskWait();
 
       // Add 4 groupless notifications
       postNotificationWithOptionalGroup(4, null);
 
-      SQLiteDatabase readableDb = OneSignalDbHelper.getInstance(blankActivity).getReadableDatabase();
-      // Grab the most recent timestamped notification from local DB
-      Integer mostRecentId = OneSignalNotificationManagerPackageHelper.getMostRecentNotifIdFromGroup(readableDb, null, true);
-
-      Map<Integer, PostedNotification> postedNotifs = ShadowRoboNotificationManager.notifications;
-      // Iterator is ordered by notification post (0 index is most recent)
-      Iterator<Map.Entry<Integer, PostedNotification>> postedNotifsIterator = postedNotifs.entrySet().iterator();
-      // Grab first active notification since groupless won't have a summary
-      Integer expectedId = postedNotifsIterator.next().getKey();
-
-      // Assert our id equals the first real notif id (most recent posted)
-      assertEquals(expectedId, mostRecentId);
+      assertEquals(4, getNotificationsInGroup("os_group_undefined").size());
    }
 
     @Test
@@ -526,13 +501,11 @@ public class GenerateNotificationRunner {
       assertEquals(0, groupCount);
    }
 
-    public Bundle postNotificationWithOptionalGroup(int notifCount, String group) {
+    private @Nullable Bundle postNotificationWithOptionalGroup(int notifCount, @Nullable String group) {
        Bundle bundle = null;
        for (int i = 0; i < notifCount; i++) {
           bundle = getBaseNotifBundle("UUID" + i);
-
-          if (group != null)
-             bundle.putString("grp", group);
+          bundle.putString("grp", group);
 
           NotificationBundleProcessor_ProcessFromGCMIntentService(blankActivity, bundle, null);
        }

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
@@ -3826,11 +3826,7 @@ public class MainOneSignalClassRunner {
       class DebugGetTagsHandler implements OneSignal.GetTagsHandler {
          @Override
          public void tagsAvailable(JSONObject tags) {
-            try {
-               queue.put(true);
-            } catch (InterruptedException e) {
-               Assert.fail("Throw unexpected");
-            }
+            queue.offer(true);
          }
       }
 
@@ -3862,11 +3858,7 @@ public class MainOneSignalClassRunner {
             OneSignal.getTags(new OneSignal.GetTagsHandler() {
                @Override
                public void tagsAvailable(JSONObject tags) {
-                  try {
-                     queue.put(true);
-                  } catch (InterruptedException e) {
-                     Assert.fail("Throw unexpected");
-                  }
+                  queue.offer(true);
                }
             });
          }

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
@@ -3840,6 +3840,9 @@ public class MainOneSignalClassRunner {
       OneSignal.getTags(first);
       OneSignal.getTags(second);
       threadAndTaskWait();
+      // TODO: Need a clean up if this is stable
+      synchronized (first) { try { if (!first.executed) first.wait(); } catch (InterruptedException e) {} }
+      synchronized (second) { try { if (!second.executed) second.wait(); } catch (InterruptedException e) {} }
 
       assertTrue(first.executed);
       assertTrue(second.executed);
@@ -3857,7 +3860,10 @@ public class MainOneSignalClassRunner {
             OneSignal.getTags(new OneSignal.GetTagsHandler() {
                @Override
                public void tagsAvailable(JSONObject tags) {
-                  executed = true;
+                  synchronized (this) {
+                     executed = true;
+                     this.notifyAll();
+                  }
                }
             });
          }

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/OutcomeEventUnitTests.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/OutcomeEventUnitTests.java
@@ -348,7 +348,6 @@ public class OutcomeEventUnitTests {
         controller.sendUniqueOutcomeEvent(OUTCOME_NAME);
         controller.sendUniqueOutcomeEvent(OUTCOME_NAME);
         controller.sendUniqueOutcomeEvent(OUTCOME_NAME);
-
         threadAndTaskWait();
 
         new Thread(new Runnable() {
@@ -367,6 +366,7 @@ public class OutcomeEventUnitTests {
 
         controller.sendUniqueOutcomeEvent(OUTCOME_NAME);
         controller.sendUniqueOutcomeEvent(OUTCOME_NAME);
+        threadAndTaskWait();
 
         new Thread(new Runnable() {
             @Override


### PR DESCRIPTION
Fixing flaky tests;
1. `testNestedGetTags`
2.  `testGetMostRecentNotifIdFromGroup`
3. `shouldGetTagsFromServerOnFirstCallAndMergeLocalAndRemote` - WIP

### 1st commit
Fixed missing "OS_" prefix on REST success callback
1. both tests failed
### 2nd commit
Object wait and notify
1. both tests passed
2. one pass, other failed on a different test `testGetMostRecentNotifIdFromGroupless`
3. a. deadlock on `testNestedGetTags`
    b. `testGetMostRecentNotifIdFromGroup` failed

### 3rd commit
Switched to `BlockingQueue`
1. both tests passed
2. both tests passed
3. both tests passed
4. 1 passed, other failed on `shouldGetTagsFromServerOnFirstCallAndMergeLocalAndRemote`
5. 1 passed, other failed on `testGetMostRecentNotifIdFromGroup`
6. 1 passed, other failed on `testGetMostRecentNotifIdFromGroup`


### 4th commit
Fixed `testGetMostRecentNotifIdFromGroup` test and groupless
1. Passed

### 5th commit
Fixed missing "OS_" prefix on REST async threads

1. Both passed
2. Both passed
3. Both passed
4. 1 pass, failed on `testAppOnFocusAfterOnSessionCall`
5. both passed
6. both passed
7. both passed
8. both passed
9. both passed
10. both passed
11. both passed
12. 1 pass, `testUniqueOutcomeFailSavedOnDBResetSession` failed

### 6th commit
Fixed `testUniqueOutcomeFailSavedOnDBResetSession`

1. both passed
2. both passed
3. Running...

Details `testAppOnFocusAfterOnSessionCall`
```java
com.test.onesignal.MainOneSignalClassRunner > shouldSetSubscriptionCorrectlyEvenAfterFirstOneSignalRestInitFail PASSED
com.test.onesignal.MainOneSignalClassRunner > shouldAddEmailSubscriptionObserverIfConsentNotGranted STARTED
com.test.onesignal.MainOneSignalClassRunner > shouldAddEmailSubscriptionObserverIfConsentNotGranted PASSED
com.test.onesignal.MainOneSignalClassRunner > shouldGetTagsFromServerOnFirstCallAndMergeLocalAndRemote STARTED
com.test.onesignal.MainOneSignalClassRunner > shouldGetTagsFromServerOnFirstCallAndMergeLocalAndRemote PASSED
com.test.onesignal.MainOneSignalClassRunner > testAppOnFocusAfterOnSessionCall STARTED
com.test.onesignal.MainOneSignalClassRunner > testAppOnFocusAfterOnSessionCall FAILED
    junit.framework.AssertionFailedError
        at junit.framework.Assert.fail(Assert.java:55)
        at junit.framework.Assert.assertTrue(Assert.java:22)
        at junit.framework.Assert.assertTrue(Assert.java:31)
        at com.test.onesignal.MainOneSignalClassRunner.testAppOnFocusAfterOnSessionCall(MainOneSignalClassRunner.java:358)
```

Details for `shouldGetTagsFromServerOnFirstCallAndMergeLocalAndRemote`
```java
com.test.onesignal.MainOneSignalClassRunner > shouldSendTagsWithRequestBatching PASSED
com.test.onesignal.MainOneSignalClassRunner > shouldSetSubscriptionCorrectlyEvenAfterFirstOneSignalRestInitFail STARTED
com.test.onesignal.MainOneSignalClassRunner > shouldSetSubscriptionCorrectlyEvenAfterFirstOneSignalRestInitFail PASSED
com.test.onesignal.MainOneSignalClassRunner > shouldAddEmailSubscriptionObserverIfConsentNotGranted STARTED
com.test.onesignal.MainOneSignalClassRunner > shouldAddEmailSubscriptionObserverIfConsentNotGranted PASSED
com.test.onesignal.MainOneSignalClassRunner > shouldGetTagsFromServerOnFirstCallAndMergeLocalAndRemote STARTED

com.test.onesignal.MainOneSignalClassRunner > shouldGetTagsFromServerOnFirstCallAndMergeLocalAndRemote FAILED
    junit.framework.AssertionFailedError: expected:<3> but was:<2>
        at junit.framework.Assert.fail(Assert.java:57)
        at junit.framework.Assert.failNotEquals(Assert.java:329)
        at junit.framework.Assert.assertEquals(Assert.java:78)
        at junit.framework.Assert.assertEquals(Assert.java:234)
        at junit.framework.Assert.assertEquals(Assert.java:241)
        at com.test.onesignal.MainOneSignalClassRunner.shouldGetTagsFromServerOnFirstCallAndMergeLocalAndRemote(MainOneSignalClassRunner.java:2605)
```

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/867)
<!-- Reviewable:end -->
