### PR TITLE
HMS location fix ups

### DIFF
--- a/OneSignalSDK/onesignal/build.gradle
+++ b/OneSignalSDK/onesignal/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'com.android.library'
-apply plugin: 'com.huawei.agconnect'
 
 android {
     compileSdkVersion 28
@@ -57,9 +56,9 @@ dependencies {
     // firebase-messaging:17.6.0 is the max version since we still have code looking for FirebaseInstanceIdService
     api 'com.google.firebase:firebase-messaging:[10.2.1, 17.3.99]'
 
-    implementation 'com.huawei.agconnect:agconnect-core:1.3.1.300'
-    implementation 'com.huawei.hms:location:3.0.2.300'
-    implementation 'com.huawei.hms:base:3.0.2.300'
+    compileOnly 'com.huawei.agconnect:agconnect-core:1.3.1.300'
+    compileOnly 'com.huawei.hms:location:4.0.0.300'
+    compileOnly 'com.huawei.hms:base:4.0.2.300'
 
     // Keep under 28 until we switch to AndroidX
     //   otherwise app can get dup classes between 26 & 28 when mixing these versions.

--- a/OneSignalSDK/unittest/build.gradle
+++ b/OneSignalSDK/unittest/build.gradle
@@ -49,7 +49,9 @@ dependencies {
 
     implementation 'com.google.firebase:firebase-core:16.0.4'
 
-    implementation 'com.huawei.hms:location:3.0.2.300'
+    implementation 'com.huawei.agconnect:agconnect-core:1.3.1.300'
+    implementation 'com.huawei.hms:location:4.0.0.300'
+    implementation 'com.huawei.hms:base:4.0.2.300'
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.robolectric:robolectric:4.3.1'

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowHMSFusedLocationProviderClient.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowHMSFusedLocationProviderClient.java
@@ -41,11 +41,8 @@ import com.huawei.hms.location.LocationRequest;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
-import java.util.Timer;
-import java.util.TimerTask;
-
 @Implements(FusedLocationProviderClient.class)
-public class ShadowFusedLocationProviderClient {
+public class ShadowHMSFusedLocationProviderClient {
 
     Context context;
     public static Double lat, log;

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowLocationUpdateListener.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowLocationUpdateListener.java
@@ -2,6 +2,7 @@ package com.onesignal;
 
 import android.location.Location;
 
+import com.huawei.hms.location.HWLocation;
 import com.huawei.hms.location.LocationResult;
 
 import org.robolectric.annotation.Implements;
@@ -21,8 +22,8 @@ public class ShadowLocationUpdateListener {
         LocationController.locationUpdateListener.onLocationChanged(location);
     }
 
-    public static void provideFakeLocation_Huawei(Location location) {
-        List<Location> locations = new ArrayList<>();
+    public static void provideFakeLocation_Huawei(HWLocation location) {
+        List<HWLocation> locations = new ArrayList<>();
         locations.add(location);
         LocationResult locationResult = LocationResult.create(locations);
         LocationController.locationUpdateListener.onLocationResult(locationResult);

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
@@ -41,6 +41,7 @@ import android.location.Location;
 import android.net.ConnectivityManager;
 import android.os.Bundle;
 
+import com.huawei.hms.location.HWLocation;
 import com.onesignal.MockOSLog;
 import com.onesignal.MockOSSharedPreferences;
 import com.onesignal.MockOneSignalDBHelper;
@@ -3382,7 +3383,7 @@ public class MainOneSignalClassRunner {
       assertEquals(SyncService.class, shadowOf(intent).getIntentClass());
 
       // Setting up a new point and testing it is sent
-      Location fakeLocation = new Location("UnitTest");
+      HWLocation fakeLocation = new HWLocation();
       fakeLocation.setLatitude(1.1d);
       fakeLocation.setLongitude(2.2d);
       fakeLocation.setAccuracy(3.3f);

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
@@ -68,7 +68,7 @@ import com.onesignal.ShadowCustomTabsClient;
 import com.onesignal.ShadowCustomTabsSession;
 import com.onesignal.ShadowFirebaseAnalytics;
 import com.onesignal.ShadowFusedLocationApiWrapper;
-import com.onesignal.ShadowFusedLocationProviderClient;
+import com.onesignal.ShadowHMSFusedLocationProviderClient;
 import com.onesignal.ShadowGoogleApiClientBuilder;
 import com.onesignal.ShadowGoogleApiClientCompatProxy;
 import com.onesignal.ShadowHuaweiTask;
@@ -3326,7 +3326,7 @@ public class MainOneSignalClassRunner {
    // ####### Unit Test Huawei Location ########
 
    @Test
-   @Config(shadows = {ShadowFusedLocationProviderClient.class})
+   @Config(shadows = {ShadowHMSFusedLocationProviderClient.class})
    public void shouldUpdateAllLocationFieldsWhenTimeStampChanges_Huawei() throws Exception {
       ShadowLocationController.googleServicesAvailable = false;
       ShadowLocationController.huaweiServicesAvailable = true;
@@ -3339,11 +3339,11 @@ public class MainOneSignalClassRunner {
       assertEquals(0.0, ShadowOneSignalRestClient.lastPost.getDouble("loc_type"));
 
       ShadowOneSignalRestClient.lastPost = null;
-      ShadowFusedLocationProviderClient.resetStatics();
-      ShadowFusedLocationProviderClient.lat = 30d;
-      ShadowFusedLocationProviderClient.log = 2.0d;
-      ShadowFusedLocationProviderClient.accuracy = 5.0f;
-      ShadowFusedLocationProviderClient.time = 2L;
+      ShadowHMSFusedLocationProviderClient.resetStatics();
+      ShadowHMSFusedLocationProviderClient.lat = 30d;
+      ShadowHMSFusedLocationProviderClient.log = 2.0d;
+      ShadowHMSFusedLocationProviderClient.accuracy = 5.0f;
+      ShadowHMSFusedLocationProviderClient.time = 2L;
       restartAppAndElapseTimeToNextSession();
       OneSignalInit();
       threadAndTaskWait();
@@ -3356,16 +3356,16 @@ public class MainOneSignalClassRunner {
 
    @Test
    @Config(shadows = {
-           ShadowFusedLocationProviderClient.class
+           ShadowHMSFusedLocationProviderClient.class
    }, sdk = 19)
    public void testLocationSchedule_Huawei() throws Exception {
       ShadowLocationController.googleServicesAvailable = false;
       ShadowLocationController.huaweiServicesAvailable = true;
       ShadowApplication.getInstance().grantPermissions("android.permission.ACCESS_FINE_LOCATION");
-      ShadowFusedLocationProviderClient.lat = 1.0d;
-      ShadowFusedLocationProviderClient.log = 2.0d;
-      ShadowFusedLocationProviderClient.accuracy = 3.0f;
-      ShadowFusedLocationProviderClient.time = 12345L;
+      ShadowHMSFusedLocationProviderClient.lat = 1.0d;
+      ShadowHMSFusedLocationProviderClient.log = 2.0d;
+      ShadowHMSFusedLocationProviderClient.accuracy = 3.0f;
+      ShadowHMSFusedLocationProviderClient.time = 12345L;
 
       // location if we have permission
       OneSignalInit();
@@ -3415,7 +3415,7 @@ public class MainOneSignalClassRunner {
 
    @Test
    @Config(shadows = {
-           ShadowFusedLocationProviderClient.class,
+           ShadowHMSFusedLocationProviderClient.class,
            ShadowHuaweiTask.class
    }, sdk = 19)
    public void testLocationFromSyncAlarm_Huawei() throws Exception {
@@ -3423,10 +3423,10 @@ public class MainOneSignalClassRunner {
       ShadowLocationController.huaweiServicesAvailable = true;
       ShadowApplication.getInstance().grantPermissions("android.permission.ACCESS_COARSE_LOCATION");
 
-      ShadowFusedLocationProviderClient.lat = 1.1d;
-      ShadowFusedLocationProviderClient.log = 2.1d;
-      ShadowFusedLocationProviderClient.accuracy = 3.1f;
-      ShadowFusedLocationProviderClient.time = 12346L;
+      ShadowHMSFusedLocationProviderClient.lat = 1.1d;
+      ShadowHMSFusedLocationProviderClient.log = 2.1d;
+      ShadowHMSFusedLocationProviderClient.accuracy = 3.1f;
+      ShadowHMSFusedLocationProviderClient.time = 12346L;
 
       OneSignalInit();
       threadAndTaskWait();
@@ -3436,13 +3436,13 @@ public class MainOneSignalClassRunner {
       shadowOf(alarmManager).getScheduledAlarms().clear();
 
       ShadowOneSignalRestClient.lastPost = null;
-      ShadowFusedLocationProviderClient.resetStatics();
-      ShadowFusedLocationProviderClient.lat = 1.0;
-      ShadowFusedLocationProviderClient.log = 2.0d;
-      ShadowFusedLocationProviderClient.accuracy = 3.0f;
-      ShadowFusedLocationProviderClient.time = 12345L;
-      ShadowFusedLocationProviderClient.shadowTask = true;
-      ShadowHuaweiTask.result = ShadowFusedLocationProviderClient.getLocation();
+      ShadowHMSFusedLocationProviderClient.resetStatics();
+      ShadowHMSFusedLocationProviderClient.lat = 1.0;
+      ShadowHMSFusedLocationProviderClient.log = 2.0d;
+      ShadowHMSFusedLocationProviderClient.accuracy = 3.0f;
+      ShadowHMSFusedLocationProviderClient.time = 12345L;
+      ShadowHMSFusedLocationProviderClient.shadowTask = true;
+      ShadowHuaweiTask.result = ShadowHMSFusedLocationProviderClient.getLocation();
 
       blankActivityController.pause();
       Robolectric.buildService(SyncService.class, new Intent()).startCommand(0, 0);
@@ -3464,7 +3464,7 @@ public class MainOneSignalClassRunner {
    }
 
    @Test
-   @Config(shadows = {ShadowFusedLocationProviderClient.class})
+   @Config(shadows = {ShadowHMSFusedLocationProviderClient.class})
    public void shouldSendLocationToEmailRecord_Huawei() throws Exception {
       ShadowLocationController.googleServicesAvailable = false;
       ShadowLocationController.huaweiServicesAvailable = true;
@@ -3483,18 +3483,18 @@ public class MainOneSignalClassRunner {
    }
 
    @Test
-   @Config(shadows = {ShadowFusedLocationProviderClient.class, ShadowHuaweiTask.class})
+   @Config(shadows = {ShadowHMSFusedLocationProviderClient.class, ShadowHuaweiTask.class})
    public void shouldRegisterWhenPromptingAfterInit_Huawei() throws Exception {
       ShadowLocationController.googleServicesAvailable = false;
       ShadowLocationController.huaweiServicesAvailable = true;
-      ShadowFusedLocationProviderClient.skipOnGetLocation = true;
+      ShadowHMSFusedLocationProviderClient.skipOnGetLocation = true;
       ShadowApplication.getInstance().grantPermissions("android.permission.ACCESS_COARSE_LOCATION");
 
       // Test promptLocation right after init race condition
       OneSignalInit();
       OneSignal.promptLocation();
 
-      ShadowHuaweiTask.callSuccessListener(ShadowFusedLocationProviderClient.getLocation());
+      ShadowHuaweiTask.callSuccessListener(ShadowHMSFusedLocationProviderClient.getLocation());
       threadAndTaskWait();
 
       ShadowOneSignalRestClient.Request request = ShadowOneSignalRestClient.requests.get(1);
@@ -3504,26 +3504,26 @@ public class MainOneSignalClassRunner {
    }
 
    @Test
-   @Config(shadows = {ShadowFusedLocationProviderClient.class, ShadowHuaweiTask.class})
+   @Config(shadows = {ShadowHMSFusedLocationProviderClient.class, ShadowHuaweiTask.class})
    public void shouldCallOnSessionEvenIfSyncJobStarted_Huawei() throws Exception {
       ShadowLocationController.googleServicesAvailable = false;
       ShadowLocationController.huaweiServicesAvailable = true;
-      ShadowFusedLocationProviderClient.shadowTask = true;
-      ShadowHuaweiTask.result = ShadowFusedLocationProviderClient.getLocation();
+      ShadowHMSFusedLocationProviderClient.shadowTask = true;
+      ShadowHuaweiTask.result = ShadowHMSFusedLocationProviderClient.getLocation();
       ShadowApplication.getInstance().grantPermissions("android.permission.ACCESS_COARSE_LOCATION");
 
       OneSignalInit();
       threadAndTaskWait();
 
       restartAppAndElapseTimeToNextSession();
-      ShadowFusedLocationProviderClient.skipOnGetLocation = true;
+      ShadowHMSFusedLocationProviderClient.skipOnGetLocation = true;
       OneSignalInit();
 
       SyncJobService syncJobService = Robolectric.buildService(SyncJobService.class).create().get();
       syncJobService.onStartJob(null);
       TestHelpers.getThreadByName("OS_SYNCSRV_BG_SYNC").join();
       OneSignalPackagePrivateHelper.runAllNetworkRunnables();
-      ShadowHuaweiTask.callSuccessListener(ShadowFusedLocationProviderClient.getLocation());
+      ShadowHuaweiTask.callSuccessListener(ShadowHMSFusedLocationProviderClient.getLocation());
       threadAndTaskWait();
 
       ShadowOneSignalRestClient.Request request = ShadowOneSignalRestClient.requests.get(3);

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/TestHelpers.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/TestHelpers.java
@@ -21,7 +21,7 @@ import com.onesignal.ShadowCustomTabsClient;
 import com.onesignal.ShadowDynamicTimer;
 import com.onesignal.ShadowFirebaseAnalytics;
 import com.onesignal.ShadowFusedLocationApiWrapper;
-import com.onesignal.ShadowFusedLocationProviderClient;
+import com.onesignal.ShadowHMSFusedLocationProviderClient;
 import com.onesignal.ShadowGcmBroadcastReceiver;
 import com.onesignal.ShadowGoogleApiClientCompatProxy;
 import com.onesignal.ShadowNotificationManagerCompat;
@@ -85,7 +85,7 @@ public class TestHelpers {
       ShadowGcmBroadcastReceiver.resetStatics();
 
       ShadowFusedLocationApiWrapper.resetStatics();
-      ShadowFusedLocationProviderClient.resetStatics();
+      ShadowHMSFusedLocationProviderClient.resetStatics();
 
       ShadowFirebaseAnalytics.resetStatics();
 


### PR DESCRIPTION
* Changed gradle to compileOnly so it isn't a direct dependecy
* Renamed ShadowFusedLocationProviderClient -> ShadowHMSFusedLocationProviderClient
   - Naming more clear this is only for HMS
* Removed hms gradle plugin from onesignal SDK target
   - It only applies to app targets

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1043)
<!-- Reviewable:end -->
