### PR TITLE
Added a `try-catch` to the getDecorView line in `setCurActivity`

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/ActivityLifecycleHandler.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/ActivityLifecycleHandler.java
@@ -92,11 +92,18 @@ class ActivityLifecycleHandler {
             entry.getValue().available(curActivity);
         }
 
-        ViewTreeObserver treeObserver = curActivity.getWindow().getDecorView().getViewTreeObserver();
-        for (Map.Entry<String, OSSystemConditionController.OSSystemConditionObserver> entry : sSystemConditionObservers.entrySet()) {
-            KeyboardListener keyboardListener = new KeyboardListener(entry.getValue(), entry.getKey());
-            treeObserver.addOnGlobalLayoutListener(keyboardListener);
-            sKeyboardListeners.put(entry.getKey(), keyboardListener);
+        try {
+            ViewTreeObserver treeObserver = curActivity.getWindow().getDecorView().getViewTreeObserver();
+            for (Map.Entry<String, OSSystemConditionController.OSSystemConditionObserver> entry : sSystemConditionObservers.entrySet()) {
+                KeyboardListener keyboardListener = new KeyboardListener(entry.getValue(), entry.getKey());
+                treeObserver.addOnGlobalLayoutListener(keyboardListener);
+                sKeyboardListeners.put(entry.getKey(), keyboardListener);
+            }
+        } catch (RuntimeException e) {
+            // Related to Unity Issue #239 on Github
+            // https://github.com/OneSignal/OneSignal-Unity-SDK/issues/239
+            // RuntimeException at ActivityLifecycleHandler.setCurActivity on Android (Unity 2.9.0)
+            e.printStackTrace();
         }
     }
 


### PR DESCRIPTION
* In a unity issue (#239) this was reported with no chance of reproducing it

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/933)
<!-- Reviewable:end -->
