### PR TITLE
Add Settings option to denied location prompt

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/AndroidSupportV4Compat.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/AndroidSupportV4Compat.java
@@ -35,6 +35,7 @@ import android.content.Context;
 import android.content.pm.PackageManager;
 import android.os.Build;
 import android.support.annotation.NonNull;
+import android.support.v4.app.ActivityCompat;
 import android.util.Log;
 
 // Designed as a compat for use of Android Support v4 revision 23.+ methods when an older revision of the library is included with the app developer's project.
@@ -68,6 +69,10 @@ class AndroidSupportV4Compat {
          // OneSignal SDK code already checks that device is Android M, omit else code from the support library.
          ActivityCompatApi23.requestPermissions(activity, permissions, requestCode);
       }
+
+      static boolean shouldShowRequestPermissionRationale(Activity activity, String permission) {
+         return ActivityCompatApi23.shouldShowRequestPermissionRationale(activity, permission);
+      }
    }
 
    @TargetApi(23)
@@ -76,6 +81,10 @@ class AndroidSupportV4Compat {
          if (activity instanceof RequestPermissionsRequestCodeValidator)
             ((RequestPermissionsRequestCodeValidator) activity).validateRequestPermissionsRequestCode(requestCode);
          activity.requestPermissions(permissions, requestCode);
+      }
+
+      static boolean shouldShowRequestPermissionRationale(Activity activity, String permission) {
+         return android.support.v4.app.ActivityCompat.shouldShowRequestPermissionRationale(activity, permission);
       }
    }
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/LocationGMS.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/LocationGMS.java
@@ -167,7 +167,7 @@ class LocationGMS {
     *
     *  For all cases we are calling prompt listeners.
     */
-   static void getLocation(Context context, boolean promptLocation, LocationHandler handler) {
+   static void getLocation(Context context, boolean promptLocation, boolean fallbackToSettings, LocationHandler handler) {
       addPromptHandlerIfAvailable(handler);
       classContext = context;
       locationHandlers.put(handler.getType(), handler);
@@ -226,7 +226,7 @@ class LocationGMS {
                //
                // For each case, we call the prompt handlers
                if (requestPermission != null && promptLocation) {
-                  PermissionsActivity.startPrompt();
+                  PermissionsActivity.startPrompt(fallbackToSettings);
                } else if (locationCoarsePermission == PackageManager.PERMISSION_GRANTED) {
                   sendAndClearPromptHandlers(promptLocation, OneSignal.PromptActionResult.PERMISSION_GRANTED);
                   startGetLocation();

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageLocationPrompt.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageLocationPrompt.java
@@ -6,7 +6,7 @@ class OSInAppMessageLocationPrompt extends OSInAppMessagePrompt {
 
     @Override
     void handlePrompt(OneSignal.OSPromptActionCompletionCallback callback) {
-        OneSignal.promptLocation(callback);
+        OneSignal.promptLocation(callback, true);
     }
 
     @Override

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -947,7 +947,7 @@ public class OneSignal {
       // Prompted so we don't ask for permissions more than once
       promptedLocation = promptedLocation || mInitBuilder.mPromptLocation;
 
-      LocationGMS.getLocation(appContext, doPrompt, locationHandler);
+      LocationGMS.getLocation(appContext, doPrompt, false, locationHandler);
    }
    private static PushRegistrator mPushRegistrator;
 
@@ -2524,10 +2524,10 @@ public class OneSignal {
     * @see <a href="https://documentation.onesignal.com/docs/permission-requests">Permission Requests | OneSignal Docs</a>
     */
    public static void promptLocation() {
-      promptLocation(null);
+      promptLocation(null, false);
    }
 
-   static void promptLocation(@Nullable final OSPromptActionCompletionCallback callback) {
+   static void promptLocation(@Nullable final OSPromptActionCompletionCallback callback, final boolean fallbackToSettings) {
       //if applicable, check if the user provided privacy consent
       if (shouldLogUserPrivacyConsentErrorMessageForMethodName("promptLocation()"))
          return;
@@ -2558,7 +2558,7 @@ public class OneSignal {
                }
             };
 
-            LocationGMS.getLocation(appContext, true, locationHandler);
+            LocationGMS.getLocation(appContext, true, fallbackToSettings, locationHandler);
             promptedLocation = true;
          }
       };

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalSyncServiceUtils.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalSyncServiceUtils.java
@@ -230,7 +230,7 @@ class OneSignalSyncServiceUtils {
                   queue.offer(object);
                }
             };
-            LocationGMS.getLocation(OneSignal.appContext, false, locationHandler);
+            LocationGMS.getLocation(OneSignal.appContext, false, false, locationHandler);
 
             // The take() will return the offered point once the callback for the locationHandler is completed
             Object point = queue.take();

--- a/OneSignalSDK/onesignal/src/main/res/values/strings.xml
+++ b/OneSignalSDK/onesignal/src/main/res/values/strings.xml
@@ -4,4 +4,6 @@
     <string name="location_not_available_title">Location Not Available</string>
     <string name="location_not_available_message">Looks like this app doesn\'t have location services configured. Please see OneSignal docs for more information.</string>
 
+    <string name="location_not_available_open_settings_message">You have previously denied sharing your device location. Please go to settings to enable.</string>
+    <string name="location_not_available_open_settings_option">Settings</string>
 </resources>


### PR DESCRIPTION
   * Whenever the user clicks on never ask again option and denies the permission,
     we will show the reason why we need it and the option to open settings and change the location permission

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1009)
<!-- Reviewable:end -->
![Screenshot_20200507_191734_com onesignal example](https://user-images.githubusercontent.com/1794653/81350827-36ae2580-9099-11ea-8bce-5eeef25bddef.jpg)

![edited-20200507-193302](https://user-images.githubusercontent.com/1794653/81351370-8ccf9880-909a-11ea-9b70-fb460ce54700.gif)
