### PR TITLE
Fix the `NPE` within `OneSignalCacheCleaner.java`

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalCacheCleaner.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalCacheCleaner.java
@@ -113,7 +113,7 @@ class OneSignalCacheCleaner {
                 } catch (JSONException e) {
                     e.printStackTrace();
                 } finally {
-                    if (cursor != null & !cursor.isClosed())
+                    if (cursor != null && !cursor.isClosed())
                         cursor.close();
                 }
 


### PR DESCRIPTION
* Boolean expression for closing of the cursor has a `NPE` because of the usage of `&` instead of `&&`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1047)
<!-- Reviewable:end -->
