### PR TITLE
Hms consumer proguard rules

### DIFF
--- a/OneSignalSDK/onesignal/consumer-proguard-rules.pro
+++ b/OneSignalSDK/onesignal/consumer-proguard-rules.pro
@@ -50,6 +50,8 @@
 
 -dontwarn com.amazon.**
 
+-dontwarn com.huawei.**
+
 # Proguard ends up removing this class even if it is used in AndroidManifest.xml so force keeping it.
 -keep public class com.onesignal.ADMMessageHandler {*;}
 


### PR DESCRIPTION
Added `dontwarn` for `com.huawei.**`

* This is to avoid any progaurd build errors / warns not finding these
classes when HMS libraries are not used in an app with proguard / R8.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1064)
<!-- Reviewable:end -->
