### PR TITLE
Updated to Robolectric 4.3.1

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalPrefs.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalPrefs.java
@@ -35,7 +35,6 @@ import android.os.HandlerThread;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Set;
 
@@ -111,11 +110,14 @@ class OneSignalPrefs {
 
         WritePrefHandlerThread(String name) {
             super(name);
-            start();
-            mHandler = new Handler(getLooper());
         }
 
         void startDelayedWrite() {
+            if (mHandler == null) {
+                start();
+                mHandler = new Handler(getLooper());
+            }
+
             synchronized (mHandler) {
                 mHandler.removeCallbacksAndMessages(null);
                 if (lastSyncTime == 0)

--- a/OneSignalSDK/unittest/build.gradle
+++ b/OneSignalSDK/unittest/build.gradle
@@ -47,6 +47,6 @@ dependencies {
     implementation 'com.google.firebase:firebase-core:16.0.4'
 
     testImplementation 'junit:junit:4.12'
-    testImplementation 'org.robolectric:robolectric:4.0'
+    testImplementation 'org.robolectric:robolectric:4.3.1'
     testImplementation 'org.awaitility:awaitility:3.1.5'
 }

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/OneSignalPrefsRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/OneSignalPrefsRunner.java
@@ -66,6 +66,6 @@ public class OneSignalPrefsRunner {
 
       final SharedPreferences prefs = blankActivity.getSharedPreferences(OneSignalPrefs.PREFS_ONESIGNAL, Context.MODE_PRIVATE);
       String value = prefs.getString("key", "");
-      assertEquals(value, "value");
+      assertEquals("value", value);
    }
 }


### PR DESCRIPTION
* Robolectric upgrade fixes issue running tests on Windows.
* Fixed looper compatibility issues with OneSignalPrefs.java.
* Removed no longer needed Looper.prepareMainLooper() before tests
* Misc clean up to runOSThreads.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/891)
<!-- Reviewable:end -->
