### PR TITLE
Hms device type fallback logic

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSUtils.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSUtils.java
@@ -152,7 +152,7 @@ class OSUtils {
       }
    }
 
-   private boolean hasHMSAvailability() {
+   private static boolean hasHMSAvailabilityLibrary() {
       try {
          // noinspection ConstantConditions
          return com.huawei.hms.api.HuaweiApiAvailability.class != null;
@@ -161,13 +161,28 @@ class OSUtils {
       }
    }
 
-   private boolean hasHMSPushKitLibrary() {
+   private static boolean hasHMSPushKitLibrary() {
       try {
          // noinspection ConstantConditions
          return com.huawei.hms.aaid.HmsInstanceId.class != null;
       } catch (Throwable e) {
          return false;
       }
+   }
+
+   private static boolean hasHMSAGConnectLibrary() {
+      try {
+         // noinspection ConstantConditions
+         return com.huawei.agconnect.config.AGConnectServicesConfig.class != null;
+      } catch (Throwable e) {
+         return false;
+      }
+   }
+
+   static boolean hasAllHMSLibrariesForPushKit() {
+      // NOTE: hasHMSAvailabilityLibrary technically is not required,
+      //   just used as recommend way to detect if "HMS Core" app exists and is enabled
+      return hasHMSAGConnectLibrary() && hasHMSPushKitLibrary();
    }
 
    Integer checkForGooglePushLibrary() {
@@ -286,8 +301,8 @@ class OSUtils {
    }
 
    private boolean supportsHMS() {
-      // 1. App must have the HMSAvailability and PushKit libraries to support HMS push
-      if (!hasHMSAvailability() || !hasHMSPushKitLibrary())
+      // 1. App should have the HMSAvailability for best detection and must have PushKit libraries
+      if (!hasHMSAvailabilityLibrary() || !hasAllHMSLibrariesForPushKit())
          return false;
 
       // 2. Device must have HMS Core installed and enabled

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSUtils.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSUtils.java
@@ -156,7 +156,7 @@ class OSUtils {
       try {
          // noinspection ConstantConditions
          return com.huawei.hms.api.HuaweiApiAvailability.class != null;
-      } catch (Throwable e) {
+      } catch (Exception e) {
          return false;
       }
    }
@@ -165,7 +165,7 @@ class OSUtils {
       try {
          // noinspection ConstantConditions
          return com.huawei.hms.aaid.HmsInstanceId.class != null;
-      } catch (Throwable e) {
+      } catch (Exception e) {
          return false;
       }
    }
@@ -174,7 +174,7 @@ class OSUtils {
       try {
          // noinspection ConstantConditions
          return com.huawei.agconnect.config.AGConnectServicesConfig.class != null;
-      } catch (Throwable e) {
+      } catch (Exception e) {
          return false;
       }
    }
@@ -344,7 +344,6 @@ class OSUtils {
       // Start - Fallback logic
       //    Libraries in the app (Google:FCM, HMS:PushKit) + Device may not have a valid combo
       // Example: App with only the FCM library in it and a Huawei device with only HMS Core
-
       if (isGMSInstalledAndEnabled())
          return UserState.DEVICE_TYPE_ANDROID;
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/PushRegistratorHMS.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/PushRegistratorHMS.java
@@ -53,7 +53,7 @@ class PushRegistratorHMS implements PushRegistrator {
     }
 
     private synchronized void getHMSTokenTask(@NonNull Context context, @NonNull RegisteredHandler callback) throws ApiException {
-        // If here is required to prevent AGConnectServicesConfig or HmsInstanceId used below
+        // Check required to prevent AGConnectServicesConfig or HmsInstanceId used below
         //   from throwing a ClassNotFoundException
         if (!OSUtils.hasAllHMSLibrariesForPushKit()) {
             callback.complete(null, UserState.PUSH_STATUS_MISSING_HMS_PUSHKIT_LIBRARY);

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/PushRegistratorHMS.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/PushRegistratorHMS.java
@@ -53,8 +53,12 @@ class PushRegistratorHMS implements PushRegistrator {
     }
 
     private synchronized void getHMSTokenTask(@NonNull Context context, @NonNull RegisteredHandler callback) throws ApiException {
-        // TODO: See if we can handle an exact message like this
-        // 2020-04-14 23:06:36.164 1565-1743/com.onesignal.example E/HMSSDK_Util: In getMetaDataAppId, Failed to read meta data for the AppID.
+        // If here is required to prevent AGConnectServicesConfig or HmsInstanceId used below
+        //   from throwing a ClassNotFoundException
+        if (!OSUtils.hasAllHMSLibrariesForPushKit()) {
+            callback.complete(null, UserState.PUSH_STATUS_MISSING_HMS_PUSHKIT_LIBRARY);
+            return;
+        }
 
         String appId = AGConnectServicesConfig.fromContext(context).getString(HMS_CLIENT_APP_ID);
         HmsInstanceId hmsInstanceId = HmsInstanceId.getInstance(context);

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserState.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserState.java
@@ -34,6 +34,7 @@ abstract class UserState {
     // Check that there is "apply plugin: 'com.huawei.agconnect'" in your app/build.gradle
     public static final int PUSH_STATUS_HMS_ARGUMENTS_INVALID = -26;
     public static final int PUSH_STATUS_HMS_API_EXCEPTION_OTHER = -27;
+    public static final int PUSH_STATUS_MISSING_HMS_PUSHKIT_LIBRARY = -28;
 
     private static final String[] LOCATION_FIELDS = new String[] { "lat", "long", "loc_acc", "loc_type", "loc_bg", "loc_time_stamp", "ad_id"};
     private static final Set<String> LOCATION_FIELDS_SET = new HashSet<>(Arrays.asList(LOCATION_FIELDS));

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowOSUtils.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowOSUtils.java
@@ -32,13 +32,18 @@ public class ShadowOSUtils {
 
    // Huawei: HMS
    public static boolean hasHMSAvailability;
-   public boolean hasHMSAvailability() {
+   public static boolean hasHMSAvailability() {
       return hasHMSAvailability;
    }
    public static boolean hasHMSPushKitLibrary;
-   public boolean hasHMSPushKitLibrary() {
+   public static boolean hasHMSPushKitLibrary() {
       return hasHMSPushKitLibrary;
    }
+   public static boolean hasHMSAGConnectLibrary;
+   public static boolean hasHMSAGConnectLibrary() {
+      return hasHMSAGConnectLibrary;
+   }
+
    public static boolean isHMSCoreInstalledAndEnabled;
    public static boolean isHMSCoreInstalledAndEnabled() {
       return isHMSCoreInstalledAndEnabled;
@@ -47,9 +52,16 @@ public class ShadowOSUtils {
       return isHMSCoreInstalledAndEnabled;
    }
 
+   public static void hasAllRecommendHMSLibraries(boolean value) {
+      // required
+      hasHMSPushKitLibrary = value;
+      hasHMSAGConnectLibrary = value;
+      // recommend
+      hasHMSAvailability = value;
+   }
+
    public static void supportsHMS(boolean value) {
-      hasHMSPushKitLibrary = true;
-      hasHMSAvailability = true;
+      hasAllRecommendHMSLibraries(value);
       isHMSCoreInstalledAndEnabled = true;
    }
 
@@ -66,6 +78,7 @@ public class ShadowOSUtils {
       isGMSInstalledAndEnabled = false;
       hasHMSAvailability = false;
       hasHMSPushKitLibrary = false;
+      hasHMSAGConnectLibrary = false;
       isHMSCoreInstalledAndEnabled = false;
 
    }

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowOSUtils.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowOSUtils.java
@@ -43,6 +43,9 @@ public class ShadowOSUtils {
    public static boolean isHMSCoreInstalledAndEnabled() {
       return isHMSCoreInstalledAndEnabled;
    }
+   public static boolean isHMSCoreInstalledAndEnabledFallback() {
+      return isHMSCoreInstalledAndEnabled;
+   }
 
    public static void supportsHMS(boolean value) {
       hasHMSPushKitLibrary = true;

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowOSUtils.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowOSUtils.java
@@ -21,10 +21,12 @@ public class ShadowOSUtils {
    boolean hasFCMLibrary() {
       return hasFCMLibrary;
    }
+
    public static boolean hasGCMLibrary;
    public static boolean hasGCMLibrary() {
       return hasGCMLibrary;
    }
+
    public static boolean isGMSInstalledAndEnabled;
    public static boolean isGMSInstalledAndEnabled() {
       return isGMSInstalledAndEnabled;
@@ -35,10 +37,12 @@ public class ShadowOSUtils {
    public static boolean hasHMSAvailability() {
       return hasHMSAvailability;
    }
+
    public static boolean hasHMSPushKitLibrary;
    public static boolean hasHMSPushKitLibrary() {
       return hasHMSPushKitLibrary;
    }
+
    public static boolean hasHMSAGConnectLibrary;
    public static boolean hasHMSAGConnectLibrary() {
       return hasHMSAGConnectLibrary;
@@ -48,20 +52,21 @@ public class ShadowOSUtils {
    public static boolean isHMSCoreInstalledAndEnabled() {
       return isHMSCoreInstalledAndEnabled;
    }
+
    public static boolean isHMSCoreInstalledAndEnabledFallback() {
       return isHMSCoreInstalledAndEnabled;
    }
 
-   public static void hasAllRecommendHMSLibraries(boolean value) {
+   public static void hasAllRecommendedHMSLibraries(boolean value) {
       // required
       hasHMSPushKitLibrary = value;
       hasHMSAGConnectLibrary = value;
-      // recommend
+      // recommended
       hasHMSAvailability = value;
    }
 
    public static void supportsHMS(boolean value) {
-      hasAllRecommendHMSLibraries(value);
+      hasAllRecommendedHMSLibraries(value);
       isHMSCoreInstalledAndEnabled = true;
    }
 

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/DeviceTypeTestsRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/DeviceTypeTestsRunner.java
@@ -83,7 +83,7 @@ public class DeviceTypeTestsRunner {
     @Test
     public void supportedHMS_isHuawei() {
         ShadowOSUtils.isHMSCoreInstalledAndEnabled = true;
-        ShadowOSUtils.hasAllRecommendHMSLibraries(true);
+        ShadowOSUtils.hasAllRecommendedHMSLibraries(true);
 
         assertEquals(DEVICE_TYPE_HUAWEI, getDeviceType());
     }
@@ -94,7 +94,7 @@ public class DeviceTypeTestsRunner {
         ShadowOSUtils.hasFCMLibrary = true;
 
         ShadowOSUtils.isHMSCoreInstalledAndEnabled = true;
-        ShadowOSUtils.hasAllRecommendHMSLibraries(true);
+        ShadowOSUtils.hasAllRecommendedHMSLibraries(true);
 
         // Prefer Google Services over Huawei if both available
         assertEquals(DEVICE_TYPE_ANDROID, getDeviceType());
@@ -106,7 +106,7 @@ public class DeviceTypeTestsRunner {
         ShadowOSUtils.hasFCMLibrary = true;
 
         ShadowOSUtils.isHMSCoreInstalledAndEnabled = true;
-        ShadowOSUtils.hasAllRecommendHMSLibraries(true);
+        ShadowOSUtils.hasAllRecommendedHMSLibraries(true);
 
         // Use HMS since device does not have the "Google Play services" app or it is disabled
         assertEquals(DEVICE_TYPE_HUAWEI, getDeviceType());

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/DeviceTypeTestsRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/DeviceTypeTestsRunner.java
@@ -116,6 +116,18 @@ public class DeviceTypeTestsRunner {
     }
 
     @Test
+    public void noPushSDKsAndOnlyHMSCoreInstalled_isHuawei() {
+        ShadowOSUtils.isHMSCoreInstalledAndEnabled = true;
+        assertEquals(DEVICE_TYPE_HUAWEI, getDeviceType());
+    }
+
+    @Test
+    public void noPushSDKsAndOnlyGoogleServicesInstalled_isAndroid() {
+        ShadowOSUtils.isGMSInstalledAndEnabled = true;
+        assertEquals(DEVICE_TYPE_ANDROID, getDeviceType());
+    }
+
+    @Test
     public void supportsFCMAndADM_PreferADM() {
         ShadowOSUtils.isGMSInstalledAndEnabled = true;
         ShadowOSUtils.hasFCMLibrary = true;

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/DeviceTypeTestsRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/DeviceTypeTestsRunner.java
@@ -83,8 +83,7 @@ public class DeviceTypeTestsRunner {
     @Test
     public void supportedHMS_isHuawei() {
         ShadowOSUtils.isHMSCoreInstalledAndEnabled = true;
-        ShadowOSUtils.hasHMSAvailability = true;
-        ShadowOSUtils.hasHMSPushKitLibrary = true;
+        ShadowOSUtils.hasAllRecommendHMSLibraries(true);
 
         assertEquals(DEVICE_TYPE_HUAWEI, getDeviceType());
     }
@@ -95,8 +94,7 @@ public class DeviceTypeTestsRunner {
         ShadowOSUtils.hasFCMLibrary = true;
 
         ShadowOSUtils.isHMSCoreInstalledAndEnabled = true;
-        ShadowOSUtils.hasHMSAvailability = true;
-        ShadowOSUtils.hasHMSPushKitLibrary = true;
+        ShadowOSUtils.hasAllRecommendHMSLibraries(true);
 
         // Prefer Google Services over Huawei if both available
         assertEquals(DEVICE_TYPE_ANDROID, getDeviceType());
@@ -108,8 +106,7 @@ public class DeviceTypeTestsRunner {
         ShadowOSUtils.hasFCMLibrary = true;
 
         ShadowOSUtils.isHMSCoreInstalledAndEnabled = true;
-        ShadowOSUtils.hasHMSAvailability = true;
-        ShadowOSUtils.hasHMSPushKitLibrary = true;
+        ShadowOSUtils.hasAllRecommendHMSLibraries(true);
 
         // Use HMS since device does not have the "Google Play services" app or it is disabled
         assertEquals(DEVICE_TYPE_HUAWEI, getDeviceType());


### PR DESCRIPTION
### Fallback detection for Huawei device if no HMS SDK
We should still detect a real Huawei with HMS only as device_type 13 even if there is no HMS library in the app.

### Added missing HMS PushKit library detection
Now correctly reports missing HMS PushKit library if app is running on an HMS only device.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1063)
<!-- Reviewable:end -->
