### PR TITLE
WritePrefHandlerThread improvements

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalPrefs.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalPrefs.java
@@ -123,7 +123,7 @@ class OneSignalPrefs {
     }
 
     public static class WritePrefHandlerThread extends HandlerThread {
-        public Handler mHandler;
+        private Handler mHandler;
 
         private static final int WRITE_CALL_DELAY_TO_BUFFER_MS = 200;
         private long lastSyncTime = 0L;
@@ -132,7 +132,7 @@ class OneSignalPrefs {
             super(name);
         }
 
-        synchronized void startDelayedWrite() {
+        private synchronized void startDelayedWrite() {
             // A Context is required to write,
             //   if not available now later OneSignal.setContext will call this again.
             if (OneSignal.appContext == null)
@@ -143,15 +143,12 @@ class OneSignalPrefs {
                 mHandler = new Handler(getLooper());
             }
 
-            synchronized (mHandler) {
-                mHandler.removeCallbacksAndMessages(null);
-                if (lastSyncTime == 0)
-                    lastSyncTime = System.currentTimeMillis();
+            mHandler.removeCallbacksAndMessages(null);
+            if (lastSyncTime == 0)
+                lastSyncTime = System.currentTimeMillis();
 
-                long delay = lastSyncTime - System.currentTimeMillis() + WRITE_CALL_DELAY_TO_BUFFER_MS;
-
-                mHandler.postDelayed(getNewRunnable(), delay);
-            }
+            long delay = lastSyncTime - System.currentTimeMillis() + WRITE_CALL_DELAY_TO_BUFFER_MS;
+            mHandler.postDelayed(getNewRunnable(), delay);
         }
 
         /**

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalPrefs.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalPrefs.java
@@ -167,10 +167,35 @@ class OneSignalPrefs {
          * Future: We may want to use this strategy for all Thread.start calls.
          *         And limit thread usages, using mostly coroutines instead.
          */
-        private VirtualMachineError threadStartError;
+
+        private Error threadStartError;
+        private RuntimeException threadStartRuntimeException;
+        private Throwable threadStartThrowable;
+
         private void startThread() {
             if (threadStartError != null)
                 throw threadStartError;
+
+            if (threadStartRuntimeException != null)
+                throw threadStartRuntimeException;
+
+            // Ideally we would just throw threadStartThrowable here,
+            //   however we can't without adding throws to this method's signature.
+            // If this is done we would have to add throws all the way up the stack to
+            //   to public SDK methods which can't be done at this time nor would
+            //   "throws Throwable" be a good public signature.
+            if (threadStartThrowable != null) {
+                // The following lines turn a Throwable into a RuntimeException
+                //   to workaround the the throwable signature noted above.
+                RuntimeException exception = new RuntimeException(
+                        threadStartThrowable.getClass().getName() +
+                            ": " +
+                            threadStartThrowable.getMessage(),
+                        threadStartThrowable
+                );
+                exception.setStackTrace(threadStartThrowable.getStackTrace());
+                throw exception;
+            }
 
             try {
                 start();
@@ -183,6 +208,27 @@ class OneSignalPrefs {
                 // pthread_create (1040KB stack) failed: Try again
                 threadStartError = e;
                 throw e;
+            }
+            catch (Error t) {
+                // Possibly some other error we didn't expect Thread.start() to throw
+                threadStartError = t;
+                throw t;
+            }
+            catch (IllegalThreadStateException e) {
+                // Adds the state of the thread to IllegalThreadStateException to provide more details
+                IllegalThreadStateException exception =
+                    new IllegalThreadStateException("Thread has state: " + this.getState());
+                exception.setStackTrace(e.getStackTrace());
+                threadStartRuntimeException = exception;
+                throw exception;
+            }
+            catch (RuntimeException e) {
+                threadStartRuntimeException = e;
+                throw e;
+            }
+            catch (Throwable t) {
+                threadStartThrowable = t;
+                throw t;
             }
         }
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalPrefs.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalPrefs.java
@@ -133,6 +133,11 @@ class OneSignalPrefs {
         }
 
         synchronized void startDelayedWrite() {
+            // A Context is required to write,
+            //   if not available now later OneSignal.setContext will call this again.
+            if (OneSignal.appContext == null)
+                return;
+
             if (mHandler == null) {
                 startThread();
                 mHandler = new Handler(getLooper());
@@ -194,10 +199,6 @@ class OneSignalPrefs {
         }
 
         private void flushBufferToDisk() {
-            // A flush will be triggered later once a context is set via OneSignal.setAppContext(...)
-            if (OneSignal.appContext == null)
-                return;
-
             for (String pref : prefsToApply.keySet()) {
                 SharedPreferences prefsToWrite = getSharedPrefsByName(pref);
                 SharedPreferences.Editor editor = prefsToWrite.edit();

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/TestHelpers.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/TestHelpers.java
@@ -130,15 +130,10 @@ public class TestHelpers {
    static void flushBufferedSharedPrefs() {
       OneSignalPrefs.WritePrefHandlerThread handlerThread = OneSignalPackagePrivateHelper.OneSignalPrefs.prefsHandler;
 
-      if (handlerThread.mHandler == null)
+      if (handlerThread.getLooper() == null)
          return;
-
-      synchronized (handlerThread.mHandler) {
-         if (handlerThread.getLooper() == null)
-            return;
-         Scheduler scheduler = shadowOf(handlerThread.getLooper()).getScheduler();
-         while (scheduler.runOneTask());
-      }
+      Scheduler scheduler = shadowOf(handlerThread.getLooper()).getScheduler();
+      while (scheduler.runOneTask());
    }
 
    // Join all OS_ threads


### PR DESCRIPTION
* This add more `Throwables` on top of what PR #975 did as it turns out `InternalError` and `OutOfMemoryError` are not the only things `Thread.start` can throw based o the following stack traces from 3.13.1.
   - https://github.com/OneSignal/OneSignal-Android-SDK/issues/917#issuecomment-615464354
  - https://github.com/OneSignal/OneSignal-Android-SDK/issues/917#issuecomment-615873549
* Moved appContext null check before thread start
  - This is more efficient as we are not creating a thread before it is possible write
  - This eliminates entries points into Thread.start to help debug  issue #917
* Clean up: Removed synchronized on mHandler
  - Cleaned up synchronized on mHandler in both startDelayedWrite and tests
  - This was not needed as startDelayedWrite as a synchronized at the method level
  - Limited access level to mHandler and startDelayedWrite now that tests don't access this anymore directly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/993)
<!-- Reviewable:end -->
