### PR TITLE
Added HMS Notif Open Activity

### DIFF
--- a/Examples/AndroidStudio/.idea/vcs.xml
+++ b/Examples/AndroidStudio/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/../.." vcs="Git" />
+  </component>
+</project>

--- a/OneSignalSDK/onesignal/src/main/AndroidManifest.xml
+++ b/OneSignalSDK/onesignal/src/main/AndroidManifest.xml
@@ -70,6 +70,13 @@
                 <action android:name="com.huawei.push.action.MESSAGING_EVENT" />
             </intent-filter>
         </service>
+        
+        <activity android:name="com.onesignal.NotificationOpenedActivityHMS"
+                  android:theme="@android:style/Theme.Translucent.NoTitleBar">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+            </intent-filter>
+        </activity>
 
         <service android:name="com.onesignal.GcmIntentService" />
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationOpenedActivityHMS.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationOpenedActivityHMS.java
@@ -31,10 +31,8 @@ import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
-import android.util.Log;
 
 import org.json.JSONArray;
-import org.json.JSONException;
 import org.json.JSONObject;
 
 // HMS Core creates a notification with an Intent when opened to start this Activity.

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationOpenedActivityHMS.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationOpenedActivityHMS.java
@@ -39,9 +39,27 @@ import org.json.JSONObject;
 //   Intent is defined via OneSignal's backend and is sent to HMS.
 // This has to be it's own Activity separate from NotificationOpenedActivity since
 //   we do not have full control over the Bundle.
