### PR TITLE
Fixed false positive FCM warning

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/PushRegistratorFCM.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/PushRegistratorFCM.java
@@ -30,6 +30,8 @@ package com.onesignal;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.pm.PackageManager;
+import android.util.Base64;
+
 import android.support.annotation.NonNull;
 
 import com.google.firebase.FirebaseApp;
@@ -44,9 +46,12 @@ import com.google.firebase.messaging.FirebaseMessaging;
 
 class PushRegistratorFCM extends PushRegistratorAbstractGoogle {
 
-   private static final String FCM_DEFAULT_PROJECT_ID = "onesignal-shared-public"; // project_info.project_id
-   private static final String FCM_DEFAULT_APP_ID = "1:754795614042:android:c682b8144a8dd52bc1ad63"; // client.client_info.mobilesdk_app_id
-   private static final String FCM_DEFAULT_API_KEY = "AIzaSyAnTLn5-_4Mc2a2P-dKUeE-aBtgyCrjlYU"; // client.api_key.current_key
+   // project_info.project_id
+   private static final String FCM_DEFAULT_PROJECT_ID = "onesignal-shared-public";
+   // client.client_info.mobilesdk_app_id
+   private static final String FCM_DEFAULT_APP_ID = "1:754795614042:android:c682b8144a8dd52bc1ad63";
+   // client.api_key.current_key
+   private static final String FCM_DEFAULT_API_KEY_BASE64 = "QUl6YVN5QW5UTG41LV80TWMyYTJQLWRLVWVFLWFCdGd5Q3JqbFlV";
 
    private static final String FCM_APP_NAME = "ONESIGNAL_SDK_FCM_APP_NAME";
 
@@ -113,7 +118,7 @@ class PushRegistratorFCM extends PushRegistratorAbstractGoogle {
    private static @NonNull String getApiKey() {
       if (OneSignal.remoteParams.fcmParams.apiKey != null)
          return OneSignal.remoteParams.fcmParams.apiKey;
-      return FCM_DEFAULT_API_KEY;
+      return new String(Base64.decode(FCM_DEFAULT_API_KEY_BASE64, Base64.DEFAULT));
    }
 
    private static @NonNull String getProjectId() {


### PR DESCRIPTION
* The "Google Play Console" > "Release Management" > "Pre-launch report" was showing the following error:
```
Your app contains exposed Google Cloud Platform (GCP) API keys. Please see this Google Help Center article for details.
Vulnerable locations:
com.onesignal.PushRegistratorFCM->getApiKey
```

* Used base64 encoding for the shared default base 64 key to avoid this false positive FCM warning
   - This is safe as it is a client side ApiKey required for FirebaseApp.initializeApp

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/971)
<!-- Reviewable:end -->
