### PR TITLE
Turned catch Throwables into a specific exception

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/BadgeCountUpdater.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/BadgeCountUpdater.java
@@ -38,6 +38,7 @@ import android.os.Bundle;
 import android.service.notification.StatusBarNotification;
 import android.support.annotation.RequiresApi;
 
+import com.onesignal.shortcutbadger.ShortcutBadgeException;
 import com.onesignal.shortcutbadger.ShortcutBadger;
 
 import com.onesignal.OneSignalDbContract.NotificationTable;
@@ -62,9 +63,9 @@ class BadgeCountUpdater {
          }
          else
             badgesEnabled = 1;
-      } catch (Throwable t) {
+      } catch (PackageManager.NameNotFoundException e) {
          badgesEnabled = 0;
-         OneSignal.Log(OneSignal.LOG_LEVEL.ERROR, "Error reading meta-data tag 'com.onesignal.BadgeCount'. Disabling badge setting.", t);
+         OneSignal.Log(OneSignal.LOG_LEVEL.ERROR, "Error reading meta-data tag 'com.onesignal.BadgeCount'. Disabling badge setting.", e);
       }
 
       return (badgesEnabled == 1);
@@ -120,10 +121,13 @@ class BadgeCountUpdater {
       if (!areBadgeSettingsEnabled(context))
          return;
 
-      // Can throw if badges are not support on the device.
-      //  Or app does not have a default launch Activity.
       try {
          ShortcutBadger.applyCountOrThrow(context, count);
-      } catch(Throwable t) {}
+      } catch (ShortcutBadgeException e) {
+         // Suppress error as there are normal cases where this will throw
+         // Can throw if:
+         //    - Badges are not support on the device.
+         //    - App does not have a default launch Activity.
+      }
    }
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/GooglePlayServicesUpgradePrompt.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/GooglePlayServicesUpgradePrompt.java
@@ -30,8 +30,10 @@ class GooglePlayServicesUpgradePrompt {
          PackageManager pm = OneSignal.appContext.getPackageManager();
          PackageInfo info = pm.getPackageInfo(GoogleApiAvailability.GOOGLE_PLAY_SERVICES_PACKAGE, PackageManager.GET_META_DATA);
          String label = (String) info.applicationInfo.loadLabel(pm);
-         return (label != null && !label.equals("Market"));
-      } catch (Throwable e) {}
+         return (!label.equals("Market"));
+      } catch (PackageManager.NameNotFoundException e) {
+         // Google Play Store might not be installed, ignore exception if so
+      }
 
       return false;
    }
@@ -86,13 +88,15 @@ class GooglePlayServicesUpgradePrompt {
          GoogleApiAvailability apiAvailability = GoogleApiAvailability.getInstance();
          int resultCode = apiAvailability.isGooglePlayServicesAvailable(OneSignal.appContext);
          // Send the Intent to trigger opening the store
-         apiAvailability.getErrorResolutionPendingIntent(
-            activity,
-            resultCode,
-            PLAY_SERVICES_RESOLUTION_REQUEST
-         ).send();
+         PendingIntent pendingIntent =
+             apiAvailability.getErrorResolutionPendingIntent(
+                 activity,
+                 resultCode,
+                 PLAY_SERVICES_RESOLUTION_REQUEST
+             );
+         if (pendingIntent != null)
+            pendingIntent.send();
       } catch (PendingIntent.CanceledException e) {
-      } catch (Throwable e) {
          e.printStackTrace();
       }
    }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/JSONUtils.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/JSONUtils.java
@@ -125,7 +125,7 @@ class JSONUtils {
         try {
             for (int i = 0; i < jsonArray.length(); i++)
                 strArray += "\"" + jsonArray.getString(i) + "\"";
-        } catch (Throwable t) {}
+        } catch (JSONException ignored) {}
 
         return strArray + "]";
     }
@@ -148,7 +148,7 @@ class JSONUtils {
                 value = keyValues.get(key);
                 if (!"".equals(value))
                     toReturn.put(key, value);
-            } catch (Throwable t) {}
+            } catch (JSONException ignored) {}
         }
 
         return toReturn;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/LocationGMS.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/LocationGMS.java
