### PR TITLE
Fixed race condition with OSInAppMessageController

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageController.java
@@ -72,7 +72,7 @@ class OSInAppMessageController implements OSDynamicTriggerControllerObserver, OS
     @Nullable
     private static OSInAppMessageController sharedInstance;
 
-    public static OSInAppMessageController getController() {
+    public static synchronized OSInAppMessageController getController() {
         OneSignalDbHelper dbHelper = OneSignal.getDBHelperInstance();
 
         // Make sure only Android 4.4 devices and higher can use IAMs


### PR DESCRIPTION
* Added synchronized to OSInAppMessageController.getController() as this
could result in more than once instace otherwise.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1057)
<!-- Reviewable:end -->