-// Designed to be started with these flags
-// Intent.FLAG_ACTIVITY_NO_HISTORY | Intent.FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET | Intent.FLAG_ACTIVITY_MULTIPLE_TASK | Intent.FLAG_ACTIVITY_NEW_TASK
-// This way if app developer does not want the app to launch then it won't do so
+
+// Designed to be started with these flags:
+// Intent.FLAG_ACTIVITY_NO_HISTORY | Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_MULTIPLE_TASK
+//   - This gives us the hex value of 0x58000000
+
+// This is to meet the following requirements
+//   1. Allows the app developer to omit foregrounding the app if they choose
+//      - FLAG_ACTIVITY_NEW_TASK | FLAG_ACTIVITY_MULTIPLE_TASK is required to do this
+//      - FLAG_ACTIVITY_SINGLE_TOP nor FLAG_ACTIVITY_NEW_TASK on it's own does this.
+//      - FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET would also work but this is deprecated.
+//   2. This Activity does not become part of the back stack.
+//      - FLAG_ACTIVITY_NO_HISTORY does this
+//   3. This Activity does not show in the recent Activities list.
+//      - FLAG_ACTIVITY_NO_HISTORY does this
+
+// Note on using  Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_MULTIPLE_TASK
+//   We always want to create a new task so it doesn't resume some existing task.
+//   If it resumes an existing task then it won't be possible to prevent the app from showing.
+//   Some developer want to process the click in the background without bring the app to the foreground.
+//   The launcher Activity is started in OneSignal.java:startOrResumeApp if the developer does want the app
+//     to be opened.
 
 public class NotificationOpenedActivityHMS extends Activity {
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationOpenedActivityHMS.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationOpenedActivityHMS.java
@@ -1,0 +1,88 @@
+/**
+ * Modified MIT License
+ *
+ * Copyright 2020 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.onesignal;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.util.Log;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+// HMS Core creates a notification with an Intent when opened to start this Activity.
+//   Intent is defined via OneSignal's backend and is sent to HMS.
+// This has to be it's own Activity separate from NotificationOpenedActivity since
+//   we do not have full control over the Bundle.
+// Designed to be started with these flags
+// Intent.FLAG_ACTIVITY_NO_HISTORY | Intent.FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET | Intent.FLAG_ACTIVITY_MULTIPLE_TASK | Intent.FLAG_ACTIVITY_NEW_TASK
+// This way if app developer does not want the app to launch then it won't do so
+
+public class NotificationOpenedActivityHMS extends Activity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        processIntent();
+    }
+
+    @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        processIntent();
+    }
+
+    private void processIntent() {
+        processOpen(getIntent());
+        finish();
+    }
+
+    private void processOpen(@Nullable Intent intent) {
+        // Validate Intent to prevent any side effects or crashes
+        //    if triggered outside of OneSignal for any reason.
+        if (!OSNotificationFormatHelper.isOneSignalIntent(intent))
+            return;
+        OneSignal.setAppContext(this);
+
+        Bundle bundle = intent.getExtras();
+        JSONObject jsonData = NotificationBundleProcessor.bundleAsJSONObject(bundle);
+
+        if (NotificationOpenedProcessor.handleIAMPreviewOpen(this, jsonData))
+            return;
+
+        OneSignal.handleNotificationOpen(
+            this,
+            new JSONArray().put(jsonData),
+            false,
+            OSNotificationFormatHelper.getOSNotificationIdFromJson(jsonData)
+        );
+    }
+
+}

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationOpenedProcessor.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationOpenedProcessor.java
@@ -61,6 +61,8 @@ class NotificationOpenedProcessor {
       processIntent(context, intent);
    }
 
+   // Was Bundle created from our SDK? Prevents external Intents
+   // TODO: Could most likely be simplified checking if BUNDLE_KEY_ONESIGNAL_DATA is present
    private static boolean isOneSignalIntent(Intent intent) {
       return intent.hasExtra(BUNDLE_KEY_ONESIGNAL_DATA) || intent.hasExtra("summary") || intent.hasExtra(BUNDLE_KEY_ANDROID_NOTIFICATION_ID);
    }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationFormatHelper.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationFormatHelper.java
@@ -1,15 +1,26 @@
 package com.onesignal;
 
+import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 
 import org.json.JSONException;
 import org.json.JSONObject;
 
+// Current: All helpers are for parsing a push payload
+// Future: This class could also support parsing our SDK generated bundles
 class OSNotificationFormatHelper {
 
     private static final String PAYLOAD_OS_ROOT_CUSTOM = "custom";
     private static final String PAYLOAD_OS_NOTIFICATION_ID = "i";
+
+    static boolean isOneSignalIntent(@Nullable Intent intent) {
+        if (intent == null)
+            return false;
+
+        Bundle bundle = intent.getExtras();
+        return OSNotificationFormatHelper.isOneSignalBundle(bundle);
+    }
 
     static boolean isOneSignalBundle(@Nullable Bundle bundle) {
         return getOSNotificationIdFromBundle(bundle) != null;

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/NotificationOpenedActivityHMSIntegrationTestsRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/NotificationOpenedActivityHMSIntegrationTestsRunner.java
@@ -1,0 +1,125 @@
+package com.test.onesignal;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.support.annotation.NonNull;
+
+import com.onesignal.NotificationOpenedActivityHMS;
+import com.onesignal.OneSignal;
+import com.onesignal.ShadowCustomTabsClient;
+import com.onesignal.ShadowCustomTabsSession;
+import com.onesignal.ShadowOSUtils;
+import com.onesignal.ShadowOSViewUtils;
+import com.onesignal.ShadowOSWebView;
+import com.onesignal.ShadowOneSignalRestClient;
+import com.onesignal.StaticResetHelper;
+import com.onesignal.example.BlankActivity;
+
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowLog;
+
+import java.util.UUID;
+
+import static com.onesignal.InAppMessagingHelpers.ONESIGNAL_APP_ID;
+import static com.test.onesignal.TestHelpers.fastColdRestartApp;
+import static com.test.onesignal.TestHelpers.threadAndTaskWait;
+import static junit.framework.Assert.assertEquals;
+import static org.robolectric.Shadows.shadowOf;
+
+
+@Config(packageName = "com.onesignal.example",
+    instrumentedPackages = { "com.onesignal" },
+    shadows = {
+        ShadowOSUtils.class,
+        ShadowOneSignalRestClient.class,
+        ShadowCustomTabsClient.class,
+        ShadowOSWebView.class,
+        ShadowOSViewUtils.class,
+        ShadowCustomTabsClient.class,
+        ShadowCustomTabsSession.class
+    },
+    sdk = 26
+)
+
+
+@RunWith(RobolectricTestRunner.class)
+public class NotificationOpenedActivityHMSIntegrationTestsRunner {
+
+    @BeforeClass // Runs only once, before any tests
+    public static void setUpClass() throws Exception {
+        ShadowLog.stream = System.out;
+        TestHelpers.beforeTestSuite();
+        StaticResetHelper.saveStaticValues();
+    }
+
+    @Before
+    public void beforeEachTest() throws Exception {
+        TestHelpers.beforeTestInitAndCleanup();
+    }
+
+    private static Intent helper_baseHMSOpenIntent() {
+        return new Intent()
+                .setFlags(Intent.FLAG_ACTIVITY_NO_HISTORY | Intent.FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET | Intent.FLAG_ACTIVITY_MULTIPLE_TASK | Intent.FLAG_ACTIVITY_NEW_TASK)
+                .setAction("android.intent.action.VIEW");
+    }
+
+    private static void helper_startHMSOpenActivity(@NonNull Intent intent) {
+        Robolectric.buildActivity(NotificationOpenedActivityHMS.class, intent).create();
+    }
+
+    // Since the Activity has to be public it could be started outside of a OneSignal flow.
+    // Ensure it doesn't crash the app.
+    @Test
+    public void emptyIntent_doesNotThrow() {
+        helper_startHMSOpenActivity(helper_baseHMSOpenIntent());
+    }
+
+    @Test
+    public void barebonesOSPayload_startsMainActivity() throws Exception {
+        OneSignal.init(RuntimeEnvironment.application, "123456789", ONESIGNAL_APP_ID);
+        fastColdRestartApp();
+
+        Intent intent = helper_baseHMSOpenIntent()
+            .putExtra(
+                "custom",
+                new JSONObject() {{
+                    put("i", UUID.randomUUID().toString());
+                }}.toString()
+            );
+
+        helper_startHMSOpenActivity(intent);
+
+        Intent startedActivity = shadowOf(RuntimeEnvironment.application).getNextStartedActivity();
+        assertEquals(startedActivity.getComponent().getClassName(), BlankActivity.class.getName());
+    }
+
+    @Test
+    public void osIAMPreview_showsPreview() throws Exception {
+        Activity activity = Robolectric.buildActivity(BlankActivity.class).create().get();
+        OneSignal.init(activity, "123456789", ONESIGNAL_APP_ID);
+        threadAndTaskWait();
+
+        Intent intent = helper_baseHMSOpenIntent()
+                .putExtra(
+                        "custom",
+                        new JSONObject() {{
+                            put("i", UUID.randomUUID().toString());
+                            put("a", new JSONObject() {{
+                                put("os_in_app_message_preview_id", "UUID");
+                            }});
+                        }}.toString()
+                );
+
+        helper_startHMSOpenActivity(intent);
+
+        assertEquals("PGh0bWw+PC9odG1sPg==", ShadowOSWebView.lastData);
+    }
+}

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/NotificationOpenedActivityHMSIntegrationTestsRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/NotificationOpenedActivityHMSIntegrationTestsRunner.java
@@ -17,7 +17,6 @@ import com.onesignal.ShadowPushRegistratorHMS;
 import com.onesignal.StaticResetHelper;
 import com.onesignal.example.BlankActivity;
 
-import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -71,7 +70,7 @@ public class NotificationOpenedActivityHMSIntegrationTestsRunner {
 
     private static Intent helper_baseHMSOpenIntent() {
         return new Intent()
-                .setFlags(Intent.FLAG_ACTIVITY_NO_HISTORY | Intent.FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET | Intent.FLAG_ACTIVITY_MULTIPLE_TASK | Intent.FLAG_ACTIVITY_NEW_TASK)
+                .setFlags(Intent.FLAG_ACTIVITY_NO_HISTORY | Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_MULTIPLE_TASK)
                 .setAction("android.intent.action.VIEW");
     }
 

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/RestClientAsserts.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/RestClientAsserts.java
@@ -303,6 +303,20 @@ class RestClientAsserts {
       assertIsUUID(request.payload.optString("app_id"));
    }
 
+   public static void assertNotificationOpenAtIndex(int index, int deviceType) throws JSONException {
+      Request request = ShadowOneSignalRestClient.requests.get(index);
+
+      assertEquals(REST_METHOD.PUT, request.method);
+
+      String[] parts = request.url.split("/");
+      assertEquals("notifications", parts[0]);
+      assertIsUUID(parts[1]);
+
+      assertHasAppId(request);
+
+      assertEquals(deviceType, request.payload.getInt("device_type"));
+   }
+
    private static void assertAppIdInUrl(@NonNull String url) {
       String[] appsPath = url.split("apps/");
       if (appsPath.length == 2) {


### PR DESCRIPTION
* This is the entry point when tapping on a HMS core notification
* This has to be it's own Activity separate from NotificationOpenedActivity
since we do not have full control over the Bundle

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1022)
<!-- Reviewable:end -->
