### PR TITLE
Changed `OSUtils.<String>newConcurrentSet()` default to `null`

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalCacheCleaner.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalCacheCleaner.java
@@ -184,12 +184,12 @@ class OneSignalCacheCleaner {
             Set<String> dismissedMessages = OneSignalPrefs.getStringSet(
                     OneSignalPrefs.PREFS_ONESIGNAL,
                     OneSignalPrefs.PREFS_OS_DISMISSED_IAMS,
-                    OSUtils.<String>newConcurrentSet());
+                    null);
 
             Set<String> impressionedMessages = OneSignalPrefs.getStringSet(
                     OneSignalPrefs.PREFS_ONESIGNAL,
                     OneSignalPrefs.PREFS_OS_IMPRESSIONED_IAMS,
-                    OSUtils.<String>newConcurrentSet());
+                    null);
 
             if (dismissedMessages != null && dismissedMessages.size() > 0) {
                 dismissedMessages.removeAll(oldMessageIds);
@@ -222,7 +222,7 @@ class OneSignalCacheCleaner {
             Set<String> clickedClickIds = OneSignalPrefs.getStringSet(
                     OneSignalPrefs.PREFS_ONESIGNAL,
                     OneSignalPrefs.PREFS_OS_CLICKED_CLICK_IDS_IAMS,
-                    OSUtils.<String>newConcurrentSet());
+                    null);
 
             if (clickedClickIds != null && clickedClickIds.size() > 0) {
                 clickedClickIds.removeAll(oldClickedClickIds);

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalPrefs.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalPrefs.java
@@ -286,7 +286,7 @@ class OneSignalPrefs {
         }
 
         SharedPreferences prefs = getSharedPrefsByName(prefsName);
-        if (prefs != null ) {
+        if (prefs != null) {
             if (type.equals(String.class))
                return prefs.getString(key, (String)defValue);
             else if (type.equals(Boolean.class))


### PR DESCRIPTION
* The default should not have been set to `OSUtils.<String>newConcurrentSet()`, this caused a `NPE`
* Correct usage is `OSUtils.newConcurrentSet()` and this is not an acceptable default
  * Return type of `OSUtils.newConcurrentSet()` is Set<T> and forcing to `<String>` will cause the NPE in some cases