### PR TITLE
Add synchronized to startDelayedWrite to solve #917

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalPrefs.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalPrefs.java
@@ -112,7 +112,7 @@ class OneSignalPrefs {
             super(name);
         }
 
-        void startDelayedWrite() {
+        synchronized void startDelayedWrite() {
             if (mHandler == null) {
                 start();
                 mHandler = new Handler(getLooper());


### PR DESCRIPTION
* This will prevent multiple calls to `startDelayedWrite` and prevent any `IllegalStateExceptions`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/932)
<!-- Reviewable:end -->
