### PR TITLE
Changed location platform detection to device_type

### DIFF
--- a/OneSignalSDK/onesignal/build.gradle
+++ b/OneSignalSDK/onesignal/build.gradle
@@ -58,10 +58,8 @@ dependencies {
 
     // Huawei PushKit
     // KEEP as "compileOnly", so OneSignal isn't a direct dependency in the POM file.
-    compileOnly 'com.huawei.hms:push:4.0.2.300'
-    compileOnly 'com.huawei.agconnect:agconnect-core:1.3.1.300'
+    compileOnly 'com.huawei.hms:push:4.0.3.301'
     compileOnly 'com.huawei.hms:location:4.0.0.300'
-    compileOnly 'com.huawei.hms:base:4.0.2.300'
 
     // Keep under 28 until we switch to AndroidX
     //   otherwise app can get dup classes between 26 & 28 when mixing these versions.

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/LocationController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/LocationController.java
@@ -458,7 +458,7 @@ class LocationController {
             if (locationUpdateListener != null)
                LocationServices.FusedLocationApi.removeLocationUpdates(googleApiClient, locationUpdateListener);
             locationUpdateListener = new LocationUpdateListener(googleApiClient);
-         } else {
+         } else if (huaweiFusedLocationClient != null) {
             if (locationUpdateListener != null)
                huaweiFusedLocationClient.removeLocationUpdates(locationUpdateListener);
             locationUpdateListener = new LocationUpdateListener(huaweiFusedLocationClient);

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/LocationController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/LocationController.java
@@ -35,16 +35,13 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.HandlerThread;
-import android.os.Looper;
 import android.support.annotation.NonNull;
 
 import com.google.android.gms.common.ConnectionResult;
-import com.google.android.gms.common.GoogleApiAvailability;
 import com.google.android.gms.common.api.GoogleApiClient;
 import com.google.android.gms.location.LocationListener;
 import com.google.android.gms.location.LocationRequest;
 import com.google.android.gms.location.LocationServices;
-import com.huawei.hms.api.HuaweiApiAvailability;
 import com.huawei.hms.location.FusedLocationProviderClient;
 import com.huawei.hms.location.LocationResult;
 import com.onesignal.AndroidSupportV4Compat.ContextCompat;
@@ -279,9 +276,9 @@ class LocationController {
          locationHandlerThread = new LocationHandlerThread();
 
       try {
-         if (isGooglePlayServicesAvailable(classContext)) {
+         if (isGooglePlayServicesAvailable()) {
             initGoogleLocation();
-         } else if (isHMSAvailable(classContext)) {
+         } else if (isHMSAvailable()) {
             initHuaweiLocation();
          } else {
             fireFailedComplete();
@@ -354,15 +351,14 @@ class LocationController {
       }
    }
 
-   protected static boolean isGooglePlayServicesAvailable(Context context) {
-      GoogleApiAvailability googleApiAvailability = GoogleApiAvailability.getInstance();
-      int status = googleApiAvailability.isGooglePlayServicesAvailable(context);
-      return status == ConnectionResult.SUCCESS;
+   // If we are using device type Android for push we can safely assume we are using Google Play services
+   private static boolean isGooglePlayServicesAvailable() {
+      return OSUtils.isAndroidDeviceType();
    }
 
-   protected static boolean isHMSAvailable(Context context) {
-      int status = HuaweiApiAvailability.getInstance().isHuaweiMobileServicesAvailable(context);
-      return status == ConnectionResult.SUCCESS;
+   // If we are using device type Huawei for push we can safely assume we are using HMS Core
+   private static boolean isHMSAvailable() {
+      return OSUtils.isHuaweiDeviceType();
    }
 
    private static int getApiFallbackWait() {
@@ -450,11 +446,11 @@ class LocationController {
       synchronized (syncLock) {
          OneSignal.Log(OneSignal.LOG_LEVEL.DEBUG, "LocationController onFocusChange!");
          // Google location not initialized or connected yet
-         if (isGooglePlayServicesAvailable(classContext) && (googleApiClient == null || !googleApiClient.realInstance().isConnected()))
+         if (isGooglePlayServicesAvailable() && (googleApiClient == null || !googleApiClient.realInstance().isConnected()))
             return;
 
          // Huawei location not initialized yet and not google play available
-         if (!isGooglePlayServicesAvailable(classContext) && isHMSAvailable(classContext) && huaweiFusedLocationClient == null)
+         if (!isGooglePlayServicesAvailable() && isHMSAvailable() && huaweiFusedLocationClient == null)
             return;
 
          if (googleApiClient != null) {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSUtils.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSUtils.java
@@ -325,6 +325,10 @@ class OSUtils {
       return new OSUtils().getDeviceType() == UserState.DEVICE_TYPE_ANDROID;
    }
 
+   static boolean isHuaweiDeviceType() {
+      return new OSUtils().getDeviceType() == UserState.DEVICE_TYPE_HUAWEI;
+   }
+
    Integer getNetType () {
       ConnectivityManager cm = (ConnectivityManager) OneSignal.appContext.getSystemService(Context.CONNECTIVITY_SERVICE);
       NetworkInfo netInfo = cm.getActiveNetworkInfo();

--- a/OneSignalSDK/unittest/build.gradle
+++ b/OneSignalSDK/unittest/build.gradle
@@ -49,10 +49,8 @@ dependencies {
 
     implementation 'com.google.firebase:firebase-core:16.0.4'
 
-    testImplementation 'com.huawei.hms:push:4.0.2.300'
-    testImplementation 'com.huawei.agconnect:agconnect-core:1.3.1.300'
-    testImplementation 'com.huawei.hms:location:4.0.0.300'
-    testImplementation 'com.huawei.hms:base:4.0.2.300'
+    implementation 'com.huawei.hms:push:4.0.2.300'
+    implementation 'com.huawei.hms:location:4.0.0.300'
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.robolectric:robolectric:4.3.1'

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowLocationController.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowLocationController.java
@@ -27,32 +27,15 @@
 
 package com.onesignal;
 
-import android.content.Context;
-
-import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
 @Implements(LocationController.class)
 public class ShadowLocationController {
 
    public static Integer apiFallbackTime = LocationController.API_FALLBACK_TIME;
-   public static boolean googleServicesAvailable = true;
-   public static boolean huaweiServicesAvailable = false;
 
    public static void reset() {
       apiFallbackTime = LocationController.API_FALLBACK_TIME;
-      googleServicesAvailable = true;
-      huaweiServicesAvailable = false;
-   }
-
-   @Implementation
-   protected static boolean isGooglePlayServicesAvailable(Context context) {
-      return googleServicesAvailable;
-   }
-
-   @Implementation
-   protected static boolean isHMSAvailable(Context context) {
-      return huaweiServicesAvailable;
    }
 
    public static int getApiFallbackWait() {

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
@@ -61,6 +61,7 @@ import com.onesignal.OSSubscriptionStateChanges;
 import com.onesignal.OneSignal;
 import com.onesignal.OneSignal.ChangeTagsUpdateHandler;
 import com.onesignal.OneSignalPackagePrivateHelper;
+import com.onesignal.OneSignalPackagePrivateHelper.UserState;
 import com.onesignal.OneSignalShadowPackageManager;
 import com.onesignal.PermissionsActivity;
 import com.onesignal.ShadowAdvertisingIdProviderGPS;
@@ -72,6 +73,7 @@ import com.onesignal.ShadowFusedLocationApiWrapper;
 import com.onesignal.ShadowHMSFusedLocationProviderClient;
 import com.onesignal.ShadowGoogleApiClientBuilder;
 import com.onesignal.ShadowGoogleApiClientCompatProxy;
+import com.onesignal.ShadowHmsInstanceId;
 import com.onesignal.ShadowHuaweiTask;
 import com.onesignal.ShadowJobService;
 import com.onesignal.ShadowLocationController;
@@ -169,6 +171,7 @@ import static org.robolectric.Shadows.shadowOf;
             ShadowNotificationManagerCompat.class,
             ShadowJobService.class,
             ShadowLocationController.class,
+            ShadowHmsInstanceId.class,
             OneSignalShadowPackageManager.class
         },
         sdk = 21
@@ -3329,8 +3332,7 @@ public class MainOneSignalClassRunner {
    @Test
    @Config(shadows = {ShadowHMSFusedLocationProviderClient.class})
    public void shouldUpdateAllLocationFieldsWhenTimeStampChanges_Huawei() throws Exception {
-      ShadowLocationController.googleServicesAvailable = false;
-      ShadowLocationController.huaweiServicesAvailable = true;
+      ShadowOSUtils.supportsHMS(true);
       ShadowApplication.getInstance().grantPermissions("android.permission.ACCESS_COARSE_LOCATION");
       OneSignalInit();
       threadAndTaskWait();
@@ -3360,8 +3362,7 @@ public class MainOneSignalClassRunner {
            ShadowHMSFusedLocationProviderClient.class
    }, sdk = 19)
    public void testLocationSchedule_Huawei() throws Exception {
-      ShadowLocationController.googleServicesAvailable = false;
-      ShadowLocationController.huaweiServicesAvailable = true;
+      ShadowOSUtils.supportsHMS(true);
       ShadowApplication.getInstance().grantPermissions("android.permission.ACCESS_FINE_LOCATION");
       ShadowHMSFusedLocationProviderClient.lat = 1.0d;
       ShadowHMSFusedLocationProviderClient.log = 2.0d;
@@ -3420,8 +3421,7 @@ public class MainOneSignalClassRunner {
            ShadowHuaweiTask.class
    }, sdk = 19)
    public void testLocationFromSyncAlarm_Huawei() throws Exception {
-      ShadowLocationController.googleServicesAvailable = false;
-      ShadowLocationController.huaweiServicesAvailable = true;
+      ShadowOSUtils.supportsHMS(true);
       ShadowApplication.getInstance().grantPermissions("android.permission.ACCESS_COARSE_LOCATION");
 
       ShadowHMSFusedLocationProviderClient.lat = 1.1d;
@@ -3467,8 +3467,7 @@ public class MainOneSignalClassRunner {
    @Test
    @Config(shadows = {ShadowHMSFusedLocationProviderClient.class})
    public void shouldSendLocationToEmailRecord_Huawei() throws Exception {
-      ShadowLocationController.googleServicesAvailable = false;
-      ShadowLocationController.huaweiServicesAvailable = true;
+      ShadowOSUtils.supportsHMS(true);
       ShadowApplication.getInstance().grantPermissions("android.permission.ACCESS_COARSE_LOCATION");
 
       OneSignalInit();
@@ -3486,8 +3485,7 @@ public class MainOneSignalClassRunner {
    @Test
    @Config(shadows = {ShadowHMSFusedLocationProviderClient.class, ShadowHuaweiTask.class})
    public void shouldRegisterWhenPromptingAfterInit_Huawei() throws Exception {
-      ShadowLocationController.googleServicesAvailable = false;
-      ShadowLocationController.huaweiServicesAvailable = true;
+      ShadowOSUtils.supportsHMS(true);
       ShadowHMSFusedLocationProviderClient.skipOnGetLocation = true;
       ShadowApplication.getInstance().grantPermissions("android.permission.ACCESS_COARSE_LOCATION");
 
@@ -3500,15 +3498,14 @@ public class MainOneSignalClassRunner {
 
       ShadowOneSignalRestClient.Request request = ShadowOneSignalRestClient.requests.get(1);
       assertEquals(REST_METHOD.POST, request.method);
-      assertEquals(1, request.payload.get("device_type"));
-      assertEquals(ShadowPushRegistratorGCM.regId, request.payload.get("identifier"));
+      assertEquals(UserState.DEVICE_TYPE_HUAWEI, request.payload.get("device_type"));
+      assertEquals(ShadowHmsInstanceId.token, request.payload.get("identifier"));
    }
 
    @Test
    @Config(shadows = {ShadowHMSFusedLocationProviderClient.class, ShadowHuaweiTask.class})
    public void shouldCallOnSessionEvenIfSyncJobStarted_Huawei() throws Exception {
-      ShadowLocationController.googleServicesAvailable = false;
-      ShadowLocationController.huaweiServicesAvailable = true;
+      ShadowOSUtils.supportsHMS(true);
       ShadowHMSFusedLocationProviderClient.shadowTask = true;
       ShadowHuaweiTask.result = ShadowHMSFusedLocationProviderClient.getLocation();
       ShadowApplication.getInstance().grantPermissions("android.permission.ACCESS_COARSE_LOCATION");


### PR DESCRIPTION
### Changed location platform detection to device_type
* This prevents code duplicating and a consistently on provider
    - If we use Google for push we should use google for location
    - If we use HMS for push we should use HMS for location.

### Removed com.huawei.hms:base
* It is already part of hms:lcation and hms:push
   - The specifc version is mis-matched with hms:push causing internal NPE errors
   - This fixes the test failing as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1045)
<!-- Reviewable:end -->
