### PR TITLE
Fixes mix of android.support 26 and 28.

### DIFF
--- a/OneSignalSDK/onesignal/build.gradle
+++ b/OneSignalSDK/onesignal/build.gradle
@@ -30,24 +30,39 @@ android {
 
 // api || implementation = compile and runtime
 
+// KEEP: version ranges, these get used in the released POM file for maven central
 dependencies {
     compileOnly fileTree(dir: 'libs', include: ['*.jar'])
 
-    compileOnly 'com.google.android.gms:play-services-gcm:16.0.0'
+    // play-services-gcm:16.1.0 is the last version before going to AndroidX
+    // compileOnly as this is just for fallback code if FCM wasn't added to the project.
+    // Remove for 4.0.0 release
+    compileOnly 'com.google.android.gms:play-services-gcm:16.1.0'
+
+    // play-services-location:16.0.0 is the last version before going to AndroidX
     // Can be compileOnly in 4.0.0, can't change until then as some projects may rely on this
-    implementation 'com.google.android.gms:play-services-location:16.0.0'
-    implementation 'com.google.android.gms:play-services-ads-identifier:16.0.0'
+    implementation 'com.google.android.gms:play-services-location:[10.2.1, 16.0.99]'
+
+    // play-services-ads-identifier:15.0.0 first version
+    //   Classes used to live in play-services-base before this
+    // play-services-ads-identifier:16.0.0 is the last version before going to AndroidX
+    implementation 'com.google.android.gms:play-services-ads-identifier:[15.0.0, 16.0.99]'
+
+    // :play-services-base:16.1.0 is the last version before going to AndroidX
     // Required for GoogleApiAvailability
-    implementation 'com.google.android.gms:play-services-base:16.0.1'
+    implementation 'com.google.android.gms:play-services-base:[10.2.1, 16.1.99]'
 
-    api 'com.google.firebase:firebase-messaging:17.3.3'
+    // firebase-messaging:18.0.0 is the last version before going to AndroidX
+    // firebase-messaging:17.6.0 is the max version since we still have code looking for FirebaseInstanceIdService
+    api 'com.google.firebase:firebase-messaging:[10.2.1, 17.3.99]'
 
-    api 'com.android.support:cardview-v7:28.0.0'
-    api 'com.android.support:support-v4:28.0.0'
-    api 'com.android.support:customtabs:28.0.0'
-
-    // Change api to implementation. Need to check however this has any effect in production
-    //   projects that pull from maven.
+    // Keep under 28 until we switch to AndroidX
+    //   otherwise app can get dup classes between 26 & 28 when mixing these versions.
+    // Also note, firebase & gms libraries use android.support:26.
+    //   - They never refer to 27 or 28
+    api 'com.android.support:cardview-v7:[26.0.0, 27.99.99]'
+    api 'com.android.support:support-v4:[26.0.0, 27.99.99]'
+    api 'com.android.support:customtabs:[26.0.0, 27.99.99]'
 }
 
 apply from: 'maven-push.gradle'

--- a/OneSignalSDK/onesignal/maven-push.gradle
+++ b/OneSignalSDK/onesignal/maven-push.gradle
@@ -26,13 +26,6 @@ class Global {
     static def POM_PACKAGING = 'aar'
     static def VERSION_NAME = '3.12.1'
 
-    // Limit upper number (exclusive) to prevent untested versions
-    static def versionGroupOverrides = [
-        'com.google.android.gms': '[10.2.1, 16.1.0)',
-        'com.google.firebase': '[10.2.1, 16.1.0)',
-        'com.android.support': '[26.0.0, 28.1.0)'
-    ]
-
     static def GROUP_ID = 'com.onesignal'
     static def POM_DESCRIPTION = 'OneSignal Android SDK'
     static def POM_URL = 'https://github.com/one-signal/OneSignal-Android-SDK'
@@ -69,17 +62,6 @@ afterEvaluate { project ->
                 pom.groupId = Global.GROUP_ID
                 pom.artifactId = Global.POM_ARTIFACT_ID
                 pom.version = Global.VERSION_NAME
-
-                pom.withXml {
-                    asNode().dependencies.'*'.findAll() {
-                        def versionOverride = Global.versionGroupOverrides[it.groupId.text()]
-                        if (versionOverride) {
-                            it.version.replaceNode { node ->
-                                new Node(it, "version", versionOverride)
-                            }
-                        }
-                    }
-                }
 
                 repository(url: Global.RELEASE_REPOSITORY_URL) {
                     authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/PushRegistratorFCM.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/PushRegistratorFCM.java
@@ -52,6 +52,8 @@ class PushRegistratorFCM extends PushRegistratorAbstractGoogle {
    //      needs to be refreshed.
    // This checks for gcm_defaultSenderId in values.xml (normally added from google-services.json)
    // https://github.com/OneSignal/OneSignal-Android-SDK/issues/552
+   // TODO: FirebaseInstanceIdService was removed in firebase-messaging:18.0.0
+   //   Can remove this method once this is our minimum version
    static void disableFirebaseInstanceIdService(Context context) {
       String senderId = OSUtils.getResourceString(context, "gcm_defaultSenderId", null);
       int componentState =


### PR DESCRIPTION
* If a project didn't use it's own copy of android.support or AndroidX it would result in duplicated android.support classes
  - Due to a mixture of android.support from fcm & gms depending on 26 and OneSignal using 28.
* Removed version alignment from maven-push.gradle and move version ranges into onesignal/build.gradle.
  - As of Firebase & gms 16 versions aren't expected to line up any more.
* Added a number of comments to why specific version ranges are used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/879)
<!-- Reviewable:end -->