@@ -164,8 +164,8 @@ class LocationGMS {
                   startGetLocation();
                else
                   fireFailedComplete();
-            } catch (Throwable t) {
-               t.printStackTrace();
+            } catch (PackageManager.NameNotFoundException e) {
+               e.printStackTrace();
             }
          }
          else

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSEmailSubscriptionStateChanges.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSEmailSubscriptionStateChanges.java
@@ -27,6 +27,7 @@
 
 package com.onesignal;
 
+import org.json.JSONException;
 import org.json.JSONObject;
 
 public class OSEmailSubscriptionStateChanges {
@@ -46,9 +47,8 @@ public class OSEmailSubscriptionStateChanges {
         try {
             mainObj.put("from", from.toJSONObject());
             mainObj.put("to", to.toJSONObject());
-        }
-        catch(Throwable t) {
-            t.printStackTrace();
+        } catch (JSONException e) {
+            e.printStackTrace();
         }
 
         return mainObj;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotification.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotification.java
@@ -141,8 +141,8 @@ public class OSNotification {
 
          mainObj.put("payload", payload.toJSONObject());
       }
-      catch(Throwable t) {
-         t.printStackTrace();
+      catch(JSONException e) {
+         e.printStackTrace();
       }
 
       return mainObj;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSSubscriptionState.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSSubscriptionState.java
@@ -30,6 +30,7 @@ package com.onesignal;
 
 import android.support.annotation.Nullable;
 
+import org.json.JSONException;
 import org.json.JSONObject;
 
 public class OSSubscriptionState implements Cloneable {
@@ -139,8 +140,9 @@ public class OSSubscriptionState implements Cloneable {
    protected Object clone() {
       try {
          return super.clone();
-      } catch (Throwable t) {}
-      return null;
+      } catch (CloneNotSupportedException e) {
+         return null;
+      }
    }
    
    public JSONObject toJSONObject() {
@@ -160,8 +162,8 @@ public class OSSubscriptionState implements Cloneable {
          mainObj.put("userSubscriptionSetting", userSubscriptionSetting);
          mainObj.put("subscribed", getSubscribed());
       }
-      catch(Throwable t) {
-         t.printStackTrace();
+      catch(JSONException e) {
+         e.printStackTrace();
       }
       
       return mainObj;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalDbHelper.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalDbHelper.java
@@ -29,6 +29,7 @@ package com.onesignal;
 
 import android.content.Context;
 import android.database.Cursor;
+import android.database.sqlite.SQLiteCantOpenDatabaseException;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteException;
 import android.database.sqlite.SQLiteOpenHelper;
@@ -134,9 +135,9 @@ public class OneSignalDbHelper extends SQLiteOpenHelper {
       while(true) {
          try {
             return getWritableDatabase();
-         } catch (Throwable t) {
+         } catch (SQLiteCantOpenDatabaseException e) {
             if (++count >= DB_OPEN_RETRY_MAX)
-               throw t;
+               throw e;
             SystemClock.sleep(count * DB_OPEN_RETRY_BACKOFF);
          }
       }
@@ -147,9 +148,9 @@ public class OneSignalDbHelper extends SQLiteOpenHelper {
       while(true) {
          try {
             return getReadableDatabase();
-         } catch (Throwable t) {
+         } catch (SQLiteCantOpenDatabaseException e) {
             if (++count >= DB_OPEN_RETRY_MAX)
-               throw t;
+               throw e;
             SystemClock.sleep(count * DB_OPEN_RETRY_BACKOFF);
          }
       }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OutcomeEventsCache.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OutcomeEventsCache.java
@@ -3,6 +3,7 @@ package com.onesignal;
 import android.content.ContentValues;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteException;
 import android.support.annotation.WorkerThread;
 
 import com.onesignal.OneSignalDbContract.OutcomeEventsTable;
@@ -28,14 +29,14 @@ class OutcomeEventsCache {
             writableDb.delete(OutcomeEventsTable.TABLE_NAME,
                     OutcomeEventsTable.COLUMN_NAME_TIMESTAMP + " = ?", new String[]{String.valueOf(event.getTimestamp())});
             writableDb.setTransactionSuccessful();
-        } catch (Throwable t) {
-            OneSignal.Log(OneSignal.LOG_LEVEL.ERROR, "Error deleting old outcome event records! ", t);
+        } catch (SQLiteException e) {
+            OneSignal.Log(OneSignal.LOG_LEVEL.ERROR, "Error deleting old outcome event records! ", e);
         } finally {
             if (writableDb != null) {
                 try {
                     writableDb.endTransaction(); // May throw if transaction was never opened or DB is full.
-                } catch (Throwable t) {
-                    OneSignal.Log(OneSignal.LOG_LEVEL.ERROR, "Error closing transaction! ", t);
+                } catch (SQLiteException e) {
+                    OneSignal.Log(OneSignal.LOG_LEVEL.ERROR, "Error closing transaction! ", e);
                 }
             }
         }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/TrackFirebaseAnalytics.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/TrackFirebaseAnalytics.java
@@ -56,7 +56,7 @@ class TrackFirebaseAnalytics {
       try {
          FirebaseAnalyticsClass = Class.forName("com.google.firebase.analytics.FirebaseAnalytics");
          return true;
-      } catch (Throwable t) {
+      } catch (ClassNotFoundException e) {
          return false;
       }
    }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStateSynchronizer.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStateSynchronizer.java
@@ -365,8 +365,8 @@ abstract class UserStateSynchronizer {
                             OSInAppMessageController.getController().receivedInAppMessageJson(jsonResponse.getJSONArray(IN_APP_MESSAGES_JSON_KEY));
 
                         onSuccessfulSync(jsonBody);
-                    } catch (Throwable t) {
-                        OneSignal.Log(OneSignal.LOG_LEVEL.ERROR, "ERROR parsing on_session or create JSON Response.", t);
+                    } catch (JSONException e) {
+                        OneSignal.Log(OneSignal.LOG_LEVEL.ERROR, "ERROR parsing on_session or create JSON Response.", e);
                     }
                 }
             }
@@ -406,8 +406,8 @@ abstract class UserStateSynchronizer {
             try {
                 JSONObject responseJson = new JSONObject(response);
                 return responseJson.has("errors") && responseJson.optString("errors").contains(contains);
-            } catch (Throwable t) {
-                t.printStackTrace();
+            } catch (JSONException e) {
+                e.printStackTrace();
             }
         }
 

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
@@ -65,6 +65,8 @@ import com.onesignal.OneSignalPackagePrivateHelper.NotificationTable;
 import com.onesignal.OneSignalPackagePrivateHelper.OneSignalPrefs;
 import com.onesignal.RestoreJobService;
 import com.onesignal.ShadowBadgeCountUpdater;
+import com.onesignal.ShadowCustomTabsClient;
+import com.onesignal.ShadowCustomTabsSession;
 import com.onesignal.ShadowGcmBroadcastReceiver;
 import com.onesignal.ShadowNotificationManagerCompat;
 import com.onesignal.ShadowOSUtils;
@@ -129,7 +131,9 @@ import static org.robolectric.Shadows.shadowOf;
             ShadowBadgeCountUpdater.class,
             ShadowNotificationManagerCompat.class,
             ShadowOSUtils.class,
-            ShadowOSViewUtils.class
+            ShadowOSViewUtils.class,
+            ShadowCustomTabsClient.class,
+            ShadowCustomTabsSession.class
         },
         sdk = 21
 )

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/NotificationLimitManagerRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/NotificationLimitManagerRunner.java
@@ -8,6 +8,8 @@ import android.support.v4.app.NotificationManagerCompat;
 import com.onesignal.OneSignal;
 import com.onesignal.OneSignalPackagePrivateHelper.NotificationLimitManager;
 import com.onesignal.ShadowAdvertisingIdProviderGPS;
+import com.onesignal.ShadowCustomTabsClient;
+import com.onesignal.ShadowCustomTabsSession;
 import com.onesignal.ShadowNotificationLimitManager;
 import com.onesignal.ShadowOSUtils;
 import com.onesignal.ShadowOneSignalRestClient;
@@ -39,7 +41,9 @@ import static junit.framework.Assert.assertEquals;
             ShadowPushRegistratorGCM.class,
             ShadowOSUtils.class,
             ShadowAdvertisingIdProviderGPS.class,
-            ShadowOneSignalRestClient.class
+            ShadowOneSignalRestClient.class,
+            ShadowCustomTabsClient.class,
+            ShadowCustomTabsSession.class,
         },
         sdk = 26
 )


### PR DESCRIPTION
* Catching Throwable is hiding root case exceptions which is causing unrelated exceptions to throw
  - Such as an NPE due to something not being set or a Thread trying to start twice.
* Only first pass, many more we can clean up.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/973)
<!-- Reviewable:end -->
