### PR TITLE
Moved event logic into OneSignalHmsEventBridge

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/HmsMessageServiceOneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/HmsMessageServiceOneSignal.java
@@ -3,6 +3,21 @@ package com.onesignal;
 import com.huawei.hms.push.HmsMessageService;
 import com.huawei.hms.push.RemoteMessage;
 
+/**
+ * The hms:push library creates an instance of this service based on the
+ * intent-filter action "com.huawei.push.action.MESSAGING_EVENT".
+ *
+ * WARNING: HMS only creates one {@link HmsMessageService} instance.
+ * This means this class will not be used by the app in the following cases:
+ *    1. Another push provider library / SDK is in the app.
+ *       - Due to ordering in the AndroidManifest.xml OneSignal may or may not be the winner.
+ *       - App needs to it's own {@link HmsMessageService} and call bridging / forwarding APIs
+ *         on each SDK / library for both to work.
+ *    2. The app has it's own  {@link HmsMessageService} class.
+ * If either of these are true the app must have it's own {@link HmsMessageService} with AndroidManifest.xml
+ * entries and call {@link OneSignalHmsEventBridge} for these methods. This is noted in the OneSignal SDK
+ * Huawei setup guide.
+ */
 public class HmsMessageServiceOneSignal extends HmsMessageService {
 
     /**
@@ -13,8 +28,7 @@ public class HmsMessageServiceOneSignal extends HmsMessageService {
      */
     @Override
     public void onNewToken(String token) {
-        OneSignal.Log(OneSignal.LOG_LEVEL.INFO, "HmsMessageServiceOneSignal.onNewToken - HMS token: " + token);
-        PushRegistratorHMS.fireCallback(token);
+        OneSignalHmsEventBridge.onNewToken(this, token);
     }
 
     /**
@@ -28,6 +42,6 @@ public class HmsMessageServiceOneSignal extends HmsMessageService {
      */
     @Override
     public void onMessageReceived(RemoteMessage message) {
-        NotificationPayloadProcessorHMS.processDataMessageReceived(this, message.getData());
+        OneSignalHmsEventBridge.onMessageReceived(this, message);
     }
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalHmsEventBridge.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalHmsEventBridge.java
@@ -1,0 +1,26 @@
+package com.onesignal;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+
+import com.huawei.hms.push.RemoteMessage;
+
+/**
+ * If you have your own {@link com.huawei.hms.push.HmsMessageService} defined in your app please also
+ * call {@link OneSignalHmsEventBridge#onNewToken} and {@link OneSignalHmsEventBridge#onMessageReceived}
+ * as this is required for some OneSignal features.
+ * If you don't have a class that extends from {@link com.huawei.hms.push.HmsMessageService}
+ * or anther SDK / Library that handles HMS push then you don't need to use this class.
+ * OneSignal automatically gets these events.
+ */
+public class OneSignalHmsEventBridge {
+
+    public static void onNewToken(@NonNull Context context, @NonNull String token) {
+        OneSignal.Log(OneSignal.LOG_LEVEL.INFO, "HmsMessageServiceOneSignal.onNewToken - HMS token: " + token);
+        PushRegistratorHMS.fireCallback(token);
+    }
+
+    public static void onMessageReceived(@NonNull Context context, @NonNull RemoteMessage message) {
+        NotificationPayloadProcessorHMS.processDataMessageReceived(context, message.getData());
+    }
+}


### PR DESCRIPTION
* Moved logic from HmsMessageServiceOneSignal into to a new
OneSignalHmsEventBridge class.
* OneSignalHmsEventBridge need to be called if by the app if:
   1. Another push provider library / SDK is in the app.
   2. The app has it's own HmsMessageService class.
* This is required as HMS only creates one HmsMessageService instance.
* See comemnts in this commit for even more details.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1077)
<!-- Reviewable:end -->
