### PR TITLE
Updated callback scenarios to return null within the success callback

### DIFF
--- a/OneSignalSDK/app/src/main/java/com/onesignal/MainActivity.java
+++ b/OneSignalSDK/app/src/main/java/com/onesignal/MainActivity.java
@@ -34,6 +34,7 @@ import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
+import android.support.annotation.Nullable;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -330,8 +331,9 @@ public class MainActivity extends Activity implements OSEmailSubscriptionObserve
    public void onSendOutcomeClicked(View view) {
       OneSignal.sendOutcome(outcomeName.getText().toString(), new OneSignal.OutcomeCallback() {
          @Override
-         public void onSuccess(OutcomeEvent outcomeEvent) {
-            updateTextView(outcomeEvent.toString());
+         public void onSuccess(@Nullable OutcomeEvent outcomeEvent) {
+            if (outcomeEvent != null)
+               updateTextView(outcomeEvent.toString());
          }
       });
    }
@@ -339,8 +341,9 @@ public class MainActivity extends Activity implements OSEmailSubscriptionObserve
    public void onSendUniqueOutcomeClicked(View view) {
       OneSignal.sendUniqueOutcome(outcomeUnique.getText().toString(), new OneSignal.OutcomeCallback() {
          @Override
-         public void onSuccess(OutcomeEvent outcomeEvent) {
-            updateTextView(outcomeEvent.toString());
+         public void onSuccess(@Nullable OutcomeEvent outcomeEvent) {
+            if (outcomeEvent != null)
+               updateTextView(outcomeEvent.toString());
          }
       });
    }
@@ -351,8 +354,9 @@ public class MainActivity extends Activity implements OSEmailSubscriptionObserve
 
       OneSignal.sendOutcomeWithValue(outcomeValueName.getText().toString(), Float.parseFloat(outcomeValue.getText().toString()), new OneSignal.OutcomeCallback() {
          @Override
-         public void onSuccess(OutcomeEvent outcomeEvent) {
-            updateTextView(outcomeEvent.toString());
+         public void onSuccess(@Nullable OutcomeEvent outcomeEvent) {
+            if (outcomeEvent != null)
+               updateTextView(outcomeEvent.toString());
          }
       });
    }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -3149,8 +3149,14 @@ public class OneSignal {
       return true;
    }
 
+   /**
+    * OutcomeEvent will be null in cases where the request was not sent:
+    *    1. OutcomeEvent cached already for re-attempt in future
+    *    2. Unique OutcomeEvent already sent for ATTRIBUTED session and notification(s)
+    *    3. Unique OutcomeEvent already sent for UNATTRIBUTED session during session
+    */
    public interface OutcomeCallback {
-      void onSuccess(OutcomeEvent outcomeEvent);
+      void onSuccess(@Nullable OutcomeEvent outcomeEvent);
    }
    /*
     * End OneSignalOutcome module

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OutcomeEventsController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OutcomeEventsController.java
@@ -122,6 +122,11 @@ class OutcomeEventsController {
                                 "\nSession: " + osSessionManager.getSession().toString() +
                                 "\nOutcome name: " + name +
                                 "\nnotificationIds: " + notificationIds);
+
+                // Return null within the callback to determine not a failure, but not a success in terms of the request made
+                if (callback != null)
+                    callback.onSuccess(null);
+
                 return;
             }
 
@@ -134,6 +139,11 @@ class OutcomeEventsController {
                         "Measure endpoint will not send because unique outcome already sent for: " +
                                 "\nSession: " + osSessionManager.getSession().toString() +
                                 "\nOutcome name: " + name);
+
+                // Return null within the callback to determine not a failure, but not a success in terms of the request made
+                if (callback != null)
+                    callback.onSuccess(null);
+
                 return;
             }
 
@@ -167,6 +177,7 @@ class OutcomeEventsController {
                 else
                     saveUnattributedUniqueOutcomeEvents();
 
+                // The only case where an actual success has occurred and the OutcomeEvent should be sent back
                 if (callback != null)
                     callback.onSuccess(outcomeEvent);
             }
@@ -186,6 +197,10 @@ class OutcomeEventsController {
                 OneSignal.onesignalLog(OneSignal.LOG_LEVEL.WARN,
                         "Sending outcome with name: " + name + " failed with status code: " + statusCode + " and response: " + response +
                                 "\nOutcome event was cached and will be reattempted on app cold start");
+
+                // Return null within the callback to determine not a failure, but not a success in terms of the request made
+                if (callback != null)
+                    callback.onSuccess(null);
             }
         };
 

--- a/OneSignalSDK/onesignal/src/unity/java/com/onesignal/OneSignalUnityProxy.java
+++ b/OneSignalSDK/onesignal/src/unity/java/com/onesignal/OneSignalUnityProxy.java
@@ -32,6 +32,8 @@ import android.app.Activity;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import android.support.annotation.Nullable;
+
 import com.onesignal.OneSignal.NotificationOpenedHandler;
 import com.onesignal.OneSignal.NotificationReceivedHandler;
 import com.onesignal.OneSignal.GetTagsHandler;
@@ -262,6 +264,42 @@ public class OneSignalUnityProxy implements
 
    public void pauseInAppMessages(boolean pause) {
       OneSignal.pauseInAppMessages(pause);
+   }
+
+   public void sendOutcome(String name) {
+      OneSignal.sendOutcome(name, new OneSignal.OutcomeCallback() {
+         @Override
+         public void onSuccess(@Nullable OutcomeEvent outcomeEvent) {
+            if (outcomeEvent == null)
+               unitySafeInvoke("onSendOutcomeSuccess", "");
+            else
+               unitySafeInvoke("onSendOutcomeSuccess", outcomeEvent.toJSONObject().toString());
+         }
+      });
+   }
+
+   public void sendUniqueOutcome(String name) {
+      OneSignal.sendUniqueOutcome(name, new OneSignal.OutcomeCallback() {
+         @Override
+         public void onSuccess(@Nullable OutcomeEvent outcomeEvent) {
+            if (outcomeEvent == null)
+               unitySafeInvoke("onSendOutcomeSuccess", "");
+            else
+               unitySafeInvoke("onSendOutcomeSuccess", outcomeEvent.toJSONObject().toString());
+         }
+      });
+   }
+
+   public void sendOutcomeWithValue(String name, float value) {
+      OneSignal.sendOutcomeWithValue(name, value, new OneSignal.OutcomeCallback() {
+         @Override
+         public void onSuccess(@Nullable OutcomeEvent outcomeEvent) {
+            if (outcomeEvent == null)
+               unitySafeInvoke("onSendOutcomeSuccess", "");
+            else
+               unitySafeInvoke("onSendOutcomeSuccess", outcomeEvent.toJSONObject().toString());
+         }
+      });
    }
 
    @Override


### PR DESCRIPTION
* In some wrapper SDKs await statements will hang no callback is sent back
* These scenarios include unique outcome for ATTRIBUTED sessions with notifications, UNATTRIBUTED sessions, and Failures
* Updated Unity Proxy to have public outcome methods exposed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/880)
<!-- Reviewable:end -->
