### PR TITLE
Fix player removed from backend bug

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalRestClient.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalRestClient.java
@@ -223,16 +223,17 @@ class OneSignalRestClient {
                if (inputStream == null)
                   inputStream = con.getInputStream();
 
+               String jsonResponse = null;
                if (inputStream != null) {
                   scanner = new Scanner(inputStream, "UTF-8");
-                  json = scanner.useDelimiter("\\A").hasNext() ? scanner.next() : "";
+                  jsonResponse = scanner.useDelimiter("\\A").hasNext() ? scanner.next() : "";
                   scanner.close();
-                  OneSignal.Log(OneSignal.LOG_LEVEL.WARN, "OneSignalRestClient: " + method + " RECEIVED JSON: " + json);
+                  OneSignal.Log(OneSignal.LOG_LEVEL.WARN, "OneSignalRestClient: " + method + " RECEIVED JSON: " + jsonResponse);
                }
                else
                   OneSignal.Log(OneSignal.LOG_LEVEL.WARN, "OneSignalRestClient: " + method + " HTTP Code: " + httpResponse + " No response body!");
 
-               callbackThread = callResponseHandlerOnFailure(responseHandler, httpResponse, null, null);
+               callbackThread = callResponseHandlerOnFailure(responseHandler, httpResponse, jsonResponse, null);
          }
       } catch (Throwable t) {
          if (t instanceof java.net.ConnectException || t instanceof java.net.UnknownHostException)

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/MockHttpURLConnection.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/MockHttpURLConnection.java
@@ -45,6 +45,7 @@ public class MockHttpURLConnection extends HttpURLConnection {
 
    public static class MockResponse {
       public String responseBody;
+      public String errorResponseBody;
       public boolean mockThreadHang;
       public int status;
       public Map<String, String> mockProps = new HashMap<>();
@@ -94,5 +95,14 @@ public class MockHttpURLConnection extends HttpURLConnection {
    @Override
    public InputStream getInputStream() throws IOException {
       return new ByteArrayInputStream(StandardCharsets.UTF_8.encode(mockResponse.responseBody).array());
+   }
+
+   @Override
+   public InputStream getErrorStream() {
+      if (mockResponse.errorResponseBody == null)
+         return null;
+
+      byte[] bytes = mockResponse.errorResponseBody.getBytes();
+      return new ByteArrayInputStream(bytes);
    }
 }

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/RESTClientRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/RESTClientRunner.java
@@ -191,6 +191,68 @@ public class RESTClientRunner {
       assertEquals(newMockResponse, secondResponse);
    }
 
+   @Test
+   public void testApiCall400Response() throws Exception {
+      final String newMockResponse = "{\"errors\":[\"test response\"]}";
+      final int statusCode = 400;
+
+      ShadowOneSignalRestClientWithMockConnection.mockResponse = new MockHttpURLConnection.MockResponse() {{
+         status = statusCode;
+         errorResponseBody = newMockResponse;
+      }};
+
+      final String[] failResponse = {null};
+      final int[] statusCodeResponse = {0};
+      OneSignalRestClient.postSync("URL", null, new OneSignalRestClient.ResponseHandler() {
+         @Override
+         public void onSuccess(String response) {
+            super.onSuccess(response);
+         }
+
+         @Override
+         public void onFailure(int statusCode, String response, Throwable throwable) {
+            super.onFailure(statusCode, response, throwable);
+            failResponse[0] = response;
+            statusCodeResponse[0] = statusCode;
+         }
+      });
+
+      threadAndTaskWait();
+      assertEquals(newMockResponse, failResponse[0]);
+      assertEquals(statusCode, statusCodeResponse[0]);
+   }
+
+   @Test
+   public void testApiCall400EmptyResponse() throws Exception {
+      final String newMockResponse = "";
+      final int statusCode = 400;
+
+      ShadowOneSignalRestClientWithMockConnection.mockResponse = new MockHttpURLConnection.MockResponse() {{
+         status = statusCode;
+         responseBody = newMockResponse;
+      }};
+
+      final String[] failResponse = {null};
+      final int[] statusCodeResponse = {0};
+      OneSignalRestClient.postSync("URL", null, new OneSignalRestClient.ResponseHandler() {
+         @Override
+         public void onSuccess(String response) {
+            super.onSuccess(response);
+         }
+
+         @Override
+         public void onFailure(int statusCode, String response, Throwable throwable) {
+            super.onFailure(statusCode, response, throwable);
+            failResponse[0] = response;
+            statusCodeResponse[0] = statusCode;
+         }
+      });
+
+      threadAndTaskWait();
+      assertEquals(newMockResponse, failResponse[0]);
+      assertEquals(statusCode, statusCodeResponse[0]);
+   }
+
    private static String getLastHTTPHeaderProp(String prop) {
       return ShadowOneSignalRestClientWithMockConnection.lastConnection.getRequestProperty(prop);
    }


### PR DESCRIPTION
  * If the player is removed from the backend then the player should be re-created
  * Fix by returning json response to handler
  * Add test to cover passing data to handler

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/888)
<!-- Reviewable:end -->
