### PR TITLE
Adds new required params to FirebaseApp.init

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalRemoteParams.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalRemoteParams.java
@@ -1,6 +1,7 @@
 package com.onesignal;
 
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -9,6 +10,12 @@ import org.json.JSONObject;
 import java.net.HttpURLConnection;
 
 class OneSignalRemoteParams {
+
+   static class FCMParams {
+      @Nullable String projectId;
+      @Nullable String appId;
+      @Nullable String apiKey;
+   }
 
    static class OutcomesParams {
       //in minutes
@@ -29,6 +36,7 @@ class OneSignalRemoteParams {
       boolean clearGroupOnSummaryClick;
       boolean receiveReceiptEnabled;
       OutcomesParams outcomesParams;
+      FCMParams fcmParams;
    }
 
    interface CallBack {
@@ -43,6 +51,11 @@ class OneSignalRemoteParams {
    private static final String INDIRECT_PARAM = "indirect";
    private static final String NOTIFICATION_ATTRIBUTION_PARAM = "notification_attribution";
    private static final String UNATTRIBUTED_PARAM = "unattributed";
+
+   private static final String FCM_PARENT_PARAM = "fcm";
+   private static final String FCM_PROJECT_ID = "project_id";
+   private static final String FCM_APP_ID = "app_id";
+   private static final String FCM_API_KEY = "api_key";
 
    private static final int INCREASE_BETWEEN_RETRIES = 10_000;
    private static final int MIN_WAIT_BETWEEN_RETRIES = 30_000;
@@ -109,8 +122,8 @@ class OneSignalRemoteParams {
          googleProjectNumber = responseJson.optString("android_sender_id", null);
          clearGroupOnSummaryClick = responseJson.optBoolean("clear_group_on_summary_click", true);
          receiveReceiptEnabled = responseJson.optBoolean("receive_receipts_enable", false);
-         outcomesParams = new OutcomesParams();
 
+         outcomesParams = new OutcomesParams();
          // Process outcomes params
          if (responseJson.has(OUTCOME_PARAM)) {
             JSONObject outcomes = responseJson.optJSONObject(OUTCOME_PARAM);
@@ -133,6 +146,14 @@ class OneSignalRemoteParams {
                JSONObject unattributed = outcomes.optJSONObject(UNATTRIBUTED_PARAM);
                outcomesParams.unattributedEnabled = unattributed.optBoolean(ENABLED_PARAM);
             }
+         }
+
+         fcmParams = new FCMParams();
+         if (responseJson.has(FCM_PARENT_PARAM)) {
+            JSONObject fcm = responseJson.optJSONObject(FCM_PARENT_PARAM);
+            fcmParams.apiKey = fcm.optString(FCM_API_KEY, null);
+            fcmParams.appId = fcm.optString(FCM_APP_ID, null);
+            fcmParams.projectId = fcm.optString(FCM_PROJECT_ID, null);
          }
       }};
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/PushRegistratorFCM.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/PushRegistratorFCM.java
@@ -30,6 +30,7 @@ package com.onesignal;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.pm.PackageManager;
+import android.support.annotation.NonNull;
 
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
@@ -42,6 +43,10 @@ import com.google.firebase.messaging.FirebaseMessaging;
 //   used instead.
 
 class PushRegistratorFCM extends PushRegistratorAbstractGoogle {
+
+   private static final String FCM_DEFAULT_PROJECT_ID = "onesignal-shared-public"; // project_info.project_id
+   private static final String FCM_DEFAULT_APP_ID = "1:754795614042:android:c682b8144a8dd52bc1ad63"; // client.client_info.mobilesdk_app_id
+   private static final String FCM_DEFAULT_API_KEY = "AIzaSyAnTLn5-_4Mc2a2P-dKUeE-aBtgyCrjlYU"; // client.api_key.current_key
 
    private static final String FCM_APP_NAME = "ONESIGNAL_SDK_FCM_APP_NAME";
 
@@ -92,9 +97,28 @@ class PushRegistratorFCM extends PushRegistratorAbstractGoogle {
       FirebaseOptions firebaseOptions =
          new FirebaseOptions.Builder()
             .setGcmSenderId(senderId)
-            .setApplicationId("OMIT_ID")
-            .setApiKey("OMIT_KEY")
+            .setApplicationId(getAppId())
+            .setApiKey(getApiKey())
+            .setProjectId(getProjectId())
             .build();
       firebaseApp = FirebaseApp.initializeApp(OneSignal.appContext, firebaseOptions, FCM_APP_NAME);
+   }
+
+   private static @NonNull String getAppId() {
+      if (OneSignal.remoteParams.fcmParams.appId != null)
+         return OneSignal.remoteParams.fcmParams.appId;
+      return FCM_DEFAULT_APP_ID;
+   }
+
+   private static @NonNull String getApiKey() {
+      if (OneSignal.remoteParams.fcmParams.apiKey != null)
+         return OneSignal.remoteParams.fcmParams.apiKey;
+      return FCM_DEFAULT_API_KEY;
+   }
+
+   private static @NonNull String getProjectId() {
+      if (OneSignal.remoteParams.fcmParams.projectId != null)
+         return OneSignal.remoteParams.fcmParams.projectId;
+      return FCM_DEFAULT_PROJECT_ID;
    }
 }


### PR DESCRIPTION
* Added required values to setApplicationId, setApiKey, and setProjectId that is used with FirebaseOptions.Builder
* Added static defaults, with the option to override later via remote params.


@andirayo
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/960)
<!-- Reviewable:end -->
