### PR TITLE
Fixes rare IllegalThreadStateException from Thread.start()

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalPrefs.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalPrefs.java
@@ -123,7 +123,7 @@ class OneSignalPrefs {
     }
 
     public static class WritePrefHandlerThread extends HandlerThread {
-        private Handler mHandler;
+        private @Nullable Handler mHandler;
 
         private static final int WRITE_CALL_DELAY_TO_BUFFER_MS = 200;
         private long lastSyncTime = 0L;
@@ -136,9 +136,11 @@ class OneSignalPrefs {
         protected void onLooperPrepared() {
             super.onLooperPrepared();
 
-            // Getting handler here as onLooperPrepared guarantees getLooper() will not return null
+            // Getting handler here as onLooperPrepared guarantees getLooper() will be non-null
             mHandler = new Handler(getLooper());
-            scheduleFlushToDiskJob();
+
+            // Kicks off our first flush, startDelayedWrite will schedule all flushes after that
+            scheduleFlushToDisk();
         }
 
         private synchronized void startDelayedWrite() {
@@ -148,7 +150,7 @@ class OneSignalPrefs {
                 return;
 
             startThread();
-            scheduleFlushToDiskJob();
+            scheduleFlushToDisk();
         }
 
         private boolean threadStartCalled;
@@ -160,7 +162,7 @@ class OneSignalPrefs {
             threadStartCalled = true;
         }
 
-        private synchronized void scheduleFlushToDiskJob() {
+        private synchronized void scheduleFlushToDisk() {
             // Could be null if looper thread just started
             if (mHandler == null)
                 return;


### PR DESCRIPTION
* The root issue is that `Thread.start()` could be called a 2nd time if
there was a problem getting a Handler after starting the thread.
Getting a Handler instance was used as the determining factor if the
thread had started or not.
* When calling `Thread.start()` there is no guarantee that the thread
has started after returning or that is may have already completed.
* To overcome the following 2 changes were made
  1. Override `HandlerThread`'s `onLooperPrepared`
     - Moving our `getLooper()` call here guarantees it will never be `null`
     - Then this means we can create a new `Handler` everytime successfully
  2. Added a boolean to make sure we only call `start()` once
     - `threadStartCalled` is set to `true` after `start()` is called.
     - This is needed as `onLooperPrepared` may not fire by the time some
       other part of the OneSignal SDK calls `scheduleFlushToDiskJob`
       again.


Relates to PR https://github.com/OneSignal/OneSignal-Android-SDK/pull/993
Fixes https://github.com/OneSignal/OneSignal-Android-SDK/issues/917

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1019)
<!-- Reviewable:end -->
