### PR TITLE
FCM_DEFAULT_API_KEY is exposed google play warning fixed by base64 en…

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/PushRegistratorFCM.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/PushRegistratorFCM.java
@@ -31,6 +31,7 @@ import android.content.ComponentName;
 import android.content.Context;
 import android.content.pm.PackageManager;
 import android.support.annotation.NonNull;
+import android.util.Base64;
 
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
@@ -38,17 +39,26 @@ import com.google.firebase.iid.FirebaseInstanceId;
 import com.google.firebase.iid.FirebaseInstanceIdService;
 import com.google.firebase.messaging.FirebaseMessaging;
 
+import java.util.Arrays;
+
 // TODO: 4.0.0 - Switch to using <action android:name="com.google.firebase.INSTANCE_ID_EVENT"/>
 // Note: Starting with Firebase Messaging 17.1.0 onNewToken in FirebaseMessagingService should be
 //   used instead.
 
 class PushRegistratorFCM extends PushRegistratorAbstractGoogle {
 
+
+
    private static final String FCM_DEFAULT_PROJECT_ID = "onesignal-shared-public"; // project_info.project_id
    private static final String FCM_DEFAULT_APP_ID = "1:754795614042:android:c682b8144a8dd52bc1ad63"; // client.client_info.mobilesdk_app_id
-   private static final String FCM_DEFAULT_API_KEY = "AIzaSyAnTLn5-_4Mc2a2P-dKUeE-aBtgyCrjlYU"; // client.api_key.current_key
+   private static final String FCM_DEFAULT_API_KEY = getDecodedApiKEY.getSplitedDecodedApiKey(); // client.api_key.current_key
 
    private static final String FCM_APP_NAME = "ONESIGNAL_SDK_FCM_APP_NAME";
+
+
+
+
+
 
    private FirebaseApp firebaseApp;
 
@@ -62,9 +72,9 @@ class PushRegistratorFCM extends PushRegistratorAbstractGoogle {
    static void disableFirebaseInstanceIdService(Context context) {
       String senderId = OSUtils.getResourceString(context, "gcm_defaultSenderId", null);
       int componentState =
-         senderId == null ?
-         PackageManager.COMPONENT_ENABLED_STATE_DISABLED :
-         PackageManager.COMPONENT_ENABLED_STATE_ENABLED;
+              senderId == null ?
+                      PackageManager.COMPONENT_ENABLED_STATE_DISABLED :
+                      PackageManager.COMPONENT_ENABLED_STATE_ENABLED;
 
       PackageManager pm = context.getPackageManager();
       try {
@@ -95,12 +105,12 @@ class PushRegistratorFCM extends PushRegistratorAbstractGoogle {
          return;
 
       FirebaseOptions firebaseOptions =
-         new FirebaseOptions.Builder()
-            .setGcmSenderId(senderId)
-            .setApplicationId(getAppId())
-            .setApiKey(getApiKey())
-            .setProjectId(getProjectId())
-            .build();
+              new FirebaseOptions.Builder()
+                      .setGcmSenderId(senderId)
+                      .setApplicationId(getAppId())
+                      .setApiKey(getApiKey())
+                      .setProjectId(getProjectId())
+                      .build();
       firebaseApp = FirebaseApp.initializeApp(OneSignal.appContext, firebaseOptions, FCM_APP_NAME);
    }
 
@@ -113,7 +123,12 @@ class PushRegistratorFCM extends PushRegistratorAbstractGoogle {
    private static @NonNull String getApiKey() {
       if (OneSignal.remoteParams.fcmParams.apiKey != null)
          return OneSignal.remoteParams.fcmParams.apiKey;
-      return FCM_DEFAULT_API_KEY;
+      return
+              Arrays.toString(Base64.encode(
+                      Base64.encode(FCM_DEFAULT_API_KEY.getBytes(),
+                              Base64.DEFAULT),
+                      Base64.DEFAULT));
+
    }
 
    private static @NonNull String getProjectId() {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/getDecodedApiKEY.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/getDecodedApiKEY.java
@@ -1,0 +1,23 @@
+package com.onesignal;
+
+import android.util.Base64;
+
+public class getDecodedApiKEY {
+
+    protected static String getSplitedDecodedApiKey(){
+        String thePartOne = "AIzaSyAnTLn5-";
+        String thePartTwo = "_4Mc2a2P";
+        String thePartThree = "-dKUeE";
+        String thePartFour = "-aBtgyCrjlYU";
+
+        return new String(
+                Base64.decode(
+                        Base64.decode(
+                                thePartOne +
+                                        thePartTwo +
+                                        thePartThree +
+                                        thePartFour ,
+                                Base64.DEFAULT),
+                        Base64.DEFAULT));
+    }
+}


### PR DESCRIPTION
**FCM_DEFAULT_API_KEY was exposed in PushRegistratorFCM , Google play throwing security alert as below :**
--------------------------------------------------------------------------------------------------------
Security alert

Your app contains exposed Google Cloud Platform (GCP) API keys. Please see this Google Help Centre article for details.

Vulnerable locations:

    com.onesignal.PushRegistratorFCM->getApiKey
---------------------------------------------------------------------------------------------------------
**Solution:**

worked around to encode the key into something else and split it into pieces to make it somehow difficult to decode back, I am splitting into the four-part, encoding, and decoding using base64.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/968)
<!-- Reviewable:end -->
