### PR TITLE
Adding 2 layers of control to prevent locks in SQL DB and minor clean up

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageController.java
@@ -32,7 +32,6 @@ class OSInAppMessageController implements OSDynamicTriggerControllerObserver, OS
 
     public static final String IN_APP_MESSAGES_JSON_KEY = "in_app_messages";
     private static final String OS_SAVE_IN_APP_MESSAGE = "OS_SAVE_IN_APP_MESSAGE";
-    private static final String OS_DELETE_IN_APP_MESSAGE = "OS_DELETE_IN_APP_MESSAGE";
 
     OSTriggerController triggerController;
     private OSSystemConditionController systemConditionController;
@@ -122,8 +121,15 @@ class OSInAppMessageController implements OSDynamicTriggerControllerObserver, OS
         initRedisplayData(dbHelper);
     }
 
+    OSInAppMessageRepository getInAppMessageRepository(OneSignalDbHelper dbHelper) {
+        if (inAppMessageRepository == null)
+            inAppMessageRepository = new OSInAppMessageRepository(dbHelper);
+
+        return inAppMessageRepository;
+    }
+
     protected void initRedisplayData(OneSignalDbHelper dbHelper) {
-        inAppMessageRepository = new OSInAppMessageRepository(dbHelper);
+        inAppMessageRepository = getInAppMessageRepository(dbHelper);
         redisplayedInAppMessages = inAppMessageRepository.getCachedInAppMessages();
 
         OneSignal.Log(OneSignal.LOG_LEVEL.DEBUG, "redisplayedInAppMessages: " + redisplayedInAppMessages.toString());

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageController.java
@@ -129,7 +129,7 @@ class OSInAppMessageController implements OSDynamicTriggerControllerObserver, OS
     }
 
     protected void initRedisplayData(OneSignalDbHelper dbHelper) {
-        inAppMessageRepository = new OSInAppMessageRepository(dbHelper);
+        inAppMessageRepository = getInAppMessageRepository(dbHelper);
         redisplayedInAppMessages = inAppMessageRepository.getCachedInAppMessages();
 
         OneSignal.Log(OneSignal.LOG_LEVEL.DEBUG, "redisplayedInAppMessages: " + redisplayedInAppMessages.toString());

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageController.java
@@ -129,7 +129,7 @@ class OSInAppMessageController implements OSDynamicTriggerControllerObserver, OS
     }
 
     protected void initRedisplayData(OneSignalDbHelper dbHelper) {
-        inAppMessageRepository = getInAppMessageRepository(dbHelper);
+        inAppMessageRepository = new OSInAppMessageRepository(dbHelper);
         redisplayedInAppMessages = inAppMessageRepository.getCachedInAppMessages();
 
         OneSignal.Log(OneSignal.LOG_LEVEL.DEBUG, "redisplayedInAppMessages: " + redisplayedInAppMessages.toString());

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageRepository.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageRepository.java
@@ -179,12 +179,12 @@ class OSInAppMessageRepository {
             Set<String> dismissedMessages = OneSignalPrefs.getStringSet(
                     OneSignalPrefs.PREFS_ONESIGNAL,
                     OneSignalPrefs.PREFS_OS_DISMISSED_IAMS,
-                    OSUtils.<String>newConcurrentSet());
+                    null);
 
             Set<String> impressionedMessages = OneSignalPrefs.getStringSet(
                     OneSignalPrefs.PREFS_ONESIGNAL,
                     OneSignalPrefs.PREFS_OS_IMPRESSIONED_IAMS,
-                    OSUtils.<String>newConcurrentSet());
+                    null);
 
             if (dismissedMessages != null && dismissedMessages.size() > 0) {
                 dismissedMessages.removeAll(oldMessageIds);
@@ -218,7 +218,7 @@ class OSInAppMessageRepository {
             Set<String> clickedClickIds = OneSignalPrefs.getStringSet(
                     OneSignalPrefs.PREFS_ONESIGNAL,
                     OneSignalPrefs.PREFS_OS_CLICKED_CLICK_IDS_IAMS,
-                    OSUtils.<String>newConcurrentSet());
+                    null);
 
             if (clickedClickIds != null && clickedClickIds.size() > 0) {
                 clickedClickIds.removeAll(oldClickedClickIds);

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageRepository.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageRepository.java
@@ -42,8 +42,8 @@ class OSInAppMessageRepository {
         } finally {
             try {
                 writableDb.endTransaction(); // May throw if transaction was never opened or DB is full.
-            } catch (Throwable t) {
-                OneSignal.Log(OneSignal.LOG_LEVEL.ERROR, "Error closing transaction! ", t);
+            } catch (SQLException e) {
+                OneSignal.Log(OneSignal.LOG_LEVEL.ERROR, "Error closing transaction! ", e);
             }
         }
     }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageRepository.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageRepository.java
@@ -2,6 +2,7 @@ package com.onesignal;
 
 import android.content.ContentValues;
 import android.database.Cursor;
+import android.database.SQLException;
 import android.database.sqlite.SQLiteDatabase;
 import android.support.annotation.WorkerThread;
 
@@ -23,18 +24,28 @@ class OSInAppMessageRepository {
     @WorkerThread
     synchronized void saveInAppMessage(OSInAppMessage inAppMessage) {
         SQLiteDatabase writableDb = dbHelper.getSQLiteDatabaseWithRetries();
+        writableDb.beginTransaction();
+        try {
+            ContentValues values = new ContentValues();
+            values.put(OneSignalDbContract.InAppMessageTable.COLUMN_NAME_MESSAGE_ID, inAppMessage.messageId);
+            values.put(OneSignalDbContract.InAppMessageTable.COLUMN_NAME_DISPLAY_QUANTITY, inAppMessage.getRedisplayStats().getDisplayQuantity());
+            values.put(OneSignalDbContract.InAppMessageTable.COLUMN_NAME_LAST_DISPLAY, inAppMessage.getRedisplayStats().getLastDisplayTime());
+            values.put(OneSignalDbContract.InAppMessageTable.COLUMN_CLICK_IDS, inAppMessage.getClickedClickIds().toString());
+            values.put(OneSignalDbContract.InAppMessageTable.COLUMN_DISPLAYED_IN_SESSION, inAppMessage.isDisplayedInSession());
 
-        ContentValues values = new ContentValues();
-        values.put(OneSignalDbContract.InAppMessageTable.COLUMN_NAME_MESSAGE_ID, inAppMessage.messageId);
-        values.put(OneSignalDbContract.InAppMessageTable.COLUMN_NAME_DISPLAY_QUANTITY, inAppMessage.getRedisplayStats().getDisplayQuantity());
-        values.put(OneSignalDbContract.InAppMessageTable.COLUMN_NAME_LAST_DISPLAY, inAppMessage.getRedisplayStats().getLastDisplayTime());
-        values.put(OneSignalDbContract.InAppMessageTable.COLUMN_CLICK_IDS, inAppMessage.getClickedClickIds().toString());
-        values.put(OneSignalDbContract.InAppMessageTable.COLUMN_DISPLAYED_IN_SESSION, inAppMessage.isDisplayedInSession());
+            int rowsUpdated = writableDb.update(OneSignalDbContract.InAppMessageTable.TABLE_NAME, values,
+                    OneSignalDbContract.InAppMessageTable.COLUMN_NAME_MESSAGE_ID + " = ?", new String[]{inAppMessage.messageId});
+            if (rowsUpdated == 0)
+                writableDb.insert(OneSignalDbContract.InAppMessageTable.TABLE_NAME, null, values);
 
-        int rowsUpdated = writableDb.update(OneSignalDbContract.InAppMessageTable.TABLE_NAME, values,
-                OneSignalDbContract.InAppMessageTable.COLUMN_NAME_MESSAGE_ID + " = ?", new String[]{inAppMessage.messageId});
-        if (rowsUpdated == 0)
-            writableDb.insert(OneSignalDbContract.InAppMessageTable.TABLE_NAME, null, values);
+            writableDb.setTransactionSuccessful();
+        } finally {
+            try {
+                writableDb.endTransaction(); // May throw if transaction was never opened or DB is full.
+            } catch (Throwable t) {
+                OneSignal.Log(OneSignal.LOG_LEVEL.ERROR, "Error closing transaction! ", t);
+            }
+        }
     }
 
     @WorkerThread
@@ -77,5 +88,148 @@ class OSInAppMessageRepository {
 
         return iams;
     }
+
+    @WorkerThread
+    synchronized void cleanCachedInAppMessages() {
+        SQLiteDatabase writableDb = dbHelper.getSQLiteDatabaseWithRetries();
+
+        // 1. Query for all old message ids and old clicked click ids
+        String[] retColumns = new String[]{
+                OneSignalDbContract.InAppMessageTable.COLUMN_NAME_MESSAGE_ID,
+                OneSignalDbContract.InAppMessageTable.COLUMN_CLICK_IDS
+        };
+
+        String whereStr = OneSignalDbContract.InAppMessageTable.COLUMN_NAME_LAST_DISPLAY + " < ?";
+
+        String sixMonthsAgoInSeconds = String.valueOf((System.currentTimeMillis() / 1_000L) - OneSignalCacheCleaner.IAM_CACHE_DATA_LIFETIME);
+        String[] whereArgs = new String[]{sixMonthsAgoInSeconds};
+
+        Set<String> oldMessageIds = OSUtils.newConcurrentSet();
+        Set<String> oldClickedClickIds = OSUtils.newConcurrentSet();
+
+        Cursor cursor = null;
+        try {
+            cursor = writableDb.query(OneSignalDbContract.InAppMessageTable.TABLE_NAME,
+                    retColumns,
+                    whereStr,
+                    whereArgs,
+                    null,
+                    null,
+                    null);
+
+            if (cursor == null || cursor.getCount() == 0) {
+                OneSignal.onesignalLog(OneSignal.LOG_LEVEL.DEBUG, "Attempted to clean 6 month old IAM data, but none exists!");
+                return;
+            }
+
+            // From cursor get all of the old message ids and old clicked click ids
+            if (cursor.moveToFirst()) {
+                do {
+                    String oldMessageId = cursor.getString(
+                            cursor.getColumnIndex(
+                                    OneSignalDbContract.InAppMessageTable.COLUMN_NAME_MESSAGE_ID));
+                    String oldClickIds = cursor.getString(
+                            cursor.getColumnIndex(
+                                    OneSignalDbContract.InAppMessageTable.COLUMN_CLICK_IDS));
+
+                    oldMessageIds.add(oldMessageId);
+                    oldClickedClickIds.addAll(OSUtils.newStringSetFromJSONArray(new JSONArray(oldClickIds)));
+                } while (cursor.moveToNext());
+            }
+        } catch (JSONException e) {
+            e.printStackTrace();
+        } finally {
+            if (cursor != null && !cursor.isClosed())
+                cursor.close();
+        }
+
+        writableDb.beginTransaction();
+        try {
+            // 2. Delete old IAMs from SQL
+            writableDb.delete(
+                    OneSignalDbContract.InAppMessageTable.TABLE_NAME,
+                    whereStr,
+                    whereArgs);
+            writableDb.setTransactionSuccessful();
+        } finally {
+            try {
+                writableDb.endTransaction(); // May throw if transaction was never opened or DB is full.
+            } catch (SQLException e) {
+                OneSignal.Log(OneSignal.LOG_LEVEL.ERROR, "Error closing transaction! ", e);
+            }
+        }
+
+        // 3. Use queried data to clean SharedPreferences
+        cleanInAppMessageIds(oldMessageIds);
+        cleanInAppMessageClickedClickIds(oldClickedClickIds);
+    }
+
+    /**
+     * Clean up 6 month old IAM ids in {@link android.content.SharedPreferences}:
+     *  1. Dismissed message ids
+     *  2. Impressioned message ids
+     * <br/><br/>
+     * Note: This should only ever be called by {@link OSInAppMessageRepository#cleanCachedInAppMessages()}
+     * <br/><br/>
+     * @see OneSignalCacheCleaner#cleanCachedInAppMessages(OneSignalDbHelper)
+     * @see OSInAppMessageRepository#cleanCachedInAppMessages()
+     */
+    private void cleanInAppMessageIds(Set<String> oldMessageIds) {
+        if (oldMessageIds != null && oldMessageIds.size() > 0) {
+            Set<String> dismissedMessages = OneSignalPrefs.getStringSet(
+                    OneSignalPrefs.PREFS_ONESIGNAL,
+                    OneSignalPrefs.PREFS_OS_DISMISSED_IAMS,
+                    OSUtils.<String>newConcurrentSet());
+
+            Set<String> impressionedMessages = OneSignalPrefs.getStringSet(
+                    OneSignalPrefs.PREFS_ONESIGNAL,
+                    OneSignalPrefs.PREFS_OS_IMPRESSIONED_IAMS,
+                    OSUtils.<String>newConcurrentSet());
+
+            if (dismissedMessages != null && dismissedMessages.size() > 0) {
+                dismissedMessages.removeAll(oldMessageIds);
+                OneSignalPrefs.saveStringSet(
+                        OneSignalPrefs.PREFS_ONESIGNAL,
+                        OneSignalPrefs.PREFS_OS_DISMISSED_IAMS,
+                        dismissedMessages);
+            }
+
+            if (impressionedMessages != null && impressionedMessages.size() > 0) {
+                impressionedMessages.removeAll(oldMessageIds);
+                OneSignalPrefs.saveStringSet(
+                        OneSignalPrefs.PREFS_ONESIGNAL,
+                        OneSignalPrefs.PREFS_OS_IMPRESSIONED_IAMS,
+                        impressionedMessages);
+            }
+        }
+    }
+
+    /**
+     * Clean up 6 month old IAM clicked click ids in {@link android.content.SharedPreferences}:
+     *  1. Clicked click ids from elements within IAM
+     * <br/><br/>
+     * Note: This should only ever be called by {@link OSInAppMessageRepository#cleanCachedInAppMessages()}
+     * <br/><br/>
+     * @see OneSignalCacheCleaner#cleanCachedInAppMessages(OneSignalDbHelper)
+     * @see OSInAppMessageRepository#cleanCachedInAppMessages()
+     */
+    private void cleanInAppMessageClickedClickIds(Set<String> oldClickedClickIds) {
+        if (oldClickedClickIds != null && oldClickedClickIds.size() > 0) {
+            Set<String> clickedClickIds = OneSignalPrefs.getStringSet(
+                    OneSignalPrefs.PREFS_ONESIGNAL,
+                    OneSignalPrefs.PREFS_OS_CLICKED_CLICK_IDS_IAMS,
+                    OSUtils.<String>newConcurrentSet());
+
+            if (clickedClickIds != null && clickedClickIds.size() > 0) {
+                clickedClickIds.removeAll(oldClickedClickIds);
+                OneSignalPrefs.saveStringSet(
+                        OneSignalPrefs.PREFS_ONESIGNAL,
+                        OneSignalPrefs.PREFS_OS_CLICKED_CLICK_IDS_IAMS,
+                        clickedClickIds);
+            }
+        }
+    }
+
+
 
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageRepository.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageRepository.java
@@ -15,6 +15,8 @@ import java.util.Set;
 
 class OSInAppMessageRepository {
 
+    final static long IAM_CACHE_DATA_LIFETIME = 15_552_000L; // 6 months in seconds
+
     private final OneSignalDbHelper dbHelper;
 
     OSInAppMessageRepository(OneSignalDbHelper dbHelper) {
@@ -101,7 +103,7 @@ class OSInAppMessageRepository {
 
         String whereStr = OneSignalDbContract.InAppMessageTable.COLUMN_NAME_LAST_DISPLAY + " < ?";
 
-        String sixMonthsAgoInSeconds = String.valueOf((System.currentTimeMillis() / 1_000L) - OneSignalCacheCleaner.IAM_CACHE_DATA_LIFETIME);
+        String sixMonthsAgoInSeconds = String.valueOf((System.currentTimeMillis() / 1_000L) - IAM_CACHE_DATA_LIFETIME);
         String[] whereArgs = new String[]{sixMonthsAgoInSeconds};
 
         Set<String> oldMessageIds = OSUtils.newConcurrentSet();

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalCacheCleaner.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalCacheCleaner.java
@@ -12,8 +12,7 @@ import com.onesignal.outcomes.OSOutcomeTableProvider;
 
 class OneSignalCacheCleaner {
 
-    private final static long NOTIFICATION_CACHE_DATA_LIFETIME = 604_800L; // 7 days in seconds
-    final static long IAM_CACHE_DATA_LIFETIME = 15_552_000L; // 6 months in seconds
+    private final static long NOTIFICATION_CACHE_DATA_LIFETIME = 604_800L; // 7 days in second
 
     private final static String OS_DELETE_CACHED_NOTIFICATIONS_THREAD = "OS_DELETE_CACHED_NOTIFICATIONS_THREAD";
     private final static String OS_DELETE_CACHED_REDISPLAYED_IAMS_THREAD = "OS_DELETE_CACHED_REDISPLAYED_IAMS_THREAD";

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalCacheCleaner.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalCacheCleaner.java
@@ -113,7 +113,7 @@ class OneSignalCacheCleaner {
                 } catch (JSONException e) {
                     e.printStackTrace();
                 } finally {
-                    if (cursor != null & !cursor.isClosed())
+                    if (cursor != null && !cursor.isClosed())
                         cursor.close();
                 }
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalCacheCleaner.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalCacheCleaner.java
@@ -71,7 +71,11 @@ class OneSignalCacheCleaner {
             @Override
             public void run() {
                 Thread.currentThread().setPriority(Process.THREAD_PRIORITY_BACKGROUND);
-                new OSInAppMessageRepository(dbHelper).cleanCachedInAppMessages();
+
+                OSInAppMessageRepository inAppMessageRepository = OSInAppMessageController
+                        .getController()
+                        .getInAppMessageRepository(dbHelper);
+                inAppMessageRepository.cleanCachedInAppMessages();
             }
         }, OS_DELETE_CACHED_REDISPLAYED_IAMS_THREAD).start();
     }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalDbHelper.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalDbHelper.java
@@ -318,15 +318,6 @@ class OneSignalDbHelper extends SQLiteOpenHelper implements OneSignalDb {
       onCreate(db);
    }
 
-   // Could enable WAL in the future but requires Android API 11
-   /*
-   @Override
-   public void onConfigure(SQLiteDatabase db) {
-      super.onConfigure(db);
-      db.enableWriteAheadLogging();
-   }
-   */
-
    static StringBuilder recentUninteractedWithNotificationsWhere() {
       long currentTimeSec = System.currentTimeMillis() / 1_000L;
       long createdAtCutoff = currentTimeSec - 604_800L; // 1 Week back

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/StaticResetHelper.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/StaticResetHelper.java
@@ -57,7 +57,6 @@ public class StaticResetHelper {
       classes.add(new ClassState(FocusTimeController.class, null));
       classes.add(new ClassState(OSSessionManager.class, null));
       classes.add(new ClassState(MockSessionManager.class, null));
-      classes.add(new ClassState(OSInAppMessageRepository.class, null));
    }
 
    private interface OtherFieldHandler {

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/StaticResetHelper.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/StaticResetHelper.java
@@ -57,6 +57,7 @@ public class StaticResetHelper {
       classes.add(new ClassState(FocusTimeController.class, null));
       classes.add(new ClassState(OSSessionManager.class, null));
       classes.add(new ClassState(MockSessionManager.class, null));
+      classes.add(new ClassState(OSInAppMessageRepository.class, null));
    }
 
    private interface OtherFieldHandler {


### PR DESCRIPTION
* Removed the commented `enableWriteAheadLogging`
  * No need for this as this allows concurrent read and writes to occur and we would rather pause a read while a write occurs
  * Pausing will ensure that we are querying the most updated data
* 2 layers of security for SQL DB regarding `OSInAppMessageRepository.java`
  * First one will be transactions using `beginTransaction`, `setTransactionSuccessful`, and `endTransaction` methods wherever we `insert`, `delete`, or `update`
  * Second one is keeping TABLE manipulation or reading within the same file and setting these methods as synchronized so that any other TABLE touching that occurs won't happen till any current methods are complete
  * The combination of the two steps should help prevent any conflicts between SQL DB and solve the locking issues

* WIP - Making sure any DB reading and writing is from the same file so `synchronized` along with transactions provide this 2 layer security around our single SQL DB instance

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1050)
<!-- Reviewable:end -->
