### PR TITLE
Create new player if missing player_id on put

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSSubscriptionState.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSSubscriptionState.java
@@ -28,6 +28,8 @@
 package com.onesignal;
 
 
+import android.support.annotation.Nullable;
+
 import org.json.JSONObject;
 
 public class OSSubscriptionState implements Cloneable {
@@ -64,8 +66,13 @@ public class OSSubscriptionState implements Cloneable {
       setAccepted(state.getEnabled());
    }
    
-   void setUserId(String id) {
-      boolean changed = !id.equals(userId);
+   void setUserId(@Nullable String id) {
+      boolean changed = false;
+      if (id == null)
+         changed = userId != null;
+      else if (!id.equals(userId))
+         changed = true;
+
       userId = id;
       if (changed)
          observable.notifyChange(this);

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStateSynchronizer.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStateSynchronizer.java
@@ -478,8 +478,10 @@ abstract class UserStateSynchronizer {
     abstract void setSubscription(boolean enable);
 
     private void handlePlayerDeletedFromServer() {
+        OneSignal.Log(OneSignal.LOG_LEVEL.WARN, "Creating new player based on missing player_id noted above.");
         OneSignal.handleSuccessfulEmailLogout();
         resetCurrentState();
+        updateIdDependents(null);
         scheduleSyncToServer();
     }
 


### PR DESCRIPTION
* If we get a "No user with this id found" message on any player update make a follow up player create call.
* There was handling for this already but it was not making a player create until a new session
  - Test was incorrectly just checking for a player call without checking the endpoint which is now fixed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/892)
<!-- Reviewable:end -->
