### PR TITLE
UnitTests for NotificationWillShowInForegroundHandler

### DIFF
--- a/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/application/MainApplication.java
+++ b/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/application/MainApplication.java
@@ -22,7 +22,7 @@ public class MainApplication extends Application {
         String appId = OneSignalPrefs.getOneSignalAppId(this);
         // If cached app id is null use the default, otherwise use cached.
         if (appId == null) {
-            appId = "380dc082-5231-4cc2-ab51-a03da5a0e4c2";
+            appId = getString(R.string.onesignal_app_id);
             OneSignalPrefs.cacheOneSignalAppId(this, appId);
         }
         OneSignal.setAppId(appId);

--- a/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/notification/AppNotificationExtenderService.java
+++ b/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/notification/AppNotificationExtenderService.java
@@ -39,7 +39,6 @@ public class AppNotificationExtenderService extends NotificationExtenderService 
    public void notificationWillShowInForeground(ExtNotificationGenerationJob notifJob) {
       OneSignal.onesignalLog(OneSignal.LOG_LEVEL.VERBOSE, "Ext notificationWillShowInForeground fired!!!!");
 
-
       notifJob.setNotificationDisplayOption(OneSignal.OSNotificationDisplay.NOTIFICATION);
       notifJob.complete(true);
    }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotification.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotification.java
@@ -442,7 +442,7 @@ class GenerateNotification {
 
    // This summary notification will be visible instead of the normal one on pre-Android 7.0 devices.
    private static void createSummaryNotification(OSNotificationGenerationJob notifJob, OneSignalNotificationBuilder notifBuilder) {
-      boolean updateSummary = notifJob.isRestoring;
+       boolean updateSummary = notifJob.isRestoring;
       JSONObject fcmJson = notifJob.jsonPayload;
 
       String group = fcmJson.optString("grp", null);

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotification.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotification.java
@@ -442,7 +442,7 @@ class GenerateNotification {
 
    // This summary notification will be visible instead of the normal one on pre-Android 7.0 devices.
    private static void createSummaryNotification(OSNotificationGenerationJob notifJob, OneSignalNotificationBuilder notifBuilder) {
-       boolean updateSummary = notifJob.isRestoring;
+      boolean updateSummary = notifJob.isRestoring;
       JSONObject fcmJson = notifJob.jsonPayload;
 
       String group = fcmJson.optString("grp", null);

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
@@ -78,8 +78,8 @@ class NotificationBundleProcessor {
             return;
          }
 
-          OSNotificationGenerationJob notifJob = new OSNotificationGenerationJob(context);
-          notifJob.isRestoring = bundle.getBoolean("restoring", false);
+         OSNotificationGenerationJob notifJob = new OSNotificationGenerationJob(context);
+         notifJob.isRestoring = bundle.getBoolean("restoring", false);
          notifJob.shownTimeStamp = bundle.getLong("timestamp");
          notifJob.jsonPayload = new JSONObject(jsonStrPayload);
          notifJob.isIamPreview = inAppPreviewPushUUID(notifJob.jsonPayload) != null;
@@ -129,7 +129,7 @@ class NotificationBundleProcessor {
         }
 
         return notifJob.getAndroidIdWithoutCreate();
-   }
+    }
 
    private static boolean shouldDisplayNotif(OSNotificationGenerationJob notifJob) {
       // Validate that the current Android device is Android 4.4 or higher and the current job is a

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
@@ -428,7 +428,7 @@ class NotificationBundleProcessor {
    }
 
     private static void processCollapseKey(OSNotificationGenerationJob notifJob) {
-        if (notifJob.isRestoring)
+      if (notifJob.isRestoring)
          return;
       if (!notifJob.jsonPayload.has("collapse_key") || "do_not_collapse".equals(notifJob.jsonPayload.optString("collapse_key")))
          return;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
@@ -77,9 +77,9 @@ class NotificationBundleProcessor {
             OneSignal.Log(OneSignal.LOG_LEVEL.ERROR, "json_payload key is nonexistent from mBundle passed to ProcessFromFCMIntentService: " + bundle);
             return;
          }
-   
-         OSNotificationGenerationJob notifJob = new OSNotificationGenerationJob(context);
-         notifJob.isRestoring = bundle.getBoolean("restoring", false);
+
+          OSNotificationGenerationJob notifJob = new OSNotificationGenerationJob(context);
+          notifJob.isRestoring = bundle.getBoolean("restoring", false);
          notifJob.shownTimeStamp = bundle.getLong("timestamp");
          notifJob.jsonPayload = new JSONObject(jsonStrPayload);
          notifJob.isIamPreview = inAppPreviewPushUUID(notifJob.jsonPayload) != null;
@@ -107,28 +107,28 @@ class NotificationBundleProcessor {
       }
    }
 
-   /**
-    * Recommended method to process notification before displaying
-    * Only use the {@link NotificationBundleProcessor#ProcessJobForDisplay(OSNotificationGenerationJob, boolean, boolean)}
-    *     in the event where you want to mark a notification as opened or displayed different than the defaults
-    */
-   static int ProcessJobForDisplay(OSNotificationGenerationJob notifJob) {
-      return ProcessJobForDisplay(notifJob, false, true);
-   }
+    /**
+     * Recommended method to process notification before displaying
+     * Only use the {@link NotificationBundleProcessor#ProcessJobForDisplay(OSNotificationGenerationJob, boolean, boolean)}
+     *     in the event where you want to mark a notification as opened or displayed different than the defaults
+     */
+    static int ProcessJobForDisplay(OSNotificationGenerationJob notifJob) {
+        return ProcessJobForDisplay(notifJob, false, true);
+    }
 
-   static int ProcessJobForDisplay(OSNotificationGenerationJob notifJob, boolean opened, boolean displayed) {
-      processCollapseKey(notifJob);
+    static int ProcessJobForDisplay(OSNotificationGenerationJob notifJob, boolean opened, boolean displayed) {
+        processCollapseKey(notifJob);
 
-      boolean doDisplay = shouldDisplayNotif(notifJob);
-      if (doDisplay)
-         OneSignal.fireNotificationWillShowInForegroundHandlers(notifJob);
+        boolean doDisplay = shouldDisplayNotif(notifJob);
+        if (doDisplay)
+            OneSignal.fireNotificationWillShowInForegroundHandlers(notifJob);
 
-      if (!notifJob.isRestoring && !notifJob.isIamPreview) {
-         processNotification(notifJob, opened);
-         OneSignal.handleNotificationReceived(notifJob, displayed);
-      }
+        if (!notifJob.isRestoring && !notifJob.isIamPreview) {
+            processNotification(notifJob, opened);
+            OneSignal.handleNotificationReceived(notifJob, displayed);
+        }
 
-      return notifJob.getAndroidIdWithoutCreate();
+        return notifJob.getAndroidIdWithoutCreate();
    }
 
    private static boolean shouldDisplayNotif(OSNotificationGenerationJob notifJob) {
@@ -427,8 +427,8 @@ class NotificationBundleProcessor {
       }
    }
 
-   private static void processCollapseKey(OSNotificationGenerationJob notifJob) {
-      if (notifJob.isRestoring)
+    private static void processCollapseKey(OSNotificationGenerationJob notifJob) {
+        if (notifJob.isRestoring)
          return;
       if (!notifJob.jsonPayload.has("collapse_key") || "do_not_collapse".equals(notifJob.jsonPayload.optString("collapse_key")))
          return;
@@ -501,14 +501,14 @@ class NotificationBundleProcessor {
       notifJob.overrideSettings = new NotificationExtenderService.OverrideSettings();
 
       // Process and save as a opened notification to prevent duplicates.
-      String alert = bundle.getString("alert");
-      if (!shouldDisplay(alert)) {
-         notifJob.overrideSettings.androidNotificationId = -1;
-         NotificationBundleProcessor.ProcessJobForDisplay(notifJob, true, false);
-      }
-      else {
-         NotificationBundleProcessor.ProcessJobForDisplay(notifJob);
-      }
+       String alert = bundle.getString("alert");
+       if (!shouldDisplay(alert)) {
+           notifJob.overrideSettings.androidNotificationId = -1;
+           NotificationBundleProcessor.ProcessJobForDisplay(notifJob, true, false);
+       }
+       else {
+           NotificationBundleProcessor.ProcessJobForDisplay(notifJob);
+       }
 
       return result;
    }
@@ -557,7 +557,7 @@ class NotificationBundleProcessor {
    }
 
    static boolean shouldDisplay(String body) {
-      return !TextUtils.isEmpty(body);
+       return !TextUtils.isEmpty(body);
    }
 
    static @NonNull JSONArray newJsonArray(JSONObject jsonObject) {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationExtenderService.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationExtenderService.java
@@ -97,11 +97,6 @@ public abstract class NotificationExtenderService extends JobIntentService {
    private Long restoreTimestamp;
    private OverrideSettings currentBaseOverrideSettings = null;
 
-   static void showNotification(final OSNotificationGenerationJob notifJob) {
-      OneSignal.onesignalLog(OneSignal.LOG_LEVEL.VERBOSE, "Attempting to show notification with notifJob payload:\n" + notifJob.toString());
-      GenerateNotification.fromJsonPayload(notifJob);
-   }
-
    // Developer may call to override some notification settings.
    // If this method is called the SDK will omit it's notification regardless of what is returned from onNotificationProcessing.
    protected final OSNotificationDisplayedResult displayNotification(OverrideSettings overrideSettings) {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationExtenderService.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationExtenderService.java
@@ -97,6 +97,11 @@ public abstract class NotificationExtenderService extends JobIntentService {
    private Long restoreTimestamp;
    private OverrideSettings currentBaseOverrideSettings = null;
 
+   static void showNotification(final OSNotificationGenerationJob notifJob) {
+      OneSignal.onesignalLog(OneSignal.LOG_LEVEL.VERBOSE, "Attempting to show notification with notifJob payload:\n" + notifJob.toString());
+      GenerateNotification.fromJsonPayload(notifJob);
+   }
+
    // Developer may call to override some notification settings.
    // If this method is called the SDK will omit it's notification regardless of what is returned from onNotificationProcessing.
    protected final OSNotificationDisplayedResult displayNotification(OverrideSettings overrideSettings) {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationGenerationJob.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationGenerationJob.java
@@ -31,10 +31,11 @@ package com.onesignal;
 import android.content.Context;
 import android.net.Uri;
 import android.os.Handler;
-import android.text.TextUtils;
 
 import com.onesignal.OneSignal.OSNotificationDisplay;
 
+import org.json.JSONArray;
+import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.security.SecureRandom;
@@ -107,10 +108,18 @@ public class OSNotificationGenerationJob {
 
    /**
     * Get the notification additional data json from the payload
+    * @return
     */
    JSONObject getAdditionalData() {
-      return jsonPayload.optJSONObject(CUSTOM_PAYLOAD_PARAM)
-                        .optJSONObject(ADDITIONAL_DATA_PAYLOAD_PARAM);
+      try {
+         return new JSONObject(jsonPayload
+                 .optString(CUSTOM_PAYLOAD_PARAM))
+                 .getJSONObject(ADDITIONAL_DATA_PAYLOAD_PARAM);
+      } catch (JSONException e) {
+         e.printStackTrace();
+      }
+
+      return new JSONObject();
    }
 
    /**
@@ -134,6 +143,10 @@ public class OSNotificationGenerationJob {
       if (overrideSettings == null)
          overrideSettings = new NotificationExtenderService.OverrideSettings();
       overrideSettings.androidNotificationId = id;
+   }
+
+   private OSNotificationDisplay getNotificationDisplayOption() {
+      return this.displayOption;
    }
 
    private void setNotificationDisplayOption(OSNotificationDisplay displayOption) {
@@ -224,6 +237,10 @@ public class OSNotificationGenerationJob {
 
       public JSONObject getAdditionalData() {
          return notifJob.getAdditionalData();
+      }
+
+      public OSNotificationDisplay getNotificationDisplayOption() {
+         return notifJob.getNotificationDisplayOption();
       }
 
       public void setNotificationDisplayOption(OSNotificationDisplay displayOption) {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSTimeoutHandler.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSTimeoutHandler.java
@@ -1,0 +1,39 @@
+package com.onesignal;
+
+import android.os.Handler;
+
+class OSTimeoutHandler {
+
+    private long timeout = 0;
+
+    private Handler timeoutHandler;
+    private Runnable timeoutRunnable;
+
+    void setTimeout(long timeout) {
+        this.timeout = timeout;
+    }
+
+    void startTimeout(final Runnable runnable) {
+        // If the handler or runnable isn't null we do not want to start another
+        if (this.timeoutHandler != null || this.timeoutRunnable != null)
+            return;
+
+        this.timeoutRunnable = runnable;
+        OSUtils.runOnMainUIThread(new Runnable() {
+            @Override
+            public void run() {
+                timeoutHandler = new Handler();
+                timeoutHandler.postDelayed(timeoutRunnable, timeout);
+            }
+        });
+    }
+
+    void destroyTimeout() {
+        if (timeoutHandler != null)
+            timeoutHandler.removeCallbacks(timeoutRunnable);
+
+        timeoutHandler = null;
+        timeoutRunnable = null;
+    }
+
+}

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -2111,19 +2111,13 @@ public class OneSignal {
       });
    }
 
-   /**
-    * Called when receiving FCM/ADM message after it has been displayed.
-    * Or right when it is received if it is a silent one
-    *   If a NotificationExtenderService is present in the developers app this will not fire for silent notifications.
-    */
-   static void handleNotificationReceived(OSNotificationGenerationJob notifJob, boolean displayed) {
-      try {
-         JSONObject jsonObject = new JSONObject(notifJob.jsonPayload.toString());
-         jsonObject.put(BUNDLE_KEY_ANDROID_NOTIFICATION_ID, notifJob.getAndroidId());
-
-         OSNotificationOpenResult openResult = generateOsNotificationOpenResult(newJsonArray(jsonObject), displayed);
-         if (trackFirebaseAnalytics != null && getFirebaseAnalyticsEnabled())
-            trackFirebaseAnalytics.trackReceivedEvent(openResult);
+   // Called when receiving FCM/ADM message after it has been displayed.
+   // Or right when it is received if it is a silent one
+   //   If a NotificationExtenderService is present in the developers app this will not fire for silent notifications.
+   static void handleNotificationReceived(JSONArray data, boolean displayed) {
+      OSNotificationOpenResult openResult = generateOsNotificationOpenResult(data, displayed);
+      if(trackFirebaseAnalytics != null && getFirebaseAnalyticsEnabled())
+         trackFirebaseAnalytics.trackReceivedEvent(openResult);
 
       } catch (JSONException e) {
          e.printStackTrace();

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -2111,13 +2111,21 @@ public class OneSignal {
       });
    }
 
-   // Called when receiving FCM/ADM message after it has been displayed.
-   // Or right when it is received if it is a silent one
-   //   If a NotificationExtenderService is present in the developers app this will not fire for silent notifications.
-   static void handleNotificationReceived(JSONArray data, boolean displayed) {
-      OSNotificationOpenResult openResult = generateOsNotificationOpenResult(data, displayed);
-      if(trackFirebaseAnalytics != null && getFirebaseAnalyticsEnabled())
-         trackFirebaseAnalytics.trackReceivedEvent(openResult);
+   /**
+    * Called when receiving FCM/ADM message after it has been displayed.
+    * Or right when it is received if it is a silent one
+    *   If a NotificationExtenderService is present in the developers app this will not fire for silent notifications.
+    */
+   static void handleNotificationReceived(OSNotificationGenerationJob notifJob, boolean displayed) {
+      int androidNotificationId = notifJob.getAndroidId();
+
+      try {
+         JSONObject jsonObject = new JSONObject(notifJob.jsonPayload.toString());
+         jsonObject.put("notificationId", androidNotificationId);
+
+         OSNotificationOpenResult openResult = generateOsNotificationOpenResult(newJsonArray(jsonObject), displayed);
+         if(trackFirebaseAnalytics != null && getFirebaseAnalyticsEnabled())
+            trackFirebaseAnalytics.trackReceivedEvent(openResult);
 
       } catch (JSONException e) {
          e.printStackTrace();

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -2117,11 +2117,9 @@ public class OneSignal {
     *   If a NotificationExtenderService is present in the developers app this will not fire for silent notifications.
     */
    static void handleNotificationReceived(OSNotificationGenerationJob notifJob, boolean displayed) {
-      int androidNotificationId = notifJob.getAndroidId();
-
       try {
          JSONObject jsonObject = new JSONObject(notifJob.jsonPayload.toString());
-         jsonObject.put("notificationId", androidNotificationId);
+         jsonObject.put(BUNDLE_KEY_ANDROID_NOTIFICATION_ID, notifJob.getAndroidId());
 
          OSNotificationOpenResult openResult = generateOsNotificationOpenResult(newJsonArray(jsonObject), displayed);
          if(trackFirebaseAnalytics != null && getFirebaseAnalyticsEnabled())

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
@@ -165,6 +165,11 @@ public class OneSignalPackagePrivateHelper {
    public static class NotificationTable extends OneSignalDbContract.NotificationTable { }
    public static class InAppMessageTable extends OneSignalDbContract.InAppMessageTable { }
    public static class NotificationRestorer extends com.onesignal.NotificationRestorer { }
+    public static class OSNotificationGenerationJob extends com.onesignal.OSNotificationGenerationJob {
+        OSNotificationGenerationJob(Context context) {
+            super(context);
+        }
+    }
 
    public static class OneSignalSyncServiceUtils_SyncRunnable extends com.onesignal.OneSignalSyncServiceUtils.SyncRunnable {
       @Override
@@ -219,10 +224,6 @@ public class OneSignalPackagePrivateHelper {
 
    public static String OneSignal_appId() {
       return OneSignal.appId;
-   }
-
-   public static void OneSignal_setAppId(String appId) {
-      OneSignal.appId = appId;
    }
 
    static public class OSSharedPreferencesWrapper extends com.onesignal.OSSharedPreferencesWrapper {}

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalShadowPackageManager.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalShadowPackageManager.java
@@ -38,7 +38,7 @@ public class OneSignalShadowPackageManager extends ShadowApplicationPackageManag
     }
 
     /**
-     * Add a meat data key and String value to the metaData Bundle for placement in the
+     * Add a meta data key and String value to the metaData Bundle for placement in the
      * shadowed getApplicationInfo
      */
     public static void addManifestMetaData(String key, Object value) {

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
@@ -42,6 +42,7 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.SystemClock;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.app.NotificationCompat;
@@ -61,6 +62,7 @@ import com.onesignal.OneSignalPackagePrivateHelper;
 import com.onesignal.OneSignalPackagePrivateHelper.NotificationRestorer;
 import com.onesignal.OneSignalPackagePrivateHelper.NotificationTable;
 import com.onesignal.OneSignalPackagePrivateHelper.TestOneSignalPrefs;
+import com.onesignal.OneSignalShadowPackageManager;
 import com.onesignal.RestoreJobService;
 import com.onesignal.ShadowBadgeCountUpdater;
 import com.onesignal.ShadowCustomTabsClient;
@@ -101,14 +103,13 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
+import static com.onesignal.OneSignalPackagePrivateHelper.FCMBroadcastReceiver_processBundle;
 import static com.onesignal.OneSignalPackagePrivateHelper.GenerateNotification.BUNDLE_KEY_ACTION_ID;
 import static com.onesignal.OneSignalPackagePrivateHelper.GenerateNotification.BUNDLE_KEY_ANDROID_NOTIFICATION_ID;
 import static com.onesignal.OneSignalPackagePrivateHelper.GenerateNotification.BUNDLE_KEY_ONESIGNAL_DATA;
 import static com.onesignal.OneSignalPackagePrivateHelper.NotificationBundleProcessor.PUSH_MINIFIED_BUTTONS_LIST;
 import static com.onesignal.OneSignalPackagePrivateHelper.NotificationBundleProcessor.PUSH_MINIFIED_BUTTON_ID;
 import static com.onesignal.OneSignalPackagePrivateHelper.NotificationBundleProcessor.PUSH_MINIFIED_BUTTON_TEXT;
-import static com.onesignal.OneSignalPackagePrivateHelper.GenerateNotification.BUNDLE_KEY_ACTION_ID;
-import static com.onesignal.OneSignalPackagePrivateHelper.GenerateNotification.BUNDLE_KEY_ANDROID_NOTIFICATION_ID;
 import static com.onesignal.OneSignalPackagePrivateHelper.NotificationBundleProcessor_ProcessFromFCMIntentService;
 import static com.onesignal.OneSignalPackagePrivateHelper.NotificationBundleProcessor_ProcessFromFCMIntentService_NoWrap;
 import static com.onesignal.OneSignalPackagePrivateHelper.NotificationOpenedProcessor_processFromContext;
@@ -139,7 +140,8 @@ import static org.robolectric.Shadows.shadowOf;
             ShadowOSUtils.class,
             ShadowOSViewUtils.class,
             ShadowCustomTabsClient.class,
-            ShadowCustomTabsSession.class
+            ShadowCustomTabsSession.class,
+            OneSignalShadowPackageManager.class
         },
         sdk = 21
 )
@@ -151,6 +153,8 @@ public class GenerateNotificationRunner {
    private Activity blankActivity;
    private static ActivityController<BlankActivity> blankActivityController;
 
+   static OSNotificationGenerationJob.ExtNotificationGenerationJob lastExtNotifJob;
+   private OSNotificationGenerationJob.AppNotificationGenerationJob lastAppNotifJob;
    private MockOneSignalDBHelper dbHelper;
 
    @BeforeClass // Runs only once, before any tests
@@ -166,6 +170,11 @@ public class GenerateNotificationRunner {
       blankActivity = blankActivityController.get();
       blankActivity.getApplicationInfo().name = "UnitTestApp";
       dbHelper = new MockOneSignalDBHelper(RuntimeEnvironment.application);
+
+      lastExtNotifJob = null;
+      lastAppNotifJob = null;
+
+      OneSignalShadowPackageManager.resetStatics();
 
       overrideNotificationId = -1;
       
@@ -1197,7 +1206,7 @@ public class GenerateNotificationRunner {
    
    @Test
    @Config(sdk = 17)
-   public void notificationExtenderServiceOverridePropertiesWithSummaryApi17() throws Exception {
+   public void notificationExtenderServiceOverridePropertiesWithSummaryApi17() {
       testNotificationExtenderServiceOverridePropertiesWithSummary();
       
       Map<Integer, PostedNotification> postedNotifs = ShadowRoboNotificationManager.notifications;
@@ -1213,7 +1222,7 @@ public class GenerateNotificationRunner {
    
    @Test
    @Config(sdk = 21)
-   public void notificationExtenderServiceOverridePropertiesWithSummary() throws Exception {
+   public void notificationExtenderServiceOverridePropertiesWithSummary() {
       testNotificationExtenderServiceOverridePropertiesWithSummary();
       
       Map<Integer, PostedNotification> postedNotifs = ShadowRoboNotificationManager.notifications;
@@ -1266,8 +1275,134 @@ public class GenerateNotificationRunner {
             assertEquals("[Modified Tile] [Modified Body(ContentText)]", line.toString());
       }
    }
-   
 
+   @Test
+   public void testExtNotificationWillShowInForegroundHandler_completeBubbles_toAppNotificationWillShowInForegroundHandler() throws Exception {
+      // 1. Setup correct notification extension service class
+      startNotificationExtensionService("com.test.onesignal.GenerateNotificationRunner$" +
+              "NotificationExtensionService_completeBubbles_toAppNotificationWillShowInForegroundHandler");
+
+      // 2. Init OneSignal
+      OneSignal.setAppId("b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
+      OneSignal.setAppContext(blankActivity);
+      OneSignal.setNotificationWillShowInForegroundHandler(new OneSignal.AppNotificationWillShowInForegroundHandler() {
+         @Override
+         public void notificationWillShowInForeground(OSNotificationGenerationJob.AppNotificationGenerationJob notifJob) {
+            lastAppNotifJob = notifJob;
+            // Call complete to end without waiting default 30 second timeout
+            notifJob.complete();
+         }
+      });
+      threadAndTaskWait();
+
+      // 3. Receive a notification
+      FCMBroadcastReceiver_processBundle(blankActivity, getBaseNotifBundle());
+      threadAndTaskWait();
+
+      // 4. Make sure the ExtNotifJob is not null and AppNotifJob is not null
+      assertNotNull(lastExtNotifJob);
+      assertNotNull(lastAppNotifJob);
+   }
+
+   /**
+    * @see #testExtNotificationWillShowInForegroundHandler_completeBubbles_toAppNotificationWillShowInForegroundHandler
+    */
+   public static class NotificationExtensionService_completeBubbles_toAppNotificationWillShowInForegroundHandler implements OneSignal.ExtNotificationWillShowInForegroundHandler {
+      @Override
+      public void notificationWillShowInForeground(OSNotificationGenerationJob.ExtNotificationGenerationJob notifJob) {
+         lastExtNotifJob = notifJob;
+         // Complete is called with true, so bubbling to AppNotificationWillShowInForegroundHandler
+         notifJob.complete(true);
+      }
+   }
+
+   @Test
+   public void testExtNotificationWillShowInForegroundHandler_completeDoesNotBubble_toAppNotificationWillShowInForegroundHandler() throws Exception {
+      // 1. Setup correct notification extension service class
+      startNotificationExtensionService("com.test.onesignal.GenerateNotificationRunner$" +
+              "NotificationExtensionService_completeDoesNotBubble_toAppNotificationWillShowInForegroundHandler");
+
+      // 2. Init OneSignal
+      OneSignal.setAppId("b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
+      OneSignal.setAppContext(blankActivity);
+      OneSignal.setNotificationWillShowInForegroundHandler(new OneSignal.AppNotificationWillShowInForegroundHandler() {
+         @Override
+         public void notificationWillShowInForeground(OSNotificationGenerationJob.AppNotificationGenerationJob notifJob) {
+            lastAppNotifJob = notifJob;
+            // Call complete to end without waiting default 30 second timeout
+            notifJob.complete();
+         }
+      });
+      threadAndTaskWait();
+
+      // 3. Receive a notification
+      FCMBroadcastReceiver_processBundle(blankActivity, getBaseNotifBundle());
+      threadAndTaskWait();
+
+      // 4. Make sure the ExtNotifJob is not null and AppNotifJob is null
+      assertNotNull(lastExtNotifJob);
+      assertNull(lastAppNotifJob);
+   }
+
+   /**
+    * @see #testExtNotificationWillShowInForegroundHandler_completeDoesNotBubble_toAppNotificationWillShowInForegroundHandler
+    */
+   public static class NotificationExtensionService_completeDoesNotBubble_toAppNotificationWillShowInForegroundHandler implements OneSignal.ExtNotificationWillShowInForegroundHandler {
+      @Override
+      public void notificationWillShowInForeground(OSNotificationGenerationJob.ExtNotificationGenerationJob notifJob) {
+         lastExtNotifJob = notifJob;
+         // Complete is called with false, so bubbling will skip past the AppNotificationWillShowInForegroundHandler
+         notifJob.complete(false);
+      }
+   }
+
+   @Test
+   public void testExtNotificationWillShowInForegroundHandler_bubblesAfter30SecondTimeout_toAppNotificationWillShowInForegroundHandler() throws Exception {
+      // 1. Setup correct notification extension service class
+      startNotificationExtensionService("com.test.onesignal.GenerateNotificationRunner$" +
+              "NotificationExtensionService_bubblesAfter30SecondTimeout_toAppNotificationWillShowInForegroundHandler");
+
+      // 2. Init OneSignal
+      OneSignal.setAppId("b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
+      OneSignal.setAppContext(blankActivity);
+      OneSignal.setNotificationWillShowInForegroundHandler(new OneSignal.AppNotificationWillShowInForegroundHandler() {
+         @Override
+         public void notificationWillShowInForeground(OSNotificationGenerationJob.AppNotificationGenerationJob notifJob) {
+            lastAppNotifJob = notifJob;
+            // Call complete to end without waiting default 30 second timeout
+            notifJob.complete();
+         }
+      });
+      threadAndTaskWait();
+
+      // 3. Receive a notification
+      FCMBroadcastReceiver_processBundle(blankActivity, getBaseNotifBundle());
+      // threadTaskAndWait(); is inside of the ExtNotificationWillShowInForegroundHandler implementation
+
+      // 4. Make sure the ExtNotifJob is not null and AppNotifJob is not null
+      assertNotNull(lastExtNotifJob);
+      assertNotNull(lastAppNotifJob);
+   }
+
+   /**
+    * @see #testExtNotificationWillShowInForegroundHandler_bubblesAfter30SecondTimeout_toAppNotificationWillShowInForegroundHandler
+    */
+   public static class NotificationExtensionService_bubblesAfter30SecondTimeout_toAppNotificationWillShowInForegroundHandler implements OneSignal.ExtNotificationWillShowInForegroundHandler {
+      @Override
+      public void notificationWillShowInForeground(OSNotificationGenerationJob.ExtNotificationGenerationJob notifJob) {
+         lastExtNotifJob = notifJob;
+         // Complete is not called, so we rely on 30 second timeout until bubbling by default to the AppNotificationWillShowInForegroundHandler
+         try {
+            threadAndTaskWait();
+         } catch (Exception e) {
+            e.printStackTrace();
+         }
+      }
+   }
+
+   // TODO: After onNotificationProcessing(OSNotificationReceivedResult) is converted to
+   //    NotificationProcessingHandler(OSNotificationReceivedResult), we wont need to create a service any longer
+   //    This method should be deleted and the startNotificationExtensionService(String) method should be used instead
    private NotificationExtenderServiceTestBase startNotificationExtender(BundleCompat bundlePayload, Class serviceClass) {
       ServiceController<NotificationExtenderServiceTestBase> controller = Robolectric.buildService(serviceClass);
       NotificationExtenderServiceTestBase service = controller.create().get();
@@ -1276,6 +1411,14 @@ public class GenerateNotificationRunner {
       controller.withIntent(testIntent).startCommand(0, 0);
 
       return service;
+   }
+
+   /**
+    * Add the correct manifest meta-data key and value regarding the NotificationExtensionServiceClass to the
+    *    mocked OneSignalShadowPackageManager metaData Bundle
+    */
+   private void startNotificationExtensionService(String servicePath) {
+      OneSignalShadowPackageManager.addManifestMetaData("com.onesignal.NotificationExtensionServiceClass", servicePath);
    }
 
    @Test
@@ -1467,8 +1610,7 @@ public class GenerateNotificationRunner {
          return true;
       }
    }
-   
-   
+
    public static class NotificationExtenderServiceTestReturnFalse extends NotificationExtenderServiceTest {
       @Override
       protected boolean onNotificationProcessing(OSNotificationReceivedResult notification) {
@@ -1489,4 +1631,5 @@ public class GenerateNotificationRunner {
          e.printStackTrace();
       }
    }
+
 }

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
@@ -51,6 +51,7 @@ import com.onesignal.FCMBroadcastReceiver;
 import com.onesignal.FCMIntentService;
 import com.onesignal.MockOneSignalDBHelper;
 import com.onesignal.NotificationExtenderService;
+import com.onesignal.OSNotification;
 import com.onesignal.OSNotificationGenerationJob;
 import com.onesignal.OSNotificationOpenResult;
 import com.onesignal.OSNotificationPayload;

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
@@ -120,13 +120,16 @@ import static com.test.onesignal.RestClientAsserts.assertReportReceivedAtIndex;
 import static com.test.onesignal.RestClientAsserts.assertRestCalls;
 import static com.test.onesignal.TestHelpers.advanceSystemTimeBy;
 import static com.test.onesignal.TestHelpers.fastColdRestartApp;
+import static com.test.onesignal.TestHelpers.getAllNotificationRecords;
 import static com.test.onesignal.TestHelpers.threadAndTaskWait;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertNull;
+import static junit.framework.Assert.assertSame;
 import static junit.framework.Assert.assertTrue;
 import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThat;
 import static org.robolectric.Shadows.shadowOf;
 
@@ -286,8 +289,8 @@ public class GenerateNotificationRunner {
       
       // Display a 3 normal notification.
       NotificationBundleProcessor_ProcessFromFCMIntentService(blankActivity, getBaseNotifBundle("UUID3"), null);
-   
-   
+
+
       Map<Integer, PostedNotification> postedNotifs = ShadowRoboNotificationManager.notifications;
       
       // Open the summary notification
@@ -312,7 +315,7 @@ public class GenerateNotificationRunner {
       bundle.putString("grp", "test1");
       bundle.putString("custom", "{\"i\": \"some_UUID\", \"a\": {\"actionButtons\": [{\"text\": \"test\"} ]}}");
       NotificationBundleProcessor_ProcessFromFCMIntentService(blankActivity, bundle, null);
-   
+
    
       Map<Integer, PostedNotification> postedNotifs = ShadowRoboNotificationManager.notifications;
       Iterator<Map.Entry<Integer, PostedNotification>> postedNotifsIterator = postedNotifs.entrySet().iterator();
@@ -1277,6 +1280,168 @@ public class GenerateNotificationRunner {
    }
 
    @Test
+   public void testExtNotificationWillShowInForegroundHandler_setNotificationDisplayOptionToNotification() throws Exception {
+      // 1. Setup correct notification extension service class
+      startNotificationExtensionService("com.test.onesignal.GenerateNotificationRunner$" +
+              "NotificationExtensionService_setNotificationDisplayOptionToNotification");
+
+      // 2. Init OneSignal
+      OneSignal.setAppId("b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
+      OneSignal.setAppContext(blankActivity);
+      OneSignal.setNotificationWillShowInForegroundHandler(new OneSignal.AppNotificationWillShowInForegroundHandler() {
+         @Override
+         public void notificationWillShowInForeground(OSNotificationGenerationJob.AppNotificationGenerationJob notifJob) {
+            notifJob.setNotificationDisplayOption(OneSignal.OSNotificationDisplay.NOTIFICATION);
+            lastAppNotifJob = notifJob;
+            // Call complete to end without waiting default 30 second timeout
+            notifJob.complete();
+         }
+      });
+      threadAndTaskWait();
+
+      // 3. Receive a notification
+      FCMBroadcastReceiver_processBundle(blankActivity, getBaseNotifBundle());
+      threadAndTaskWait();
+
+      // 4. Make sure the ExtNotifJob is not null and AppNotifJob is not null
+      assertNotNull(lastExtNotifJob);
+      assertNotNull(lastAppNotifJob);
+      assertEquals(OneSignal.OSNotificationDisplay.NOTIFICATION, lastAppNotifJob.getNotificationDisplayOption());
+
+      // 5. Make sure 1 notification exists in DB
+      assertNotificationDbRecords(1);
+   }
+
+   @Test
+   public void testExtNotificationWillShowInForegroundHandler_setNotificationDisplayOptionToNotification_andThenToSilent() throws Exception {
+      // 1. Setup correct notification extension service class
+      startNotificationExtensionService("com.test.onesignal.GenerateNotificationRunner$" +
+              "NotificationExtensionService_setNotificationDisplayOptionToNotification");
+
+      // 2. Init OneSignal
+      OneSignal.setAppId("b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
+      OneSignal.setAppContext(blankActivity);
+      OneSignal.setNotificationWillShowInForegroundHandler(new OneSignal.AppNotificationWillShowInForegroundHandler() {
+         @Override
+         public void notificationWillShowInForeground(OSNotificationGenerationJob.AppNotificationGenerationJob notifJob) {
+            notifJob.setNotificationDisplayOption(OneSignal.OSNotificationDisplay.SILENT);
+            lastAppNotifJob = notifJob;
+            // Call complete to end without waiting default 30 second timeout
+            notifJob.complete();
+         }
+      });
+      threadAndTaskWait();
+
+      // 3. Receive a notification
+      FCMBroadcastReceiver_processBundle(blankActivity, getBaseNotifBundle());
+      threadAndTaskWait();
+
+      // 4. Make sure the ExtNotifJob is not null and AppNotifJob is not null
+      assertNotNull(lastExtNotifJob);
+      assertNotNull(lastAppNotifJob);
+      assertEquals(OneSignal.OSNotificationDisplay.SILENT, lastAppNotifJob.getNotificationDisplayOption());
+
+      // 5. Make sure 1 notification exists in DB
+      assertNotificationDbRecords(1);
+   }
+
+   /**
+    * @see #testExtNotificationWillShowInForegroundHandler_setNotificationDisplayOptionToNotification
+    * @see #testExtNotificationWillShowInForegroundHandler_setNotificationDisplayOptionToNotification_andThenToSilent
+    */
+   public static class NotificationExtensionService_setNotificationDisplayOptionToNotification implements OneSignal.ExtNotificationWillShowInForegroundHandler {
+      @Override
+      public void notificationWillShowInForeground(OSNotificationGenerationJob.ExtNotificationGenerationJob notifJob) {
+         notifJob.setNotificationDisplayOption(OneSignal.OSNotificationDisplay.NOTIFICATION);
+         lastExtNotifJob = notifJob;
+
+         // Complete is called with true, so bubbling to AppNotificationWillShowInForegroundHandler
+         notifJob.complete(true);
+      }
+   }
+
+   @Test
+   public void testExtNotificationWillShowInForegroundHandler_setNotificationDisplayOptionToSilent() throws Exception {
+      // 1. Setup correct notification extension service class
+      startNotificationExtensionService("com.test.onesignal.GenerateNotificationRunner$" +
+              "NotificationExtensionService_setNotificationDisplayOptionToSilent");
+
+      // 2. Init OneSignal
+      OneSignal.setAppId("b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
+      OneSignal.setAppContext(blankActivity);
+      OneSignal.setNotificationWillShowInForegroundHandler(new OneSignal.AppNotificationWillShowInForegroundHandler() {
+         @Override
+         public void notificationWillShowInForeground(OSNotificationGenerationJob.AppNotificationGenerationJob notifJob) {
+            notifJob.setNotificationDisplayOption(OneSignal.OSNotificationDisplay.SILENT);
+            lastAppNotifJob = notifJob;
+            // Call complete to end without waiting default 30 second timeout
+            notifJob.complete();
+         }
+      });
+      threadAndTaskWait();
+
+      // 3. Receive a notification
+      FCMBroadcastReceiver_processBundle(blankActivity, getBaseNotifBundle());
+      threadAndTaskWait();
+
+      // 4. Make sure the ExtNotifJob is not null and AppNotifJob is not null
+      assertNotNull(lastExtNotifJob);
+      assertNotNull(lastAppNotifJob);
+      assertEquals(OneSignal.OSNotificationDisplay.SILENT, lastAppNotifJob.getNotificationDisplayOption());
+
+      // 5. Make sure 1 notification exists in DB
+      assertNotificationDbRecords(1);
+   }
+
+   @Test
+   public void testExtNotificationWillShowInForegroundHandler_setNotificationDisplayOptionToSilent_andThenToNotification() throws Exception {
+      // 1. Setup correct notification extension service class
+      startNotificationExtensionService("com.test.onesignal.GenerateNotificationRunner$" +
+              "NotificationExtensionService_setNotificationDisplayOptionToSilent");
+
+      // 2. Init OneSignal
+      OneSignal.setAppId("b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
+      OneSignal.setAppContext(blankActivity);
+      OneSignal.setNotificationWillShowInForegroundHandler(new OneSignal.AppNotificationWillShowInForegroundHandler() {
+         @Override
+         public void notificationWillShowInForeground(OSNotificationGenerationJob.AppNotificationGenerationJob notifJob) {
+            notifJob.setNotificationDisplayOption(OneSignal.OSNotificationDisplay.NOTIFICATION);
+            lastAppNotifJob = notifJob;
+            // Call complete to end without waiting default 30 second timeout
+            notifJob.complete();
+         }
+      });
+      threadAndTaskWait();
+
+      // 3. Receive a notification
+      FCMBroadcastReceiver_processBundle(blankActivity, getBaseNotifBundle());
+      threadAndTaskWait();
+
+      // 4. Make sure the ExtNotifJob is not null and AppNotifJob is not null
+      assertNotNull(lastExtNotifJob);
+      assertNotNull(lastAppNotifJob);
+      assertEquals(OneSignal.OSNotificationDisplay.NOTIFICATION, lastAppNotifJob.getNotificationDisplayOption());
+
+      // 5. Make sure 1 notification exists in DB
+      assertNotificationDbRecords(1);
+   }
+
+   /**
+    * @see #testExtNotificationWillShowInForegroundHandler_setNotificationDisplayOptionToSilent
+    * @see #testExtNotificationWillShowInForegroundHandler_setNotificationDisplayOptionToSilent_andThenToNotification
+    */
+   public static class NotificationExtensionService_setNotificationDisplayOptionToSilent implements OneSignal.ExtNotificationWillShowInForegroundHandler {
+      @Override
+      public void notificationWillShowInForeground(OSNotificationGenerationJob.ExtNotificationGenerationJob notifJob) {
+         notifJob.setNotificationDisplayOption(OneSignal.OSNotificationDisplay.SILENT);
+         lastExtNotifJob = notifJob;
+
+         // Complete is called with true, so bubbling to AppNotificationWillShowInForegroundHandler
+         notifJob.complete(true);
+      }
+   }
+
+   @Test
    public void testExtNotificationWillShowInForegroundHandler_completeBubbles_toAppNotificationWillShowInForegroundHandler() throws Exception {
       // 1. Setup correct notification extension service class
       startNotificationExtensionService("com.test.onesignal.GenerateNotificationRunner$" +
@@ -1302,10 +1467,39 @@ public class GenerateNotificationRunner {
       // 4. Make sure the ExtNotifJob is not null and AppNotifJob is not null
       assertNotNull(lastExtNotifJob);
       assertNotNull(lastAppNotifJob);
+      assertEquals(OneSignal.OSNotificationDisplay.NOTIFICATION, lastAppNotifJob.getNotificationDisplayOption());
+
+      // 5. Make sure 1 notification exists in DB
+      assertNotificationDbRecords(1);
+   }
+
+   @Test
+   public void testExtNotificationWillShowInForegroundHandler_completeBubbles_withNullAppNotificationWillShowInForegroundHandler() throws Exception {
+      // 1. Setup correct notification extension service class
+      startNotificationExtensionService("com.test.onesignal.GenerateNotificationRunner$" +
+              "NotificationExtensionService_completeBubbles_toAppNotificationWillShowInForegroundHandler");
+
+      // 2. Init OneSignal
+      OneSignal.setAppId("b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
+      OneSignal.setAppContext(blankActivity);
+      threadAndTaskWait();
+
+      // 3. Receive a notification
+      FCMBroadcastReceiver_processBundle(blankActivity, getBaseNotifBundle());
+      // threadTaskAndWait(); is inside of the ExtNotificationWillShowInForegroundHandler implementation
+
+      // 4. Make sure the ExtNotifJob is not null and AppNotifJob is not null
+      assertNotNull(lastExtNotifJob);
+      assertEquals(OneSignal.OSNotificationDisplay.NOTIFICATION, lastExtNotifJob.getNotificationDisplayOption());
+      assertNull(lastAppNotifJob);
+
+      // 5. Make sure 1 notification exists in DB
+      assertNotificationDbRecords(1);
    }
 
    /**
     * @see #testExtNotificationWillShowInForegroundHandler_completeBubbles_toAppNotificationWillShowInForegroundHandler
+    * @see #testExtNotificationWillShowInForegroundHandler_completeBubbles_withNullAppNotificationWillShowInForegroundHandler
     */
    public static class NotificationExtensionService_completeBubbles_toAppNotificationWillShowInForegroundHandler implements OneSignal.ExtNotificationWillShowInForegroundHandler {
       @Override
@@ -1341,11 +1535,40 @@ public class GenerateNotificationRunner {
 
       // 4. Make sure the ExtNotifJob is not null and AppNotifJob is null
       assertNotNull(lastExtNotifJob);
+      assertEquals(OneSignal.OSNotificationDisplay.NOTIFICATION, lastExtNotifJob.getNotificationDisplayOption());
       assertNull(lastAppNotifJob);
+
+      // 5. Make sure 1 notification exists in DB
+      assertNotificationDbRecords(1);
+   }
+
+   @Test
+   public void testExtNotificationWillShowInForegroundHandler_completeDoesNotBubble_toNullAppNotificationWillShowInForegroundHandler() throws Exception {
+      // 1. Setup correct notification extension service class
+      startNotificationExtensionService("com.test.onesignal.GenerateNotificationRunner$" +
+              "NotificationExtensionService_completeDoesNotBubble_toAppNotificationWillShowInForegroundHandler");
+
+      // 2. Init OneSignal
+      OneSignal.setAppId("b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
+      OneSignal.setAppContext(blankActivity);
+      threadAndTaskWait();
+
+      // 3. Receive a notification
+      FCMBroadcastReceiver_processBundle(blankActivity, getBaseNotifBundle());
+      threadAndTaskWait();
+
+      // 4. Make sure the ExtNotifJob is not null and AppNotifJob is null
+      assertNotNull(lastExtNotifJob);
+      assertEquals(OneSignal.OSNotificationDisplay.NOTIFICATION, lastExtNotifJob.getNotificationDisplayOption());
+      assertNull(lastAppNotifJob);
+
+      // 5. Make sure 1 notification exists in DB
+      assertNotificationDbRecords(1);
    }
 
    /**
     * @see #testExtNotificationWillShowInForegroundHandler_completeDoesNotBubble_toAppNotificationWillShowInForegroundHandler
+    * @see #testExtNotificationWillShowInForegroundHandler_completeDoesNotBubble_toNullAppNotificationWillShowInForegroundHandler
     */
    public static class NotificationExtensionService_completeDoesNotBubble_toAppNotificationWillShowInForegroundHandler implements OneSignal.ExtNotificationWillShowInForegroundHandler {
       @Override
@@ -1357,7 +1580,7 @@ public class GenerateNotificationRunner {
    }
 
    @Test
-   public void testExtNotificationWillShowInForegroundHandler_bubblesAfter30SecondTimeout_toAppNotificationWillShowInForegroundHandler() throws Exception {
+   public void testNotificationWillShowInForegroundHandler_bubbles30SecondTimeout_forExtAndAppHandlers() throws Exception {
       // 1. Setup correct notification extension service class
       startNotificationExtensionService("com.test.onesignal.GenerateNotificationRunner$" +
               "NotificationExtensionService_bubblesAfter30SecondTimeout_toAppNotificationWillShowInForegroundHandler");
@@ -1382,9 +1605,74 @@ public class GenerateNotificationRunner {
       // 4. Make sure the ExtNotifJob is not null and AppNotifJob is not null
       assertNotNull(lastExtNotifJob);
       assertNotNull(lastAppNotifJob);
+      assertEquals(OneSignal.OSNotificationDisplay.NOTIFICATION, lastAppNotifJob.getNotificationDisplayOption());
+
+      // 5. Make sure 1 notification exists in DB
+      assertNotificationDbRecords(1);
+   }
+
+   @Test
+   public void testExtNotificationWillShowInForegroundHandler_bubblesAfter30SecondTimeout_withNullAppNotificationWillShowInForegroundHandler() throws Exception {
+      // 1. Setup correct notification extension service class
+      startNotificationExtensionService("com.test.onesignal.GenerateNotificationRunner$" +
+              "NotificationExtensionService_bubblesAfter30SecondTimeout_toAppNotificationWillShowInForegroundHandler");
+
+      // 2. Init OneSignal
+      OneSignal.setAppId("b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
+      OneSignal.setAppContext(blankActivity);
+      threadAndTaskWait();
+
+      // 3. Receive a notification
+      FCMBroadcastReceiver_processBundle(blankActivity, getBaseNotifBundle());
+      // threadTaskAndWait(); is inside of the ExtNotificationWillShowInForegroundHandler implementation
+
+      // 4. Make sure the ExtNotifJob is not null and AppNotifJob is null
+      assertNotNull(lastExtNotifJob);
+      assertEquals(OneSignal.OSNotificationDisplay.NOTIFICATION, lastExtNotifJob.getNotificationDisplayOption());
+      assertNull(lastAppNotifJob);
+
+      // 5. Make sure 1 notification exists in DB
+      assertNotificationDbRecords(1);
+   }
+
+   @Test
+   public void testExtNotificationWillShowInForegroundHandler_bubblesAfter30SecondTimeout_toAppNotificationWillShowInForegroundHandler() throws Exception {
+      // 1. Setup correct notification extension service class
+      startNotificationExtensionService("com.test.onesignal.GenerateNotificationRunner$" +
+              "NotificationExtensionService_bubblesAfter30SecondTimeout_toAppNotificationWillShowInForegroundHandler");
+
+      // 2. Init OneSignal
+      OneSignal.setAppId("b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
+      OneSignal.setAppContext(blankActivity);
+      OneSignal.setNotificationWillShowInForegroundHandler(new OneSignal.AppNotificationWillShowInForegroundHandler() {
+         @Override
+         public void notificationWillShowInForeground(OSNotificationGenerationJob.AppNotificationGenerationJob notifJob) {
+            lastAppNotifJob = notifJob;
+            // Complete is not called, so we rely on 30 second timeout until bubbling by default out of the AppNotificationWillShowInForegroundHandler
+            try {
+               threadAndTaskWait();
+            } catch (Exception e) {
+               e.printStackTrace();
+            }
+         }
+      });
+
+      // 3. Receive a notification
+      FCMBroadcastReceiver_processBundle(blankActivity, getBaseNotifBundle());
+      // threadTaskAndWait(); is inside of the ExtNotificationWillShowInForegroundHandler and  implementation
+
+      // 4. Make sure the ExtNotifJob is not null and AppNotifJob is not null
+      assertNotNull(lastExtNotifJob);
+      assertNotNull(lastAppNotifJob);
+      assertEquals(OneSignal.OSNotificationDisplay.NOTIFICATION, lastAppNotifJob.getNotificationDisplayOption());
+
+      // 5. Make sure 1 notification exists in DB
+      assertNotificationDbRecords(1);
    }
 
    /**
+    * @see #testNotificationWillShowInForegroundHandler_bubbles30SecondTimeout_forExtAndAppHandlers
+    * @see #testExtNotificationWillShowInForegroundHandler_bubblesAfter30SecondTimeout_withNullAppNotificationWillShowInForegroundHandler
     * @see #testExtNotificationWillShowInForegroundHandler_bubblesAfter30SecondTimeout_toAppNotificationWillShowInForegroundHandler
     */
    public static class NotificationExtensionService_bubblesAfter30SecondTimeout_toAppNotificationWillShowInForegroundHandler implements OneSignal.ExtNotificationWillShowInForegroundHandler {
@@ -1398,6 +1686,108 @@ public class GenerateNotificationRunner {
             e.printStackTrace();
          }
       }
+   }
+
+   @Test
+   public void testNotificationWillShowInForegroundHandler_notifJobPayload() throws Exception {
+      // 1. Setup correct notification extension service class
+      startNotificationExtensionService("com.test.onesignal.GenerateNotificationRunner$" +
+              "NotificationExtensionService_notifJobPayload");
+
+      // 2. Init OneSignal
+      OneSignal.setAppId("b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
+      OneSignal.setAppContext(blankActivity);
+      OneSignal.setNotificationWillShowInForegroundHandler(new OneSignal.AppNotificationWillShowInForegroundHandler() {
+         @Override
+         public void notificationWillShowInForeground(OSNotificationGenerationJob.AppNotificationGenerationJob notifJob) {
+            lastAppNotifJob = notifJob;
+
+            try {
+               // Until getting passed the foreground handler or being overwritten the Android notif id will be -1 until it is shown
+               assertEquals(-1, notifJob.getAndroidNotificationId());
+
+               // Make sure all of the accessible getters have the expected values
+               assertEquals("UUID1", notifJob.getApiNotificationId());
+               assertEquals("title1", notifJob.getTitle());
+               assertEquals("Notif message 1", notifJob.getBody());
+               JsonAsserts.equals(new JSONObject("{\"myKey1\": \"myValue1\", \"myKey2\": \"myValue2\"}"), notifJob.getAdditionalData());
+            } catch (JSONException e) {
+               e.printStackTrace();
+            }
+
+            // Call complete to end without waiting default 30 second timeout
+            notifJob.complete();
+         }
+      });
+
+      // 3. Receive a notification
+      // Setup - Display a single notification with a grouped.
+      Bundle bundle = getBaseNotifBundle("UUID1");
+      bundle.putString("title", "title1");
+      bundle.putString("alert", "Notif message 1");
+      bundle.putString("custom", "{\"i\": \"UUID1\", " +
+              "                    \"a\": {" +
+              "                              \"myKey1\": \"myValue1\", " +
+              "                              \"myKey2\": \"myValue2\"" +
+              "                           }" +
+              "                   }");
+      FCMBroadcastReceiver_processBundle(blankActivity, bundle);
+      threadAndTaskWait();
+
+      // 4. Make sure the ExtNotifJob is not null and AppNotifJob is not null
+      assertNotNull(lastExtNotifJob);
+      assertNotNull(lastAppNotifJob);
+      // Not restoring or duplicate notification, so the Android notif id should not be -1
+      assertNotEquals(-1, lastAppNotifJob.getAndroidNotificationId());
+      assertEquals(OneSignal.OSNotificationDisplay.NOTIFICATION, lastAppNotifJob.getNotificationDisplayOption());
+
+      // 6. Make sure 1 notification exists in DB
+      assertNotificationDbRecords(1);
+   }
+
+   /**
+    * @see #testNotificationWillShowInForegroundHandler_notifJobPayload
+    */
+   public static class NotificationExtensionService_notifJobPayload implements OneSignal.ExtNotificationWillShowInForegroundHandler {
+      @Override
+      public void notificationWillShowInForeground(OSNotificationGenerationJob.ExtNotificationGenerationJob notifJob) {
+         lastExtNotifJob = notifJob;
+
+         try {
+            // Until getting passed the foreground handler or being overwritten the Android notif id will be -1 until it is shown
+            assertEquals(-1, notifJob.getAndroidNotificationId());
+
+            // Make sure all of the accessible getters have the expected values
+            assertEquals("UUID1", notifJob.getApiNotificationId());
+            assertEquals("title1", notifJob.getTitle());
+            assertEquals("Notif message 1", notifJob.getBody());
+            JsonAsserts.equals(new JSONObject("{\"myKey1\": \"myValue1\", \"myKey2\": \"myValue2\"}"), notifJob.getAdditionalData());
+         } catch (JSONException e) {
+            e.printStackTrace();
+         }
+
+         // Complete is called with true, so bubbling to AppNotificationWillShowInForegroundHandler
+         notifJob.complete(true);
+      }
+   }
+
+   @Test
+   public void testNullExtAndAppNotificationWillShowInForegroundHandlers() throws Exception {
+      // 1. Init OneSignal
+      OneSignal.setAppId("b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
+      OneSignal.setAppContext(blankActivity);
+      threadAndTaskWait();
+
+      // 3. Receive a notification
+      FCMBroadcastReceiver_processBundle(blankActivity, getBaseNotifBundle());
+      threadAndTaskWait();
+
+      // 4. Make sure the ExtNotifJob is null and AppNotifJob is null
+      assertNull(lastExtNotifJob);
+      assertNull(lastAppNotifJob);
+
+      // 5. Make sure 1 notification exists in DB
+      assertNotificationDbRecords(1);
    }
 
    // TODO: After onNotificationProcessing(OSNotificationReceivedResult) is converted to

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
@@ -51,7 +51,6 @@ import com.onesignal.FCMBroadcastReceiver;
 import com.onesignal.FCMIntentService;
 import com.onesignal.MockOneSignalDBHelper;
 import com.onesignal.NotificationExtenderService;
-import com.onesignal.OSNotification;
 import com.onesignal.OSNotificationGenerationJob;
 import com.onesignal.OSNotificationOpenResult;
 import com.onesignal.OSNotificationPayload;

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
@@ -1741,7 +1741,7 @@ public class GenerateNotificationRunner {
       assertNotEquals(-1, lastAppNotifJob.getAndroidNotificationId());
       assertEquals(OneSignal.OSNotificationDisplay.NOTIFICATION, lastAppNotifJob.getNotificationDisplayOption());
 
-      // 6. Make sure 1 notification exists in DB
+      // 5. Make sure 1 notification exists in DB
       assertNotificationDbRecords(1);
    }
 
@@ -1778,15 +1778,15 @@ public class GenerateNotificationRunner {
       OneSignal.setAppContext(blankActivity);
       threadAndTaskWait();
 
-      // 3. Receive a notification
+      // 2. Receive a notification
       FCMBroadcastReceiver_processBundle(blankActivity, getBaseNotifBundle());
       threadAndTaskWait();
 
-      // 4. Make sure the ExtNotifJob is null and AppNotifJob is null
+      // 3. Make sure the ExtNotifJob is null and AppNotifJob is null
       assertNull(lastExtNotifJob);
       assertNull(lastAppNotifJob);
 
-      // 5. Make sure 1 notification exists in DB
+      // 4. Make sure 1 notification exists in DB
       assertNotificationDbRecords(1);
    }
 

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
@@ -52,6 +52,7 @@ import com.onesignal.OSEmailSubscriptionStateChanges;
 import com.onesignal.OSNotification;
 import com.onesignal.OSNotificationAction;
 import com.onesignal.OSNotificationGenerationJob;
+import com.onesignal.OSNotificationGenerationJob.AppNotificationGenerationJob;
 import com.onesignal.OSNotificationOpenResult;
 import com.onesignal.OSNotificationPayload;
 import com.onesignal.OSPermissionObserver;
@@ -123,9 +124,6 @@ import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Pattern;
-
-import com.onesignal.OSNotificationGenerationJob.ExtNotificationGenerationJob;
-import com.onesignal.OSNotificationGenerationJob.AppNotificationGenerationJob;
 
 import static com.onesignal.OneSignalPackagePrivateHelper.FCMBroadcastReceiver_processBundle;
 import static com.onesignal.OneSignalPackagePrivateHelper.NotificationBundleProcessor_Process;

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
@@ -131,7 +131,6 @@ import static com.onesignal.OneSignalPackagePrivateHelper.FCMBroadcastReceiver_p
 import static com.onesignal.OneSignalPackagePrivateHelper.NotificationBundleProcessor_Process;
 import static com.onesignal.OneSignalPackagePrivateHelper.NotificationOpenedProcessor_processFromContext;
 import static com.onesignal.OneSignalPackagePrivateHelper.OneSignal_getSessionListener;
-import static com.onesignal.OneSignalPackagePrivateHelper.OneSignal_setAppId;
 import static com.onesignal.OneSignalPackagePrivateHelper.OneSignal_setSessionManager;
 import static com.onesignal.OneSignalPackagePrivateHelper.OneSignal_setTrackerFactory;
 import static com.onesignal.OneSignalPackagePrivateHelper.bundleAsJSONObject;


### PR DESCRIPTION
* Removed unnecessary nested Threads wrapping Runnables

UnitTests in this PR:
* No extension service class tests
  * Testing the scenario where no foreground handlers have been setup
  * `testNullExtAndAppNotificationWillShowInForegroundHandlers`
* `NotificationExtensionService_notifJobPayload` class tests
  * Testing that the data in the accessible getters is correct for the notifJobs
  * `testNullExtAndAppNotificationWillShowInForegroundHandlers`
* `NotificationExtensionService_bubblesAfter30SecondTimeout_toAppNotificationWillShowInForegroundHandler` class tests
  * Testing 30 second notification timeout bubbling
  * `testNotificationWillShowInForegroundHandler_bubbles30SecondTimeout_forExtAndAppHandlers`
  * `testExtNotificationWillShowInForegroundHandler_bubblesAfter30SecondTimeout_withNullAppNotificationWillShowInForegroundHandler`
  * `testExtNotificationWillShowInForegroundHandler_bubblesAfter30SecondTimeout_toAppNotificationWillShowInForegroundHandler`
* `NotificationExtensionService_completeDoesNotBubble_toAppNotificationWillShowInForegroundHandler` class tests
  * Testing scenarios where no bubbling should occur
  * `testExtNotificationWillShowInForegroundHandler_completeDoesNotBubble_toAppNotificationWillShowInForegroundHandler`
  * `testExtNotificationWillShowInForegroundHandler_completeDoesNotBubble_toNullAppNotificationWillShowInForegroundHandler`
* `NotificationExtensionService_completeBubbles_toAppNotificationWillShowInForegroundHandler` class tests
  * Testing scenarios where bubbling is controlled with complete method
  * `testExtNotificationWillShowInForegroundHandler_completeBubbles_toAppNotificationWillShowInForegroundHandler`
  * testExtNotificationWillShowInForegroundHandler_completeBubbles_withNullAppNotificationWillShowInForegroundHandler
* `NotificationExtensionService_setNotificationDisplayOptionToSilent` class tests
  * Testing scenarios where `setNotificationDisplayOption` is set to `SILENT`
  * `testExtNotificationWillShowInForegroundHandler_setNotificationDisplayOptionToSilent`
  * `testExtNotificationWillShowInForegroundHandler_setNotificationDisplayOptionToSilent_andThenToNotification`
* `NotificationExtensionService_setNotificationDisplayOptionToNotification` class tests
  * Testing scenarios where `setNotificationDisplayOption` is set to `NOTIFICATION`
  * `testExtNotificationWillShowInForegroundHandler_setNotificationDisplayOptionToNotification`
  * `testExtNotificationWillShowInForegroundHandler_setNotificationDisplayOptionToNotification_andThenToSilent`
* `NotificationExtensionService_workTimeLongerThanTimeout`
  * `testNotificationWillShowInForegroundHandler_workTimeLongerThanTimeout`

Other scenarios:
https://onesignal.atlassian.net/browse/OS-4175

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1030)
<!-- Reviewable:end -->
