### PR TITLE
SQL DB Lock Exception added and IAM Cache Clean

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotification.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotification.java
@@ -42,7 +42,6 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import android.R.drawable;
-import android.annotation.TargetApi;
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.Notification;
@@ -529,7 +528,7 @@ class GenerateNotification {
       Cursor cursor = null;
       
       try {
-         SQLiteDatabase readableDb = dbHelper.getReadableDbWithRetries();
+         SQLiteDatabase readableDb = dbHelper.getSQLiteDatabaseWithRetries();
    
          String[] retColumn = { NotificationTable.COLUMN_NAME_ANDROID_NOTIFICATION_ID,
              NotificationTable.COLUMN_NAME_FULL_DATA,
@@ -772,7 +771,7 @@ class GenerateNotification {
       // Save the group summary notification id so it can be updated later.
       SQLiteDatabase writableDb = null;
       try {
-         writableDb = dbHelper.getWritableDbWithRetries();
+         writableDb = dbHelper.getSQLiteDatabaseWithRetries();
          writableDb.beginTransaction();
       
          ContentValues values = new ContentValues();

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
@@ -183,7 +183,7 @@ class NotificationBundleProcessor {
          SQLiteDatabase writableDb = null;
 
          try {
-            writableDb = dbHelper.getWritableDbWithRetries();
+            writableDb = dbHelper.getSQLiteDatabaseWithRetries();
    
             writableDb.beginTransaction();
             
@@ -255,7 +255,7 @@ class NotificationBundleProcessor {
       SQLiteDatabase writableDb = null;
 
       try {
-         writableDb = dbHelper.getWritableDbWithRetries();
+         writableDb = dbHelper.getSQLiteDatabaseWithRetries();
          writableDb.beginTransaction();
 
          ContentValues values = new ContentValues();
@@ -434,7 +434,7 @@ class NotificationBundleProcessor {
       Cursor cursor = null;
 
       try {
-         SQLiteDatabase readableDb = dbHelper.getReadableDbWithRetries();
+         SQLiteDatabase readableDb = dbHelper.getSQLiteDatabaseWithRetries();
          cursor = readableDb.query(
                NotificationTable.TABLE_NAME,
                new String[]{NotificationTable.COLUMN_NAME_ANDROID_NOTIFICATION_ID}, // retColumn

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationLimitManager.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationLimitManager.java
@@ -84,7 +84,7 @@ class NotificationLimitManager {
 
       Cursor cursor = null;
       try {
-         SQLiteDatabase readableDb = dbHelper.getReadableDbWithRetries();
+         SQLiteDatabase readableDb = dbHelper.getSQLiteDatabaseWithRetries();
          cursor = readableDb.query(
             NotificationTable.TABLE_NAME,
             new String[] { NotificationTable.COLUMN_NAME_ANDROID_NOTIFICATION_ID },

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationOpenedProcessor.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationOpenedProcessor.java
@@ -99,7 +99,7 @@ class NotificationOpenedProcessor {
       SQLiteDatabase writableDb = null;
 
       try {
-         writableDb = dbHelper.getWritableDbWithRetries();
+         writableDb = dbHelper.getSQLiteDatabaseWithRetries();
          writableDb.beginTransaction();
 
          // We just opened a summary notification.

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationRestorer.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationRestorer.java
@@ -137,7 +137,7 @@ class NotificationRestorer {
 
       Cursor cursor = null;
       try {
-         SQLiteDatabase readableDb = dbHelper.getReadableDbWithRetries();
+         SQLiteDatabase readableDb = dbHelper.getSQLiteDatabaseWithRetries();
          cursor = readableDb.query(
             NotificationTable.TABLE_NAME,
             COLUMNS_FOR_RESTORE,

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationSummaryManager.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationSummaryManager.java
@@ -133,7 +133,7 @@ class NotificationSummaryManager {
       String[] whereArgs = { group };
       
       try {
-         SQLiteDatabase readableDb = dbHelper.getReadableDbWithRetries();
+         SQLiteDatabase readableDb = dbHelper.getSQLiteDatabaseWithRetries();
          cursor = readableDb.query(
              NotificationTable.TABLE_NAME,
              NotificationRestorer.COLUMNS_FOR_RESTORE,

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessage.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessage.java
@@ -17,7 +17,7 @@ class OSInAppMessage {
     private static final String IAM_ID = "id";
     private static final String IAM_VARIANTS = "variants";
     private static final String IAM_TRIGGERS = "triggers";
-    private static final String IAM_RE_DISPLAY = "redisplay";
+    private static final String IAM_REDISPLAY_STATS = "redisplay";
     private static final String DISPLAY_DURATION = "display_duration";
 
     /**
@@ -51,7 +51,7 @@ class OSInAppMessage {
     /**
      * Reference to redisplay properties
      */
-    private OSInAppMessageDisplayStats displayStats = new OSInAppMessageDisplayStats();
+    private OSInAppMessageRedisplayStats redisplayStats = new OSInAppMessageRedisplayStats();
 
     private double displayDuration;
     private boolean displayedInSession = false;
@@ -63,11 +63,11 @@ class OSInAppMessage {
         this.isPreview = isPreview;
     }
 
-    OSInAppMessage(@NonNull String messageId, @NonNull Set<String> clickIds, boolean displayedInSession, OSInAppMessageDisplayStats displayStats) {
+    OSInAppMessage(@NonNull String messageId, @NonNull Set<String> clickIds, boolean displayedInSession, OSInAppMessageRedisplayStats redisplayStats) {
         this.messageId = messageId;
         this.clickedClickIds = clickIds;
         this.displayedInSession = displayedInSession;
-        this.displayStats = displayStats;
+        this.redisplayStats = redisplayStats;
     }
 
     OSInAppMessage(JSONObject json) throws JSONException {
@@ -77,9 +77,8 @@ class OSInAppMessage {
         this.triggers = parseTriggerJson(json.getJSONArray(IAM_TRIGGERS));
         this.clickedClickIds = new HashSet<>();
 
-        if (json.has(IAM_RE_DISPLAY)) {
-            this.displayStats = new OSInAppMessageDisplayStats(json.getJSONObject(IAM_RE_DISPLAY));
-        }
+        if (json.has(IAM_REDISPLAY_STATS))
+            this.redisplayStats = new OSInAppMessageRedisplayStats(json.getJSONObject(IAM_REDISPLAY_STATS));
     }
 
     private HashMap<String, HashMap<String, String>> parseVariants(JSONObject json) throws JSONException {
@@ -139,9 +138,7 @@ class OSInAppMessage {
 
             json.put(IAM_VARIANTS, variants);
             json.put(DISPLAY_DURATION, this.displayDuration);
-
-            if (displayStats.isRedisplayEnabled())
-                json.put(IAM_RE_DISPLAY, displayStats.toJSONObject());
+            json.put(IAM_REDISPLAY_STATS, this.redisplayStats.toJSONObject());
 
             JSONArray orConditions = new JSONArray();
             for (ArrayList<OSTrigger> andArray : this.triggers) {
@@ -213,8 +210,12 @@ class OSInAppMessage {
         clickedClickIds.add(clickId);
     }
 
-    OSInAppMessageDisplayStats getDisplayStats() {
-        return displayStats;
+    OSInAppMessageRedisplayStats getRedisplayStats() {
+        return redisplayStats;
+    }
+
+    void setRedisplayStats(int displayQuantity, long lastDisplayTime) {
+        this.redisplayStats = new OSInAppMessageRedisplayStats(displayQuantity, lastDisplayTime);
     }
 
     @Override
@@ -223,7 +224,7 @@ class OSInAppMessage {
                 "messageId='" + messageId + '\'' +
                 ", triggers=" + triggers +
                 ", clickedClickIds=" + clickedClickIds +
-                ", displayStats=" + displayStats +
+                ", displayStats=" + redisplayStats +
                 ", actionTaken=" + actionTaken +
                 ", isPreview=" + isPreview +
                 '}';

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessage.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessage.java
@@ -164,7 +164,6 @@ class OSInAppMessage {
 
     /**
      * Called when an action is taken to track uniqueness
-     *
      * @return true if action taken was unique
      */
     boolean takeActionAsUnique() {
@@ -243,4 +242,5 @@ class OSInAppMessage {
         int result = messageId.hashCode();
         return result;
     }
+
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageRedisplayStats.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageRedisplayStats.java
@@ -3,31 +3,31 @@ package com.onesignal;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-class OSInAppMessageDisplayStats {
+class OSInAppMessageRedisplayStats {
 
     private static final String DISPLAY_LIMIT = "limit";
     private static final String DISPLAY_DELAY = "delay";
 
-    //Last IAM display time in seconds
+    // Last IAM display time in seconds
     private long lastDisplayTime = -1;
-    //Current quantity of displays
+    // Current quantity of displays
     private int displayQuantity = 0;
-    //Quantity of displays limit
-    private int displayLimit = Integer.MAX_VALUE;
-    //Delay between displays in seconds
+    // Quantity of displays limit
+    private int displayLimit = 1;
+    // Delay between displays in seconds
     private long displayDelay = 0;
 
     private boolean redisplayEnabled = false;
 
-    OSInAppMessageDisplayStats() {
+    OSInAppMessageRedisplayStats() {
     }
 
-    OSInAppMessageDisplayStats(int displayQuantity, long lastDisplayTime) {
+    OSInAppMessageRedisplayStats(int displayQuantity, long lastDisplayTime) {
         this.displayQuantity = displayQuantity;
         this.lastDisplayTime = lastDisplayTime;
     }
 
-    OSInAppMessageDisplayStats(JSONObject json) throws JSONException {
+    OSInAppMessageRedisplayStats(JSONObject json) throws JSONException {
         this.redisplayEnabled = true;
         Object displayLimit = json.get(DISPLAY_LIMIT);
         Object displayDelay = json.get(DISPLAY_DELAY);
@@ -41,7 +41,7 @@ class OSInAppMessageDisplayStats {
             this.displayDelay = (Integer) displayDelay;
     }
 
-    void setDisplayStats(OSInAppMessageDisplayStats displayStats) {
+    void setDisplayStats(OSInAppMessageRedisplayStats displayStats) {
         setLastDisplayTime(displayStats.getLastDisplayTime());
         setDisplayQuantity(displayStats.getDisplayQuantity());
     }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageRepository.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageRepository.java
@@ -24,21 +24,9 @@ class OSInAppMessageRepository {
         this.dbHelper = dbHelper;
     }
 
-    /**
-     * Remove IAMs that the last display time was six month ago
-     */
-    @WorkerThread
-    synchronized void deleteOldRedisplayedInAppMessages() {
-        long sixMonthsAgo = System.currentTimeMillis() / 1000 - OS_IAM_MAX_CACHE_TIME;
-        SQLiteDatabase writableDb = dbHelper.getWritableDbWithRetries();
-        writableDb.delete(OneSignalDbContract.InAppMessageTable.TABLE_NAME,
-                OneSignalDbContract.InAppMessageTable.COLUMN_NAME_LAST_DISPLAY + "< ?",
-                new String[]{String.valueOf(sixMonthsAgo)});
-    }
-
     @WorkerThread
     synchronized void saveInAppMessage(OSInAppMessage inAppMessage) {
-        SQLiteDatabase writableDb = dbHelper.getWritableDbWithRetries();
+        SQLiteDatabase writableDb = dbHelper.getSQLiteDatabaseWithRetries();
 
         ContentValues values = new ContentValues();
         values.put(OneSignalDbContract.InAppMessageTable.COLUMN_NAME_MESSAGE_ID, inAppMessage.messageId);
@@ -59,7 +47,7 @@ class OSInAppMessageRepository {
         Cursor cursor = null;
 
         try {
-            SQLiteDatabase readableDb = dbHelper.getReadableDbWithRetries();
+            SQLiteDatabase readableDb = dbHelper.getSQLiteDatabaseWithRetries();
             cursor = readableDb.query(
                     OneSignalDbContract.InAppMessageTable.TABLE_NAME,
                     null,

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageRepository.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageRepository.java
@@ -9,7 +9,6 @@ import org.json.JSONArray;
 import org.json.JSONException;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -63,7 +62,7 @@ class OSInAppMessageRepository {
                     long lastDisplay = cursor.getLong(cursor.getColumnIndex(OneSignalDbContract.InAppMessageTable.COLUMN_NAME_LAST_DISPLAY));
                     boolean displayed = cursor.getInt(cursor.getColumnIndex(OneSignalDbContract.InAppMessageTable.COLUMN_DISPLAYED_IN_SESSION)) == 1;
 
-                    Set<String> clickIdsSet = OSUtils.newStringSetFromString(clickIds);
+                    Set<String> clickIdsSet = OSUtils.newStringSetFromJSONArray(new JSONArray(clickIds));
 
                     OSInAppMessage inAppMessage = new OSInAppMessage(messageId, clickIdsSet, displayed, new OSInAppMessageRedisplayStats(displayQuantity, lastDisplay));
                     iams.add(inAppMessage);

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSUtils.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSUtils.java
@@ -447,9 +447,16 @@ class OSUtils {
       return Collections.newSetFromMap(new ConcurrentHashMap<T, Boolean>());
    }
 
-   // Creates a new Set<String> from a String
-   static Set<String> newStringSetFromString(String setString) {
-      return new HashSet<>(Collections.singletonList(setString));
+   // Creates a new Set<String> from a Set String by converting and iterating a JSONArray
+   static Set<String> newStringSetFromString(String setString) throws JSONException {
+      Set<String> stringSet = new HashSet<>();
+
+      JSONArray clickIdsArray = new JSONArray(setString);
+      for (int i = 0; i < clickIdsArray.length(); i++) {
+         stringSet.add(clickIdsArray.getString(i));
+      }
+
+      return stringSet;
    }
 
    static boolean hasConfigChangeFlag(Activity activity, int configChangeFlag) {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSUtils.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSUtils.java
@@ -54,7 +54,10 @@ import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -442,6 +445,11 @@ class OSUtils {
    // Creates a new Set<T> that supports reads and writes from more than one thread at a time
    static <T> Set<T> newConcurrentSet() {
       return Collections.newSetFromMap(new ConcurrentHashMap<T, Boolean>());
+   }
+
+   // Creates a new Set<String> from a String
+   static Set<String> newStringSetFromString(String setString) {
+      return new HashSet<>(Collections.singletonList(setString));
    }
 
    static boolean hasConfigChangeFlag(Activity activity, int configChangeFlag) {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSUtils.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSUtils.java
@@ -448,12 +448,11 @@ class OSUtils {
    }
 
    // Creates a new Set<String> from a Set String by converting and iterating a JSONArray
-   static Set<String> newStringSetFromString(String setString) throws JSONException {
+   static Set<String> newStringSetFromJSONArray(JSONArray jsonArray) throws JSONException {
       Set<String> stringSet = new HashSet<>();
 
-      JSONArray clickIdsArray = new JSONArray(setString);
-      for (int i = 0; i < clickIdsArray.length(); i++) {
-         stringSet.add(clickIdsArray.getString(i));
+      for (int i = 0; i < jsonArray.length(); i++) {
+         stringSet.add(jsonArray.getString(i));
       }
 
       return stringSet;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -2588,7 +2588,7 @@ public class OneSignal {
             OneSignalDbHelper dbHelper = OneSignalDbHelper.getInstance(appContext);
             Cursor cursor = null;
             try {
-               SQLiteDatabase readableDb = dbHelper.getReadableDbWithRetries();
+               SQLiteDatabase readableDb = dbHelper.getSQLiteDatabaseWithRetries();
 
                String[] retColumn = {OneSignalDbContract.NotificationTable.COLUMN_NAME_ANDROID_NOTIFICATION_ID};
 
@@ -2614,7 +2614,7 @@ public class OneSignal {
                // Mark all notifications as dismissed unless they were already opened.
                SQLiteDatabase writableDb = null;
                try {
-                  writableDb = dbHelper.getWritableDbWithRetries();
+                  writableDb = dbHelper.getSQLiteDatabaseWithRetries();
                   writableDb.beginTransaction();
 
                   String whereStr = NotificationTable.COLUMN_NAME_OPENED + " = 0";
@@ -2668,7 +2668,7 @@ public class OneSignal {
             OneSignalDbHelper dbHelper = OneSignalDbHelper.getInstance(appContext);
             SQLiteDatabase writableDb = null;
             try {
-               writableDb = dbHelper.getWritableDbWithRetries();
+               writableDb = dbHelper.getSQLiteDatabaseWithRetries();
                writableDb.beginTransaction();
 
                String whereStr = NotificationTable.COLUMN_NAME_ANDROID_NOTIFICATION_ID + " = " + id + " AND " +
@@ -2730,7 +2730,7 @@ public class OneSignal {
             Cursor cursor = null;
 
             try {
-               SQLiteDatabase readableDb = dbHelper.getReadableDbWithRetries();
+               SQLiteDatabase readableDb = dbHelper.getSQLiteDatabaseWithRetries();
 
                String[] retColumn = { NotificationTable.COLUMN_NAME_ANDROID_NOTIFICATION_ID };
 
@@ -2762,7 +2762,7 @@ public class OneSignal {
 
             SQLiteDatabase writableDb = null;
             try {
-               writableDb = dbHelper.getWritableDbWithRetries();
+               writableDb = dbHelper.getSQLiteDatabaseWithRetries();
                writableDb.beginTransaction();
 
                String whereStr = NotificationTable.COLUMN_NAME_GROUP_ID + " = ? AND " +
@@ -3041,7 +3041,7 @@ public class OneSignal {
       Cursor cursor = null;
 
       try {
-         SQLiteDatabase readableDb = dbHelper.getReadableDbWithRetries();
+         SQLiteDatabase readableDb = dbHelper.getSQLiteDatabaseWithRetries();
 
          String[] retColumn = {NotificationTable.COLUMN_NAME_NOTIFICATION_ID};
          String[] whereArgs = {id};

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalCacheCleaner.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalCacheCleaner.java
@@ -89,6 +89,11 @@ class OneSignalCacheCleaner {
                             null,
                             null);
 
+                    if (cursor == null || cursor.getCount() == 0) {
+                        OneSignal.onesignalLog(OneSignal.LOG_LEVEL.DEBUG, "Attempted to clean 6 month old IAM data, but none exists!");
+                        return;
+                    }
+
                     // From cursor get all of the old message ids and old clicked click ids
                     if (cursor.moveToFirst()) {
                         do {
@@ -169,23 +174,18 @@ class OneSignalCacheCleaner {
      */
     private static void cleanCachedSharedPreferenceIamData(Set<String> oldMessageIds, Set<String> oldClickedClickIds) {
         // IAMs without redisplay on with pile up and we need to clean these for dismissing, impressions, and clicks
-        Set<String> dismissedMessages = OneSignalPrefs.getStringSet(
-                OneSignalPrefs.PREFS_ONESIGNAL,
-                OneSignalPrefs.PREFS_OS_DISMISSED_IAMS,
-                OSUtils.<String>newConcurrentSet());
+        if (oldMessageIds != null && oldMessageIds.size() > 0) {
+            Set<String> dismissedMessages = OneSignalPrefs.getStringSet(
+                    OneSignalPrefs.PREFS_ONESIGNAL,
+                    OneSignalPrefs.PREFS_OS_DISMISSED_IAMS,
+                    OSUtils.<String>newConcurrentSet());
 
-        Set<String> impressionedMessages = OneSignalPrefs.getStringSet(
-                OneSignalPrefs.PREFS_ONESIGNAL,
-                OneSignalPrefs.PREFS_OS_IMPRESSIONED_IAMS,
-                OSUtils.<String>newConcurrentSet());
+            Set<String> impressionedMessages = OneSignalPrefs.getStringSet(
+                    OneSignalPrefs.PREFS_ONESIGNAL,
+                    OneSignalPrefs.PREFS_OS_IMPRESSIONED_IAMS,
+                    OSUtils.<String>newConcurrentSet());
 
-        Set<String> clickedClickIds = OneSignalPrefs.getStringSet(
-                OneSignalPrefs.PREFS_ONESIGNAL,
-                OneSignalPrefs.PREFS_OS_CLICKED_CLICK_IDS_IAMS,
-                OSUtils.<String>newConcurrentSet());
-
-        if (oldMessageIds != null) {
-            if (dismissedMessages != null) {
+            if (dismissedMessages != null && dismissedMessages.size() > 0) {
                 dismissedMessages.removeAll(oldMessageIds);
                 OneSignalPrefs.saveStringSet(
                         OneSignalPrefs.PREFS_ONESIGNAL,
@@ -193,7 +193,7 @@ class OneSignalCacheCleaner {
                         dismissedMessages);
             }
 
-            if (impressionedMessages != null) {
+            if (impressionedMessages != null && impressionedMessages.size() > 0) {
                 impressionedMessages.removeAll(oldMessageIds);
                 OneSignalPrefs.saveStringSet(
                         OneSignalPrefs.PREFS_ONESIGNAL,
@@ -202,12 +202,19 @@ class OneSignalCacheCleaner {
             }
         }
 
-        if (clickedClickIds != null && oldClickedClickIds != null) {
-            clickedClickIds.removeAll(oldClickedClickIds);
-            OneSignalPrefs.saveStringSet(
+        if (oldClickedClickIds != null && oldClickedClickIds.size() > 0) {
+            Set<String> clickedClickIds = OneSignalPrefs.getStringSet(
                     OneSignalPrefs.PREFS_ONESIGNAL,
                     OneSignalPrefs.PREFS_OS_CLICKED_CLICK_IDS_IAMS,
-                    clickedClickIds);
+                    OSUtils.<String>newConcurrentSet());
+
+            if (clickedClickIds != null && clickedClickIds.size() > 0) {
+                clickedClickIds.removeAll(oldClickedClickIds);
+                OneSignalPrefs.saveStringSet(
+                        OneSignalPrefs.PREFS_ONESIGNAL,
+                        OneSignalPrefs.PREFS_OS_CLICKED_CLICK_IDS_IAMS,
+                        clickedClickIds);
+            }
         }
     }
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalCacheCleaner.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalCacheCleaner.java
@@ -4,39 +4,32 @@ import com.onesignal.OneSignalDbContract.NotificationTable;
 import com.onesignal.OneSignalDbContract.CachedUniqueOutcomeNotificationTable;
 
 import android.content.Context;
+import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.os.Process;
+import android.support.annotation.WorkerThread;
+
+import java.util.Set;
 
 class OneSignalCacheCleaner {
 
-    private static String OS_DELETE_OLD_CACHED_DATA = "OS_DELETE_OLD_CACHED_DATA";
+    private final static long ONE_WEEK_IN_MILLIS = 604_800L;
+    private final static long SIX_MONTHS_IN_MILLIS = 15_552_000L;
+
+    private final static String OS_DELETE_CACHED_NOTIFICATIONS_THREAD = "OS_DELETE_CACHED_NOTIFICATIONS_THREAD";
+    private final static String OS_DELETE_CACHED_REDISPLAYED_IAMS_THREAD = "OS_DELETE_CACHED_REDISPLAYED_IAMS_THREAD";
 
     /**
      * We clean outdated cache from several places within the OneSignal SDK here
-     * 1. In App Messaging id sets (impressions, clicks, views)
-     * 2. Notifications after 1 week
-     * 3. Unique outcome events linked to notification ids (1 week)
+     * 1. Notifications & unique outcome events linked to notification ids (1 week)
+     * 2. Cached In App Messaging Sets in SharedPreferences (impressions, clicks, views) and SQL IAMs
      */
-    synchronized static void cleanOldCachedData(final Context context) {
-        new Thread(new Runnable() {
-            @Override
-            public void run() {
-                Thread.currentThread().setPriority(Process.THREAD_PRIORITY_BACKGROUND);
-                OneSignalDbHelper dbHelper = OneSignalDbHelper.getInstance(context);
-                SQLiteDatabase writableDb = dbHelper.getWritableDbWithRetries();
+    static void cleanOldCachedData(final Context context) {
+        OneSignalDbHelper dbHelper = OneSignalDbHelper.getInstance(context);
+        SQLiteDatabase writableDb = dbHelper.getSQLiteDatabaseWithRetries();
 
-                cleanInAppMessagingCache();
-                cleanNotificationCache(writableDb);
-            }
-        }, OS_DELETE_OLD_CACHED_DATA).start();
-    }
-
-    /**
-     * TODO: Needs to be implemented to clean out old IAM data used to track impressions, clicks, and viewed IAMs
-     */
-    static void cleanInAppMessagingCache() {
-        // NOTE: Currently IAMs will pile up overtime and since IAMs can be modified, active, inactive, etc.
-        //  we never truly know when it is the correct time to remove these ids form our cache
+        cleanNotificationCache(writableDb);
+        cleanCachedInAppMessages(writableDb);
     }
 
     /**
@@ -44,29 +37,155 @@ class OneSignalCacheCleaner {
      * 1. NotificationTable.TABLE_NAME
      * 2. CachedUniqueOutcomeNotificationTable.TABLE_NAME
      */
-    static void cleanNotificationCache(SQLiteDatabase writableDb) {
-        cleanOldNotificationData(writableDb);
-        cleanOldUniqueOutcomeEventNotificationsCache(writableDb);
-    }
+    synchronized static void cleanNotificationCache(final SQLiteDatabase writableDb) {
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                Thread.currentThread().setPriority(Process.THREAD_PRIORITY_BACKGROUND);
 
-    /**
-     * Deletes any notifications with created timestamps older than 7 days
-     */
-    private static void cleanOldNotificationData(SQLiteDatabase writableDb) {
-        writableDb.delete(NotificationTable.TABLE_NAME,
-                NotificationTable.COLUMN_NAME_CREATED_TIME + " < " + ((System.currentTimeMillis() / 1_000L) - 604_800L),
-                null);
-    }
+                cleanCachedNotifications(writableDb);
+                cleanCachedUniqueOutcomeEventNotifications(writableDb);
+            }
 
-    /**
-     * Deletes any notifications whose ids do not exist inside of the NotificationTable.TABLE_NAME
-     */
-    static void cleanOldUniqueOutcomeEventNotificationsCache(SQLiteDatabase writableDb) {
-        writableDb.delete(CachedUniqueOutcomeNotificationTable.TABLE_NAME,
-                "NOT EXISTS(SELECT NULL FROM " + NotificationTable.TABLE_NAME +
+            /**
+             * Deletes notifications with created timestamps older than 7 days
+             */
+            private void cleanCachedNotifications(SQLiteDatabase writableDb) {
+                String whereStr = NotificationTable.COLUMN_NAME_CREATED_TIME + " < ?";
+
+                String sevenDaysAgoInSeconds = String.valueOf((System.currentTimeMillis() / 1_000L) - ONE_WEEK_IN_MILLIS);
+                String[] whereArgs = new String[]{ sevenDaysAgoInSeconds };
+
+                writableDb.delete(
+                        NotificationTable.TABLE_NAME,
+                        whereStr,
+                        whereArgs);
+            }
+
+            /**
+             * Deletes cached unique outcome notifications whose ids do not exist inside of the NotificationTable.TABLE_NAME
+             */
+            private void cleanCachedUniqueOutcomeEventNotifications(SQLiteDatabase writableDb) {
+                String whereStr = "NOT EXISTS(SELECT NULL FROM " + NotificationTable.TABLE_NAME +
                         " n WHERE" +
-                        " n." + NotificationTable.COLUMN_NAME_NOTIFICATION_ID  + " = " + CachedUniqueOutcomeNotificationTable.COLUMN_NAME_NOTIFICATION_ID + ")",
-                null);
+                        " n." + NotificationTable.COLUMN_NAME_NOTIFICATION_ID +
+                        " = " + CachedUniqueOutcomeNotificationTable.COLUMN_NAME_NOTIFICATION_ID + ")";
+
+                writableDb.delete(
+                        CachedUniqueOutcomeNotificationTable.TABLE_NAME,
+                        whereStr,
+                        null);
+            }
+
+        }, OS_DELETE_CACHED_NOTIFICATIONS_THREAD).start();
+    }
+
+    /**
+     * Remove IAMs that the last display time was six month ago
+     * 1. Query for all old message ids and old clicked click ids
+     * 2. Delete old IAMs from SQL
+     * 3. Use queried data to clean SharedPreferences
+     */
+    @WorkerThread
+    synchronized static void cleanCachedInAppMessages(final SQLiteDatabase writableDb) {
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                Thread.currentThread().setPriority(Process.THREAD_PRIORITY_BACKGROUND);
+
+                // 1. Query for all old message ids and old clicked click ids
+                String[] retColumns = new String[]{
+                        OneSignalDbContract.InAppMessageTable.COLUMN_NAME_MESSAGE_ID,
+                        OneSignalDbContract.InAppMessageTable.COLUMN_CLICK_IDS
+                };
+
+                String whereStr = OneSignalDbContract.InAppMessageTable.COLUMN_NAME_LAST_DISPLAY + " < ?";
+
+                String sixMonthsAgoInSeconds = String.valueOf((System.currentTimeMillis() / 1_000L) - SIX_MONTHS_IN_MILLIS);
+                String[] whereArgs = new String[]{sixMonthsAgoInSeconds};
+
+                Cursor cursor = writableDb.query(OneSignalDbContract.InAppMessageTable.TABLE_NAME,
+                        retColumns,
+                        whereStr,
+                        whereArgs,
+                        null,
+                        null,
+                        null);
+
+                // From cursor get all of the old message ids and old clicked click ids
+                Set<String> oldMessageIds = OSUtils.newConcurrentSet();
+                Set<String> oldClickedClickIds = OSUtils.newConcurrentSet();
+                if (cursor.moveToFirst()) {
+                    do {
+                        String oldMessageId = cursor.getString(
+                                cursor.getColumnIndex(
+                                        OneSignalDbContract.InAppMessageTable.COLUMN_NAME_MESSAGE_ID));
+                        String oldClickIds = cursor.getString(
+                                cursor.getColumnIndex(
+                                        OneSignalDbContract.InAppMessageTable.COLUMN_NAME_MESSAGE_ID));
+
+                        oldMessageIds.add(oldMessageId);
+                        oldClickedClickIds.addAll(OSUtils.newStringSetFromString(oldClickIds));
+                    } while (cursor.moveToNext());
+                }
+                cursor.close();
+
+                // 2. Delete old IAMs from SQL
+                writableDb.delete(
+                        OneSignalDbContract.InAppMessageTable.TABLE_NAME,
+                        whereStr,
+                        whereArgs);
+
+                // 3. Use queried data to clean SharedPreferences
+                cleanCachedSharedPreferenceIamData(oldMessageIds, oldClickedClickIds);
+            }
+
+            private void cleanCachedSharedPreferenceIamData(Set<String> oldMessageIds, Set<String> oldClickedClickIds) {
+                // IAMs without redisplay on with pile up and we need to clean these for dismissing, impressions, and clicks
+                Set<String> dismissedMessages = OneSignalPrefs.getStringSet(
+                        OneSignalPrefs.PREFS_ONESIGNAL,
+                        OneSignalPrefs.PREFS_OS_DISMISSED_IAMS,
+                        OSUtils.<String>newConcurrentSet());
+
+                Set<String> impressionedMessages = OneSignalPrefs.getStringSet(
+                        OneSignalPrefs.PREFS_ONESIGNAL,
+                        OneSignalPrefs.PREFS_OS_IMPRESSIONED_IAMS,
+                        OSUtils.<String>newConcurrentSet());
+
+                Set<String> clickedClickIds = OneSignalPrefs.getStringSet(
+                        OneSignalPrefs.PREFS_ONESIGNAL,
+                        OneSignalPrefs.PREFS_OS_CLICKED_CLICK_IDS_IAMS,
+                        OSUtils.<String>newConcurrentSet());
+
+                if (oldMessageIds != null) {
+                    if (dismissedMessages != null) {
+                        dismissedMessages.removeAll(oldMessageIds);
+                        OneSignalPrefs.saveStringSet(
+                                OneSignalPrefs.PREFS_ONESIGNAL,
+                                OneSignalPrefs.PREFS_OS_DISMISSED_IAMS,
+                                dismissedMessages);
+                    }
+
+                    if (impressionedMessages != null) {
+                        impressionedMessages.removeAll(oldMessageIds);
+                        OneSignalPrefs.saveStringSet(
+                                OneSignalPrefs.PREFS_ONESIGNAL,
+                                OneSignalPrefs.PREFS_OS_IMPRESSIONED_IAMS,
+                                impressionedMessages);
+                    }
+                }
+
+                if (clickedClickIds != null && oldClickedClickIds != null) {
+                    clickedClickIds.removeAll(oldClickedClickIds);
+                    OneSignalPrefs.saveStringSet(
+                            OneSignalPrefs.PREFS_ONESIGNAL,
+                            OneSignalPrefs.PREFS_OS_CLICKED_CLICK_IDS_IAMS,
+                            clickedClickIds);
+                }
+
+            }
+
+        }, OS_DELETE_CACHED_REDISPLAYED_IAMS_THREAD).start();
     }
 
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalCacheCleaner.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalCacheCleaner.java
@@ -123,7 +123,8 @@ class OneSignalCacheCleaner {
                         whereArgs);
 
                 // 3. Use queried data to clean SharedPreferences
-                cleanCachedSharedPreferenceIamData(oldMessageIds, oldClickedClickIds);
+                cleanInAppMessageIds(oldMessageIds);
+                cleanInAppMessageClickedClickIds(oldClickedClickIds);
             }
 
         }, OS_DELETE_CACHED_REDISPLAYED_IAMS_THREAD).start();
@@ -167,14 +168,15 @@ class OneSignalCacheCleaner {
     }
 
     /**
-     * Deletes old IAM SharedPreference dismissed and impressioned message ids as well as clicked click ids
+     * Clean up 6 month old IAM ids in {@link android.content.SharedPreferences}:
+     *  1. Dismissed message ids
+     *  2. Impressioned message ids
      * <br/><br/>
      * Note: This should only ever be called by {@link OneSignalCacheCleaner#cleanCachedInAppMessages(SQLiteDatabase)}
      * <br/><br/>
      * @see OneSignalCacheCleaner#cleanCachedInAppMessages(SQLiteDatabase)
      */
-    private static void cleanCachedSharedPreferenceIamData(Set<String> oldMessageIds, Set<String> oldClickedClickIds) {
-        // IAMs without redisplay on with pile up and we need to clean these for dismissing, impressions, and clicks
+    private static void cleanInAppMessageIds(Set<String> oldMessageIds) {
         if (oldMessageIds != null && oldMessageIds.size() > 0) {
             Set<String> dismissedMessages = OneSignalPrefs.getStringSet(
                     OneSignalPrefs.PREFS_ONESIGNAL,
@@ -202,7 +204,17 @@ class OneSignalCacheCleaner {
                         impressionedMessages);
             }
         }
+    }
 
+    /**
+     * Clean up 6 month old IAM clicked click ids in {@link android.content.SharedPreferences}:
+     *  1. Clicked click ids from elements within IAM
+     * <br/><br/>
+     * Note: This should only ever be called by {@link OneSignalCacheCleaner#cleanCachedInAppMessages(SQLiteDatabase)}
+     * <br/><br/>
+     * @see OneSignalCacheCleaner#cleanCachedInAppMessages(SQLiteDatabase)
+     */
+    private static void cleanInAppMessageClickedClickIds(Set<String> oldClickedClickIds) {
         if (oldClickedClickIds != null && oldClickedClickIds.size() > 0) {
             Set<String> clickedClickIds = OneSignalPrefs.getStringSet(
                     OneSignalPrefs.PREFS_ONESIGNAL,

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OutcomeEventsCache.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OutcomeEventsCache.java
@@ -22,7 +22,7 @@ class OutcomeEventsCache {
      */
     @WorkerThread
     synchronized static void deleteOldOutcomeEvent(OutcomeEvent event, OneSignalDbHelper dbHelper) {
-        SQLiteDatabase writableDb = dbHelper.getWritableDbWithRetries();
+        SQLiteDatabase writableDb = dbHelper.getSQLiteDatabaseWithRetries();
 
         try {
             writableDb.beginTransaction();
@@ -49,7 +49,7 @@ class OutcomeEventsCache {
      */
     @WorkerThread
     synchronized static void saveOutcomeEvent(OutcomeEvent event, OneSignalDbHelper dbHelper) {
-        SQLiteDatabase writableDb = dbHelper.getWritableDbWithRetries();
+        SQLiteDatabase writableDb = dbHelper.getSQLiteDatabaseWithRetries();
         String notificationIds = event.getNotificationIds() != null ? event.getNotificationIds().toString() : "[]";
 
         ContentValues values = new ContentValues();
@@ -73,7 +73,7 @@ class OutcomeEventsCache {
         Cursor cursor = null;
 
         try {
-            SQLiteDatabase readableDb = dbHelper.getReadableDbWithRetries();
+            SQLiteDatabase readableDb = dbHelper.getSQLiteDatabaseWithRetries();
             cursor = readableDb.query(
                     OutcomeEventsTable.TABLE_NAME,
                     null,
@@ -118,7 +118,7 @@ class OutcomeEventsCache {
         if (notificationIds == null)
             return;
 
-        SQLiteDatabase writableDb = dbHelper.getWritableDbWithRetries();
+        SQLiteDatabase writableDb = dbHelper.getSQLiteDatabaseWithRetries();
         try {
             for (int i = 0; i < notificationIds.length(); i++) {
                 ContentValues values = new ContentValues();
@@ -141,7 +141,7 @@ class OutcomeEventsCache {
     synchronized static JSONArray getNotCachedUniqueOutcomeNotifications(String name, JSONArray notificationIds, OneSignalDbHelper dbHelper) {
         JSONArray uniqueNotificationIds = new JSONArray();
 
-        SQLiteDatabase readableDb = dbHelper.getReadableDbWithRetries();
+        SQLiteDatabase readableDb = dbHelper.getSQLiteDatabaseWithRetries();
         Cursor cursor = null;
 
         try {

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/InAppMessagingHelpers.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/InAppMessagingHelpers.java
@@ -104,7 +104,7 @@ public class InAppMessagingHelpers {
         return new OSTestInAppMessage(json);
     }
 
-    private static OSTestInAppMessage buildTestMessage(final JSONArray triggerJson) throws JSONException {
+    public static OSTestInAppMessage buildTestMessage(final JSONArray triggerJson) throws JSONException {
         return new OSTestInAppMessage(basicIAMJSONObject(triggerJson));
     }
 

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
@@ -30,7 +30,7 @@ public class OneSignalPackagePrivateHelper {
       abstract void run(T object) throws Exception;
    }
 
-   static private void processNetworkHandles(RunnableArg runnable) throws Exception {
+   private static void processNetworkHandles(RunnableArg runnable) throws Exception {
       Set<Map.Entry<Integer, UserStateSynchronizer.NetworkHandlerThread>> entrySet;
 
       entrySet = OneSignalStateSynchronizer.getPushStateSynchronizer().networkHandlerThreads.entrySet();
@@ -248,7 +248,7 @@ public class OneSignalPackagePrivateHelper {
       OneSignal.appId = appId;
    }
 
-   static public class RemoteOutcomeParams extends com.onesignal.OneSignalRemoteParams.OutcomesParams {
+   public static class RemoteOutcomeParams extends com.onesignal.OneSignalRemoteParams.OutcomesParams {
 
       public RemoteOutcomeParams() {
          this(true, true, true);
@@ -261,13 +261,22 @@ public class OneSignalPackagePrivateHelper {
       }
    }
 
-   static public class BadgeCountUpdater extends com.onesignal.BadgeCountUpdater {
+   public static SQLiteDatabase OneSignal_getSQLiteDatabase(Context context) {
+      return OneSignalDbHelper.getInstance(context).getSQLiteDatabase();
+   }
+
+   public static void OneSignal_cleanOutcomeDatabaseTable(Context context) {
+      OneSignalDbHelper.cleanOutcomeDatabaseTable(
+              OneSignal_getSQLiteDatabase(context));
+   }
+
+   public static class BadgeCountUpdater extends com.onesignal.BadgeCountUpdater {
       public static void update(SQLiteDatabase readableDb, Context context) {
          com.onesignal.BadgeCountUpdater.update(readableDb, context);
       }
    }
 
-   static public class NotificationLimitManager extends com.onesignal.NotificationLimitManager {
+   public static class NotificationLimitManager extends com.onesignal.NotificationLimitManager {
       public static void clearOldestOverLimitFallback(Context context, int notifsToMakeRoomFor) {
          com.onesignal.NotificationLimitManager.clearOldestOverLimitFallback(context, notifsToMakeRoomFor);
       }

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
@@ -16,7 +16,6 @@ import org.robolectric.util.Scheduler;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -226,7 +225,7 @@ public class OneSignalPackagePrivateHelper {
       NotificationSummaryManager.updateSummaryNotificationAfterChildRemoved(context, writableDb, group, dismissed);
    }
 
-   public class OneSignalPrefs extends com.onesignal.OneSignalPrefs {}
+   public class TestOneSignalPrefs extends com.onesignal.OneSignalPrefs {}
 
    public static void OneSignal_onAppLostFocus() {
       OneSignal.onAppLostFocus();
@@ -293,7 +292,7 @@ public class OneSignalPackagePrivateHelper {
    public static class OSTestInAppMessage extends com.onesignal.OSInAppMessage {
 
       public OSTestInAppMessage(@NonNull String messageId, int displaysQuantity, long lastDisplayTime, boolean displayed, Set<String> clickIds) {
-         super(messageId, clickIds, displayed, new OSInAppMessageDisplayStats(displaysQuantity, lastDisplayTime));
+         super(messageId, clickIds, displayed, new OSInAppMessageRedisplayStats(displaysQuantity, lastDisplayTime));
       }
 
       OSTestInAppMessage(JSONObject json) throws JSONException {
@@ -357,8 +356,13 @@ public class OneSignalPackagePrivateHelper {
       }
 
       @Override
-      public OSTestInAppMessageDisplayStats getDisplayStats() {
-         return new OSTestInAppMessageDisplayStats(super.getDisplayStats());
+      public OSTestInAppMessageDisplayStats getRedisplayStats() {
+         return new OSTestInAppMessageDisplayStats(super.getRedisplayStats());
+      }
+
+      @Override
+      public void setRedisplayStats(int displayQuantity, long lastDisplayTime) {
+         super.setRedisplayStats(displayQuantity, lastDisplayTime);
       }
 
       public JSONObject toJSONObject() {
@@ -366,16 +370,16 @@ public class OneSignalPackagePrivateHelper {
       }
    }
 
-   public static class OSTestInAppMessageDisplayStats extends com.onesignal.OSInAppMessageDisplayStats {
+   public static class OSTestInAppMessageDisplayStats extends OSInAppMessageRedisplayStats {
 
-      private OSInAppMessageDisplayStats displayStats;
+      private OSInAppMessageRedisplayStats displayStats;
 
-      OSTestInAppMessageDisplayStats(OSInAppMessageDisplayStats displayStats) {
+      OSTestInAppMessageDisplayStats(OSInAppMessageRedisplayStats displayStats) {
          this.displayStats = displayStats;
       }
 
       @Override
-      public void setDisplayStats(OSInAppMessageDisplayStats displayStats) {
+      public void setDisplayStats(OSInAppMessageRedisplayStats displayStats) {
          this.displayStats.setDisplayStats(displayStats);
       }
 
@@ -494,7 +498,7 @@ public class OneSignalPackagePrivateHelper {
       for (OSInAppMessage message : messages) {
          try {
             OSTestInAppMessage testInAppMessage = new OSTestInAppMessage(message);
-            testInAppMessage.getDisplayStats().setDisplayStats(message.getDisplayStats());
+            testInAppMessage.getRedisplayStats().setDisplayStats(message.getRedisplayStats());
             testMessages.add(testInAppMessage);
 
          } catch (JSONException e) {

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/DatabaseRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/DatabaseRunner.java
@@ -78,7 +78,7 @@ public class DatabaseRunner {
    public void shouldUpgradeDbFromV2ToV3() {
       // 1. Init DB as version 2 and add one notification record
       ShadowOneSignalDbHelper.DATABASE_VERSION = 2;
-      SQLiteDatabase writableDatabase = OneSignalDbHelper.getInstance(RuntimeEnvironment.application).getWritableDatabase();
+      SQLiteDatabase writableDatabase = OneSignalPackagePrivateHelper.OneSignal_getSQLiteDatabase(RuntimeEnvironment.application);
       writableDatabase.beginTransaction();
       ContentValues values = new ContentValues();
       values.put(NotificationTable.COLUMN_NAME_ANDROID_NOTIFICATION_ID, 1);
@@ -103,7 +103,7 @@ public class DatabaseRunner {
    public void shouldUpgradeDbFromV3ToV4() throws Exception {
       // 1. Init DB as version 3
       ShadowOneSignalDbHelper.DATABASE_VERSION = 3;
-      SQLiteDatabase readableDatabase = OneSignalDbHelper.getInstance(RuntimeEnvironment.application).getReadableDatabase();
+      SQLiteDatabase readableDatabase = OneSignalPackagePrivateHelper.OneSignal_getSQLiteDatabase(RuntimeEnvironment.application);
 
       Cursor cursor = readableDatabase.rawQuery("SELECT name FROM sqlite_master WHERE type ='table' AND name='" + OutcomeEventsTable.TABLE_NAME + "'", null);
 
@@ -134,7 +134,7 @@ public class DatabaseRunner {
 
       assertEquals(events.size(), 0);
 
-      SQLiteDatabase writableDatabase = OneSignalDbHelper.getInstance(RuntimeEnvironment.application).getWritableDatabase();
+      SQLiteDatabase writableDatabase = OneSignalPackagePrivateHelper.OneSignal_getSQLiteDatabase(RuntimeEnvironment.application);
       // 5. Table now must exist
       writableDatabase.insert(OutcomeEventsTable.TABLE_NAME, null, values);
       writableDatabase.close();
@@ -159,7 +159,7 @@ public class DatabaseRunner {
    public void shouldUpgradeDbFromV4ToV5() {
       // 1. Init DB as version 4
       ShadowOneSignalDbHelper.DATABASE_VERSION = 4;
-      SQLiteDatabase writableDatabase = OneSignalDbHelper.getInstance(RuntimeEnvironment.application).getWritableDatabase();
+      SQLiteDatabase writableDatabase = OneSignalPackagePrivateHelper.OneSignal_getSQLiteDatabase(RuntimeEnvironment.application);
       writableDatabase.execSQL(SQL_CREATE_OUTCOME_REVISION1_ENTRIES);
 
       Cursor cursor = writableDatabase.rawQuery("SELECT name FROM sqlite_master WHERE type ='table' AND name='" + CachedUniqueOutcomeNotificationTable.TABLE_NAME + "'", null);
@@ -188,7 +188,7 @@ public class DatabaseRunner {
 
       assertEquals(notifications.size(), 0);
 
-      writableDatabase = OneSignalDbHelper.getInstance(RuntimeEnvironment.application).getWritableDatabase();
+      writableDatabase = OneSignalPackagePrivateHelper.OneSignal_getSQLiteDatabase(RuntimeEnvironment.application);
       // 5. Table now must exist
       writableDatabase.insert(CachedUniqueOutcomeNotificationTable.TABLE_NAME, null, values);
       writableDatabase.close();
@@ -202,7 +202,7 @@ public class DatabaseRunner {
    public void shouldUpgradeDbFromV5ToV6() {
       // 1. Init outcome table as version 5
       ShadowOneSignalDbHelper.DATABASE_VERSION = 5;
-      SQLiteDatabase writableDatabase = OneSignalDbHelper.getInstance(RuntimeEnvironment.application).getWritableDatabase();
+      SQLiteDatabase writableDatabase = OneSignalPackagePrivateHelper.OneSignal_getSQLiteDatabase(RuntimeEnvironment.application);
 
       // Create table with the schema we had in DB v4
       writableDatabase.execSQL(SQL_CREATE_OUTCOME_REVISION1_ENTRIES);
@@ -216,7 +216,7 @@ public class DatabaseRunner {
 
       // 2. restSetStaticFields so the db reloads and upgrade is done to version 6
       ShadowOneSignalDbHelper.restSetStaticFields();
-      writableDatabase = OneSignalDbHelper.getInstance(RuntimeEnvironment.application).getWritableDatabase();
+      writableDatabase = OneSignalPackagePrivateHelper.OneSignal_getSQLiteDatabase(RuntimeEnvironment.application);
 
       // 3. Ensure the upgrade kept our existing record
       Cursor cursor = writableDatabase.query(
@@ -249,7 +249,7 @@ public class DatabaseRunner {
    public void shouldUpgradeDbFromV6ToV7() throws JSONException {
       // 1. Init DB as version 6
       ShadowOneSignalDbHelper.DATABASE_VERSION = 6;
-      SQLiteDatabase writableDatabase = OneSignalDbHelper.getInstance(RuntimeEnvironment.application).getWritableDatabase();
+      SQLiteDatabase writableDatabase = OneSignalPackagePrivateHelper.OneSignal_getSQLiteDatabase(RuntimeEnvironment.application);
       writableDatabase.execSQL(SQL_CREATE_OUTCOME_REVISION1_ENTRIES);
 
       Cursor cursor = writableDatabase.rawQuery("SELECT name FROM sqlite_master WHERE type ='table' AND name='" + InAppMessageTable.TABLE_NAME + "'", null);
@@ -289,7 +289,7 @@ public class DatabaseRunner {
 
       assertEquals(savedInAppMessages.size(), 0);
 
-      writableDatabase = OneSignalDbHelper.getInstance(RuntimeEnvironment.application).getWritableDatabase();
+      writableDatabase = OneSignalPackagePrivateHelper.OneSignal_getSQLiteDatabase(RuntimeEnvironment.application);
       // 5. Table now must exist
       writableDatabase.insert(InAppMessageTable.TABLE_NAME, null, values);
       writableDatabase.close();

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/DatabaseRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/DatabaseRunner.java
@@ -5,7 +5,6 @@ import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 
 import com.onesignal.InAppMessagingHelpers;
-import com.onesignal.OneSignalDbHelper;
 import com.onesignal.OneSignalPackagePrivateHelper;
 import com.onesignal.OneSignalPackagePrivateHelper.CachedUniqueOutcomeNotification;
 import com.onesignal.OneSignalPackagePrivateHelper.CachedUniqueOutcomeNotificationTable;
@@ -275,8 +274,8 @@ public class DatabaseRunner {
       
       ContentValues values = new ContentValues();
       values.put(InAppMessageTable.COLUMN_NAME_MESSAGE_ID, inAppMessage.messageId);
-      values.put(InAppMessageTable.COLUMN_NAME_DISPLAY_QUANTITY, inAppMessage.getDisplayStats().getDisplayQuantity());
-      values.put(InAppMessageTable.COLUMN_NAME_LAST_DISPLAY, inAppMessage.getDisplayStats().getLastDisplayTime());
+      values.put(InAppMessageTable.COLUMN_NAME_DISPLAY_QUANTITY, inAppMessage.getRedisplayStats().getDisplayQuantity());
+      values.put(InAppMessageTable.COLUMN_NAME_LAST_DISPLAY, inAppMessage.getRedisplayStats().getLastDisplayTime());
       values.put(InAppMessageTable.COLUMN_CLICK_IDS, inAppMessage.getClickedClickIds().toString());
       values.put(InAppMessageTable.COLUMN_DISPLAYED_IN_SESSION, inAppMessage.isDisplayedInSession());
 
@@ -298,8 +297,8 @@ public class DatabaseRunner {
 
       assertEquals(savedInAppMessagesAfterCreation.size(), 1);
       OSTestInAppMessage savedInAppMessage = savedInAppMessagesAfterCreation.get(0);
-      assertEquals(savedInAppMessage.getDisplayStats().getDisplayQuantity(), inAppMessage.getDisplayStats().getDisplayQuantity());
-      assertEquals(savedInAppMessage.getDisplayStats().getLastDisplayTime(), inAppMessage.getDisplayStats().getLastDisplayTime());
+      assertEquals(savedInAppMessage.getRedisplayStats().getDisplayQuantity(), inAppMessage.getRedisplayStats().getDisplayQuantity());
+      assertEquals(savedInAppMessage.getRedisplayStats().getLastDisplayTime(), inAppMessage.getRedisplayStats().getLastDisplayTime());
       assertEquals(savedInAppMessage.getClickedClickIds().toString(), inAppMessage.getClickedClickIds().toString());
       assertEquals(savedInAppMessage.isDisplayedInSession(), inAppMessage.isDisplayedInSession());
    }

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
@@ -57,12 +57,11 @@ import com.onesignal.OSNotificationOpenResult;
 import com.onesignal.OSNotificationPayload;
 import com.onesignal.OSNotificationReceivedResult;
 import com.onesignal.OneSignal;
-import com.onesignal.OneSignalDbHelper;
 import com.onesignal.OneSignalNotificationManagerPackageHelper;
 import com.onesignal.OneSignalPackagePrivateHelper;
 import com.onesignal.OneSignalPackagePrivateHelper.NotificationRestorer;
 import com.onesignal.OneSignalPackagePrivateHelper.NotificationTable;
-import com.onesignal.OneSignalPackagePrivateHelper.OneSignalPrefs;
+import com.onesignal.OneSignalPackagePrivateHelper.TestOneSignalPrefs;
 import com.onesignal.RestoreJobService;
 import com.onesignal.ShadowBadgeCountUpdater;
 import com.onesignal.ShadowCustomTabsClient;
@@ -476,7 +475,7 @@ public class GenerateNotificationRunner {
    }
 
    private void setClearGroupSummaryClick(boolean shouldDismissAll) {
-      OneSignalPrefs.saveBool(OneSignalPrefs.PREFS_ONESIGNAL, OneSignalPrefs.PREFS_OS_CLEAR_GROUP_SUMMARY_CLICK, shouldDismissAll);
+      TestOneSignalPrefs.saveBool(TestOneSignalPrefs.PREFS_ONESIGNAL, TestOneSignalPrefs.PREFS_OS_CLEAR_GROUP_SUMMARY_CLICK, shouldDismissAll);
    }
 
 
@@ -865,7 +864,7 @@ public class GenerateNotificationRunner {
 
    @Test
    public void restoreNotificationsPastExpireTimeIfSettingIsDisabled() {
-      OneSignalPrefs.saveBool(OneSignalPrefs.PREFS_ONESIGNAL, OneSignalPrefs.PREFS_OS_RESTORE_TTL_FILTER, false);
+      TestOneSignalPrefs.saveBool(TestOneSignalPrefs.PREFS_ONESIGNAL, TestOneSignalPrefs.PREFS_OS_RESTORE_TTL_FILTER, false);
       helperShouldRestoreNotificationsPastExpireTime(true);
    }
 

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
@@ -367,7 +367,7 @@ public class GenerateNotificationRunner {
         OneSignal.init(blankActivity, "123456789", "b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
         threadAndTaskWait();
 
-        SQLiteDatabase readableDb = OneSignalDbHelper.getInstance(blankActivity).getReadableDatabase();
+        SQLiteDatabase readableDb = OneSignalPackagePrivateHelper.OneSignal_getSQLiteDatabase(RuntimeEnvironment.application);
 
         postNotificationsAndSimulateSummaryClick(true, "test1");
 
@@ -383,7 +383,7 @@ public class GenerateNotificationRunner {
         OneSignal.init(blankActivity, "123456789", "b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
         threadAndTaskWait();
 
-        SQLiteDatabase readableDb = OneSignalDbHelper.getInstance(blankActivity).getReadableDatabase();
+        SQLiteDatabase readableDb = OneSignalPackagePrivateHelper.OneSignal_getSQLiteDatabase(RuntimeEnvironment.application);
 
         postNotificationsAndSimulateSummaryClick(false, "test1");
 
@@ -399,7 +399,7 @@ public class GenerateNotificationRunner {
       OneSignal.init(blankActivity, "123456789", "b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
       threadAndTaskWait();
 
-      SQLiteDatabase readableDb = OneSignalDbHelper.getInstance(blankActivity).getReadableDatabase();
+      SQLiteDatabase readableDb = OneSignalPackagePrivateHelper.OneSignal_getSQLiteDatabase(RuntimeEnvironment.application);
 
       postNotificationsAndSimulateSummaryClick(true, "test1");
 
@@ -415,7 +415,7 @@ public class GenerateNotificationRunner {
       OneSignal.init(blankActivity, "123456789", "b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
       threadAndTaskWait();
 
-      SQLiteDatabase readableDb = OneSignalDbHelper.getInstance(blankActivity).getReadableDatabase();
+      SQLiteDatabase readableDb = OneSignalPackagePrivateHelper.OneSignal_getSQLiteDatabase(RuntimeEnvironment.application);
 
       postNotificationsAndSimulateSummaryClick(false, "test1");
 
@@ -431,7 +431,7 @@ public class GenerateNotificationRunner {
       OneSignal.init(blankActivity, "123456789", "b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
       threadAndTaskWait();
 
-      SQLiteDatabase readableDb = OneSignalDbHelper.getInstance(blankActivity).getReadableDatabase();
+      SQLiteDatabase readableDb = OneSignalPackagePrivateHelper.OneSignal_getSQLiteDatabase(RuntimeEnvironment.application);
 
       postNotificationsAndSimulateSummaryClick(true, null);
 
@@ -447,7 +447,7 @@ public class GenerateNotificationRunner {
       OneSignal.init(blankActivity, "123456789", "b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
       threadAndTaskWait();
 
-      SQLiteDatabase readableDb = OneSignalDbHelper.getInstance(blankActivity).getReadableDatabase();
+      SQLiteDatabase readableDb = OneSignalPackagePrivateHelper.OneSignal_getSQLiteDatabase(RuntimeEnvironment.application);
 
       postNotificationsAndSimulateSummaryClick(false, null);
 
@@ -501,7 +501,7 @@ public class GenerateNotificationRunner {
       count = OneSignalNotificationManagerPackageHelper.getActiveNotifications(blankActivity).length;
       assertEquals(5, count);
 
-      SQLiteDatabase readableDb = OneSignalDbHelper.getInstance(blankActivity).getReadableDatabase();
+      SQLiteDatabase readableDb = OneSignalPackagePrivateHelper.OneSignal_getSQLiteDatabase(RuntimeEnvironment.application);
       // Validate no DB changes occurred and this is only a runtime change to the groupless notifs
       // Check for 4 null group id notifs
       int nullGroupCount = queryNotificationCountFromGroup(readableDb, null, true);
@@ -757,7 +757,7 @@ public class GenerateNotificationRunner {
       assertEquals(1, ShadowBadgeCountUpdater.lastCount);
 
       // Should have 1 DB record with the correct time stamp
-      SQLiteDatabase readableDb = OneSignalDbHelper.getInstance(blankActivity).getReadableDatabase();
+      SQLiteDatabase readableDb = OneSignalPackagePrivateHelper.OneSignal_getSQLiteDatabase(RuntimeEnvironment.application);
       Cursor cursor = readableDb.query(NotificationTable.TABLE_NAME, new String[] { "created_time" }, null, null, null, null, null);
       assertEquals(1, cursor.getCount());
       // Time stamp should be set and within a small range.
@@ -776,7 +776,7 @@ public class GenerateNotificationRunner {
 
       // Should not display a duplicate notification, count should still be 1
       NotificationBundleProcessor_ProcessFromGCMIntentService(blankActivity, bundle, null);
-      readableDb = OneSignalDbHelper.getInstance(blankActivity).getReadableDatabase();
+      readableDb = OneSignalPackagePrivateHelper.OneSignal_getSQLiteDatabase(RuntimeEnvironment.application);
       cursor = readableDb.query(NotificationTable.TABLE_NAME, null, null, null, null, null, null);
       assertEquals(1, cursor.getCount());
       assertEquals(0, ShadowBadgeCountUpdater.lastCount);
@@ -799,7 +799,7 @@ public class GenerateNotificationRunner {
       // First opened should of been cleaned up, 1 week old non opened notification should stay, and one new record.
       bundle = getBaseNotifBundle("UUID3");
       NotificationBundleProcessor_ProcessFromGCMIntentService(blankActivity, bundle, null);
-      readableDb = OneSignalDbHelper.getInstance(blankActivity).getReadableDatabase();
+      readableDb = OneSignalPackagePrivateHelper.OneSignal_getSQLiteDatabase(RuntimeEnvironment.application);
       cursor = readableDb.query(NotificationTable.TABLE_NAME, new String[] { }, null, null, null, null, null);
 
       assertEquals(1, cursor.getCount());
@@ -877,7 +877,7 @@ public class GenerateNotificationRunner {
       advanceSystemTimeBy(604_801);
 
       // Should not count as a badge
-      SQLiteDatabase readableDb = OneSignalDbHelper.getInstance(blankActivity).getReadableDatabase();
+      SQLiteDatabase readableDb = OneSignalPackagePrivateHelper.OneSignal_getSQLiteDatabase(blankActivity);
       OneSignalPackagePrivateHelper.BadgeCountUpdater.update(readableDb, blankActivity);
       assertEquals(0, ShadowBadgeCountUpdater.lastCount);
    }
@@ -908,7 +908,7 @@ public class GenerateNotificationRunner {
 
 
       // Should be 2 DB entries (summary and individual)
-      SQLiteDatabase readableDb = OneSignalDbHelper.getInstance(blankActivity).getReadableDatabase();
+      SQLiteDatabase readableDb = OneSignalPackagePrivateHelper.OneSignal_getSQLiteDatabase(blankActivity);
       Cursor cursor = readableDb.query(NotificationTable.TABLE_NAME, null, null, null, null, null, null);
       assertEquals(2, cursor.getCount());
       cursor.close();
@@ -938,7 +938,7 @@ public class GenerateNotificationRunner {
 
 
       // Should be 3 DB entries (summary and 2 individual)
-      readableDb = OneSignalDbHelper.getInstance(blankActivity).getReadableDatabase();
+      readableDb = OneSignalPackagePrivateHelper.OneSignal_getSQLiteDatabase(blankActivity);
       cursor = readableDb.query(NotificationTable.TABLE_NAME, null, null, null, null, null, null);
       assertEquals(3, cursor.getCount());
 
@@ -971,7 +971,7 @@ public class GenerateNotificationRunner {
    
    @Test
    public void shouldHandleOpeningInAppAlertWithGroupKeySet() {
-      SQLiteDatabase writableDb = OneSignalDbHelper.getInstance(RuntimeEnvironment.application).getWritableDatabase();
+      SQLiteDatabase writableDb = OneSignalPackagePrivateHelper.OneSignal_getSQLiteDatabase(RuntimeEnvironment.application);
       NotificationSummaryManager_updateSummaryNotificationAfterChildRemoved(blankActivity, writableDb, "some_group", false);
    }
    
@@ -988,7 +988,7 @@ public class GenerateNotificationRunner {
       NotificationBundleProcessor_ProcessFromGCMIntentService(blankActivity, bundle, null);
    
       // Test1 - Manually trigger a refresh on grouped notification.
-      SQLiteDatabase writableDb = OneSignalDbHelper.getInstance(RuntimeEnvironment.application).getWritableDatabase();
+      SQLiteDatabase writableDb = OneSignalPackagePrivateHelper.OneSignal_getSQLiteDatabase(RuntimeEnvironment.application);
       NotificationSummaryManager_updateSummaryNotificationAfterChildRemoved(blankActivity, writableDb, "test1", false);
       assertEquals(0, ShadowRoboNotificationManager.notifications.size());
    
@@ -999,7 +999,7 @@ public class GenerateNotificationRunner {
       NotificationBundleProcessor_ProcessFromGCMIntentService(blankActivity, bundle, null);
    
       // Test2 - Manually trigger a refresh on grouped notification.
-      writableDb = OneSignalDbHelper.getInstance(RuntimeEnvironment.application).getWritableDatabase();
+      writableDb = OneSignalPackagePrivateHelper.OneSignal_getSQLiteDatabase(RuntimeEnvironment.application);
       NotificationSummaryManager_updateSummaryNotificationAfterChildRemoved(blankActivity, writableDb, "test1", false);
       assertEquals(0, ShadowRoboNotificationManager.notifications.size());
    }
@@ -1487,7 +1487,7 @@ public class GenerateNotificationRunner {
    }
 
    private void assertNotificationDbRecords(int expected) {
-      SQLiteDatabase readableDb = OneSignalDbHelper.getInstance(blankActivity).getReadableDatabase();
+      SQLiteDatabase readableDb = OneSignalPackagePrivateHelper.OneSignal_getSQLiteDatabase(blankActivity);
       Cursor cursor = readableDb.query(NotificationTable.TABLE_NAME, new String[] { "created_time" }, null, null, null, null, null);
       assertEquals(expected, cursor.getCount());
       cursor.close();

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/InAppMessageIntegrationTests.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/InAppMessageIntegrationTests.java
@@ -1281,7 +1281,7 @@ public class InAppMessageIntegrationTests {
     }
 
     @Test
-    public void testInAppMessageRedisplayCacheUpdate() throws Exception {
+    public void testInAppMessageRedisplayCacheCleaning() throws Exception {
         final long currentTimeInSeconds = System.currentTimeMillis() / 1000;
 
         final OSTestInAppMessage inAppMessage = InAppMessagingHelpers.buildTestMessageWithSingleTriggerAndRedisplay(

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/InAppMessageIntegrationTests.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/InAppMessageIntegrationTests.java
@@ -8,7 +8,7 @@ import com.onesignal.OneSignal;
 import com.onesignal.OneSignalPackagePrivateHelper;
 import com.onesignal.OneSignalPackagePrivateHelper.OSTestInAppMessage;
 import com.onesignal.OneSignalPackagePrivateHelper.OSTestTrigger;
-import com.onesignal.OneSignalPackagePrivateHelper.OneSignalPrefs;
+import com.onesignal.OneSignalPackagePrivateHelper.TestOneSignalPrefs;
 import com.onesignal.ShadowAdvertisingIdProviderGPS;
 import com.onesignal.ShadowCustomTabsClient;
 import com.onesignal.ShadowCustomTabsSession;
@@ -469,9 +469,9 @@ public class InAppMessageIntegrationTests {
         assertEquals(3, ShadowOneSignalRestClient.requests.size());
 
         // Verify clickId was persisted locally
-        Set<String> testClickedMessages = OneSignalPackagePrivateHelper.OneSignalPrefs.getStringSet(
-           OneSignalPackagePrivateHelper.OneSignalPrefs.PREFS_ONESIGNAL,
-           OneSignalPackagePrivateHelper.OneSignalPrefs.PREFS_OS_CLICKED_CLICK_IDS_IAMS,
+        Set<String> testClickedMessages = TestOneSignalPrefs.getStringSet(
+           TestOneSignalPrefs.PREFS_ONESIGNAL,
+           TestOneSignalPrefs.PREFS_OS_CLICKED_CLICK_IDS_IAMS,
            null
         );
         assertEquals(1, testClickedMessages.size());
@@ -484,9 +484,9 @@ public class InAppMessageIntegrationTests {
         threadAndTaskWait();
 
         // Enable Outcomes
-        OneSignalPackagePrivateHelper.OneSignalPrefs.saveBool(
-                OneSignalPackagePrivateHelper.OneSignalPrefs.PREFS_ONESIGNAL,
-                OneSignalPackagePrivateHelper.OneSignalPrefs.PREFS_OS_UNATTRIBUTED_ENABLED,
+        TestOneSignalPrefs.saveBool(
+                TestOneSignalPrefs.PREFS_ONESIGNAL,
+                TestOneSignalPrefs.PREFS_OS_UNATTRIBUTED_ENABLED,
                 true
         );
 
@@ -527,9 +527,9 @@ public class InAppMessageIntegrationTests {
         threadAndTaskWait();
 
         // Enable Outcomes
-        OneSignalPackagePrivateHelper.OneSignalPrefs.saveBool(
-                OneSignalPackagePrivateHelper.OneSignalPrefs.PREFS_ONESIGNAL,
-                OneSignalPackagePrivateHelper.OneSignalPrefs.PREFS_OS_UNATTRIBUTED_ENABLED,
+        TestOneSignalPrefs.saveBool(
+                TestOneSignalPrefs.PREFS_ONESIGNAL,
+                TestOneSignalPrefs.PREFS_OS_UNATTRIBUTED_ENABLED,
                 true
         );
 
@@ -571,9 +571,9 @@ public class InAppMessageIntegrationTests {
         threadAndTaskWait();
 
         // Enable Outcomes
-        OneSignalPackagePrivateHelper.OneSignalPrefs.saveBool(
-                OneSignalPackagePrivateHelper.OneSignalPrefs.PREFS_ONESIGNAL,
-                OneSignalPackagePrivateHelper.OneSignalPrefs.PREFS_OS_UNATTRIBUTED_ENABLED,
+        TestOneSignalPrefs.saveBool(
+                TestOneSignalPrefs.PREFS_ONESIGNAL,
+                TestOneSignalPrefs.PREFS_OS_UNATTRIBUTED_ENABLED,
                 true
         );
 
@@ -625,9 +625,9 @@ public class InAppMessageIntegrationTests {
         threadAndTaskWait();
 
         // Disable Outcomes
-        OneSignalPackagePrivateHelper.OneSignalPrefs.saveBool(
-                OneSignalPackagePrivateHelper.OneSignalPrefs.PREFS_ONESIGNAL,
-                OneSignalPackagePrivateHelper.OneSignalPrefs.PREFS_OS_UNATTRIBUTED_ENABLED,
+        TestOneSignalPrefs.saveBool(
+                TestOneSignalPrefs.PREFS_ONESIGNAL,
+                TestOneSignalPrefs.PREFS_OS_UNATTRIBUTED_ENABLED,
                 false
         );
 
@@ -663,9 +663,9 @@ public class InAppMessageIntegrationTests {
         threadAndTaskWait();
 
         // Enable Outcomes
-        OneSignalPackagePrivateHelper.OneSignalPrefs.saveBool(
-                OneSignalPackagePrivateHelper.OneSignalPrefs.PREFS_ONESIGNAL,
-                OneSignalPackagePrivateHelper.OneSignalPrefs.PREFS_OS_UNATTRIBUTED_ENABLED,
+        TestOneSignalPrefs.saveBool(
+                TestOneSignalPrefs.PREFS_ONESIGNAL,
+                TestOneSignalPrefs.PREFS_OS_UNATTRIBUTED_ENABLED,
                 true
         );
 
@@ -896,9 +896,9 @@ public class InAppMessageIntegrationTests {
         assertEquals(3, ShadowOneSignalRestClient.requests.size());
 
         // Verify impressioned messageId was persisted locally
-        Set<String> testImpressionedMessages = OneSignalPackagePrivateHelper.OneSignalPrefs.getStringSet(
-                OneSignalPackagePrivateHelper.OneSignalPrefs.PREFS_ONESIGNAL,
-                OneSignalPackagePrivateHelper.OneSignalPrefs.PREFS_OS_IMPRESSIONED_IAMS,
+        Set<String> testImpressionedMessages = TestOneSignalPrefs.getStringSet(
+                TestOneSignalPrefs.PREFS_ONESIGNAL,
+                TestOneSignalPrefs.PREFS_OS_IMPRESSIONED_IAMS,
                 null
         );
         assertEquals(1, testImpressionedMessages.size());
@@ -965,8 +965,8 @@ public class InAppMessageIntegrationTests {
         assertEquals(0, OneSignalPackagePrivateHelper.getInAppMessageDisplayQueue().size());
         // Check if data after dismiss is set correctly
         assertEquals(1, OneSignalPackagePrivateHelper.getRedisplayInAppMessages().size());
-        assertEquals(1, OneSignalPackagePrivateHelper.getRedisplayInAppMessages().get(0).getDisplayStats().getDisplayQuantity());
-        long lastDisplayTime =  OneSignalPackagePrivateHelper.getRedisplayInAppMessages().get(0).getDisplayStats().getLastDisplayTime();
+        assertEquals(1, OneSignalPackagePrivateHelper.getRedisplayInAppMessages().get(0).getRedisplayStats().getDisplayQuantity());
+        long lastDisplayTime =  OneSignalPackagePrivateHelper.getRedisplayInAppMessages().get(0).getRedisplayStats().getLastDisplayTime();
         assertTrue(lastDisplayTime > 0);
 
         // Change time for delay to be covered
@@ -985,8 +985,8 @@ public class InAppMessageIntegrationTests {
         assertEquals(0, OneSignalPackagePrivateHelper.getInAppMessageDisplayQueue().size());
         // Check if data after dismiss is set correctly
         assertEquals(1,  OneSignalPackagePrivateHelper.getRedisplayInAppMessages().size());
-        assertEquals(2,  OneSignalPackagePrivateHelper.getRedisplayInAppMessages().get(0).getDisplayStats().getDisplayQuantity());
-        assertTrue( OneSignalPackagePrivateHelper.getRedisplayInAppMessages().get(0).getDisplayStats().getLastDisplayTime() - lastDisplayTime >= DELAY);
+        assertEquals(2,  OneSignalPackagePrivateHelper.getRedisplayInAppMessages().get(0).getRedisplayStats().getDisplayQuantity());
+        assertTrue( OneSignalPackagePrivateHelper.getRedisplayInAppMessages().get(0).getRedisplayStats().getLastDisplayTime() - lastDisplayTime >= DELAY);
     }
 
     @Test
@@ -995,15 +995,15 @@ public class InAppMessageIntegrationTests {
 
         // Create an IAM
         final OSTestInAppMessage message = InAppMessagingHelpers.buildTestMessageWitRedisplay(LIMIT, DELAY);
-        message.getDisplayStats().setLastDisplayTime(currentTimeInSeconds);
-        message.getDisplayStats().setDisplayQuantity(1);
+        message.getRedisplayStats().setLastDisplayTime(currentTimeInSeconds);
+        message.getRedisplayStats().setDisplayQuantity(1);
         message.setDisplayedInSession(true);
         // Save IAM on DB
         TestHelpers.saveIAM(message);
         // Save IAM for dismiss
-        OneSignalPrefs.saveStringSet(
-                OneSignalPrefs.PREFS_ONESIGNAL,
-                OneSignalPrefs.PREFS_OS_DISMISSED_IAMS,
+        TestOneSignalPrefs.saveStringSet(
+                TestOneSignalPrefs.PREFS_ONESIGNAL,
+                TestOneSignalPrefs.PREFS_OS_DISMISSED_IAMS,
                 new HashSet<>(Collections.singletonList(message.messageId))
         );
 
@@ -1064,8 +1064,8 @@ public class InAppMessageIntegrationTests {
         assertEquals(0, OneSignalPackagePrivateHelper.getInAppMessageDisplayQueue().size());
         // Check if data after dismiss is set correctly
         assertEquals(1, OneSignalPackagePrivateHelper.getRedisplayInAppMessages().size());
-        assertEquals(1, OneSignalPackagePrivateHelper.getRedisplayInAppMessages().get(0).getDisplayStats().getDisplayQuantity());
-        long lastDisplayTime = OneSignalPackagePrivateHelper.getRedisplayInAppMessages().get(0).getDisplayStats().getLastDisplayTime();
+        assertEquals(1, OneSignalPackagePrivateHelper.getRedisplayInAppMessages().get(0).getRedisplayStats().getDisplayQuantity());
+        long lastDisplayTime = OneSignalPackagePrivateHelper.getRedisplayInAppMessages().get(0).getRedisplayStats().getLastDisplayTime();
         assertTrue(lastDisplayTime > 0);
 
         OneSignal.addTrigger("test_1", 2);
@@ -1100,8 +1100,8 @@ public class InAppMessageIntegrationTests {
 
         // Check if data after dismiss is set correctly
         assertEquals(1, OneSignalPackagePrivateHelper.getRedisplayInAppMessages().size());
-        assertEquals(1, OneSignalPackagePrivateHelper.getRedisplayInAppMessages().get(0).getDisplayStats().getDisplayQuantity());
-        long lastDisplayTime = OneSignalPackagePrivateHelper.getRedisplayInAppMessages().get(0).getDisplayStats().getLastDisplayTime();
+        assertEquals(1, OneSignalPackagePrivateHelper.getRedisplayInAppMessages().get(0).getRedisplayStats().getDisplayQuantity());
+        long lastDisplayTime = OneSignalPackagePrivateHelper.getRedisplayInAppMessages().get(0).getRedisplayStats().getLastDisplayTime();
         assertTrue(lastDisplayTime > 0);
 
         // Set trigger, will evaluate IAMs again
@@ -1109,8 +1109,8 @@ public class InAppMessageIntegrationTests {
 
         // Check that the IAM was not displayed again because time between display is not covered
         assertEquals(1, OneSignalPackagePrivateHelper.getRedisplayInAppMessages().size());
-        assertEquals(1, OneSignalPackagePrivateHelper.getRedisplayInAppMessages().get(0).getDisplayStats().getDisplayQuantity());
-        assertEquals(lastDisplayTime, OneSignalPackagePrivateHelper.getRedisplayInAppMessages().get(0).getDisplayStats().getLastDisplayTime());
+        assertEquals(1, OneSignalPackagePrivateHelper.getRedisplayInAppMessages().get(0).getRedisplayStats().getDisplayQuantity());
+        assertEquals(lastDisplayTime, OneSignalPackagePrivateHelper.getRedisplayInAppMessages().get(0).getRedisplayStats().getLastDisplayTime());
     }
 
     @Test
@@ -1135,8 +1135,8 @@ public class InAppMessageIntegrationTests {
 
         // Check if data after dismiss is set correctly
         assertEquals(1, OneSignalPackagePrivateHelper.getRedisplayInAppMessages().size());
-        assertEquals(1, OneSignalPackagePrivateHelper.getRedisplayInAppMessages().get(0).getDisplayStats().getDisplayQuantity());
-        long lastDisplayTime = OneSignalPackagePrivateHelper.getRedisplayInAppMessages().get(0).getDisplayStats().getLastDisplayTime();
+        assertEquals(1, OneSignalPackagePrivateHelper.getRedisplayInAppMessages().get(0).getRedisplayStats().getDisplayQuantity());
+        long lastDisplayTime = OneSignalPackagePrivateHelper.getRedisplayInAppMessages().get(0).getRedisplayStats().getLastDisplayTime();
         assertTrue(lastDisplayTime > 0);
 
         // Wait for the delay between redisplay
@@ -1147,8 +1147,8 @@ public class InAppMessageIntegrationTests {
 
         // Check that the IAM was not displayed again because Limit of display is 1
         assertEquals(1, OneSignalPackagePrivateHelper.getRedisplayInAppMessages().size());
-        assertEquals(1, OneSignalPackagePrivateHelper.getRedisplayInAppMessages().get(0).getDisplayStats().getDisplayQuantity());
-        assertEquals(lastDisplayTime, OneSignalPackagePrivateHelper.getRedisplayInAppMessages().get(0).getDisplayStats().getLastDisplayTime());
+        assertEquals(1, OneSignalPackagePrivateHelper.getRedisplayInAppMessages().get(0).getRedisplayStats().getDisplayQuantity());
+        assertEquals(lastDisplayTime, OneSignalPackagePrivateHelper.getRedisplayInAppMessages().get(0).getRedisplayStats().getLastDisplayTime());
     }
 
     @Test
@@ -1180,8 +1180,8 @@ public class InAppMessageIntegrationTests {
 
         // Check if data after dismiss is set correctly
         assertEquals(1, OneSignalPackagePrivateHelper.getRedisplayInAppMessages().size());
-        assertEquals(1, OneSignalPackagePrivateHelper.getRedisplayInAppMessages().get(0).getDisplayStats().getDisplayQuantity());
-        long lastDisplayTime = OneSignalPackagePrivateHelper.getRedisplayInAppMessages().get(0).getDisplayStats().getLastDisplayTime();
+        assertEquals(1, OneSignalPackagePrivateHelper.getRedisplayInAppMessages().get(0).getRedisplayStats().getDisplayQuantity());
+        long lastDisplayTime = OneSignalPackagePrivateHelper.getRedisplayInAppMessages().get(0).getRedisplayStats().getLastDisplayTime();
         assertTrue(lastDisplayTime > 0);
 
         // Wait for the delay between redisplay
@@ -1210,8 +1210,8 @@ public class InAppMessageIntegrationTests {
         OneSignalPackagePrivateHelper.dismissCurrentMessage();
         // Check if data after dismiss is set correctly
         assertEquals(1, OneSignalPackagePrivateHelper.getRedisplayInAppMessages().size());
-        assertEquals(2, OneSignalPackagePrivateHelper.getRedisplayInAppMessages().get(0).getDisplayStats().getDisplayQuantity());
-        assertTrue(OneSignalPackagePrivateHelper.getRedisplayInAppMessages().get(0).getDisplayStats().getLastDisplayTime() - lastDisplayTime >= DELAY);
+        assertEquals(2, OneSignalPackagePrivateHelper.getRedisplayInAppMessages().get(0).getRedisplayStats().getDisplayQuantity());
+        assertTrue(OneSignalPackagePrivateHelper.getRedisplayInAppMessages().get(0).getRedisplayStats().getLastDisplayTime() - lastDisplayTime >= DELAY);
     }
 
     @Test
@@ -1239,9 +1239,9 @@ public class InAppMessageIntegrationTests {
         assertEquals(3, ShadowOneSignalRestClient.requests.size());
 
         // Verify clickId was persisted locally
-        Set<String> testClickedMessages = OneSignalPackagePrivateHelper.OneSignalPrefs.getStringSet(
-                OneSignalPackagePrivateHelper.OneSignalPrefs.PREFS_ONESIGNAL,
-                OneSignalPackagePrivateHelper.OneSignalPrefs.PREFS_OS_CLICKED_CLICK_IDS_IAMS,
+        Set<String> testClickedMessages = TestOneSignalPrefs.getStringSet(
+                TestOneSignalPrefs.PREFS_ONESIGNAL,
+                TestOneSignalPrefs.PREFS_OS_CLICKED_CLICK_IDS_IAMS,
                 null
         );
         assertEquals(1, testClickedMessages.size());
@@ -1261,9 +1261,9 @@ public class InAppMessageIntegrationTests {
         assertEquals(4, ShadowOneSignalRestClient.requests.size());
 
         // Verify clickId was persisted locally
-        Set<String> secondRestClickedMessages = OneSignalPackagePrivateHelper.OneSignalPrefs.getStringSet(
-                OneSignalPackagePrivateHelper.OneSignalPrefs.PREFS_ONESIGNAL,
-                OneSignalPackagePrivateHelper.OneSignalPrefs.PREFS_OS_CLICKED_CLICK_IDS_IAMS,
+        Set<String> secondRestClickedMessages = TestOneSignalPrefs.getStringSet(
+                TestOneSignalPrefs.PREFS_ONESIGNAL,
+                TestOneSignalPrefs.PREFS_OS_CLICKED_CLICK_IDS_IAMS,
                 null
         );
         assertEquals(1, secondRestClickedMessages.size());
@@ -1281,6 +1281,81 @@ public class InAppMessageIntegrationTests {
     }
 
     @Test
+    public void testCachedIAMSharedPreferenceAndSQL_cleanedAfterSixMonths() throws Exception {
+        final long currentTimeInSeconds = System.currentTimeMillis() / 1_000L;
+
+        // 1. Setup IAMs
+        // Create an IAM younger than 6 months
+        final OSTestInAppMessage iam1 = InAppMessagingHelpers.buildTestMessage(null);
+        iam1.setRedisplayStats(1, currentTimeInSeconds - SIX_MONTHS_TIME_SECONDS + 1);
+        String clickId1 = "iam1_click_id_1";
+        iam1.addClickId(clickId1);
+        TestHelpers.saveIAM(iam1);
+
+        // Create an IAM older than 6 months
+        final OSTestInAppMessage iam2 = InAppMessagingHelpers.buildTestMessage(null);
+        iam2.setRedisplayStats(1, currentTimeInSeconds - SIX_MONTHS_TIME_SECONDS - 1);
+        String clickId2 = "iam2_click_id_1";
+        iam2.addClickId(clickId2);
+        TestHelpers.saveIAM(iam2);
+
+        // 2. Cache IAMs as dismissed, impressioned, and clicked
+        Set<String> messageIds = new HashSet<String>() {{
+            add(iam1.messageId);
+            add(iam2.messageId);
+        }};
+        TestOneSignalPrefs.saveStringSet(
+                TestOneSignalPrefs.PREFS_ONESIGNAL,
+                TestOneSignalPrefs.PREFS_OS_DISMISSED_IAMS,
+                messageIds);
+
+        TestOneSignalPrefs.saveStringSet(
+                TestOneSignalPrefs.PREFS_ONESIGNAL,
+                TestOneSignalPrefs.PREFS_OS_IMPRESSIONED_IAMS,
+                messageIds);
+
+        Set<String> clickedClickIds = new HashSet<String>() {{
+            addAll(iam1.getClickedClickIds());
+            addAll(iam2.getClickedClickIds());
+        }};
+        TestOneSignalPrefs.saveStringSet(
+                TestOneSignalPrefs.PREFS_ONESIGNAL,
+                TestOneSignalPrefs.PREFS_OS_CLICKED_CLICK_IDS_IAMS,
+                clickedClickIds);
+
+        // 3. Init OneSignal so it attempts to clean IAM cache
+        OneSignalInit();
+        threadAndTaskWait();
+
+        // 4. Validate all data associated with the 6 month old IAM has been deleted
+        Set<String> testDismissedMessages = TestOneSignalPrefs.getStringSet(
+                TestOneSignalPrefs.PREFS_ONESIGNAL,
+                TestOneSignalPrefs.PREFS_OS_DISMISSED_IAMS,
+                null);
+        assertEquals(1, testDismissedMessages.size());
+        assertTrue(testDismissedMessages.contains(iam1.messageId));
+
+        Set<String> testImpressionedMessages = TestOneSignalPrefs.getStringSet(
+                TestOneSignalPrefs.PREFS_ONESIGNAL,
+                TestOneSignalPrefs.PREFS_OS_IMPRESSIONED_IAMS,
+                null);
+        assertEquals(1, testImpressionedMessages.size());
+        assertTrue(testImpressionedMessages.contains(iam1.messageId));
+
+        Set<String> testClickedClickIds = TestOneSignalPrefs.getStringSet(
+                TestOneSignalPrefs.PREFS_ONESIGNAL,
+                TestOneSignalPrefs.PREFS_OS_CLICKED_CLICK_IDS_IAMS,
+                null);
+        assertEquals(1, testClickedClickIds.size());
+        assertTrue(testClickedClickIds.contains(clickId1));
+
+        // 5. Make sure only IAM left is the IAM younger than 6 months
+        List<OSTestInAppMessage> savedInAppMessagesAfterInit = TestHelpers.getAllInAppMessages();
+        assertEquals(1, savedInAppMessagesAfterInit.size());
+        assertEquals(iam1.messageId, savedInAppMessagesAfterInit.get(0).messageId);
+    }
+
+    @Test
     public void testInAppMessageRedisplayCacheCleaning() throws Exception {
         final long currentTimeInSeconds = System.currentTimeMillis() / 1000;
 
@@ -1289,10 +1364,10 @@ public class InAppMessageIntegrationTests {
 
         String firstID = inAppMessage.messageId + "_test";
         inAppMessage.messageId = firstID;
-        inAppMessage.getDisplayStats().setLastDisplayTime(currentTimeInSeconds - SIX_MONTHS_TIME_SECONDS + 1);
+        inAppMessage.getRedisplayStats().setLastDisplayTime(currentTimeInSeconds - SIX_MONTHS_TIME_SECONDS + 1);
         TestHelpers.saveIAM(inAppMessage);
 
-        inAppMessage.getDisplayStats().setLastDisplayTime(currentTimeInSeconds - SIX_MONTHS_TIME_SECONDS - 1);
+        inAppMessage.getRedisplayStats().setLastDisplayTime(currentTimeInSeconds - SIX_MONTHS_TIME_SECONDS - 1);
         inAppMessage.messageId += "1";
         TestHelpers.saveIAM(inAppMessage);
 

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/InAppMessagingUnitTests.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/InAppMessagingUnitTests.java
@@ -161,11 +161,11 @@ public class InAppMessagingUnitTests {
                 LIMIT,
                 DELAY
         );
-        assertTrue(message.getDisplayStats().isRedisplayEnabled());
-        assertEquals(LIMIT, message.getDisplayStats().getDisplayLimit());
-        assertEquals(DELAY, message.getDisplayStats().getDisplayDelay());
-        assertEquals(-1, message.getDisplayStats().getLastDisplayTime());
-        assertEquals(0, message.getDisplayStats().getDisplayQuantity());
+        assertTrue(message.getRedisplayStats().isRedisplayEnabled());
+        assertEquals(LIMIT, message.getRedisplayStats().getDisplayLimit());
+        assertEquals(DELAY, message.getRedisplayStats().getDisplayDelay());
+        assertEquals(-1, message.getRedisplayStats().getLastDisplayTime());
+        assertEquals(0, message.getRedisplayStats().getDisplayQuantity());
 
         OSTestInAppMessage messageWithoutDisplay = InAppMessagingHelpers.buildTestMessageWithSingleTrigger(
                 OSTriggerKind.SESSION_TIME,
@@ -173,11 +173,11 @@ public class InAppMessagingUnitTests {
                 OSTriggerOperator.GREATER_THAN_OR_EQUAL_TO.toString(),
                 3
         );
-        assertFalse(messageWithoutDisplay.getDisplayStats().isRedisplayEnabled());
-        assertEquals(Integer.MAX_VALUE, messageWithoutDisplay.getDisplayStats().getDisplayLimit());
-        assertEquals(0, messageWithoutDisplay.getDisplayStats().getDisplayDelay());
-        assertEquals(-1, messageWithoutDisplay.getDisplayStats().getLastDisplayTime());
-        assertEquals(0, messageWithoutDisplay.getDisplayStats().getDisplayQuantity());
+        assertFalse(messageWithoutDisplay.getRedisplayStats().isRedisplayEnabled());
+        assertEquals(1, messageWithoutDisplay.getRedisplayStats().getDisplayLimit());
+        assertEquals(0, messageWithoutDisplay.getRedisplayStats().getDisplayDelay());
+        assertEquals(-1, messageWithoutDisplay.getRedisplayStats().getLastDisplayTime());
+        assertEquals(0, messageWithoutDisplay.getRedisplayStats().getDisplayQuantity());
     }
 
     @Test
@@ -188,12 +188,12 @@ public class InAppMessagingUnitTests {
         );
 
         for (int i = 0; i < LIMIT; i++) {
-            assertTrue(message.getDisplayStats().shouldDisplayAgain());
-            message.getDisplayStats().incrementDisplayQuantity();
+            assertTrue(message.getRedisplayStats().shouldDisplayAgain());
+            message.getRedisplayStats().incrementDisplayQuantity();
         }
 
-        message.getDisplayStats().incrementDisplayQuantity();
-        assertFalse(message.getDisplayStats().shouldDisplayAgain());
+        message.getRedisplayStats().incrementDisplayQuantity();
+        assertFalse(message.getRedisplayStats().shouldDisplayAgain());
     }
 
     @Test
@@ -203,15 +203,15 @@ public class InAppMessagingUnitTests {
                 DELAY
         );
 
-        assertTrue(message.getDisplayStats().isDelayTimeSatisfied());
+        assertTrue(message.getRedisplayStats().isDelayTimeSatisfied());
 
-        message.getDisplayStats().setLastDisplayTimeToCurrent();
+        message.getRedisplayStats().setLastDisplayTimeToCurrent();
         advanceSystemTimeBy(DELAY);
-        assertTrue(message.getDisplayStats().isDelayTimeSatisfied());
+        assertTrue(message.getRedisplayStats().isDelayTimeSatisfied());
 
-        message.getDisplayStats().setLastDisplayTimeToCurrent();
+        message.getRedisplayStats().setLastDisplayTimeToCurrent();
         advanceSystemTimeBy(DELAY - 1);
-        assertFalse(message.getDisplayStats().isDelayTimeSatisfied());
+        assertFalse(message.getRedisplayStats().isDelayTimeSatisfied());
     }
 
     @Test

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
@@ -3371,7 +3371,7 @@ public class MainOneSignalClassRunner {
       assertEquals(0, ShadowRoboNotificationManager.notifications.size());
 
       // Make sure they are marked dismissed.
-      SQLiteDatabase readableDb = OneSignalDbHelper.getInstance(blankActivity).getReadableDatabase();
+      SQLiteDatabase readableDb = OneSignalPackagePrivateHelper.OneSignal_getSQLiteDatabase(RuntimeEnvironment.application);
       Cursor cursor = readableDb.query(OneSignalPackagePrivateHelper.NotificationTable.TABLE_NAME, new String[] { "created_time" },
           OneSignalPackagePrivateHelper.NotificationTable.COLUMN_NAME_DISMISSED + " = 1", null, null, null, null);
       assertEquals(2, cursor.getCount());

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/OneSignalPrefsRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/OneSignalPrefsRunner.java
@@ -5,7 +5,7 @@ import android.content.Context;
 import android.content.SharedPreferences;
 
 import com.onesignal.OneSignal;
-import com.onesignal.OneSignalPackagePrivateHelper.OneSignalPrefs;
+import com.onesignal.OneSignalPackagePrivateHelper.TestOneSignalPrefs;
 import com.onesignal.StaticResetHelper;
 import com.onesignal.example.BlankActivity;
 
@@ -40,7 +40,7 @@ public class OneSignalPrefsRunner {
 
    @Before // Before each test
    public void beforeEachTest() {
-      OneSignalPrefs.initializePool();
+      TestOneSignalPrefs.initializePool();
       ActivityController<BlankActivity> blankActivityController = Robolectric.buildActivity(BlankActivity.class).create();
       blankActivity = blankActivityController.get();
    }
@@ -52,19 +52,19 @@ public class OneSignalPrefsRunner {
 
    @Test
    public void testNullContextDoesNotCrash() {
-      OneSignalPrefs.saveString(OneSignalPrefs.PREFS_ONESIGNAL,"key", "value");
+      TestOneSignalPrefs.saveString(TestOneSignalPrefs.PREFS_ONESIGNAL,"key", "value");
       TestHelpers.flushBufferedSharedPrefs();
    }
 
    @Test
    public void tesWriteWithNullContextAndSavesAfterSetting() {
-      OneSignalPrefs.saveString(OneSignalPrefs.PREFS_ONESIGNAL,"key", "value");
+      TestOneSignalPrefs.saveString(TestOneSignalPrefs.PREFS_ONESIGNAL,"key", "value");
       TestHelpers.flushBufferedSharedPrefs();
 
       OneSignal.setAppContext(blankActivity);
       TestHelpers.flushBufferedSharedPrefs();
 
-      final SharedPreferences prefs = blankActivity.getSharedPreferences(OneSignalPrefs.PREFS_ONESIGNAL, Context.MODE_PRIVATE);
+      final SharedPreferences prefs = blankActivity.getSharedPreferences(TestOneSignalPrefs.PREFS_ONESIGNAL, Context.MODE_PRIVATE);
       String value = prefs.getString("key", "");
       assertEquals("value", value);
    }

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/OutcomeEventUnitTests.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/OutcomeEventUnitTests.java
@@ -34,6 +34,7 @@ import com.onesignal.MockOutcomesUtils;
 import com.onesignal.MockSessionManager;
 import com.onesignal.OneSignal;
 import com.onesignal.OneSignalDbHelper;
+import com.onesignal.OneSignalPackagePrivateHelper;
 import com.onesignal.OneSignalPackagePrivateHelper.OSSessionManager;
 import com.onesignal.OutcomeEvent;
 import com.onesignal.ShadowOSUtils;
@@ -118,7 +119,7 @@ public class OutcomeEventUnitTests {
 
     @After
     public void tearDown() throws Exception {
-        dbHelper.cleanOutcomeDatabase();
+        OneSignalPackagePrivateHelper.OneSignal_cleanOutcomeDatabaseTable(RuntimeEnvironment.application);
         dbHelper.close();
         notificationData.clearNotificationSharedPreferences();
         sessionManager.resetMock();

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/TestHelpers.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/TestHelpers.java
@@ -111,7 +111,8 @@ public class TestHelpers {
       if (lastException != null)
          throw lastException;
 
-      OneSignalDbHelper.getInstance(RuntimeEnvironment.application).getReadableDatabase().close();
+      // TODO: Do we need this here?
+      OneSignalPackagePrivateHelper.OneSignal_getSQLiteDatabase(RuntimeEnvironment.application).close();
    }
 
    static void stopAllOSThreads() {
@@ -231,7 +232,7 @@ public class TestHelpers {
    }
 
    static ArrayList<HashMap<String, Object>> getAllNotificationRecords() {
-      SQLiteDatabase readableDatabase = OneSignalDbHelper.getInstance(RuntimeEnvironment.application).getReadableDatabase();
+      SQLiteDatabase readableDatabase = OneSignalPackagePrivateHelper.OneSignal_getSQLiteDatabase(RuntimeEnvironment.application);
       Cursor cursor = readableDatabase.query(
          OneSignalPackagePrivateHelper.NotificationTable.TABLE_NAME,
          null,
@@ -266,7 +267,7 @@ public class TestHelpers {
    }
 
    static List<OutcomeEvent>  getAllOutcomesRecords() {
-      SQLiteDatabase readableDatabase = OneSignalDbHelper.getInstance(RuntimeEnvironment.application).getReadableDatabase();
+      SQLiteDatabase readableDatabase = OneSignalPackagePrivateHelper.OneSignal_getSQLiteDatabase(RuntimeEnvironment.application);
       Cursor cursor = readableDatabase.query(
               OneSignalPackagePrivateHelper.OutcomeEventsTable.TABLE_NAME,
               null,
@@ -305,7 +306,7 @@ public class TestHelpers {
    }
 
    static ArrayList<CachedUniqueOutcomeNotification> getAllUniqueOutcomeNotificationRecords() {
-      SQLiteDatabase readableDatabase = OneSignalDbHelper.getInstance(RuntimeEnvironment.application).getReadableDatabase();
+      SQLiteDatabase readableDatabase = OneSignalPackagePrivateHelper.OneSignal_getSQLiteDatabase(RuntimeEnvironment.application);
       Cursor cursor = readableDatabase.query(
               OneSignalPackagePrivateHelper.CachedUniqueOutcomeNotificationTable.TABLE_NAME,
               null,
@@ -336,7 +337,7 @@ public class TestHelpers {
    }
 
    synchronized static void saveIAM(OSTestInAppMessage inAppMessage) {
-      SQLiteDatabase writableDatabase = OneSignalDbHelper.getInstance(RuntimeEnvironment.application).getWritableDatabase();
+      SQLiteDatabase writableDatabase = OneSignalPackagePrivateHelper.OneSignal_getSQLiteDatabase(RuntimeEnvironment.application);
 
       ContentValues values = new ContentValues();
       values.put(OneSignalPackagePrivateHelper.InAppMessageTable.COLUMN_NAME_MESSAGE_ID, inAppMessage.messageId);
@@ -350,7 +351,7 @@ public class TestHelpers {
    }
 
    synchronized static List<OSTestInAppMessage> getAllInAppMessages() throws JSONException {
-      SQLiteDatabase readableDatabase = OneSignalDbHelper.getInstance(RuntimeEnvironment.application).getReadableDatabase();
+      SQLiteDatabase readableDatabase = OneSignalPackagePrivateHelper.OneSignal_getSQLiteDatabase(RuntimeEnvironment.application);
       Cursor cursor = readableDatabase.query(
               OneSignalPackagePrivateHelper.InAppMessageTable.TABLE_NAME,
               null,
@@ -362,7 +363,7 @@ public class TestHelpers {
       );
 
       List<OSTestInAppMessage> iams = new ArrayList<>();
-      if (cursor.moveToFirst()) {
+      if (cursor.moveToFirst())
          do {
             String messageId = cursor.getString(cursor.getColumnIndex(OneSignalPackagePrivateHelper.InAppMessageTable.COLUMN_NAME_MESSAGE_ID));
             String clickIds = cursor.getString(cursor.getColumnIndex(OneSignalPackagePrivateHelper.InAppMessageTable.COLUMN_CLICK_IDS));
@@ -380,10 +381,8 @@ public class TestHelpers {
             OSTestInAppMessage inAppMessage = new OSTestInAppMessage(messageId, displayQuantity, lastDisplay, displayed, clickIdsSet);
             iams.add(inAppMessage);
          } while (cursor.moveToNext());
-      }
 
       cursor.close();
-      readableDatabase.close();
 
       return iams;
    }

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/TestHelpers.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/TestHelpers.java
@@ -11,12 +11,11 @@ import android.os.Looper;
 import android.os.SystemClock;
 import android.support.annotation.Nullable;
 
-import com.onesignal.OneSignalDbHelper;
 import com.onesignal.OneSignalPackagePrivateHelper;
 import com.onesignal.OneSignalPackagePrivateHelper.CachedUniqueOutcomeNotification;
 import com.onesignal.OneSignalPackagePrivateHelper.OSSessionManager;
 import com.onesignal.OneSignalPackagePrivateHelper.OSTestInAppMessage;
-import com.onesignal.OneSignalPackagePrivateHelper.OneSignalPrefs;
+import com.onesignal.OneSignalPackagePrivateHelper.TestOneSignalPrefs;
 import com.onesignal.OneSignalShadowPackageManager;
 import com.onesignal.OutcomeEvent;
 import com.onesignal.ShadowCustomTabsClient;
@@ -60,7 +59,7 @@ public class TestHelpers {
    static Exception lastException;
 
    static void beforeTestInitAndCleanup() throws Exception {
-      OneSignalPackagePrivateHelper.OneSignalPrefs.initializePool();
+      TestOneSignalPrefs.initializePool();
       if (!ranBeforeTestSuite)
          return;
 
@@ -131,7 +130,7 @@ public class TestHelpers {
    }
 
    static void flushBufferedSharedPrefs() {
-      OneSignalPrefs.WritePrefHandlerThread handlerThread = OneSignalPackagePrivateHelper.OneSignalPrefs.prefsHandler;
+      TestOneSignalPrefs.WritePrefHandlerThread handlerThread = TestOneSignalPrefs.prefsHandler;
 
       if (handlerThread.getLooper() == null)
          return;
@@ -341,8 +340,8 @@ public class TestHelpers {
 
       ContentValues values = new ContentValues();
       values.put(OneSignalPackagePrivateHelper.InAppMessageTable.COLUMN_NAME_MESSAGE_ID, inAppMessage.messageId);
-      values.put(OneSignalPackagePrivateHelper.InAppMessageTable.COLUMN_NAME_DISPLAY_QUANTITY, inAppMessage.getDisplayStats().getDisplayQuantity());
-      values.put(OneSignalPackagePrivateHelper.InAppMessageTable.COLUMN_NAME_LAST_DISPLAY, inAppMessage.getDisplayStats().getLastDisplayTime());
+      values.put(OneSignalPackagePrivateHelper.InAppMessageTable.COLUMN_NAME_DISPLAY_QUANTITY, inAppMessage.getRedisplayStats().getDisplayQuantity());
+      values.put(OneSignalPackagePrivateHelper.InAppMessageTable.COLUMN_NAME_LAST_DISPLAY, inAppMessage.getRedisplayStats().getLastDisplayTime());
       values.put(OneSignalPackagePrivateHelper.InAppMessageTable.COLUMN_CLICK_IDS, inAppMessage.getClickedClickIds().toString());
       values.put(OneSignalPackagePrivateHelper.InAppMessageTable.COLUMN_DISPLAYED_IN_SESSION, inAppMessage.isDisplayedInSession());
 


### PR DESCRIPTION
* IAM data will pile up on devices and down the road this could become an issue
  * Includes cleaning impressions, clicks, dismissals and SQL data for IAMs
* Db lock issue was present during opening db retries, related to #988
  * Added an extra exception to go along with SQLiteCantOpenDatabaseException, SQLiteDatabaseLockedException
* Replaced all `getWritableDatabase` and `getReadableDatabase` with `getSQLiteDatabase`
* Replaced all `getWritableDatabase` and `getReadableDatabase` with `getSQLiteDatabaseWithRetries`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1007)
<!-- Reviewable:end -->
