### PR TITLE
Added try-catch and logging for future stacktraces

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationChannelManager.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationChannelManager.java
@@ -174,7 +174,17 @@ class NotificationChannelManager {
       channel.setShowBadge(payload.optInt("bdg", 1) == 1);
       channel.setBypassDnd(payload.optInt("bdnd", 0) == 1);
 
-      notificationManager.createNotificationChannel(channel);
+      OneSignal.onesignalLog(OneSignal.LOG_LEVEL.VERBOSE, "Creating notification channel with channel:\n" + channel.toString());
+      try {
+         notificationManager.createNotificationChannel(channel);
+      } catch (IllegalArgumentException e) {
+         // TODO: Remove this try-catch once it is figured out which argument is causing Issue #895
+         //    try-catch added to prevent crashing from the illegal argument
+         //    Added logging above this try-catch so we can evaluate the payload of the next victim
+         //    to report a stacktrace
+         //    https://github.com/OneSignal/OneSignal-Android-SDK/issues/895
+         e.printStackTrace();
+      }
       return channel_id;
    }
    


### PR DESCRIPTION
* No way of knowing exactly what argument is causing this issue
  * The NotificationChannel is bundled with lots of attributes and one of them is causing a conflict inside of the `NotificationChannel`'s `createChannelNotification` method
* Added logging for future evaluation
* Added try-catch to prevent crashing

Related to #895 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/939)
<!-- Reviewable:end -->
