### PR TITLE
Fixing issue #650 - locked thread between location and user sync

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/FocusTimeController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/FocusTimeController.java
@@ -66,7 +66,7 @@ class FocusTimeController {
       if (OneSignal.isForeground())
          return;
 
-      for(FocusTimeProcessorBase focusTimeProcessor : focusTimeProcessors)
+      for (FocusTimeProcessorBase focusTimeProcessor : focusTimeProcessors)
          focusTimeProcessor.syncUnsentTimeFromSyncJob();
    }
 
@@ -75,7 +75,7 @@ class FocusTimeController {
       if (timeElapsed == null)
         return false;
 
-      for(FocusTimeProcessorBase focusTimeProcessor : focusTimeProcessors)
+      for (FocusTimeProcessorBase focusTimeProcessor : focusTimeProcessors)
          focusTimeProcessor.addTime(timeElapsed, lastSessionResult.session, focusType);
       return true;
    }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/LocationGMS.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/LocationGMS.java
@@ -311,6 +311,9 @@ class LocationGMS {
          synchronized (syncLock) {
             PermissionsActivity.answered = false;
 
+            if (mGoogleApiClient == null || mGoogleApiClient.realInstance() == null)
+               return;
+
             if (mLastLocation == null) {
                mLastLocation = FusedLocationApiWrapper.getLastLocation(mGoogleApiClient.realInstance());
                if (mLastLocation != null)

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalSyncServiceUtils.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalSyncServiceUtils.java
@@ -217,7 +217,7 @@ class OneSignalSyncServiceUtils {
          // Issue #650
          // https://github.com/OneSignal/OneSignal-Android-SDK/issues/650
          try {
-            final BlockingQueue<LocationGMS.LocationPoint> queue = new ArrayBlockingQueue<>(1);
+            final BlockingQueue<Object> queue = new ArrayBlockingQueue<>(1);
             LocationGMS.LocationHandler locationHandler = new LocationGMS.LocationHandler() {
                @Override
                public LocationGMS.CALLBACK_TYPE getType() {
@@ -226,15 +226,16 @@ class OneSignalSyncServiceUtils {
 
                @Override
                public void complete(LocationGMS.LocationPoint point) {
-                  queue.offer(point);
+                  Object object = point != null ?  point : new Object();
+                  queue.offer(object);
                }
             };
             LocationGMS.getLocation(OneSignal.appContext, false, locationHandler);
 
             // The take() will return the offered point once the callback for the locationHandler is completed
-            LocationGMS.LocationPoint point = queue.take();
-            if (point != null)
-               OneSignalStateSynchronizer.updateLocation(point);
+            Object point = queue.take();
+            if (point instanceof LocationGMS.LocationPoint)
+               OneSignalStateSynchronizer.updateLocation((LocationGMS.LocationPoint) point);
 
          } catch (InterruptedException e) {
             e.printStackTrace();


### PR DESCRIPTION
* SyncUserState was moving on and causing a thread lock with the complete() LocationGMS work
* BlockingQueue used to make sure that the complete() callback is completely finished before moving on

Closes #650

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/935)
<!-- Reviewable:end -->
