### PR TITLE
Update API URL to circumvent block in Egypt

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalRestClient.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalRestClient.java
@@ -50,7 +50,7 @@ class OneSignalRestClient {
    static final String CACHE_KEY_GET_TAGS = "CACHE_KEY_GET_TAGS";
    static final String CACHE_KEY_REMOTE_PARAMS = "CACHE_KEY_REMOTE_PARAMS";
    
-   private static final String BASE_URL = "https://onesignal.com/api/v1/";
+   private static final String BASE_URL = "https://api.onesignal.com/v1/";
    
    private static final int THREAD_ID = 10000;
    private static final int TIMEOUT = 120_000;


### PR DESCRIPTION
It appears that subdomains of onesignal.com are not blocked by the Egyptian ISP TE Data (also known as WE)

Fixes #919, #883, #859, #855, #849, #847

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/924)
<!-- Reviewable:end -->
