### PR TITLE
When prompting for permissions, we use a PermissionActivity

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/PermissionsActivity.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/PermissionsActivity.java
@@ -73,6 +73,7 @@ public class PermissionsActivity extends Activity {
       // Activity maybe invoked directly through automated testing, omit prompting on old Android versions.
       if (Build.VERSION.SDK_INT < 23) {
          finish();
+         overridePendingTransition(R.anim.onesignal_fade_in, R.anim.onesignal_fade_out);
          return;
       }
 
@@ -96,6 +97,7 @@ public class PermissionsActivity extends Activity {
 
       ActivityLifecycleHandler.removeActivityAvailableListener(TAG);
       finish();
+      overridePendingTransition(R.anim.onesignal_fade_in, R.anim.onesignal_fade_out);
    }
 
 
@@ -110,6 +112,7 @@ public class PermissionsActivity extends Activity {
                Intent intent = new Intent(activity, PermissionsActivity.class);
                intent.setFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
                activity.startActivity(intent);
+               activity.overridePendingTransition(R.anim.onesignal_fade_in, R.anim.onesignal_fade_out);
             }
          }
       };

--- a/OneSignalSDK/onesignal/src/main/res/anim/onesignal_fade_in.xml
+++ b/OneSignalSDK/onesignal/src/main/res/anim/onesignal_fade_in.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<alpha xmlns:android="http://schemas.android.com/apk/res/android"
+    android:interpolator="@android:interpolator/accelerate_decelerate"
+    android:fromAlpha="0.0"
+    android:toAlpha="1.0"
+    android:duration="0" />

--- a/OneSignalSDK/onesignal/src/main/res/anim/onesignal_fade_out.xml
+++ b/OneSignalSDK/onesignal/src/main/res/anim/onesignal_fade_out.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<alpha xmlns:android="http://schemas.android.com/apk/res/android"
+    android:interpolator="@android:interpolator/accelerate_decelerate"
+    android:fromAlpha="1.0"
+    android:toAlpha="0.0"
+    android:duration="0" />

--- a/OneSignalSDK/onesignal/src/main/res/raw/consumer_onesignal_keep.xml
+++ b/OneSignalSDK/onesignal/src/main/res/raw/consumer_onesignal_keep.xml
@@ -4,7 +4,12 @@
      Also documented file names to use as defaults. -->
 <!-- onesignal_bgimage_notif_layout is always kept as it's id used directly in code.  -->
 <resources xmlns:tools="http://schemas.android.com/tools"
-           tools:keep="@drawable/ic_os_notification_fallback_white_24dp,@drawable/ic_stat_onesignal_default,@drawable/ic_onesignal_large_icon_default,@raw/onesignal_default_sound"
+           tools:keep="@anim/onesignal_fade_in,
+                       @anim/onesignal_fade_out,
+                       @drawable/ic_os_notification_fallback_white_24dp,
+                       @drawable/ic_stat_onesignal_default,
+                       @drawable/ic_onesignal_large_icon_default,
+                       @raw/onesignal_default_sound"
            tools:discard="@raw/consumer_onesignal_keep" />
 
 <!-- Discard above doesn't seem to be working, file is added to .APK anyway but is only a packed size of 47 bytes.


### PR DESCRIPTION
* This is not a fully built out tool, but it is working for location currently
  * Eventually we may be able to use this for other permission prompts as well

* The issue was the default transition from current activity to our PermissionActivity
* This is now fixed by creating a 0s duration anim for fading in and fading out of the activity

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/920)
<!-- Reviewable:end -->
