### PR TITLE
Refactor prep for `InFocusDisplayOption` in `NotifForegroundHandler`

### DIFF
--- a/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/application/MainApplication.java
+++ b/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/application/MainApplication.java
@@ -27,8 +27,8 @@ public class MainApplication extends Application {
         OneSignal.setAppId(appId);
         OneSignal.setAppContext(this);
 
+        OneSignal.setNotificationDisplayOption(OneSignal.OSNotificationDisplay.NOTIFICATION);
         OneSignal.unsubscribeWhenNotificationsAreDisabled(true);
-        OneSignal.setInFocusDisplaying(OneSignal.OSInFocusDisplayOption.Notification);
         OneSignal.pauseInAppMessages(true);
         OneSignal.setLocationShared(false);
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotification.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotification.java
@@ -91,7 +91,7 @@ class GenerateNotification {
    static void fromJsonPayload(NotificationGenerationJob notifJob) {
       setStatics(notifJob.context);
 
-      if (!notifJob.restoring && notifJob.showAsAlert && ActivityLifecycleHandler.curActivity != null) {
+      if (!notifJob.isRestoring && ActivityLifecycleHandler.curActivity != null) {
          showNotificationAsAlert(notifJob.jsonPayload, ActivityLifecycleHandler.curActivity, notifJob.getAndroidId());
          return;
       }
@@ -343,7 +343,7 @@ class GenerateNotification {
       applyNotificationExtender(notifJob, notifBuilder);
       
       // Keeps notification from playing sound + vibrating again
-      if (notifJob.restoring)
+      if (notifJob.isRestoring)
          removeNotifyOptions(notifBuilder);
 
       int makeRoomFor = 1;
@@ -430,7 +430,7 @@ class GenerateNotification {
 
          notifJob.overriddenBodyFromExtender = mContentText;
          notifJob.overriddenTitleFromExtender = mContentTitle;
-         if (!notifJob.restoring) {
+         if (!notifJob.isRestoring) {
             notifJob.overriddenFlags = mNotification.flags;
             notifJob.overriddenSound = mNotification.sound;
          }
@@ -446,7 +446,7 @@ class GenerateNotification {
       // Includes Android 4.3 through 6.0.1. Android 7.1 handles this correctly without this.
       // Android 4.2 and older just post the summary only.
       boolean singleNotifWorkArounds = Build.VERSION.SDK_INT > Build.VERSION_CODES.JELLY_BEAN_MR1 && Build.VERSION.SDK_INT < Build.VERSION_CODES.N
-                                       && !notifJob.restoring;
+                                       && !notifJob.isRestoring;
       
       if (singleNotifWorkArounds) {
          if (notifJob.overriddenSound != null && !notifJob.overriddenSound.equals(notifJob.orgSound))
@@ -484,7 +484,7 @@ class GenerateNotification {
 
    // This summary notification will be visible instead of the normal one on pre-Android 7.0 devices.
    private static void createSummaryNotification(NotificationGenerationJob notifJob, OneSignalNotificationBuilder notifBuilder) {
-      boolean updateSummary = notifJob.restoring;
+      boolean updateSummary = notifJob.isRestoring;
       JSONObject fcmJson = notifJob.jsonPayload;
 
       String group = fcmJson.optString("grp", null);

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/GooglePlayServicesUpgradePrompt.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/GooglePlayServicesUpgradePrompt.java
@@ -55,7 +55,7 @@ class GooglePlayServicesUpgradePrompt {
          @Override
          public void run() {
             final Activity activity = ActivityLifecycleHandler.curActivity;
-            if (activity == null || OneSignal.mDisableGmsMissingPrompt)
+            if (activity == null)
                return;
 
             // Load resource strings so a developer can customize this dialog

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
@@ -70,13 +70,13 @@ class NotificationBundleProcessor {
          }
    
          NotificationGenerationJob notifJob = new NotificationGenerationJob(context);
-         notifJob.restoring = bundle.getBoolean("restoring", false);
+         notifJob.isRestoring = bundle.getBoolean("restoring", false);
          notifJob.shownTimeStamp = bundle.getLong("timestamp");
          notifJob.jsonPayload = new JSONObject(jsonStrPayload);
-         notifJob.isInAppPreviewPush = inAppPreviewPushUUID(notifJob.jsonPayload) != null;
+         notifJob.isIamPreview = inAppPreviewPushUUID(notifJob.jsonPayload) != null;
 
-         if (!notifJob.restoring &&
-             !notifJob.isInAppPreviewPush &&
+         if (!notifJob.isRestoring &&
+             !notifJob.isIamPreview &&
              OneSignal.notValidOrDuplicated(context, notifJob.jsonPayload))
             return;
 
@@ -91,7 +91,7 @@ class NotificationBundleProcessor {
 
          // Delay to prevent CPU spikes.
          //    Normally more than one notification is restored at a time.
-         if (notifJob.restoring)
+         if (notifJob.isRestoring)
             OSUtils.sleep(100);
       } catch (JSONException e) {
          e.printStackTrace();
@@ -99,19 +99,18 @@ class NotificationBundleProcessor {
    }
 
    static int ProcessJobForDisplay(NotificationGenerationJob notifJob) {
-      notifJob.showAsAlert = OneSignal.getInAppAlertNotificationEnabled() && OneSignal.isAppActive();
       processCollapseKey(notifJob);
 
       boolean doDisplay = shouldDisplayNotif(notifJob);
       if (doDisplay)
             GenerateNotification.fromJsonPayload(notifJob);
 
-      if (!notifJob.restoring && !notifJob.isInAppPreviewPush) {
+      if (!notifJob.isRestoring && !notifJob.isIamPreview) {
          processNotification(notifJob, false);
          try {
             JSONObject jsonObject = new JSONObject(notifJob.jsonPayload.toString());
             jsonObject.put("notificationId", notifJob.getAndroidId());
-            OneSignal.handleNotificationReceived(newJsonArray(jsonObject), true, notifJob.showAsAlert);
+            OneSignal.handleNotificationReceived(newJsonArray(jsonObject), true);
          } catch(Throwable t) {}
       }
 
@@ -121,7 +120,7 @@ class NotificationBundleProcessor {
    private static boolean shouldDisplayNotif(NotificationGenerationJob notifJob) {
       // Validate that the current Android device is Android 4.4 or higher and the current job is a
       //    preview push
-      if (notifJob.isInAppPreviewPush && Build.VERSION.SDK_INT <= Build.VERSION_CODES.JELLY_BEAN_MR2)
+      if (notifJob.isIamPreview && Build.VERSION.SDK_INT <= Build.VERSION_CODES.JELLY_BEAN_MR2)
          return false;
 
       // Otherwise, this is a normal notification and should be shown
@@ -412,7 +411,7 @@ class NotificationBundleProcessor {
    }
 
    private static void processCollapseKey(NotificationGenerationJob notifJob) {
-      if (notifJob.restoring)
+      if (notifJob.isRestoring)
          return;
       if (!notifJob.jsonPayload.has("collapse_key") || "do_not_collapse".equals(notifJob.jsonPayload.optString("collapse_key")))
          return;
@@ -488,7 +487,7 @@ class NotificationBundleProcessor {
          //    Make a new thread to do our OneSignal work on.
          new Thread(new Runnable() {
             public void run() {
-               OneSignal.handleNotificationReceived(bundleAsJsonArray(bundle), false, false);
+               OneSignal.handleNotificationReceived(bundleAsJsonArray(bundle), false);
             }
          }, "OS_PROC_BUNDLE").start();
       }
@@ -541,12 +540,8 @@ class NotificationBundleProcessor {
 
    static boolean shouldDisplay(String body) {
       boolean hasBody = body != null && !"".equals(body);
-      boolean showAsAlert = OneSignal.getInAppAlertNotificationEnabled();
       boolean isActive = OneSignal.isAppActive();
-      return hasBody &&
-                (OneSignal.getNotificationsWhenActiveEnabled()
-              || showAsAlert
-              || !isActive);
+      return hasBody && !isActive;
    }
 
    static @NonNull JSONArray newJsonArray(JSONObject jsonObject) {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationChannelManager.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationChannelManager.java
@@ -69,7 +69,7 @@ class NotificationChannelManager {
 
       NotificationManager notificationManager = OneSignalNotificationManager.getNotificationManager(context);
 
-      if (notifJob.restoring)
+      if (notifJob.isRestoring)
          return createRestoreChannel(notificationManager);
       
       // Allow channels created outside the SDK

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationExtenderService.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationExtenderService.java
@@ -191,7 +191,7 @@ public abstract class NotificationExtenderService extends JobIntentService {
                notifJob.overrideSettings.androidNotificationId = -1;
 
                NotificationBundleProcessor.processNotification(notifJob, true);
-               OneSignal.handleNotificationReceived(NotificationBundleProcessor.newJsonArray(currentJsonPayload), false, false);
+               OneSignal.handleNotificationReceived(NotificationBundleProcessor.newJsonArray(currentJsonPayload), false);
             }
             // If are are not displaying a restored notification make sure we mark it as dismissed
             //   This will prevent it from being restored again.
@@ -222,7 +222,7 @@ public abstract class NotificationExtenderService extends JobIntentService {
 
    private NotificationGenerationJob createNotifJobFromCurrent() {
       NotificationGenerationJob notifJob = new NotificationGenerationJob(this);
-      notifJob.restoring = currentlyRestoring;
+      notifJob.isRestoring = currentlyRestoring;
       notifJob.jsonPayload = currentJsonPayload;
       notifJob.shownTimeStamp = restoreTimestamp;
       notifJob.overrideSettings = currentBaseOverrideSettings;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationGenerationJob.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationGenerationJob.java
@@ -38,13 +38,11 @@ import java.security.SecureRandom;
 class NotificationGenerationJob {
    Context context;
    JSONObject jsonPayload;
-   boolean restoring;
-   boolean isInAppPreviewPush;
-   
-   boolean showAsAlert;
-   
+   boolean isRestoring;
+   boolean isIamPreview;
+
    Long shownTimeStamp;
-   
+
    CharSequence overriddenBodyFromExtender;
    CharSequence overriddenTitleFromExtender;
    Uri overriddenSound;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationSummaryManager.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationSummaryManager.java
@@ -6,8 +6,6 @@ import android.content.Context;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 
-import androidx.annotation.RequiresApi;
-
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -112,7 +110,7 @@ class NotificationSummaryManager {
             return cursor;
          
          NotificationGenerationJob notifJob = new NotificationGenerationJob(context);
-         notifJob.restoring = true;
+         notifJob.isRestoring = true;
          notifJob.shownTimeStamp = datetime;
       
          JSONObject payload = new JSONObject();

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotification.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotification.java
@@ -34,38 +34,23 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import com.onesignal.OneSignal.OSNotificationDisplay;
+
 /**
  * The notification the user received
  * <br/><br/>
  * {@link #isAppInFocus} - Was app in focus.
- * <br/>
  * {@link #shown} - Was notification shown to the user. Will be {@code false} for silent notifications.
- * <br/>
  * {@link #androidNotificationId} - Android Notification ID assigned to the notification. Can be used to cancel or replace the notification
- * <br/>
  * {@link #payload} - Payload received from OneSignal
- * <br/>
- * {@link #displayType} - How the notification was displayed ot the user. Can be set to {@link DisplayType#Notification Notification},
- * {@link DisplayType#InAppAlert InAppAlert}, or {@link DisplayType#None None} if it was not displayed.
- * <br/>
+ * {@link #displayOption} - How the notification will be displayed to the user, includes options:
+ *    {@link OSNotificationDisplay#SILENT}
+ *    {@link OSNotificationDisplay#NOTIFICATION}
+ * <br/><br/>
  * {@link #groupedNotifications} - If the notification is a summary notification for a group, this will contain
  * all notification payloads it was created from.
  */
 public class OSNotification {
-
-   /**
-    * How the notification was displayed to the user. Part of {@link OSNotification}.
-    */
-   public enum DisplayType {
-      // Notification shown in the notification shade.
-      Notification,
-
-      // Notification shown as an in app alert.
-      InAppAlert,
-
-      // Notification was silent and not displayed.
-      None
-   }
    
    public OSNotification() {
    }
@@ -74,7 +59,7 @@ public class OSNotification {
       isAppInFocus = jsonObject.optBoolean("isAppInFocus");
       shown = jsonObject.optBoolean("shown", shown);
       androidNotificationId = jsonObject.optInt("androidNotificationId");
-      displayType = DisplayType.values()[jsonObject.optInt("displayType")];
+      displayOption = OSNotificationDisplay.values()[jsonObject.optInt("displayType")];
 
       if (jsonObject.has("groupedNotifications")) {
          JSONArray jsonArray = jsonObject.optJSONArray("groupedNotifications");
@@ -99,7 +84,7 @@ public class OSNotification {
    // Notification payload received from OneSignal
    public OSNotificationPayload payload;
 
-   public DisplayType displayType;
+   public OSNotificationDisplay displayOption;
 
    // Will be set if a summary notification is opened.
    //    The payload will be the most recent notification received.
@@ -112,7 +97,7 @@ public class OSNotification {
          mainObj.put("isAppInFocus", isAppInFocus);
          mainObj.put("shown", shown);
          mainObj.put("androidNotificationId", androidNotificationId);
-         mainObj.put("displayType", displayType.ordinal());
+         mainObj.put("displayType", displayOption.ordinal());
 
          if (groupedNotifications != null) {
             JSONArray payloadJsonArray = new JSONArray();

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -82,19 +82,27 @@ public class OneSignal {
    // If the app is this amount time or longer in the background we will count the session as done
    static final long MIN_ON_SESSION_TIME_MILLIS = 30 * 1_000L;
 
-   public enum LOG_LEVEL {
+    public enum LOG_LEVEL {
       NONE, FATAL, ERROR, WARN, INFO, DEBUG, VERBOSE
    }
 
-   public enum OSInFocusDisplayOption {
-      None, InAppAlert, Notification
+   public enum OSNotificationDisplay {
+      SILENT,
+      NOTIFICATION;
+
+      boolean isSilent() {
+         return this.equals(SILENT);
+      }
+
+      boolean isNotification() {
+         return this.equals(NOTIFICATION);
+      }
    }
 
    enum AppEntryAction {
       NOTIFICATION_CLICK,
       APP_OPEN,
-      APP_CLOSE,
-      ;
+      APP_CLOSE;
 
       boolean isNotificationClick() {
           return this.equals(NOTIFICATION_CLICK);
@@ -113,8 +121,9 @@ public class OneSignal {
     * An interface used to handle notifications that are received.
     * <br/>
     * Set this during OneSignal init in
-    * {@link OneSignal#setNotificationWillShowInForegroundHandler(NotificationWillShowInForegroundHandler) setNotificationWillShowInForegroundHandler}
+    * {@link OneSignal#setNotificationWillShowInForegroundHandler(NotificationWillShowInForegroundHandler)}
     * <br/><br/>
+    * TODO: Update docs with new NotificationWillShowInForegroundHandler
     * @see <a href="https://documentation.onesignal.com/docs/android-native-sdk#section--notificationreceivedhandler-">NotificationReceivedHandler | OneSignal Docs</a>
     */
    public interface NotificationWillShowInForegroundHandler {
@@ -130,8 +139,9 @@ public class OneSignal {
     * An interface used to process a OneSignal notification the user just tapped on.
     * <br/>
     * Set this during OneSignal init in
-    * {@link OneSignal#setNotificationOpenedHandler(NotificationOpenedHandler) setNotificationOpenedHandler}
+    * {@link OneSignal#setNotificationOpenedHandler(NotificationOpenedHandler)}
     * <br/><br/>
+    * TODO: Update docs with new NotificationOpenedHandler
     * @see <a href="https://documentation.onesignal.com/docs/android-native-sdk#section--notificationopenedhandler-">NotificationOpenedHandler | OneSignal Docs</a>
     */
    public interface NotificationOpenedHandler {
@@ -257,11 +267,11 @@ public class OneSignal {
    static NotificationWillShowInForegroundHandler notificationWillShowInForegroundHandler;
    static NotificationOpenedHandler notificationOpenedHandler;
    static InAppMessageClickHandler inAppMessageClickHandler;
+
    static boolean mPromptLocation;
-   static boolean mDisableGmsMissingPrompt;
    static boolean mUnsubscribeWhenNotificationsAreDisabled = true;
    // TODO: Will be apart of NotificationWillShowInForegroundHandler
-   static OSInFocusDisplayOption mDisplayOption = OSInFocusDisplayOption.Notification;
+   static OSNotificationDisplay mDisplayOption = OSNotificationDisplay.NOTIFICATION;
    // TODO: End of old mInitBuilder params
 
    // Is the init() of OneSignal SDK finished yet
@@ -475,6 +485,18 @@ public class OneSignal {
     */
    public static void unsubscribeWhenNotificationsAreDisabled(boolean set) {
       mUnsubscribeWhenNotificationsAreDisabled = set;
+   }
+
+   /**
+    * If {@link NotificationWillShowInForegroundHandler} is not set, the ability to control a
+    *    default {@link OSNotificationDisplay} should still exist
+    */
+   public static void setNotificationDisplayOption(OSNotificationDisplay displayOption) {
+      mDisplayOption = displayOption;
+   }
+
+   public static OSNotificationDisplay getCurrentNotificationDisplayOption() {
+      return mDisplayOption;
    }
 
    /**
@@ -926,7 +948,7 @@ public class OneSignal {
    }
    private static void fireCallbackForOpenedNotifications() {
       for(JSONArray dataArray : unprocessedOpenedNotifs)
-         runNotificationOpenedCallback(dataArray, true, false);
+         runNotificationOpenedCallback(dataArray, true);
 
       unprocessedOpenedNotifs.clear();
    }
@@ -1917,18 +1939,18 @@ public class OneSignal {
       return urlOpened;
    }
 
-   private static void runNotificationOpenedCallback(final JSONArray dataArray, final boolean shown, boolean fromAlert) {
+   private static void runNotificationOpenedCallback(final JSONArray dataArray, final boolean shown) {
       if (notificationOpenedHandler == null) {
          unprocessedOpenedNotifs.add(dataArray);
          return;
       }
 
-      fireNotificationOpenedHandler(generateOsNotificationOpenResult(dataArray, shown, fromAlert));
+      fireNotificationOpenedHandler(generateOsNotificationOpenResult(dataArray, shown));
    }
 
    // Also called for received but OSNotification is extracted from it.
    @NonNull
-   private static OSNotificationOpenResult generateOsNotificationOpenResult(JSONArray dataArray, boolean shown, boolean fromAlert) {
+   private static OSNotificationOpenResult generateOsNotificationOpenResult(JSONArray dataArray, boolean shown) {
       int jsonArraySize = dataArray.length();
 
       boolean firstMessage = true;
@@ -1965,10 +1987,7 @@ public class OneSignal {
       openResult.action = new OSNotificationAction();
       openResult.action.actionID = actionSelected;
       openResult.action.type = actionSelected != null ? OSNotificationAction.ActionType.ActionTaken : OSNotificationAction.ActionType.Opened;
-      if (fromAlert)
-         openResult.notification.displayType = OSNotification.DisplayType.InAppAlert;
-      else
-         openResult.notification.displayType = OSNotification.DisplayType.Notification;
+      openResult.notification.displayOption = OSNotificationDisplay.NOTIFICATION;
 
       return openResult;
    }
@@ -1985,8 +2004,8 @@ public class OneSignal {
    // Called when receiving FCM/ADM message after it has been displayed.
    // Or right when it is received if it is a silent one
    //   If a NotificationExtenderService is present in the developers app this will not fire for silent notifications.
-   static void handleNotificationReceived(JSONArray data, boolean displayed, boolean fromAlert) {
-      OSNotificationOpenResult openResult = generateOsNotificationOpenResult(data, displayed, fromAlert);
+   static void handleNotificationReceived(JSONArray data, boolean displayed) {
+      OSNotificationOpenResult openResult = generateOsNotificationOpenResult(data, displayed);
       if(trackFirebaseAnalytics != null && getFirebaseAnalyticsEnabled())
          trackFirebaseAnalytics.trackReceivedEvent(openResult);
 
@@ -2006,7 +2025,7 @@ public class OneSignal {
       notificationOpenedRESTCall(inContext, data);
 
       if (trackFirebaseAnalytics != null && getFirebaseAnalyticsEnabled())
-         trackFirebaseAnalytics.trackOpenedEvent(generateOsNotificationOpenResult(data, true, fromAlert));
+         trackFirebaseAnalytics.trackOpenedEvent(generateOsNotificationOpenResult(data, true));
 
       boolean urlOpened = false;
       boolean defaultOpenActionDisabled = "DISABLE".equals(OSUtils.getManifestMeta(inContext, "com.onesignal.NotificationOpened.DEFAULT"));
@@ -2021,7 +2040,7 @@ public class OneSignal {
          sessionManager.onDirectSessionFromNotificationOpen(notificationId);
       }
 
-      runNotificationOpenedCallback(data, true, fromAlert);
+      runNotificationOpenedCallback(data, true);
    }
 
    static boolean startOrResumeApp(Context inContext) {
@@ -2284,50 +2303,6 @@ public class OneSignal {
               OneSignalPrefs.PREFS_ONESIGNAL,
               OneSignalPrefs.PREFS_OS_LAST_SESSION_TIME,
               -31 * 1000L);
-   }
-
-   /**
-    * Setting to control how OneSignal notifications will be shown when one is received while your app
-    * is in focus.
-    * <br/><br/>
-    * {@link OneSignal.OSInFocusDisplayOption#Notification Notification} - native notification display while user has app in focus (can be distracting).
-    * <br/>
-    * {@link OneSignal.OSInFocusDisplayOption#InAppAlert In-App Alert (Default)} - native alert dialog display, which can be helpful during development.
-    * <br/>
-    * {@link OneSignal.OSInFocusDisplayOption#None None} - notification is silent.
-    *
-    * @param displayOption the {@link OneSignal.OSInFocusDisplayOption OSInFocusDisplayOption} to set
-    */
-   public static void setInFocusDisplaying(OSInFocusDisplayOption displayOption) {
-      mDisplayOption = displayOption;
-   }
-
-   public static OSInFocusDisplayOption currentInFocusDisplayOption() {
-      return mDisplayOption;
-   }
-
-   private static OSInFocusDisplayOption getInFocusDisplaying(int displayOption) {
-      switch(displayOption) {
-         case 0:
-            return OSInFocusDisplayOption.None;
-         case 1:
-            return OSInFocusDisplayOption.InAppAlert;
-         case 2:
-            return OSInFocusDisplayOption.Notification;
-      }
-
-      if (displayOption < 0)
-         return OSInFocusDisplayOption.None;
-      return OSInFocusDisplayOption.Notification;
-   }
-
-   static boolean getNotificationsWhenActiveEnabled() {
-      // If OneSignal hasn't been initialized yet it is best to display a normal notification.
-      return mDisplayOption == OSInFocusDisplayOption.Notification;
-   }
-
-   static boolean getInAppAlertNotificationEnabled() {
-      return mDisplayOption == OSInFocusDisplayOption.InAppAlert;
    }
 
    /**

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
@@ -16,7 +16,6 @@ import org.robolectric.util.Scheduler;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -175,7 +174,7 @@ public class OneSignalPackagePrivateHelper {
       NotificationGenerationJob notifJob = new NotificationGenerationJob(context);
       notifJob.jsonPayload = jsonPayload;
       notifJob.overrideSettings = overrideSettings;
-      notifJob.restoring = restoring;
+      notifJob.isRestoring = restoring;
       return NotificationBundleProcessor.ProcessJobForDisplay(notifJob);
    }
 

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
@@ -28,7 +28,6 @@
 package com.test.onesignal;
 
 import android.app.Activity;
-import android.app.AlertDialog;
 import android.app.Notification;
 import android.app.NotificationManager;
 import android.app.job.JobScheduler;
@@ -46,7 +45,6 @@ import android.os.SystemClock;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.app.NotificationCompat;
-import android.widget.Button;
 
 import com.onesignal.BundleCompat;
 import com.onesignal.FCMBroadcastReceiver;
@@ -94,7 +92,6 @@ import org.robolectric.Shadows;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.android.controller.ServiceController;
 import org.robolectric.annotation.Config;
-import org.robolectric.shadows.ShadowAlertDialog;
 import org.robolectric.shadows.ShadowLog;
 
 import java.lang.reflect.Field;
@@ -245,7 +242,6 @@ public class GenerateNotificationRunner {
    
    @Test
    public void shouldContainPayloadWhenOldSummaryNotificationIsOpened() {
-      OneSignal.setInFocusDisplaying(OneSignal.OSInFocusDisplayOption.Notification);
       OneSignal.setAppId("b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
       OneSignal.setAppContext(blankActivity);
       OneSignal.setNotificationOpenedHandler(new OneSignal.NotificationOpenedHandler() {
@@ -286,7 +282,6 @@ public class GenerateNotificationRunner {
    @Test
    public void shouldSetCorrectNumberOfButtonsOnSummaryNotification() throws Exception {
       // Setup - Init
-      OneSignal.setInFocusDisplaying(OneSignal.OSInFocusDisplayOption.Notification);
       OneSignal.setAppId("b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
       OneSignal.setAppContext(blankActivity);
       threadAndTaskWait();
@@ -309,7 +304,6 @@ public class GenerateNotificationRunner {
    @Test
    public void shouldCancelAllNotificationsPartOfAGroup() throws Exception {
       // Setup - Init
-      OneSignal.setInFocusDisplaying(OneSignal.OSInFocusDisplayOption.Notification);
       OneSignal.setAppId("b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
       OneSignal.setAppContext(blankActivity);
       threadAndTaskWait();
@@ -361,7 +355,6 @@ public class GenerateNotificationRunner {
     @Test
     @Config(sdk = Build.VERSION_CODES.LOLLIPOP)
     public void testNotifDismissAllOnGroupSummaryClickForAndroidUnderM() throws Exception {
-        OneSignal.setInFocusDisplaying(OneSignal.OSInFocusDisplayOption.Notification);
         OneSignal.setAppId("b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
         OneSignal.setAppContext(blankActivity);
         threadAndTaskWait();
@@ -378,7 +371,6 @@ public class GenerateNotificationRunner {
     @Test
     @Config(sdk = Build.VERSION_CODES.LOLLIPOP)
     public void testNotifDismissRecentOnGroupSummaryClickForAndroidUnderM() throws Exception {
-        OneSignal.setInFocusDisplaying(OneSignal.OSInFocusDisplayOption.Notification);
         OneSignal.setAppId("b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
         OneSignal.setAppContext(blankActivity);
         threadAndTaskWait();
@@ -395,7 +387,6 @@ public class GenerateNotificationRunner {
    @Test
    @Config(sdk = Build.VERSION_CODES.N)
    public void testNotifDismissAllOnGroupSummaryClick() throws Exception {
-      OneSignal.setInFocusDisplaying(OneSignal.OSInFocusDisplayOption.Notification);
       OneSignal.setAppId("b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
       OneSignal.setAppContext(blankActivity);
       threadAndTaskWait();
@@ -412,7 +403,6 @@ public class GenerateNotificationRunner {
    @Test
    @Config(sdk = Build.VERSION_CODES.N)
    public void testNotifDismissRecentOnGroupSummaryClick() throws Exception {
-      OneSignal.setInFocusDisplaying(OneSignal.OSInFocusDisplayOption.Notification);
       OneSignal.setAppId("b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
       OneSignal.setAppContext(blankActivity);
       threadAndTaskWait();
@@ -429,7 +419,6 @@ public class GenerateNotificationRunner {
    @Test
    @Config(sdk = Build.VERSION_CODES.N)
    public void testNotifDismissAllOnGrouplessSummaryClick() throws Exception {
-      OneSignal.setInFocusDisplaying(OneSignal.OSInFocusDisplayOption.Notification);
       OneSignal.setAppId("b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
       OneSignal.setAppContext(blankActivity);
       threadAndTaskWait();
@@ -446,7 +435,6 @@ public class GenerateNotificationRunner {
    @Test
    @Config(sdk = Build.VERSION_CODES.N)
    public void testNotifDismissRecentOnGrouplessSummaryClick() throws Exception {
-      OneSignal.setInFocusDisplaying(OneSignal.OSInFocusDisplayOption.Notification);
       OneSignal.setAppId("b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
       OneSignal.setAppContext(blankActivity);
       threadAndTaskWait();
@@ -487,7 +475,6 @@ public class GenerateNotificationRunner {
    @Test
    @Config(sdk = Build.VERSION_CODES.N)
    public void testGrouplessSummaryKeyReassignmentAtFourOrMoreNotification() throws Exception {
-      OneSignal.setInFocusDisplaying(OneSignal.OSInFocusDisplayOption.Notification);
       OneSignal.setAppId("b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
       OneSignal.setAppContext(blankActivity);
       threadAndTaskWait();
@@ -558,7 +545,6 @@ public class GenerateNotificationRunner {
    @Test
    public void shouldCancelNotificationAndUpdateSummary() throws Exception {
       // Setup - Init
-      OneSignal.setInFocusDisplaying(OneSignal.OSInFocusDisplayOption.Notification);
       OneSignal.setAppId("b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
       OneSignal.setAppContext(blankActivity);
       threadAndTaskWait();
@@ -712,7 +698,6 @@ public class GenerateNotificationRunner {
    @Test
    public void shouldUpdateNormalNotificationDisplayWhenReplacingANotification() throws Exception {
       // Setup - init
-      OneSignal.setInFocusDisplaying(OneSignal.OSInFocusDisplayOption.Notification);
       OneSignal.setAppId("b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
       OneSignal.setAppContext(blankActivity);
       threadAndTaskWait();
@@ -977,70 +962,6 @@ public class GenerateNotificationRunner {
       SQLiteDatabase writableDb = OneSignalDbHelper.getInstance(RuntimeEnvironment.application).getWritableDatabase();
       NotificationSummaryManager_updateSummaryNotificationAfterChildRemoved(blankActivity, writableDb, "some_group", false);
    }
-   
-   @Test
-   public void shouldNotDisplaySummaryWhenDismissingAnInAppAlertIfOneDidntAlreadyExist() throws Exception {
-      // Setup - init
-      OneSignal.setInFocusDisplaying(OneSignal.OSInFocusDisplayOption.InAppAlert);
-      OneSignal.setAppId("b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
-      OneSignal.setAppContext(blankActivity);
-      blankActivityController.resume();
-      threadAndTaskWait();
-   
-      // Setup1 - Display a notification with a group set
-      Bundle bundle = getBaseNotifBundle("UUID1");
-      bundle.putString("grp", "test1");
-      NotificationBundleProcessor_ProcessFromFCMIntentService(blankActivity, bundle, null);
-   
-      // Test1 - Manually trigger a refresh on grouped notification.
-      SQLiteDatabase writableDb = OneSignalDbHelper.getInstance(RuntimeEnvironment.application).getWritableDatabase();
-      NotificationSummaryManager_updateSummaryNotificationAfterChildRemoved(blankActivity, writableDb, "test1", false);
-      assertEquals(0, ShadowRoboNotificationManager.notifications.size());
-   
-   
-      // Setup2 - Display a 2nd notification with the same group key
-      bundle = getBaseNotifBundle("UUID2");
-      bundle.putString("grp", "test1");
-      NotificationBundleProcessor_ProcessFromFCMIntentService(blankActivity, bundle, null);
-   
-      // Test2 - Manually trigger a refresh on grouped notification.
-      writableDb = OneSignalDbHelper.getInstance(RuntimeEnvironment.application).getWritableDatabase();
-      NotificationSummaryManager_updateSummaryNotificationAfterChildRemoved(blankActivity, writableDb, "test1", false);
-      assertEquals(0, ShadowRoboNotificationManager.notifications.size());
-   }
-
-   @Test
-   public void shouldCorrectlyDisplaySummaryWithMixedInAppAlertsAndNotifications() throws Exception {
-      // Setup - init
-      OneSignal.setInFocusDisplaying(OneSignal.OSInFocusDisplayOption.InAppAlert);
-      OneSignal.setAppId("b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
-      OneSignal.setAppContext(blankActivity);
-      blankActivityController.resume();
-      threadAndTaskWait();
-   
-      // Setup - Display a notification with a group set
-      Bundle bundle = getBaseNotifBundle("UUID1");
-      bundle.putString("grp", "test1");
-      NotificationBundleProcessor_ProcessFromFCMIntentService(blankActivity, bundle, null);
-      
-      assertEquals(0, ShadowRoboNotificationManager.notifications.size());
-   
-      // Setup - Background app
-      blankActivityController.pause();
-      threadAndTaskWait();
-   
-      // Setup - Send 2 more notifications with the same group
-      bundle = getBaseNotifBundle("UUID2");
-      bundle.putString("grp", "test1");
-      NotificationBundleProcessor_ProcessFromFCMIntentService(blankActivity, bundle, null);
-      bundle = getBaseNotifBundle("UUID3");
-      bundle.putString("grp", "test1");
-      NotificationBundleProcessor_ProcessFromFCMIntentService(blankActivity, bundle, null);
-   
-      // Test - equals 3 - Should be 2 notifications + 1 summary.
-      //         Alert should stay as an in-app alert.
-      assertEquals(3, ShadowRoboNotificationManager.notifications.size());
-   }
 
    @Test
    @Config(shadows = {ShadowFCMBroadcastReceiver.class})
@@ -1087,23 +1008,6 @@ public class GenerateNotificationRunner {
 
       assertEquals(NotificationCompat.PRIORITY_LOW, ShadowRoboNotificationManager.getLastNotif().priority);
       assertEquals(0, ShadowRoboNotificationManager.getLastNotif().defaults);
-   }
-
-   // TODO: Fails because of no appId being set because manifest placeholders removed
-   @Test
-   public void shouldAddDefaultButtonToAlertDialog() throws Exception {
-      OneSignal.setInFocusDisplaying(OneSignal.OSInFocusDisplayOption.InAppAlert);
-      OneSignal.setAppId("b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
-      OneSignal.setAppContext(blankActivity);
-      blankActivityController.resume();
-      threadAndTaskWait();
-
-      Bundle bundle = getBaseNotifBundle();
-      NotificationBundleProcessor_ProcessFromFCMIntentService(blankActivity, bundle, null);
-
-      AlertDialog alert = ShadowAlertDialog.getLatestAlertDialog();
-      Button button = alert.getButton(AlertDialog.BUTTON_NEUTRAL);
-      assertEquals(button.getText(), "Ok");
    }
 
    @Test
@@ -1234,7 +1138,7 @@ public class GenerateNotificationRunner {
    private OSNotification lastNotificationReceived;
    @Test
    public void shouldStillFireReceivedHandlerWhenNotificationExtenderServiceIsUsed() throws Exception {
-      OneSignal.setInFocusDisplaying(OneSignal.OSInFocusDisplayOption.None);
+      OneSignal.setNotificationDisplayOption(OneSignal.OSNotificationDisplay.SILENT);
       OneSignal.setAppId("b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
       OneSignal.setAppContext(blankActivity);
       OneSignal.setNotificationWillShowInForegroundHandler(new OneSignal.NotificationWillShowInForegroundHandler() {
@@ -1254,7 +1158,6 @@ public class GenerateNotificationRunner {
 
    @Test
    public void shouldNotFailedNotificationExtenderServiceWhenAlertIsNull() throws Exception {
-      OneSignal.setInFocusDisplaying(OneSignal.OSInFocusDisplayOption.Notification);
       OneSignal.setAppId("b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
       OneSignal.setAppContext(blankActivity);
       threadAndTaskWait();

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
@@ -1034,7 +1034,7 @@ public class MainOneSignalClassRunner {
       blankActivityController.resume();
       threadAndTaskWait();
 
-      OneSignal.setInFocusDisplaying(OneSignal.OSInFocusDisplayOption.Notification);
+      OneSignal.setNotificationDisplayOption(OneSignal.OSNotificationDisplay.NOTIFICATION);
 
       Bundle bundle = getBaseNotifBundle();
       boolean processResult = FCMBroadcastReceiver_processBundle(blankActivity, bundle);
@@ -1050,7 +1050,7 @@ public class MainOneSignalClassRunner {
       // Don't fire for duplicates
       notificationOpenedMessage = null;
       notificationReceivedBody = null;
-      OneSignal.setInFocusDisplaying(OneSignal.OSInFocusDisplayOption.None);
+      OneSignal.setNotificationDisplayOption(OneSignal.OSNotificationDisplay.SILENT);
       assertNull(notificationOpenedMessage);
 
       FCMBroadcastReceiver_processBundle(blankActivity, bundle);
@@ -1059,7 +1059,7 @@ public class MainOneSignalClassRunner {
       assertNull(notificationReceivedBody);
 
       // Test that only NotificationReceivedHandler fires
-      OneSignal.setInFocusDisplaying(OneSignal.OSInFocusDisplayOption.None);
+      OneSignal.setNotificationDisplayOption(OneSignal.OSNotificationDisplay.SILENT);
       bundle = getBaseNotifBundle("UUID2");
       notificationOpenedMessage = null;
       notificationReceivedBody = null;
@@ -2586,18 +2586,18 @@ public class MainOneSignalClassRunner {
          @Override
          public void onFailure(JSONObject response) {}
       });
-      OneSignal.setInFocusDisplaying(OneSignal.OSInFocusDisplayOption.Notification);
+      OneSignal.setNotificationDisplayOption(OneSignal.OSNotificationDisplay.NOTIFICATION);
       OneSignal.removeNotificationOpenedHandler();
       OneSignal.removeNotificationWillShowInForegroundHandler();
       threadAndTaskWait();
 
-      assertEquals(OneSignal.OSInFocusDisplayOption.Notification, OneSignal.currentInFocusDisplayOption());
+      assertEquals(OneSignal.OSNotificationDisplay.NOTIFICATION, OneSignal.getCurrentNotificationDisplayOption());
       assertNull(OneSignal.getPermissionSubscriptionState());
 
       OneSignal.setAppContext(blankActivity);
       threadAndTaskWait();
 
-      assertEquals(OneSignal.OSInFocusDisplayOption.Notification, OneSignal.currentInFocusDisplayOption());
+      assertEquals(OneSignal.OSNotificationDisplay.NOTIFICATION, OneSignal.getCurrentNotificationDisplayOption());
       assertTrue(OneSignal.getPermissionSubscriptionState().getSubscriptionStatus().getSubscribed());
    }
 
@@ -2620,18 +2620,18 @@ public class MainOneSignalClassRunner {
          @Override
          public void onFailure(JSONObject response) {}
       });
-      OneSignal.setInFocusDisplaying(OneSignal.OSInFocusDisplayOption.Notification);
+      OneSignal.setNotificationDisplayOption(OneSignal.OSNotificationDisplay.NOTIFICATION);
       OneSignal.removeNotificationOpenedHandler();
       OneSignal.removeNotificationWillShowInForegroundHandler();
       threadAndTaskWait();
 
-      assertEquals(OneSignal.OSInFocusDisplayOption.Notification, OneSignal.currentInFocusDisplayOption());
+      assertEquals(OneSignal.OSNotificationDisplay.NOTIFICATION, OneSignal.getCurrentNotificationDisplayOption());
       assertFalse(OneSignal.getPermissionSubscriptionState().getSubscriptionStatus().getSubscribed());
 
       OneSignal.setAppId(ONESIGNAL_APP_ID);
       threadAndTaskWait();
 
-      assertEquals(OneSignal.OSInFocusDisplayOption.Notification, OneSignal.currentInFocusDisplayOption());
+      assertEquals(OneSignal.OSNotificationDisplay.NOTIFICATION, OneSignal.getCurrentNotificationDisplayOption());
       assertTrue(OneSignal.getPermissionSubscriptionState().getSubscriptionStatus().getSubscribed());
    }
 
@@ -2652,19 +2652,19 @@ public class MainOneSignalClassRunner {
          @Override
          public void onFailure(JSONObject response) {}
       });
-      OneSignal.setInFocusDisplaying(OneSignal.OSInFocusDisplayOption.Notification);
+      OneSignal.setNotificationDisplayOption(OneSignal.OSNotificationDisplay.NOTIFICATION);
       OneSignal.removeNotificationOpenedHandler();
       OneSignal.removeNotificationWillShowInForegroundHandler();
       threadAndTaskWait();
 
-      assertEquals(OneSignal.OSInFocusDisplayOption.Notification, OneSignal.currentInFocusDisplayOption());
+      assertEquals(OneSignal.OSNotificationDisplay.NOTIFICATION, OneSignal.getCurrentNotificationDisplayOption());
       assertNull(OneSignal.getPermissionSubscriptionState());
 
       OneSignal.setAppContext(blankActivity);
       OneSignal.setAppId(ONESIGNAL_APP_ID);
       threadAndTaskWait();
 
-      assertEquals(OneSignal.OSInFocusDisplayOption.Notification, OneSignal.currentInFocusDisplayOption());
+      assertEquals(OneSignal.OSNotificationDisplay.NOTIFICATION, OneSignal.getCurrentNotificationDisplayOption());
       assertTrue(OneSignal.getPermissionSubscriptionState().getSubscriptionStatus().getSubscribed());
    }
 
@@ -2685,19 +2685,19 @@ public class MainOneSignalClassRunner {
          @Override
          public void onFailure(JSONObject response) {}
       });
-      OneSignal.setInFocusDisplaying(OneSignal.OSInFocusDisplayOption.Notification);
+      OneSignal.setNotificationDisplayOption(OneSignal.OSNotificationDisplay.NOTIFICATION);
       OneSignal.removeNotificationOpenedHandler();
       OneSignal.removeNotificationWillShowInForegroundHandler();
       threadAndTaskWait();
 
-      assertEquals(OneSignal.OSInFocusDisplayOption.Notification, OneSignal.currentInFocusDisplayOption());
+      assertEquals(OneSignal.OSNotificationDisplay.NOTIFICATION, OneSignal.getCurrentNotificationDisplayOption());
       assertNull(OneSignal.getPermissionSubscriptionState());
 
       OneSignal.setAppContext(blankActivity);
       OneSignal.setAppId(ONESIGNAL_APP_ID);
       threadAndTaskWait();
 
-      assertEquals(OneSignal.OSInFocusDisplayOption.Notification, OneSignal.currentInFocusDisplayOption());
+      assertEquals(OneSignal.OSNotificationDisplay.NOTIFICATION, OneSignal.getCurrentNotificationDisplayOption());
       assertTrue(OneSignal.getPermissionSubscriptionState().getSubscriptionStatus().getSubscribed());
    }
 
@@ -4364,7 +4364,7 @@ public class MainOneSignalClassRunner {
       actionButton.id = "id";
       osNotification.payload.actionButtons.add(actionButton);
 
-      osNotification.displayType = OSNotification.DisplayType.None;
+      osNotification.displayOption = OneSignal.OSNotificationDisplay.SILENT;
 
       osNotification.groupedNotifications = new ArrayList<>();
       OSNotificationPayload groupedPayload = new OSNotificationPayload();

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/NotificationLimitManagerRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/NotificationLimitManagerRunner.java
@@ -69,7 +69,7 @@ public class NotificationLimitManagerRunner {
 
       OneSignal.setAppId("b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
       OneSignal.setAppContext(blankActivity);
-      OneSignal.setInFocusDisplaying(OneSignal.OSInFocusDisplayOption.Notification);
+      OneSignal.setNotificationDisplayOption(OneSignal.OSNotificationDisplay.NOTIFICATION);
       threadAndTaskWait();
    }
 


### PR DESCRIPTION
* `NotificationWillShowInForegroundHandler` will be responsible for setting the notifications display type if a dev decides so
  * Alternative is a global setter that also controls the default for `OSNotificationDisplay` if no `NotificationWillShowInForegroundHandler` is set
  * Renamed `None` to `SILENT` and `Notification` to `NOTIFICATION` to follow a caps snake-case enum convention
* Removed `InAppAlert` from `InFocusDisplayOption`
  * Refactored `InFocusDisplayOption` to `OSNotificationDisplay`
  * Cleaned out `InAppAlert` related `UnitTests`