### PR TITLE
Add a 2nd run of runOSThreads if first didn't find

### DIFF
--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/TestHelpers.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/TestHelpers.java
@@ -172,7 +172,8 @@ public class TestHelpers {
 
       boolean createdNewThread;
       do {
-         createdNewThread = runOSThreads();
+         // We run a 2nd time if we did not find any threads to ensure we don't skip any
+         createdNewThread = runOSThreads() || runOSThreads();
          
          boolean advancedRunnables = OneSignalPackagePrivateHelper.runAllNetworkRunnables();
          advancedRunnables = OneSignalPackagePrivateHelper.runFocusRunnables() || advancedRunnables;


### PR DESCRIPTION
* Add a 2nd run of runOSThreads if first didn't find any thread.

1. Both Passed
2. Both Passed
3. Both Passed
4. Both Passed
5. Both Passed
6. Both Passed
7. Both Passed
8.  Both Passed
9. Both Passed
10. 1 passed, 1 failed on `doesNotSendSameExternalId`
11. Both Passed
12. Both Passed
13. Both Passed
14. Both Passed
15. Both failed on first test `tesWriteWithNullContextAndSavesAfterSetting` due to stalling.
   - Don't think I have ever seen this before.
16. Both Passed

```java
com.test.onesignal.MainOneSignalClassRunner > shouldFirePermissionObserverWhenUserDisablesNotifications PASSED
com.test.onesignal.MainOneSignalClassRunner > ensureFailureOnPauseIsSentFromSyncService_forPendingActiveTime STARTED
com.test.onesignal.MainOneSignalClassRunner > ensureFailureOnPauseIsSentFromSyncService_forPendingActiveTime PASSED
com.test.onesignal.MainOneSignalClassRunner > doesNotSendSameExternalId STARTED
com.test.onesignal.MainOneSignalClassRunner > doesNotSendSameExternalId FAILED
    java.lang.IllegalArgumentException: Invalid UUID string: 
        at java.util.UUID.fromString(UUID.java:194)
        at com.test.onesignal.TypeAsserts.assertIsUUID(TypeAsserts.java:10)
        at com.test.onesignal.RestClientAsserts.assertHasAppId(RestClientAsserts.java:185)
        at com.test.onesignal.RestClientValidator.validateRequest(RestClientValidator.java:29)
        at com.onesignal.ShadowOneSignalRestClient.trackRequest(ShadowOneSignalRestClient.java:201)
        at com.onesignal.ShadowOneSignalRestClient.postSync(ShadowOneSignalRestClient.java:268)
        at com.onesignal.OneSignalRestClient.postSync(OneSignalRestClient.java)
        at com.onesignal.UserStateSynchronizer.doCreateOrNewSession(UserStateSynchronizer.java:328)
        at com.onesignal.UserStateSynchronizer.internalSyncUserState(UserStateSynchronizer.java:224)
        at com.onesignal.UserStateSynchronizer.syncUserState(UserStateSynchronizer.java:191)
        at com.onesignal.UserStateSynchronizer$NetworkHandlerThread$1.run(UserStateSynchronizer.java:88)
        at android.os.Handler.handleCallback(Handler.java:739)
        at android.os.Handler.dispatchMessage(Handler.java:95)
        at org.robolectric.shadows.ShadowMessageQueue.dispatchMessage(ShadowMessageQueue.java:144)
        at org.robolectric.shadows.ShadowMessageQueue.access$200(ShadowMessageQueue.java:35)
        at org.robolectric.shadows.ShadowMessageQueue$1.run(ShadowMessageQueue.java:123)
        at org.robolectric.util.Scheduler$ScheduledRunnable.run(Scheduler.java:386)
        at org.robolectric.util.Scheduler.runOneTask(Scheduler.java:278)
        at com.onesignal.OneSignalPackagePrivateHelper$1.run(OneSignalPackagePrivateHelper.java:51)
        at com.onesignal.OneSignalPackagePrivateHelper$1.run(OneSignalPackagePrivateHelper.java:46)
        at com.onesignal.OneSignalPackagePrivateHelper.processNetworkHandles(OneSignalPackagePrivateHelper.java:35)
        at com.onesignal.OneSignalPackagePrivateHelper.runAllNetworkRunnables(OneSignalPackagePrivateHelper.java:57)
        at com.test.onesignal.TestHelpers.threadAndTaskWait(TestHelpers.java:178)
        at com.test.onesignal.MainOneSignalClassRunner.doesNotSendSameExternalId(MainOneSignalClassRunner.java:3777)
```



<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/872)
<!-- Reviewable:end -->
