### PR TITLE
Add DialogFragment detection and improvement on system detection

### DIFF
--- a/OneSignalSDK/onesignal/build.gradle
+++ b/OneSignalSDK/onesignal/build.gradle
@@ -63,6 +63,7 @@ dependencies {
     api 'com.android.support:cardview-v7:[26.0.0, 27.99.99]'
     api 'com.android.support:support-v4:[26.0.0, 27.99.99]'
     api 'com.android.support:customtabs:[26.0.0, 27.99.99]'
+    api 'com.android.support:appcompat-v7:[26.0.0, 27.99.99]'
 }
 
 apply from: 'maven-push.gradle'

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/ActivityLifecycleHandler.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/ActivityLifecycleHandler.java
@@ -288,7 +288,7 @@ class ActivityLifecycleHandler {
                     }
                 }
                 ActivityLifecycleHandler.removeSystemConditionObserver(key);
-                observer.messageTriggerConditionChanged();
+                observer.systemConditionChanged();
             }
         }
     }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSSystemConditionController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSSystemConditionController.java
@@ -1,12 +1,20 @@
 package com.onesignal;
 
+import android.content.Context;
+import android.support.annotation.NonNull;
+import android.support.v4.app.DialogFragment;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentManager;
+import android.support.v7.app.AppCompatActivity;
+
 import java.lang.ref.WeakReference;
+import java.util.List;
 
 class OSSystemConditionController {
 
     interface OSSystemConditionObserver {
         // Alerts the systemConditionObserver that a system condition has being activated
-        void messageTriggerConditionChanged();
+        void systemConditionChanged();
     }
 
     private static final String TAG = OSSystemConditionController.class.getCanonicalName();
@@ -18,13 +26,51 @@ class OSSystemConditionController {
 
     boolean systemConditionsAvailable() {
         if (ActivityLifecycleHandler.curActivity == null) {
+            OneSignal.onesignalLog(OneSignal.LOG_LEVEL.WARN, "OSSystemConditionObserver curActivity null");
             return false;
         }
+
+        if (isDialogFragmentShowing(ActivityLifecycleHandler.curActivity)) {
+            OneSignal.onesignalLog(OneSignal.LOG_LEVEL.WARN, "OSSystemConditionObserver dialog fragment detected");
+            return false;
+        }
+
         boolean keyboardUp = OSViewUtils.isKeyboardUp(new WeakReference<>(ActivityLifecycleHandler.curActivity));
         if (keyboardUp) {
             ActivityLifecycleHandler.setSystemConditionObserver(TAG, systemConditionObserver);
+            OneSignal.onesignalLog(OneSignal.LOG_LEVEL.WARN, "OSSystemConditionObserver keyboard up detected");
         }
         return !keyboardUp;
     }
 
+    boolean isDialogFragmentShowing(Context context) {
+        // Detect if user has a dialog fragment showing
+        if (context instanceof AppCompatActivity) {
+            final FragmentManager manager = ((AppCompatActivity) context).getSupportFragmentManager();
+            manager.registerFragmentLifecycleCallbacks(new FragmentManager.FragmentLifecycleCallbacks() {
+
+                @Override
+                public void onFragmentDetached(@NonNull FragmentManager fm, @NonNull Fragment fragmentDetached) {
+                    super.onFragmentDetached(fm, fragmentDetached);
+                    if (fragmentDetached instanceof DialogFragment) {
+                        manager.unregisterFragmentLifecycleCallbacks(this);
+                        systemConditionObserver.systemConditionChanged();
+                    }
+                }
+
+            }, true);
+            List<Fragment> fragments = manager.getFragments();
+            int size = fragments.size();
+            if (size > 0) {
+                // We only care of the last fragment available
+                Fragment fragment = fragments.get(size - 1);
+                return fragment.isVisible() && fragment instanceof DialogFragment;
+            }
+        }
+
+        // We already have Activity lifecycle listener, that listener will handle Activity focus/unFocus state
+        //   - Permission prompts will make activity loose focus
+        // We cannot detect AlertDialogs because they are added to the decor view as linear layout without an identification
+        return false;
+    }
 }


### PR DESCRIPTION
  * Not show IAM if an DialogFragment is visible
  * Queue IAM even if systems conditions aren't correct
  * Reevaluate condition and display IAM after systems condition changed, no need for triggers evaluation

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/980)
<!-- Reviewable:end -->
