### PR TITLE
Fix to make sure the opened handler is fired after OneSignal SDK setup

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -2079,14 +2079,14 @@ public class OneSignal {
       if (!defaultOpenActionDisabled)
          urlOpened = openURLFromNotification(inContext, data);
 
-      runNotificationOpenedCallback(data, true, fromAlert);
-
       // Check if the notification click should lead to a DIRECT session
       if (shouldInitDirectSessionFromNotificationOpen(inContext, fromAlert, urlOpened, defaultOpenActionDisabled)) {
          // We want to set the app entry state to NOTIFICATION_CLICK when coming from background
          appEntryState = AppEntryAction.NOTIFICATION_CLICK;
          sessionManager.onDirectSessionFromNotificationOpen(notificationId);
       }
+
+      runNotificationOpenedCallback(data, true, fromAlert);
    }
 
    static boolean startOrResumeApp(Context inContext) {


### PR DESCRIPTION
* We were not setting the sessionManager to the correct session on notification click
* Now we fire the callback for opened notifications after all OneSignal work is done
* Unit test written to make sure sending outcomes from opened handler works correctly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/906)
<!-- Reviewable:end -->
