### PR TITLE
Added null check to fix `NullPointerException` being thrown

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSViewUtils.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSViewUtils.java
@@ -11,6 +11,7 @@ import android.support.annotation.NonNull;
 import android.util.DisplayMetrics;
 import android.view.View;
 import android.view.Window;
+import android.view.WindowInsets;
 
 import java.lang.ref.WeakReference;
 
@@ -91,12 +92,13 @@ class OSViewUtils {
     private static int getWindowHeightAPI23Plus(@NonNull Activity activity) {
         View decorView = activity.getWindow().getDecorView();
         // Use use stable heights as SystemWindowInset subtracts the keyboard
-        if (decorView.getRootWindowInsets() == null)
+        WindowInsets windowInsets = decorView.getRootWindowInsets();
+        if (windowInsets == null)
             return decorView.getHeight();
 
         return decorView.getHeight() -
-               decorView.getRootWindowInsets().getStableInsetBottom() -
-               decorView.getRootWindowInsets().getStableInsetTop();
+               windowInsets.getStableInsetBottom() -
+               windowInsets.getStableInsetTop();
     }
 
     private static int getWindowHeightLollipop(@NonNull Activity activity) {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSViewUtils.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSViewUtils.java
@@ -91,11 +91,12 @@ class OSViewUtils {
     private static int getWindowHeightAPI23Plus(@NonNull Activity activity) {
         View decorView = activity.getWindow().getDecorView();
         // Use use stable heights as SystemWindowInset subtracts the keyboard
-        int heightWithoutKeyboard =
-           decorView.getHeight() -
-           decorView.getRootWindowInsets().getStableInsetBottom() -
-           decorView.getRootWindowInsets().getStableInsetTop();
-        return heightWithoutKeyboard;
+        if (decorView.getRootWindowInsets() == null)
+            return decorView.getHeight();
+
+        return decorView.getHeight() -
+               decorView.getRootWindowInsets().getStableInsetBottom() -
+               decorView.getRootWindowInsets().getStableInsetTop();
     }
 
     private static int getWindowHeightLollipop(@NonNull Activity activity) {


### PR DESCRIPTION
* getRootWindowInsets() from `Activity` `DecorView` is null some cases (most likely when opening the app from cold start)
* null check will now return early with the decorView height instead of the difference of the height, top inset, and bottom inset

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/931)
<!-- Reviewable:end -->
