### PR TITLE
Moved logic out of NotificationOpenedActivityHMS

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
@@ -58,7 +58,7 @@ import static com.onesignal.NotificationExtenderService.EXTENDER_SERVICE_JOB_ID;
  * */
 class NotificationBundleProcessor {
 
-   private static final String PUSH_ADDITIONAL_DATA_KEY = "a";
+   public static final String PUSH_ADDITIONAL_DATA_KEY = "a";
 
    public static final String PUSH_MINIFIED_BUTTONS_LIST = "o";
    public static final String PUSH_MINIFIED_BUTTON_ID = "i";

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationOpenedActivityHMS.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationOpenedActivityHMS.java
@@ -78,7 +78,7 @@ public class NotificationOpenedActivityHMS extends Activity {
     }
 
     private void processOpen(@Nullable Intent intent) {
-        NotificationPayloadProcessorHMS.handleHmsNotificationOpenIntent(this, intent);
+        NotificationPayloadProcessorHMS.handleHMSNotificationOpenIntent(this, intent);
     }
 
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationOpenedActivityHMS.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationOpenedActivityHMS.java
@@ -32,9 +32,6 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 
-import org.json.JSONArray;
-import org.json.JSONObject;
-
 // HMS Core creates a notification with an Intent when opened to start this Activity.
 //   Intent is defined via OneSignal's backend and is sent to HMS.
 // This has to be it's own Activity separate from NotificationOpenedActivity since
@@ -81,24 +78,7 @@ public class NotificationOpenedActivityHMS extends Activity {
     }
 
     private void processOpen(@Nullable Intent intent) {
-        // Validate Intent to prevent any side effects or crashes
-        //    if triggered outside of OneSignal for any reason.
-        if (!OSNotificationFormatHelper.isOneSignalIntent(intent))
-            return;
-        OneSignal.setAppContext(this);
-
-        Bundle bundle = intent.getExtras();
-        JSONObject jsonData = NotificationBundleProcessor.bundleAsJSONObject(bundle);
-
-        if (NotificationOpenedProcessor.handleIAMPreviewOpen(this, jsonData))
-            return;
-
-        OneSignal.handleNotificationOpen(
-            this,
-            new JSONArray().put(jsonData),
-            false,
-            OSNotificationFormatHelper.getOSNotificationIdFromJson(jsonData)
-        );
+        NotificationPayloadProcessorHMS.handleHmsNotificationOpenIntent(this, intent);
     }
 
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationPayloadProcessorHMS.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationPayloadProcessorHMS.java
@@ -1,0 +1,74 @@
+package com.onesignal;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import static com.onesignal.GenerateNotification.BUNDLE_KEY_ACTION_ID;
+
+class NotificationPayloadProcessorHMS {
+
+    static void handleHmsNotificationOpenIntent(@NonNull Activity activity, @Nullable Intent intent) {
+        OneSignal.setAppContext(activity);
+        if (intent == null)
+            return;
+
+        JSONObject jsonData = covertHmsOpenIntentToJson(intent);
+        if (jsonData == null)
+            return;
+
+        handleProcessJsonOpenData(activity, jsonData);
+    }
+
+    // Takes in a Notification Open Intent fired from HMS Core and coverts it to an OS formatted JSONObject
+    // Returns null if it is NOT a notification sent from OneSignal's backend
+    private static @Nullable JSONObject covertHmsOpenIntentToJson(@Nullable Intent intent) {
+        // Validate Intent to prevent any side effects or crashes
+        //    if triggered outside of OneSignal for any reason.
+        if (!OSNotificationFormatHelper.isOneSignalIntent(intent))
+            return null;
+
+        Bundle bundle = intent.getExtras();
+        JSONObject jsonData = NotificationBundleProcessor.bundleAsJSONObject(bundle);
+        reformatButtonClickAction(jsonData);
+
+        return jsonData;
+    }
+
+    // Un-nests JSON, key actionId, if it exists under custom
+    // Example:
+    //   From this:
+    //      { custom: { actionId: "exampleId" } }
+    //   To this:
+    //      { custom: { }, actionId: "exampleId" } }
+    private static void reformatButtonClickAction(@NonNull JSONObject jsonData) {
+        try {
+            JSONObject custom = NotificationBundleProcessor.getCustomJSONObject(jsonData);
+            String actionId = (String)custom.remove(BUNDLE_KEY_ACTION_ID);
+            if (actionId == null)
+                return;
+
+            jsonData.put(BUNDLE_KEY_ACTION_ID, actionId);
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static void handleProcessJsonOpenData(@NonNull Activity activity, @NonNull JSONObject jsonData) {
+        if (NotificationOpenedProcessor.handleIAMPreviewOpen(activity, jsonData))
+            return;
+
+        OneSignal.handleNotificationOpen(
+            activity,
+            new JSONArray().put(jsonData),
+            false,
+            OSNotificationFormatHelper.getOSNotificationIdFromJson(jsonData)
+        );
+    }
+}

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationPayloadProcessorHMS.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationPayloadProcessorHMS.java
@@ -14,12 +14,12 @@ import static com.onesignal.GenerateNotification.BUNDLE_KEY_ACTION_ID;
 
 class NotificationPayloadProcessorHMS {
 
-    static void handleHmsNotificationOpenIntent(@NonNull Activity activity, @Nullable Intent intent) {
+    static void handleHMSNotificationOpenIntent(@NonNull Activity activity, @Nullable Intent intent) {
         OneSignal.setAppContext(activity);
         if (intent == null)
             return;
 
-        JSONObject jsonData = covertHmsOpenIntentToJson(intent);
+        JSONObject jsonData = covertHMSOpenIntentToJson(intent);
         if (jsonData == null)
             return;
 
@@ -28,7 +28,7 @@ class NotificationPayloadProcessorHMS {
 
     // Takes in a Notification Open Intent fired from HMS Core and coverts it to an OS formatted JSONObject
     // Returns null if it is NOT a notification sent from OneSignal's backend
-    private static @Nullable JSONObject covertHmsOpenIntentToJson(@Nullable Intent intent) {
+    private static @Nullable JSONObject covertHMSOpenIntentToJson(@Nullable Intent intent) {
         // Validate Intent to prevent any side effects or crashes
         //    if triggered outside of OneSignal for any reason.
         if (!OSNotificationFormatHelper.isOneSignalIntent(intent))

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationFormatHelper.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationFormatHelper.java
@@ -11,8 +11,8 @@ import org.json.JSONObject;
 // Future: This class could also support parsing our SDK generated bundles
 class OSNotificationFormatHelper {
 
-    static final String PAYLOAD_OS_ROOT_CUSTOM = "custom";
-    private static final String PAYLOAD_OS_NOTIFICATION_ID = "i";
+    public static final String PAYLOAD_OS_ROOT_CUSTOM = "custom";
+    public static final String PAYLOAD_OS_NOTIFICATION_ID = "i";
 
     static boolean isOneSignalIntent(@Nullable Intent intent) {
         if (intent == null)

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationFormatHelper.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationFormatHelper.java
@@ -11,7 +11,7 @@ import org.json.JSONObject;
 // Future: This class could also support parsing our SDK generated bundles
 class OSNotificationFormatHelper {
 
-    private static final String PAYLOAD_OS_ROOT_CUSTOM = "custom";
+    static final String PAYLOAD_OS_ROOT_CUSTOM = "custom";
     private static final String PAYLOAD_OS_NOTIFICATION_ID = "i";
 
     static boolean isOneSignalIntent(@Nullable Intent intent) {

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
@@ -530,4 +530,6 @@ public class OneSignalPackagePrivateHelper {
    public static class GenerateNotification extends com.onesignal.GenerateNotification {}
 
    public static class NotificationBundleProcessor extends com.onesignal.NotificationBundleProcessor {}
+
+   public static class OSNotificationFormatHelper extends com.onesignal.OSNotificationFormatHelper {}
 }

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/NotificationOpenedActivityHMSIntegrationTestsRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/NotificationOpenedActivityHMSIntegrationTestsRunner.java
@@ -5,6 +5,7 @@ import android.content.Intent;
 import android.support.annotation.NonNull;
 
 import com.onesignal.NotificationOpenedActivityHMS;
+import com.onesignal.OSNotificationOpenResult;
 import com.onesignal.OneSignal;
 import com.onesignal.OneSignalPackagePrivateHelper.UserState;
 import com.onesignal.ShadowCustomTabsClient;
@@ -17,6 +18,7 @@ import com.onesignal.ShadowPushRegistratorHMS;
 import com.onesignal.StaticResetHelper;
 import com.onesignal.example.BlankActivity;
 
+import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -30,13 +32,13 @@ import org.robolectric.shadows.ShadowLog;
 
 import java.util.UUID;
 
+import static com.onesignal.OneSignalPackagePrivateHelper.GenerateNotification.BUNDLE_KEY_ACTION_ID;
 import static com.onesignal.InAppMessagingHelpers.ONESIGNAL_APP_ID;
 import static com.test.onesignal.RestClientAsserts.assertNotificationOpenAtIndex;
 import static com.test.onesignal.TestHelpers.fastColdRestartApp;
 import static com.test.onesignal.TestHelpers.threadAndTaskWait;
 import static junit.framework.Assert.assertEquals;
 import static org.robolectric.Shadows.shadowOf;
-
 
 @Config(
     packageName = "com.onesignal.example",
@@ -68,27 +70,50 @@ public class NotificationOpenedActivityHMSIntegrationTestsRunner {
         ShadowOSUtils.supportsHMS(true);
     }
 
-    private static Intent helper_baseHMSOpenIntent() {
+    private static @NonNull Intent helper_baseHMSOpenIntent() {
         return new Intent()
                 .setFlags(Intent.FLAG_ACTIVITY_NO_HISTORY | Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_MULTIPLE_TASK)
                 .setAction("android.intent.action.VIEW");
+    }
+
+    private static @NonNull Intent helper_basicOSHMSOpenIntent() throws JSONException {
+        return helper_baseHMSOpenIntent()
+                .putExtra(
+                    "custom",
+                    new JSONObject() {{
+                        put("i", UUID.randomUUID().toString());
+                }}.toString()
+        );
+    }
+
+    private static @NonNull Intent helper_basicOSHMSOpenIntentWithActionId(final @NonNull String actionId) throws JSONException {
+        return helper_baseHMSOpenIntent()
+                .putExtra(
+                        "custom",
+                        new JSONObject() {{
+                            put("i", UUID.randomUUID().toString());
+                            put(BUNDLE_KEY_ACTION_ID, actionId);
+                        }}.toString()
+                );
     }
 
     private static void helper_startHMSOpenActivity(@NonNull Intent intent) {
         Robolectric.buildActivity(NotificationOpenedActivityHMS.class, intent).create();
     }
 
-    private static void helper_initSDKAndFireHMSNotificationOpenIntent() throws Exception {
+    private static void helper_initSDKAndFireHMSNotificationBarebonesOSOpenIntent() throws Exception {
+        Intent intent = helper_basicOSHMSOpenIntent();
+        helper_initSDKAndFireHMSNotificationOpenWithIntent(intent);
+    }
+
+    private static void helper_initSDKAndFireHMSNotificationActionButtonTapIntent(@NonNull String actionId) throws Exception {
+        Intent intent = helper_basicOSHMSOpenIntentWithActionId(actionId);
+        helper_initSDKAndFireHMSNotificationOpenWithIntent(intent);
+    }
+
+    private static void helper_initSDKAndFireHMSNotificationOpenWithIntent(@NonNull Intent intent) throws Exception {
         OneSignal.init(RuntimeEnvironment.application, "123456789", ONESIGNAL_APP_ID);
         fastColdRestartApp();
-
-        Intent intent = helper_baseHMSOpenIntent()
-                .putExtra(
-                        "custom",
-                        new JSONObject() {{
-                            put("i", UUID.randomUUID().toString());
-                        }}.toString()
-                );
 
         helper_startHMSOpenActivity(intent);
     }
@@ -102,7 +127,7 @@ public class NotificationOpenedActivityHMSIntegrationTestsRunner {
 
     @Test
     public void barebonesOSPayload_startsMainActivity() throws Exception {
-        helper_initSDKAndFireHMSNotificationOpenIntent();
+        helper_initSDKAndFireHMSNotificationBarebonesOSOpenIntent();
 
         Intent startedActivity = shadowOf(RuntimeEnvironment.application).getNextStartedActivity();
         assertEquals(startedActivity.getComponent().getClassName(), BlankActivity.class.getName());
@@ -110,8 +135,24 @@ public class NotificationOpenedActivityHMSIntegrationTestsRunner {
 
     @Test
     public void barebonesOSPayload_makesNotificationOpenRequest() throws Exception {
-        helper_initSDKAndFireHMSNotificationOpenIntent();
+        helper_initSDKAndFireHMSNotificationBarebonesOSOpenIntent();
         assertNotificationOpenAtIndex(1, UserState.DEVICE_TYPE_HUAWEI);
+    }
+
+    private static final String TEST_ACTION_ID = "myTestActionId";
+    private static String lastActionId;
+    @Test
+    public void firesOSNotificationOpenCallbackWithActionId() throws Exception {
+        helper_initSDKAndFireHMSNotificationActionButtonTapIntent(TEST_ACTION_ID);
+
+        OneSignal.startInit(RuntimeEnvironment.application).setNotificationOpenedHandler(new OneSignal.NotificationOpenedHandler() {
+            @Override
+            public void notificationOpened(OSNotificationOpenResult result) {
+                lastActionId = result.action.actionID;
+            }
+        }).init();
+
+        assertEquals(TEST_ACTION_ID, lastActionId);
     }
 
     @Test

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/NotificationOpenedActivityHMSIntegrationTestsRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/NotificationOpenedActivityHMSIntegrationTestsRunner.java
@@ -32,6 +32,9 @@ import org.robolectric.shadows.ShadowLog;
 
 import java.util.UUID;
 
+import static com.onesignal.OneSignalPackagePrivateHelper.NotificationBundleProcessor.PUSH_ADDITIONAL_DATA_KEY;
+import static com.onesignal.OneSignalPackagePrivateHelper.OSNotificationFormatHelper.PAYLOAD_OS_ROOT_CUSTOM;
+import static com.onesignal.OneSignalPackagePrivateHelper.OSNotificationFormatHelper.PAYLOAD_OS_NOTIFICATION_ID;
 import static com.onesignal.OneSignalPackagePrivateHelper.GenerateNotification.BUNDLE_KEY_ACTION_ID;
 import static com.onesignal.InAppMessagingHelpers.ONESIGNAL_APP_ID;
 import static com.test.onesignal.RestClientAsserts.assertNotificationOpenAtIndex;
@@ -57,6 +60,8 @@ import static org.robolectric.Shadows.shadowOf;
 @RunWith(RobolectricTestRunner.class)
 public class NotificationOpenedActivityHMSIntegrationTestsRunner {
 
+    private static final String TEST_ACTION_ID = "myTestActionId";
+
     @BeforeClass // Runs only once, before any tests
     public static void setUpClass() throws Exception {
         ShadowLog.stream = System.out;
@@ -79,19 +84,19 @@ public class NotificationOpenedActivityHMSIntegrationTestsRunner {
     private static @NonNull Intent helper_basicOSHMSOpenIntent() throws JSONException {
         return helper_baseHMSOpenIntent()
                 .putExtra(
-                    "custom",
-                    new JSONObject() {{
-                        put("i", UUID.randomUUID().toString());
-                }}.toString()
+                        PAYLOAD_OS_ROOT_CUSTOM,
+                        new JSONObject() {{
+                            put(PAYLOAD_OS_NOTIFICATION_ID, UUID.randomUUID().toString());
+                        }}.toString()
         );
     }
 
     private static @NonNull Intent helper_basicOSHMSOpenIntentWithActionId(final @NonNull String actionId) throws JSONException {
         return helper_baseHMSOpenIntent()
                 .putExtra(
-                        "custom",
+                        PAYLOAD_OS_ROOT_CUSTOM,
                         new JSONObject() {{
-                            put("i", UUID.randomUUID().toString());
+                            put(PAYLOAD_OS_NOTIFICATION_ID, UUID.randomUUID().toString());
                             put(BUNDLE_KEY_ACTION_ID, actionId);
                         }}.toString()
                 );
@@ -139,7 +144,6 @@ public class NotificationOpenedActivityHMSIntegrationTestsRunner {
         assertNotificationOpenAtIndex(1, UserState.DEVICE_TYPE_HUAWEI);
     }
 
-    private static final String TEST_ACTION_ID = "myTestActionId";
     private static String lastActionId;
     @Test
     public void firesOSNotificationOpenCallbackWithActionId() throws Exception {
@@ -163,10 +167,10 @@ public class NotificationOpenedActivityHMSIntegrationTestsRunner {
 
         Intent intent = helper_baseHMSOpenIntent()
                 .putExtra(
-                        "custom",
+                        PAYLOAD_OS_ROOT_CUSTOM,
                         new JSONObject() {{
-                            put("i", UUID.randomUUID().toString());
-                            put("a", new JSONObject() {{
+                            put(PAYLOAD_OS_NOTIFICATION_ID, UUID.randomUUID().toString());
+                            put(PUSH_ADDITIONAL_DATA_KEY, new JSONObject() {{
                                 put("os_in_app_message_preview_id", "UUID");
                             }});
                         }}.toString()


### PR DESCRIPTION
* Moved most logic into NotificationPayloadProcessorHMS so the Activity
has a single responsibility, to be an entry point only.
* Added HMS action button id formatting logic
* Added new HMS open integration test.
  - It covers testing firing the open callback + actionId is set.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1060)
<!-- Reviewable:end -->
