### PR TITLE
HmsMessageService.onMessageReceived displaying

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/GcmBroadcastReceiver.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/GcmBroadcastReceiver.java
@@ -131,7 +131,7 @@ public class GcmBroadcastReceiver extends WakefulBroadcastReceiver {
       return processedResult;
    }
 
-   private static void startGCMService(Context context, Bundle bundle) {
+   static void startGCMService(Context context, Bundle bundle) {
       // If no remote resources have to be downloaded don't create a job which could add some delay.
       if (!NotificationBundleProcessor.hasRemoteResource(bundle)) {
          BundleCompat taskExtras = setCompatBundleForServer(bundle, BundleCompatFactory.getInstance());

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/HmsMessageServiceOneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/HmsMessageServiceOneSignal.java
@@ -1,6 +1,7 @@
 package com.onesignal;
 
 import com.huawei.hms.push.HmsMessageService;
+import com.huawei.hms.push.RemoteMessage;
 
 public class HmsMessageServiceOneSignal extends HmsMessageService {
 
@@ -16,4 +17,17 @@ public class HmsMessageServiceOneSignal extends HmsMessageService {
         PushRegistratorHMS.fireCallback(token);
     }
 
+    /**
+     * This method is called in the following cases:
+     *   1. "Data messages" - App process is alive when received.
+     *   2. "Notification Message" - foreground_show = false and app is in focus
+     * This method callback must be completed in 10 seconds, start a new Job if more time is needed.
+     *   - This may only be a restriction for #1
+     *   - 10 sec limit didn't seem to hit for #2, even when backgrounding the app after the method starts
+     * @param message RemoteMessage
+     */
+    @Override
+    public void onMessageReceived(RemoteMessage message) {
+        NotificationPayloadProcessorHMS.processDataMessageReceived(this, message.getData());
+    }
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationPayloadProcessorHMS.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationPayloadProcessorHMS.java
@@ -1,6 +1,7 @@
 package com.onesignal;
 
 import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
@@ -70,5 +71,21 @@ class NotificationPayloadProcessorHMS {
             false,
             OSNotificationFormatHelper.getOSNotificationIdFromJson(jsonData)
         );
+    }
+
+    static void processDataMessageReceived(@NonNull Context context, @NonNull String data) {
+        OneSignal.setAppContext(context);
+        Bundle bundle = OSUtils.jsonStringToBundle(data);
+        if (bundle == null)
+            return;
+
+        NotificationBundleProcessor.ProcessedBundleResult processedResult = NotificationBundleProcessor.processBundleFromReceiver(context, bundle);
+
+        // Return if the notification will NOT be handled by normal GcmIntentService display flow.
+        if (processedResult.processed())
+            return;
+
+        // TODO: 4.0.0 or after - What is in GcmBroadcastReceiver should be split into a shared class to support FCM, HMS, and ADM
+        GcmBroadcastReceiver.startGCMService(context, bundle);
     }
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationPayloadProcessorHMS.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationPayloadProcessorHMS.java
@@ -73,8 +73,11 @@ class NotificationPayloadProcessorHMS {
         );
     }
 
-    static void processDataMessageReceived(@NonNull Context context, @NonNull String data) {
+    public static void processDataMessageReceived(@NonNull Context context, @Nullable String data) {
         OneSignal.setAppContext(context);
+        if (data == null)
+            return;
+
         Bundle bundle = OSUtils.jsonStringToBundle(data);
         if (bundle == null)
             return;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSUtils.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSUtils.java
@@ -59,6 +59,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Locale;
 import java.util.Set;
 import java.util.UUID;
@@ -631,6 +632,23 @@ class OSUtils {
             result.add((String) value);
       }
       return result;
+   }
+
+   static @Nullable Bundle jsonStringToBundle(@NonNull String data) {
+      try {
+         JSONObject jsonObject = new JSONObject(data);
+         Bundle bundle = new Bundle();
+         Iterator iterator = jsonObject.keys();
+         while (iterator.hasNext()) {
+            String key = (String)iterator.next();
+            String value = jsonObject.getString(key);
+            bundle.putString(key, value);
+         }
+         return bundle;
+      } catch (JSONException e) {
+         e.printStackTrace();
+         return null;
+      }
    }
 
    static boolean shouldLogMissingAppIdError(@Nullable String appId) {

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
@@ -532,4 +532,6 @@ public class OneSignalPackagePrivateHelper {
    public static class NotificationBundleProcessor extends com.onesignal.NotificationBundleProcessor {}
 
    public static class OSNotificationFormatHelper extends com.onesignal.OSNotificationFormatHelper {}
+
+   public static class NotificationPayloadProcessorHMS extends com.onesignal.NotificationPayloadProcessorHMS {}
 }

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/HMSDataMessageReceivedIntegrationTestsRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/HMSDataMessageReceivedIntegrationTestsRunner.java
@@ -1,0 +1,95 @@
+package com.test.onesignal;
+
+import android.annotation.SuppressLint;
+import android.app.Activity;
+
+import com.onesignal.OneSignalPackagePrivateHelper.NotificationPayloadProcessorHMS;
+import com.onesignal.ShadowNotificationManagerCompat;
+import com.onesignal.ShadowOSUtils;
+import com.onesignal.ShadowRoboNotificationManager;
+import com.onesignal.StaticResetHelper;
+import com.onesignal.example.BlankActivity;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.android.controller.ActivityController;
+import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowLog;
+
+import java.util.UUID;
+
+import static com.onesignal.OneSignalPackagePrivateHelper.OSNotificationFormatHelper.PAYLOAD_OS_NOTIFICATION_ID;
+import static com.onesignal.OneSignalPackagePrivateHelper.OSNotificationFormatHelper.PAYLOAD_OS_ROOT_CUSTOM;
+import static junit.framework.Assert.assertEquals;
+
+@Config(
+    // NOTE: We can remove "instrumentedPackages" if we make ShadowRoboNotificationManager's constructor public
+    instrumentedPackages = { "com.onesignal" },
+    packageName = "com.onesignal.example",
+    shadows = {
+        ShadowRoboNotificationManager.class,
+        ShadowNotificationManagerCompat.class
+    },
+    sdk = 26
+)
+@RunWith(RobolectricTestRunner.class)
+public class HMSDataMessageReceivedIntegrationTestsRunner {
+    @SuppressLint("StaticFieldLeak")
+    private static Activity blankActivity;
+    private static ActivityController<BlankActivity> blankActivityController;
+
+    private static final String ALERT_TEST_MESSAGE_BODY = "Test Message body";
+
+    @BeforeClass // Runs only once, before any tests
+    public static void setUpClass() throws Exception {
+        ShadowLog.stream = System.out;
+        TestHelpers.beforeTestSuite();
+        StaticResetHelper.saveStaticValues();
+    }
+
+    @Before
+    public void beforeEachTest() throws Exception {
+        TestHelpers.beforeTestInitAndCleanup();
+
+        ShadowOSUtils.supportsHMS(true);
+
+        blankActivityController = Robolectric.buildActivity(BlankActivity.class).create();
+        blankActivity = blankActivityController.get();
+    }
+
+    private static @NonNull String helperBasicOSPayload() throws JSONException {
+        return new JSONObject() {{
+            put(PAYLOAD_OS_ROOT_CUSTOM, new JSONObject() {{
+                put(PAYLOAD_OS_NOTIFICATION_ID, UUID.randomUUID().toString());
+            }});
+            put("alert", ALERT_TEST_MESSAGE_BODY);
+        }}.toString();
+    }
+
+    @Test
+    public void nullData_shouldNotThrow() {
+        NotificationPayloadProcessorHMS.processDataMessageReceived(blankActivity, null);
+    }
+
+    @Test
+    public void blankData_shouldNotThrow() {
+        NotificationPayloadProcessorHMS.processDataMessageReceived(blankActivity, "");
+    }
+
+    @Test
+    public void basicPayload_shouldDisplayNotification() throws JSONException {
+        blankActivityController.pause();
+        NotificationPayloadProcessorHMS.processDataMessageReceived(blankActivity, helperBasicOSPayload());
+        assertEquals(ALERT_TEST_MESSAGE_BODY, ShadowRoboNotificationManager.getLastShadowNotif().getBigText());
+    }
+
+    // NOTE: More tests can be added but they would be duplicated with GenerateNotificationRunner
+    //       In 4.0.0 or later these should be written in a reusable way between HMS, FCM, and ADM
+}


### PR DESCRIPTION
## TODO
Need integration tests yet.

## Changes
* Now if an HMS "Data Message" is received in the OneSignal format it
will be processed through the normal flow like GCM / FCM messages do.
   -  All features we support for FCM Android notificatons now apply to
         these types.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1070)
<!-- Reviewable:end -->
