### PR TITLE
Crash reported by several people pointing null from `getTags` success

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalStateSynchronizer.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalStateSynchronizer.java
@@ -27,7 +27,6 @@
 
 package com.onesignal;
 
-import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import org.json.JSONException;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStatePushSynchronizer.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStatePushSynchronizer.java
@@ -27,6 +27,13 @@ class UserStatePushSynchronizer extends UserStateSynchronizer {
                 @Override
                 void onSuccess(String responseStr) {
                     serverSuccess = true;
+
+                    // This should not typically come from the server as null or empty, but due to Issue #904
+                    // This check is added and will prevent further crashes
+                    // https://github.com/OneSignal/OneSignal-Android-SDK/issues/904
+                    if (responseStr == null || responseStr.isEmpty())
+                        responseStr = "{}";
+
                     try {
                         JSONObject lastGetTagsResponse = new JSONObject(responseStr);
                         if (lastGetTagsResponse.has("tags")) {


### PR DESCRIPTION
* Added null and empty check for `getTags` response and assign to empty json string if necessary

Closes #904 
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/934)
<!-- Reviewable:end -->
