### PR TITLE
Removed any closes on the SQL DBs, causing DB lock issues

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageRepository.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageRepository.java
@@ -34,7 +34,6 @@ class OSInAppMessageRepository {
         writableDb.delete(OneSignalDbContract.InAppMessageTable.TABLE_NAME,
                 OneSignalDbContract.InAppMessageTable.COLUMN_NAME_LAST_DISPLAY + "< ?",
                 new String[]{String.valueOf(sixMonthsAgo)});
-        writableDb.close();
     }
 
     @WorkerThread
@@ -52,7 +51,6 @@ class OSInAppMessageRepository {
                 OneSignalDbContract.InAppMessageTable.COLUMN_NAME_MESSAGE_ID + " = ?", new String[]{inAppMessage.messageId});
         if (rowsUpdated == 0)
             writableDb.insert(OneSignalDbContract.InAppMessageTable.TABLE_NAME, null, values);
-        writableDb.close();
     }
 
     @WorkerThread

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OutcomeEventsCache.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OutcomeEventsCache.java
@@ -60,7 +60,6 @@ class OutcomeEventsCache {
         values.put(OutcomeEventsTable.COLUMN_NAME_WEIGHT, event.getWeight());
 
         writableDb.insert(OutcomeEventsTable.TABLE_NAME, null, values);
-        writableDb.close();
     }
 
     /**
@@ -133,8 +132,6 @@ class OutcomeEventsCache {
         } catch (JSONException e) {
             e.printStackTrace();
         }
-
-        writableDb.close();
     }
 
     /**


### PR DESCRIPTION
* SQL DB was designed so that Java will simply garbage collect when it deems necessary to do so
* No need to close the DB for within our SDK manually
* Relates to issues
   - #988
   - #945

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/995)
<!-- Reviewable:end -->
