### PR TITLE
Only attempt to get Google ad_id if using FCM

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -452,7 +452,15 @@ public class OneSignal {
    @Nullable private static OSOutcomeEventsController outcomeEventsController;
    @Nullable private static OSOutcomeEventsFactory outcomeEventsFactory;
 
-   private static AdvertisingIdentifierProvider mainAdIdProvider = new AdvertisingIdProviderGPS();
+   @Nullable private static AdvertisingIdentifierProvider adIdProvider;
+   private static synchronized @Nullable AdvertisingIdentifierProvider getAdIdProvider() {
+      if (adIdProvider == null) {
+         if (OSUtils.isAndroidDeviceType())
+            adIdProvider = new AdvertisingIdProviderGPS();
+      }
+
+      return adIdProvider;
+   }
 
    @SuppressWarnings("WeakerAccess")
    public static String sdkType = "native";
@@ -1342,9 +1350,11 @@ public class OneSignal {
 
       deviceInfo.put("app_id", getSavedAppId());
 
-      String adId = mainAdIdProvider.getIdentifier(appContext);
-      if (adId != null)
-         deviceInfo.put("ad_id", adId);
+      if (getAdIdProvider() != null) {
+         String adId = getAdIdProvider().getIdentifier(appContext);
+         if (adId != null)
+            deviceInfo.put("ad_id", adId);
+      }
       deviceInfo.put("device_os", Build.VERSION.RELEASE);
       deviceInfo.put("timezone", getTimeZoneOffset());
       deviceInfo.put("language", OSUtils.getCorrectedLanguage());

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowAdvertisingIdProviderGPS.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowAdvertisingIdProviderGPS.java
@@ -35,12 +35,19 @@ import org.robolectric.annotation.Implements;
 public class ShadowAdvertisingIdProviderGPS {
    
    private static final String MOCK_ID = "11111111-2222-3333-4444-555555555555";
+
+   public static boolean calledGetIdentifier;
+
+   public static void resetStatics() {
+      calledGetIdentifier = false;
+   }
    
    public static String getLastValue() {
       return MOCK_ID;
    }
    
    public String getIdentifier(Context appContext) {
+      calledGetIdentifier = true;
       return MOCK_ID;
    }
 }

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
@@ -134,6 +134,7 @@ import static com.onesignal.ShadowOneSignalRestClient.REST_METHOD;
 import static com.test.onesignal.GenerateNotificationRunner.getBaseNotifBundle;
 import static com.test.onesignal.RestClientAsserts.assertAmazonPlayerCreateAtIndex;
 import static com.test.onesignal.RestClientAsserts.assertAndroidPlayerCreateAtIndex;
+import static com.test.onesignal.RestClientAsserts.assertHuaweiPlayerCreateAtIndex;
 import static com.test.onesignal.RestClientAsserts.assertOnFocusAtIndex;
 import static com.test.onesignal.RestClientAsserts.assertOnFocusAtIndexDoesNotHaveKeys;
 import static com.test.onesignal.RestClientAsserts.assertOnSessionAtIndex;
@@ -320,6 +321,59 @@ public class MainOneSignalClassRunner {
 
       // 3. Make sure device_type is Amazon (2) in player create
       assertAmazonPlayerCreateAtIndex(1);
+   }
+
+   @Test
+   public void testAmazonDoesNotGetAdId() throws Exception {
+      // 1. Mock Amazon device type for this test
+      ShadowOSUtils.supportsADM = true;
+
+      // 2. Init OneSignal so the app id is cached
+      OneSignalInit();
+      threadAndTaskWait();
+
+      // 3. Make sure device_type is Amazon (2) in player create
+      assertAmazonPlayerCreateAtIndex(1);
+
+      // 4. Assert Player Create does NOT have an ad_id
+      ShadowOneSignalRestClient.Request request = ShadowOneSignalRestClient.requests.get(1);
+      JsonAsserts.doesNotContainKeys(request.payload, new ArrayList<String>() {{ add("ad_id"); }});
+
+      // 5. Assert we did NOT try to get a Google Ad id
+      assertFalse(ShadowAdvertisingIdProviderGPS.calledGetIdentifier);
+   }
+
+   @Test
+   public void testDeviceTypeIsHuawei_forPlayerCreate() throws Exception {
+      // 1. Mock Amazon device type for this test
+      ShadowOSUtils.supportsHMS(true);
+
+      // 2. Init OneSignal so the app id is cached
+      OneSignalInit();
+      threadAndTaskWait();
+
+      // 3. Make sure device_type is Huawei (13) in player create
+      assertHuaweiPlayerCreateAtIndex(1);
+   }
+
+   @Test
+   public void testHuaweiDoesNotGetAdId() throws Exception {
+      // 1. Mock Huawei device type for this test
+      ShadowOSUtils.supportsHMS(true);
+
+      // 2. Init OneSignal so the app id is cached
+      OneSignalInit();
+      threadAndTaskWait();
+
+      // 3. Make sure device_type is Huawei (13) in player create
+      assertHuaweiPlayerCreateAtIndex(1);
+
+      // 4. Assert Player Create does NOT have an ad_id
+      ShadowOneSignalRestClient.Request request = ShadowOneSignalRestClient.requests.get(1);
+      JsonAsserts.doesNotContainKeys(request.payload, new ArrayList<String>() {{ add("ad_id"); }});
+
+      // 5. Assert we did NOT try to get a Google Ad id
+      assertFalse(ShadowAdvertisingIdProviderGPS.calledGetIdentifier);
    }
 
    @Test

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
@@ -3398,7 +3398,8 @@ public class MainOneSignalClassRunner {
       assertEquals(3.3f, ShadowOneSignalRestClient.lastPost.opt("loc_acc"));
 
       assertEquals(false, ShadowOneSignalRestClient.lastPost.opt("loc_bg"));
-      assertEquals("11111111-2222-3333-4444-555555555555", ShadowOneSignalRestClient.lastPost.opt("ad_id"));
+      // Currently not getting ad_id for HMS devices
+      assertNull(ShadowOneSignalRestClient.lastPost.opt("ad_id"));
 
       // Testing loc_bg
       blankActivityController.pause();
@@ -3412,7 +3413,8 @@ public class MainOneSignalClassRunner {
       assertEquals(3.3f, ShadowOneSignalRestClient.lastPost.opt("loc_acc"));
       assertEquals(true, ShadowOneSignalRestClient.lastPost.opt("loc_bg"));
       assertEquals(1, ShadowOneSignalRestClient.lastPost.optInt("loc_type"));
-      assertEquals("11111111-2222-3333-4444-555555555555", ShadowOneSignalRestClient.lastPost.opt("ad_id"));
+      // Currently not getting ad_id for HMS devices
+      assertNull(ShadowOneSignalRestClient.lastPost.opt("ad_id"));
    }
 
    @Test

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/TestHelpers.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/TestHelpers.java
@@ -17,6 +17,7 @@ import com.onesignal.OneSignalPackagePrivateHelper.OSTestInAppMessage;
 import com.onesignal.OneSignalPackagePrivateHelper.TestOneSignalPrefs;
 import com.onesignal.OneSignalShadowPackageManager;
 import com.onesignal.OutcomeEvent;
+import com.onesignal.ShadowAdvertisingIdProviderGPS;
 import com.onesignal.ShadowCustomTabsClient;
 import com.onesignal.ShadowDynamicTimer;
 import com.onesignal.ShadowFirebaseAnalytics;
@@ -82,6 +83,7 @@ public class TestHelpers {
       ShadowPushRegistratorADM.resetStatics();
       ShadowHmsInstanceId.resetStatics();
       ShadowPushRegistratorHMS.resetStatics();
+      ShadowAdvertisingIdProviderGPS.resetStatics();
 
       ShadowNotificationManagerCompat.enabled = true;
 


### PR DESCRIPTION
* This cleans up the "Error getting Google Ad id"  on HMS only devices

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1061)
<!-- Reviewable:end -->
