### PR TITLE
 Make IAM influence after IAM display, Add click action handler

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSOutcomeEventsController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSOutcomeEventsController.java
@@ -104,8 +104,6 @@ class OSOutcomeEventsController {
                 sendOutcomeEvent(name, null);
             }
         }
-        // Requests are sent or cached at this point
-        osSessionManager.onDirectInfluenceFromIAMClickFinished();
     }
 
     void sendUniqueOutcomeEvent(@NonNull final String name, @Nullable OneSignal.OutcomeCallback callback) {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSSessionManager.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSSessionManager.java
@@ -77,6 +77,7 @@ public class OSSessionManager {
         logger.debug("OneSignal SessionManager onInAppMessageReceived messageId: " + messageId);
         OSChannelTracker inAppMessageTracker = trackerFactory.getIAMChannelTracker();
         inAppMessageTracker.saveLastId(messageId);
+        inAppMessageTracker.resetAndInitInfluence();
     }
 
     void onDirectInfluenceFromIAMClick(@NonNull String messageId) {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -1044,8 +1044,8 @@ public class OneSignal {
             );
             OneSignalPrefs.saveBool(
                OneSignalPrefs.PREFS_ONESIGNAL,
-               OneSignalPrefs.PREFS_OS_OUTCOMES_V2,
-                    params.influenceParams.v2Enabled
+               preferences.getOutcomesV2KeyName(),
+               params.influenceParams.outcomesV2ServiceEnabled
             );
             logger.debug("OneSignal saveInfluenceParams: " + params.influenceParams.toString());
             trackerFactory.saveInfluenceParams(params.influenceParams);

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalPrefs.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalPrefs.java
@@ -102,7 +102,7 @@ class OneSignalPrefs {
     // Receive Receipts (aka Confirmed Deliveries)
     public static final String PREFS_OS_RECEIVE_RECEIPTS_ENABLED = "PREFS_OS_RECEIVE_RECEIPTS_ENABLED";
     // Outcomes
-    public static final String PREFS_OS_OUTCOMES_V2 = "PREFS_OS_OUTCOMES_V2";
+    static final String PREFS_OS_OUTCOMES_V2 = "PREFS_OS_OUTCOMES_V2";
     // Player Purchase Keys
     static final String PREFS_PURCHASE_TOKENS = "purchaseTokens";
     static final String PREFS_EXISTING_PURCHASES = "ExistingPurchases";

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalRemoteParams.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalRemoteParams.java
@@ -28,7 +28,7 @@ public class OneSignalRemoteParams {
       boolean directEnabled = false;
       boolean indirectEnabled = false;
       boolean unattributedEnabled = false;
-      boolean v2Enabled = false;
+      boolean outcomesV2ServiceEnabled = false;
 
       public int getIndirectNotificationAttributionWindow() {
          return indirectNotificationAttributionWindow;
@@ -92,12 +92,12 @@ public class OneSignalRemoteParams {
    private static int androidParamsRetries = 0;
 
    private static final String OUTCOME_PARAM = "outcomes";
-   private static final String V2_PARAM = "v2_active";
+   private static final String OUTCOMES_V2_SERVICE_PARAM = "v2_enabled";
    private static final String ENABLED_PARAM = "enabled";
    private static final String DIRECT_PARAM = "direct";
    private static final String INDIRECT_PARAM = "indirect";
    private static final String NOTIFICATION_ATTRIBUTION_PARAM = "notification_attribution";
-   private static final String IAM_ATTRIBUTION_PARAM = "iam_attribution";
+   private static final String IAM_ATTRIBUTION_PARAM = "in_app_message_attribution";
    private static final String UNATTRIBUTED_PARAM = "unattributed";
 
    private static final String FCM_PARENT_PARAM = "fcm";
@@ -189,8 +189,8 @@ public class OneSignalRemoteParams {
    }
 
    static private void processOutcomeJson(JSONObject outcomeJson, InfluenceParams influenceParams) {
-      if (outcomeJson.has(V2_PARAM))
-         influenceParams.v2Enabled = outcomeJson.optBoolean(V2_PARAM);
+      if (outcomeJson.has(OUTCOMES_V2_SERVICE_PARAM))
+         influenceParams.outcomesV2ServiceEnabled = outcomeJson.optBoolean(OUTCOMES_V2_SERVICE_PARAM);
 
       if (outcomeJson.has(DIRECT_PARAM)) {
          JSONObject direct = outcomeJson.optJSONObject(DIRECT_PARAM);

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/outcomes/OSOutcomeEventsCache.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/outcomes/OSOutcomeEventsCache.java
@@ -41,7 +41,7 @@ class OSOutcomeEventsCache {
         this.preferences = preferences;
     }
 
-    boolean isOutcomesV2Available() {
+    boolean isOutcomesV2ServiceEnabled() {
         return preferences.getBool(
                 preferences.getPreferencesName(),
                 preferences.getOutcomesV2KeyName(),

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/outcomes/OSOutcomeEventsFactory.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/outcomes/OSOutcomeEventsFactory.java
@@ -23,11 +23,22 @@ public class OSOutcomeEventsFactory {
     public OSOutcomeEventsRepository getRepository() {
         if (repository == null)
             createRepository();
+        else
+            validateRepositoryVersion();
         return repository;
     }
 
+    private void validateRepositoryVersion() {
+        if (!outcomeEventsCache.isOutcomesV2ServiceEnabled() && repository instanceof OSOutcomeEventsV1Repository)
+            return;
+        if (outcomeEventsCache.isOutcomesV2ServiceEnabled() && repository instanceof OSOutcomeEventsV2Repository)
+            return;
+
+        createRepository();
+    }
+
     private void createRepository() {
-        if (outcomeEventsCache.isOutcomesV2Available())
+        if (outcomeEventsCache.isOutcomesV2ServiceEnabled())
             repository = new OSOutcomeEventsV2Repository(logger, outcomeEventsCache, new OSOutcomeEventsV2Service(apiClient));
         else
             repository = new OSOutcomeEventsV1Repository(logger, outcomeEventsCache, new OSOutcomeEventsV1Service(apiClient));

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/OutcomeEventIntegrationTests.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/OutcomeEventIntegrationTests.java
@@ -273,17 +273,11 @@ public class OutcomeEventIntegrationTests {
         OneSignal.sendUniqueOutcome(ONESIGNAL_OUTCOME_NAME);
         threadAndTaskWait();
 
-        JSONObject sources = new JSONObject();
-        JSONObject direct = new JSONObject();
         JSONArray notificationIds = new JSONArray();
         notificationIds.put(ONESIGNAL_NOTIFICATION_ID + "1");
 
-        direct.put("notification_ids", notificationIds);
-        direct.put("in_app_message_ids", new JSONArray());
-        sources.put("direct", direct);
-
         // Check measure end point was most recent request and contains clicked notification
-        assertMeasureOnV2AtIndex(3, ONESIGNAL_OUTCOME_NAME, sources);
+        assertMeasureOnV2AtIndex(3, ONESIGNAL_OUTCOME_NAME, new JSONArray(), notificationIds, null, null);
         // Only 4 requests have been made
         assertRestCalls(4);
 
@@ -370,15 +364,8 @@ public class OutcomeEventIntegrationTests {
         OneSignal.sendUniqueOutcome(ONESIGNAL_OUTCOME_NAME);
         threadAndTaskWait();
 
-        JSONObject sources = new JSONObject();
-        JSONObject indirect = new JSONObject();
-
-        indirect.put("notification_ids", notificationIds);
-        indirect.put("in_app_message_ids", new JSONArray());
-        sources.put("indirect", indirect);
-
         // Check measure end point was most recent request and contains received notification
-        assertMeasureOnV2AtIndex(2, ONESIGNAL_OUTCOME_NAME, sources);
+        assertMeasureOnV2AtIndex(2, ONESIGNAL_OUTCOME_NAME, null, null, new JSONArray(), notificationIds);
         // Only 3 requests have been made
         assertRestCalls(3);
 
@@ -414,14 +401,8 @@ public class OutcomeEventIntegrationTests {
         // Make sure session is INDIRECT
         assertNotificationChannelIndirectInfluence(2);
 
-        sources = new JSONObject();
-        indirect = new JSONObject();
-
-        indirect.put("notification_ids", new JSONArray().put(ONESIGNAL_NOTIFICATION_ID + "2"));
-        indirect.put("in_app_message_ids", new JSONArray());
-        sources.put("indirect", indirect);
         // Check measure end point was most recent request and contains received notification
-        assertMeasureOnV2AtIndex(4, ONESIGNAL_OUTCOME_NAME, sources);
+        assertMeasureOnV2AtIndex(4, ONESIGNAL_OUTCOME_NAME, null, null, new JSONArray(),  new JSONArray().put(ONESIGNAL_NOTIFICATION_ID + "2"));
     }
 
     @Test
@@ -490,7 +471,7 @@ public class OutcomeEventIntegrationTests {
         threadAndTaskWait();
 
         // Check measure end point was most recent request and contains received notification
-        assertMeasureOnV2AtIndex(2, ONESIGNAL_OUTCOME_NAME, new JSONObject());
+        assertMeasureOnV2AtIndex(2, ONESIGNAL_OUTCOME_NAME, null, null, null, null);
         // Only 3 requests have been made
         assertRestCalls(3);
 
@@ -520,7 +501,7 @@ public class OutcomeEventIntegrationTests {
         assertNotificationChannelUnattributedInfluence();
 
         // Check measure end point was most recent request and contains received notification
-        assertMeasureOnV2AtIndex(4, ONESIGNAL_OUTCOME_NAME, new JSONObject());
+        assertMeasureOnV2AtIndex(4, ONESIGNAL_OUTCOME_NAME, null, null, null, null);
     }
 
     @Test
@@ -580,17 +561,11 @@ public class OutcomeEventIntegrationTests {
         blankActivityController.resume();
         threadAndTaskWait();
 
-        JSONObject sources = new JSONObject();
-        JSONObject direct = new JSONObject();
         JSONArray notificationIds = new JSONArray();
         notificationIds.put(ONESIGNAL_NOTIFICATION_ID);
 
-        direct.put("notification_ids", notificationIds);
-        direct.put("in_app_message_ids", new JSONArray());
-        sources.put("direct", direct);
-
         // Make sure a measure request is made with the correct session and notifications
-        assertMeasureOnV2AtIndex(3, ONESIGNAL_OUTCOME_NAME, sources);
+        assertMeasureOnV2AtIndex(3, ONESIGNAL_OUTCOME_NAME, new JSONArray(), notificationIds, null, null);
     }
 
     @Test

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/OutcomeEventV2UnitTests.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/OutcomeEventV2UnitTests.java
@@ -230,9 +230,6 @@ public class OutcomeEventV2UnitTests {
         sessionManager.initSessionFromCache();
         sessionManager.onInAppMessageReceived(IAM_ID);
 
-        // Restart session by app open should set INDIRECT influence
-        sessionManager.restartSessionIfNeeded(OneSignal.AppEntryAction.APP_OPEN);
-
         controller.sendOutcomeEvent(OUTCOME_NAME);
         threadAndTaskWait();
 


### PR DESCRIPTION
   * Changes Tests to accomplish new functionality
   * Minor improvements changes
   * If the user sends and outcome from the click action handler callback, that outcome should be DIRECT influenced by IAM
   * DIRECT influences by IAM can be from click action handler or click action outcome

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1005)
<!-- Reviewable:end -->
