### PR TITLE
Adding testing and runtime dependencies for androidx.work

### DIFF
--- a/OneSignalSDK/onesignal/build.gradle
+++ b/OneSignalSDK/onesignal/build.gradle
@@ -54,6 +54,7 @@ dependencies {
     api 'androidx.legacy:legacy-support-v4:[1.0.0, 1.99.99]'
     api 'androidx.browser:browser:[1.0.0, 1.99.99]'
     api 'androidx.appcompat:appcompat:[1.0.0, 1.99.99]'
+    api 'androidx.work:work-runtime:[2.0.0, 2.99.99]'
 }
 
 apply from: 'maven-push.gradle'

--- a/OneSignalSDK/unittest/build.gradle
+++ b/OneSignalSDK/unittest/build.gradle
@@ -50,6 +50,8 @@ dependencies {
     implementation 'com.huawei.hms:location:4.0.0.300'
 
     testImplementation 'junit:junit:4.12'
+    testImplementation 'androidx.test:core:1.2.0'
+    testImplementation 'androidx.work:work-testing:2.3.4'
     testImplementation 'org.robolectric:robolectric:4.3.1'
     testImplementation 'org.awaitility:awaitility:3.1.5'
 }

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/DatabaseRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/DatabaseRunner.java
@@ -4,6 +4,8 @@ import android.content.ContentValues;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 
+import androidx.test.core.app.ApplicationProvider;
+
 import com.onesignal.InAppMessagingHelpers;
 import com.onesignal.MockOneSignalDBHelper;
 import com.onesignal.OneSignalPackagePrivateHelper;
@@ -30,7 +32,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowLog;
 
@@ -79,7 +80,7 @@ public class DatabaseRunner {
         TestHelpers.beforeTestInitAndCleanup();
 
         outcomeTableProvider = new OSOutcomeTableProvider();
-        dbHelper = new MockOneSignalDBHelper(RuntimeEnvironment.application);
+        dbHelper = new MockOneSignalDBHelper(ApplicationProvider.getApplicationContext());
     }
 
     @After

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/DeviceTypeTestsRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/DeviceTypeTestsRunner.java
@@ -1,5 +1,7 @@
 package com.test.onesignal;
 
+import androidx.test.core.app.ApplicationProvider;
+
 import com.onesignal.OneSignal;
 import com.onesignal.ShadowOSUtils;
 import com.onesignal.StaticResetHelper;
@@ -9,15 +11,13 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowLog;
 
 import static com.onesignal.OneSignalPackagePrivateHelper.UserState.DEVICE_TYPE_ANDROID;
-import static com.onesignal.OneSignalPackagePrivateHelper.UserState.DEVICE_TYPE_HUAWEI;
 import static com.onesignal.OneSignalPackagePrivateHelper.UserState.DEVICE_TYPE_FIREOS;
+import static com.onesignal.OneSignalPackagePrivateHelper.UserState.DEVICE_TYPE_HUAWEI;
 import static com.onesignal.OneSignalPackagePrivateHelper.getDeviceType;
-
 import static org.junit.Assert.assertEquals;
 
 @Config(
@@ -40,7 +40,7 @@ public class DeviceTypeTestsRunner {
     @Before
     public void beforeEachTest() throws Exception {
         TestHelpers.beforeTestInitAndCleanup();
-        OneSignal.setAppContext(RuntimeEnvironment.application);
+        OneSignal.setAppContext(ApplicationProvider.getApplicationContext());
     }
 
     @Test

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
@@ -43,10 +43,12 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.SystemClock;
+import android.widget.Button;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.app.NotificationCompat;
-import android.widget.Button;
+import androidx.test.core.app.ApplicationProvider;
 
 import com.onesignal.BundleCompat;
 import com.onesignal.FCMBroadcastReceiver;
@@ -90,7 +92,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.RuntimeEnvironment;
 import org.robolectric.Shadows;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.android.controller.ServiceController;
@@ -110,8 +111,6 @@ import static com.onesignal.OneSignalPackagePrivateHelper.GenerateNotification.B
 import static com.onesignal.OneSignalPackagePrivateHelper.NotificationBundleProcessor.PUSH_MINIFIED_BUTTONS_LIST;
 import static com.onesignal.OneSignalPackagePrivateHelper.NotificationBundleProcessor.PUSH_MINIFIED_BUTTON_ID;
 import static com.onesignal.OneSignalPackagePrivateHelper.NotificationBundleProcessor.PUSH_MINIFIED_BUTTON_TEXT;
-import static com.onesignal.OneSignalPackagePrivateHelper.GenerateNotification.BUNDLE_KEY_ACTION_ID;
-import static com.onesignal.OneSignalPackagePrivateHelper.GenerateNotification.BUNDLE_KEY_ANDROID_NOTIFICATION_ID;
 import static com.onesignal.OneSignalPackagePrivateHelper.NotificationBundleProcessor_ProcessFromFCMIntentService;
 import static com.onesignal.OneSignalPackagePrivateHelper.NotificationBundleProcessor_ProcessFromFCMIntentService_NoWrap;
 import static com.onesignal.OneSignalPackagePrivateHelper.NotificationOpenedProcessor_processFromContext;
@@ -168,7 +167,7 @@ public class GenerateNotificationRunner {
       blankActivityController = Robolectric.buildActivity(BlankActivity.class).create();
       blankActivity = blankActivityController.get();
       blankActivity.getApplicationInfo().name = "UnitTestApp";
-      dbHelper = new MockOneSignalDBHelper(RuntimeEnvironment.application);
+      dbHelper = new MockOneSignalDBHelper(ApplicationProvider.getApplicationContext());
 
       overrideNotificationId = -1;
       
@@ -1368,7 +1367,7 @@ public class GenerateNotificationRunner {
    private NotificationExtenderServiceTestBase startNotificationExtender(BundleCompat bundlePayload, Class serviceClass) {
       ServiceController<NotificationExtenderServiceTestBase> controller = Robolectric.buildService(serviceClass);
       NotificationExtenderServiceTestBase service = controller.create().get();
-      Intent testIntent = new Intent(RuntimeEnvironment.application, NotificationExtenderServiceTestReturnFalse.class);
+      Intent testIntent = new Intent(ApplicationProvider.getApplicationContext(), NotificationExtenderServiceTestReturnFalse.class);
       testIntent.putExtras((Bundle)bundlePayload.getBundle());
       controller.withIntent(testIntent).startCommand(0, 0);
 

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/InAppMessageIntegrationTests.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/InAppMessageIntegrationTests.java
@@ -3,6 +3,8 @@ package com.test.onesignal;
 import android.annotation.SuppressLint;
 import android.app.Activity;
 
+import androidx.test.core.app.ApplicationProvider;
+
 import com.onesignal.InAppMessagingHelpers;
 import com.onesignal.MockOSLog;
 import com.onesignal.MockOSSharedPreferences;
@@ -18,8 +20,8 @@ import com.onesignal.ShadowAdvertisingIdProviderGPS;
 import com.onesignal.ShadowCustomTabsClient;
 import com.onesignal.ShadowCustomTabsSession;
 import com.onesignal.ShadowDynamicTimer;
-import com.onesignal.ShadowJobService;
 import com.onesignal.ShadowGMSLocationController;
+import com.onesignal.ShadowJobService;
 import com.onesignal.ShadowNotificationManagerCompat;
 import com.onesignal.ShadowOSUtils;
 import com.onesignal.ShadowOSViewUtils;
@@ -43,7 +45,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.RuntimeEnvironment;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowLog;
@@ -131,7 +132,7 @@ public class InAppMessageIntegrationTests {
         sessionManager = new MockSessionManager(OneSignal_getSessionListener(), trackerFactory, new MockOSLog());
         blankActivityController = Robolectric.buildActivity(BlankActivity.class).create();
         blankActivity = blankActivityController.get();
-        dbHelper = new MockOneSignalDBHelper(RuntimeEnvironment.application);
+        dbHelper = new MockOneSignalDBHelper(ApplicationProvider.getApplicationContext());
         TestHelpers.beforeTestInitAndCleanup();
     }
 

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
@@ -41,6 +41,8 @@ import android.location.Location;
 import android.net.ConnectivityManager;
 import android.os.Bundle;
 
+import androidx.test.core.app.ApplicationProvider;
+
 import com.huawei.hms.location.HWLocation;
 import com.onesignal.MockOSLog;
 import com.onesignal.MockOSSharedPreferences;
@@ -70,15 +72,15 @@ import com.onesignal.ShadowCustomTabsClient;
 import com.onesignal.ShadowCustomTabsSession;
 import com.onesignal.ShadowFirebaseAnalytics;
 import com.onesignal.ShadowFusedLocationApiWrapper;
-import com.onesignal.ShadowHMSFusedLocationProviderClient;
+import com.onesignal.ShadowGMSLocationController;
+import com.onesignal.ShadowGMSLocationUpdateListener;
 import com.onesignal.ShadowGoogleApiClientBuilder;
 import com.onesignal.ShadowGoogleApiClientCompatProxy;
+import com.onesignal.ShadowHMSFusedLocationProviderClient;
 import com.onesignal.ShadowHMSLocationUpdateListener;
 import com.onesignal.ShadowHmsInstanceId;
 import com.onesignal.ShadowHuaweiTask;
 import com.onesignal.ShadowJobService;
-import com.onesignal.ShadowGMSLocationController;
-import com.onesignal.ShadowGMSLocationUpdateListener;
 import com.onesignal.ShadowNotificationManagerCompat;
 import com.onesignal.ShadowOSUtils;
 import com.onesignal.ShadowOneSignal;
@@ -103,7 +105,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.RuntimeEnvironment;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowAlarmManager;
@@ -127,7 +128,6 @@ import static com.onesignal.OneSignalPackagePrivateHelper.FCMBroadcastReceiver_p
 import static com.onesignal.OneSignalPackagePrivateHelper.NotificationBundleProcessor_Process;
 import static com.onesignal.OneSignalPackagePrivateHelper.NotificationOpenedProcessor_processFromContext;
 import static com.onesignal.OneSignalPackagePrivateHelper.OneSignal_getSessionListener;
-import static com.onesignal.OneSignalPackagePrivateHelper.OneSignal_setAppId;
 import static com.onesignal.OneSignalPackagePrivateHelper.OneSignal_setSessionManager;
 import static com.onesignal.OneSignalPackagePrivateHelper.OneSignal_setTrackerFactory;
 import static com.onesignal.OneSignalPackagePrivateHelper.bundleAsJSONObject;
@@ -263,7 +263,7 @@ public class MainOneSignalClassRunner {
       blankActivity = blankActivityController.get();
       trackerFactory = new OSTrackerFactory(new MockOSSharedPreferences(), new MockOSLog());
       sessionManager = new MockSessionManager(OneSignal_getSessionListener(), trackerFactory, new MockOSLog());
-      dbHelper = new MockOneSignalDBHelper(RuntimeEnvironment.application);
+      dbHelper = new MockOneSignalDBHelper(ApplicationProvider.getApplicationContext());
 
       cleanUp();
    }
@@ -283,7 +283,7 @@ public class MainOneSignalClassRunner {
       // Application.onCreate
 //      OneSignal_setGoogleProjectNumber("123456789");
       OneSignal.setAppId(ONESIGNAL_APP_ID);
-      OneSignal.setAppContext(RuntimeEnvironment.application);
+      OneSignal.setAppContext(ApplicationProvider.getApplicationContext());
       threadAndTaskWait();
       // Testing we still register the user in the background if this is the first time. (Note Context is application)
       assertNotNull(ShadowOneSignalRestClient.lastPost);
@@ -293,7 +293,7 @@ public class MainOneSignalClassRunner {
 
       // Restart app, should not send onSession automatically
       OneSignal.setAppId(ONESIGNAL_APP_ID);
-      OneSignal.setAppContext(RuntimeEnvironment.application);
+      OneSignal.setAppContext(ApplicationProvider.getApplicationContext());
       threadAndTaskWait();
       assertNull(ShadowOneSignalRestClient.lastPost);
 
@@ -451,7 +451,7 @@ public class MainOneSignalClassRunner {
       threadAndTaskWait();
 
       // Create a dummy PermissionsActivity to compare in the test cases
-      Intent expectedActivity = new Intent(RuntimeEnvironment.application, PermissionsActivity.class);
+      Intent expectedActivity = new Intent(ApplicationProvider.getApplicationContext(), PermissionsActivity.class);
 
       /* Without showing the LocationGMS prompt we check to see that the current
        * activity is not equal to PermissionsActivity since it is not showing yet */
@@ -1153,7 +1153,7 @@ public class MainOneSignalClassRunner {
 
       // First run should set badge to 0
       OneSignal.setAppId(ONESIGNAL_APP_ID);
-      OneSignal.setAppContext(RuntimeEnvironment.application);
+      OneSignal.setAppContext(ApplicationProvider.getApplicationContext());
       threadAndTaskWait();
       assertEquals(0, ShadowBadgeCountUpdater.lastCount);
 
@@ -1166,7 +1166,7 @@ public class MainOneSignalClassRunner {
       // Nor an app restart
       StaticResetHelper.restSetStaticFields();
       OneSignal.setAppId(ONESIGNAL_APP_ID);
-      OneSignal.setAppContext(RuntimeEnvironment.application);
+      OneSignal.setAppContext(ApplicationProvider.getApplicationContext());
       threadAndTaskWait();
       assertEquals(-1, ShadowBadgeCountUpdater.lastCount);
    }
@@ -1462,7 +1462,7 @@ public class MainOneSignalClassRunner {
 
    @Test
    public void testOfflineCrashes() throws Exception {
-      ConnectivityManager connectivityManager = (ConnectivityManager)RuntimeEnvironment.application.getSystemService(Context.CONNECTIVITY_SERVICE);
+      ConnectivityManager connectivityManager = (ConnectivityManager)ApplicationProvider.getApplicationContext().getSystemService(Context.CONNECTIVITY_SERVICE);
       ShadowConnectivityManager shadowConnectivityManager = shadowOf(connectivityManager);
       shadowConnectivityManager.setActiveNetworkInfo(null);
 
@@ -2387,7 +2387,7 @@ public class MainOneSignalClassRunner {
       threadAndTaskWait();
 
       // Tags did not get synced so SyncService should be scheduled
-      AlarmManager alarmManager = (AlarmManager)RuntimeEnvironment.application.getSystemService(Context.ALARM_SERVICE);
+      AlarmManager alarmManager = (AlarmManager)ApplicationProvider.getApplicationContext().getSystemService(Context.ALARM_SERVICE);
       ShadowAlarmManager shadowAlarmManager = shadowOf(alarmManager);
       assertEquals(1, shadowAlarmManager.getScheduledAlarms().size());
       assertEquals(SyncService.class, shadowOf(shadowOf(shadowAlarmManager.getNextScheduledAlarm().operation).getSavedIntent()).getIntentClass());
@@ -3366,7 +3366,7 @@ public class MainOneSignalClassRunner {
       assertEquals(1, ShadowOneSignalRestClient.lastPost.optInt("loc_type"));
 
       // Checking make sure an update is scheduled.
-      AlarmManager alarmManager = (AlarmManager)RuntimeEnvironment.application.getSystemService(Context.ALARM_SERVICE);
+      AlarmManager alarmManager = (AlarmManager)ApplicationProvider.getApplicationContext().getSystemService(Context.ALARM_SERVICE);
       assertEquals(1, shadowOf(alarmManager).getScheduledAlarms().size());
       Intent intent = shadowOf(shadowOf(alarmManager).getNextScheduledAlarm().operation).getSavedIntent();
       assertEquals(SyncService.class, shadowOf(intent).getIntentClass());
@@ -3421,7 +3421,7 @@ public class MainOneSignalClassRunner {
       threadAndTaskWait();
 
       fastColdRestartApp();
-      AlarmManager alarmManager = (AlarmManager)RuntimeEnvironment.application.getSystemService(Context.ALARM_SERVICE);
+      AlarmManager alarmManager = (AlarmManager)ApplicationProvider.getApplicationContext().getSystemService(Context.ALARM_SERVICE);
       shadowOf(alarmManager).getScheduledAlarms().clear();
       ShadowOneSignalRestClient.lastPost = null;
 
@@ -3442,7 +3442,7 @@ public class MainOneSignalClassRunner {
       assertEquals(true, ShadowOneSignalRestClient.lastPost.opt("loc_bg"));
 
       // Checking make sure an update is scheduled.
-      alarmManager = (AlarmManager)RuntimeEnvironment.application.getSystemService(Context.ALARM_SERVICE);
+      alarmManager = (AlarmManager)ApplicationProvider.getApplicationContext().getSystemService(Context.ALARM_SERVICE);
       assertEquals(1, shadowOf(alarmManager).getScheduledAlarms().size());
       Intent intent = shadowOf(shadowOf(alarmManager).getNextScheduledAlarm().operation).getSavedIntent();
       assertEquals(SyncService.class, shadowOf(intent).getIntentClass());
@@ -3560,7 +3560,7 @@ public class MainOneSignalClassRunner {
       assertEquals(1, ShadowOneSignalRestClient.lastPost.optInt("loc_type"));
 
       // Checking make sure an update is scheduled.
-      AlarmManager alarmManager = (AlarmManager)RuntimeEnvironment.application.getSystemService(Context.ALARM_SERVICE);
+      AlarmManager alarmManager = (AlarmManager)ApplicationProvider.getApplicationContext().getSystemService(Context.ALARM_SERVICE);
       assertEquals(1, shadowOf(alarmManager).getScheduledAlarms().size());
       Intent intent = shadowOf(shadowOf(alarmManager).getNextScheduledAlarm().operation).getSavedIntent();
       assertEquals(SyncService.class, shadowOf(intent).getIntentClass());
@@ -3617,7 +3617,7 @@ public class MainOneSignalClassRunner {
       threadAndTaskWait();
 
       fastColdRestartApp();
-      AlarmManager alarmManager = (AlarmManager)RuntimeEnvironment.application.getSystemService(Context.ALARM_SERVICE);
+      AlarmManager alarmManager = (AlarmManager)ApplicationProvider.getApplicationContext().getSystemService(Context.ALARM_SERVICE);
       shadowOf(alarmManager).getScheduledAlarms().clear();
 
       ShadowOneSignalRestClient.lastPost = null;
@@ -3641,7 +3641,7 @@ public class MainOneSignalClassRunner {
       assertEquals(true, ShadowOneSignalRestClient.lastPost.opt("loc_bg"));
 
       // Checking make sure an update is scheduled.
-      alarmManager = (AlarmManager)RuntimeEnvironment.application.getSystemService(Context.ALARM_SERVICE);
+      alarmManager = (AlarmManager)ApplicationProvider.getApplicationContext().getSystemService(Context.ALARM_SERVICE);
       assertEquals(1, shadowOf(alarmManager).getScheduledAlarms().size());
       Intent intent = shadowOf(shadowOf(alarmManager).getNextScheduledAlarm().operation).getSavedIntent();
       assertEquals(SyncService.class, shadowOf(intent).getIntentClass());

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/NotificationOpenedActivityHMSIntegrationTestsRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/NotificationOpenedActivityHMSIntegrationTestsRunner.java
@@ -1,8 +1,11 @@
 package com.test.onesignal;
 
 import android.app.Activity;
+import android.app.Application;
 import android.content.Intent;
 import android.support.annotation.NonNull;
+
+import androidx.test.core.app.ApplicationProvider;
 
 import com.onesignal.NotificationOpenedActivityHMS;
 import com.onesignal.OSNotificationOpenResult;
@@ -118,7 +121,7 @@ public class NotificationOpenedActivityHMSIntegrationTestsRunner {
 
     private static void helper_initSDKAndFireHMSNotificationOpenWithIntent(@NonNull Intent intent) throws Exception {
         OneSignal.setAppId(ONESIGNAL_APP_ID);
-        OneSignal.setAppContext(RuntimeEnvironment.application);
+        OneSignal.setAppContext(ApplicationProvider.getApplicationContext());
         fastColdRestartApp();
 
         helper_startHMSOpenActivity(intent);
@@ -135,7 +138,7 @@ public class NotificationOpenedActivityHMSIntegrationTestsRunner {
     public void barebonesOSPayload_startsMainActivity() throws Exception {
         helper_initSDKAndFireHMSNotificationBarebonesOSOpenIntent();
 
-        Intent startedActivity = shadowOf(RuntimeEnvironment.application).getNextStartedActivity();
+        Intent startedActivity = shadowOf((Application) ApplicationProvider.getApplicationContext()).getNextStartedActivity();
         assertEquals(startedActivity.getComponent().getClassName(), BlankActivity.class.getName());
     }
 
@@ -151,7 +154,7 @@ public class NotificationOpenedActivityHMSIntegrationTestsRunner {
         helper_initSDKAndFireHMSNotificationActionButtonTapIntent(TEST_ACTION_ID);
 
         OneSignal.setAppId(ONESIGNAL_APP_ID);
-        OneSignal.setAppContext(RuntimeEnvironment.application);
+        OneSignal.setAppContext(ApplicationProvider.getApplicationContext());
         OneSignal.setNotificationOpenedHandler(new OneSignal.NotificationOpenedHandler() {
             @Override
             public void notificationOpened(OSNotificationOpenResult result) {

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/OutcomeEventIntegrationTests.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/OutcomeEventIntegrationTests.java
@@ -5,6 +5,8 @@ import android.app.Activity;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 
+import androidx.test.core.app.ApplicationProvider;
+
 import com.onesignal.MockOSLog;
 import com.onesignal.MockOSSharedPreferences;
 import com.onesignal.MockOneSignalDBHelper;
@@ -16,8 +18,8 @@ import com.onesignal.OneSignalPackagePrivateHelper;
 import com.onesignal.ShadowAdvertisingIdProviderGPS;
 import com.onesignal.ShadowCustomTabsClient;
 import com.onesignal.ShadowCustomTabsSession;
-import com.onesignal.ShadowJobService;
 import com.onesignal.ShadowGMSLocationController;
+import com.onesignal.ShadowJobService;
 import com.onesignal.ShadowNotificationManagerCompat;
 import com.onesignal.ShadowOSUtils;
 import com.onesignal.ShadowOneSignalRestClient;
@@ -40,7 +42,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.RuntimeEnvironment;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowLog;
@@ -140,7 +141,7 @@ public class OutcomeEventIntegrationTests {
     public void beforeEachTest() throws Exception {
         blankActivityController = Robolectric.buildActivity(BlankActivity.class).create();
         blankActivity = blankActivityController.get();
-        dbHelper = new MockOneSignalDBHelper(RuntimeEnvironment.application);
+        dbHelper = new MockOneSignalDBHelper(ApplicationProvider.getApplicationContext());
         preferences = new OneSignalPackagePrivateHelper.OSSharedPreferencesWrapper();
         trackerFactory = new OSTrackerFactory(preferences, logger);
         sessionManager = new MockSessionManager(sessionListener, trackerFactory, logger);

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/OutcomeEventUnitTests.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/OutcomeEventUnitTests.java
@@ -29,6 +29,8 @@ package com.test.onesignal;
 
 import android.support.annotation.NonNull;
 
+import androidx.test.core.app.ApplicationProvider;
+
 import com.onesignal.MockOSLog;
 import com.onesignal.MockOSSharedPreferences;
 import com.onesignal.MockOneSignalAPIClient;
@@ -53,7 +55,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowLog;
 
@@ -120,7 +121,7 @@ public class OutcomeEventUnitTests {
     public void beforeEachTest() throws Exception {
         outcomeEvents = null;
 
-        dbHelper = new MockOneSignalDBHelper(RuntimeEnvironment.application);
+        dbHelper = new MockOneSignalDBHelper(ApplicationProvider.getApplicationContext());
         // Mock on a custom HashMap in order to not use custom context
         preferences = new MockOSSharedPreferences();
 

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/OutcomeEventV2UnitTests.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/OutcomeEventV2UnitTests.java
@@ -29,6 +29,8 @@ package com.test.onesignal;
 
 import android.support.annotation.NonNull;
 
+import androidx.test.core.app.ApplicationProvider;
+
 import com.onesignal.MockOSLog;
 import com.onesignal.MockOSSharedPreferences;
 import com.onesignal.MockOneSignalAPIClient;
@@ -54,7 +56,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowLog;
 
@@ -125,7 +126,7 @@ public class OutcomeEventV2UnitTests {
     public void beforeEachTest() throws Exception {
         outcomeEvents = null;
 
-        dbHelper = new MockOneSignalDBHelper(RuntimeEnvironment.application);
+        dbHelper = new MockOneSignalDBHelper(ApplicationProvider.getApplicationContext());
         // Mock on a custom HashMap in order to not use custom context
         preferences = new MockOSSharedPreferences();
         // Save v2 flag

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/TestHelpers.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/TestHelpers.java
@@ -1,5 +1,6 @@
 package com.test.onesignal;
 
+import android.app.AlarmManager;
 import android.app.job.JobInfo;
 import android.app.job.JobScheduler;
 import android.app.job.JobService;
@@ -9,8 +10,13 @@ import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.os.Looper;
 import android.os.SystemClock;
+import android.util.Log;
 
 import androidx.annotation.Nullable;
+import androidx.test.core.app.ApplicationProvider;
+import androidx.work.Configuration;
+import androidx.work.testing.SynchronousExecutor;
+import androidx.work.testing.WorkManagerTestInitHelper;
 
 import com.onesignal.OneSignalDb;
 import com.onesignal.OneSignalPackagePrivateHelper;
@@ -24,8 +30,8 @@ import com.onesignal.ShadowDynamicTimer;
 import com.onesignal.ShadowFCMBroadcastReceiver;
 import com.onesignal.ShadowFirebaseAnalytics;
 import com.onesignal.ShadowFusedLocationApiWrapper;
-import com.onesignal.ShadowHMSFusedLocationProviderClient;
 import com.onesignal.ShadowGoogleApiClientCompatProxy;
+import com.onesignal.ShadowHMSFusedLocationProviderClient;
 import com.onesignal.ShadowHmsInstanceId;
 import com.onesignal.ShadowNotificationManagerCompat;
 import com.onesignal.ShadowOSUtils;
@@ -48,7 +54,7 @@ import junit.framework.Assert;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.robolectric.Robolectric;
-import org.robolectric.RuntimeEnvironment;
+import org.robolectric.shadows.ShadowAlarmManager;
 import org.robolectric.shadows.ShadowApplication;
 import org.robolectric.shadows.ShadowSystemClock;
 import org.robolectric.util.Scheduler;
@@ -71,6 +77,10 @@ public class TestHelpers {
       TestOneSignalPrefs.initializePool();
       if (!ranBeforeTestSuite)
          return;
+
+      setupTestWorkManager(ApplicationProvider.getApplicationContext());
+
+      resetAlarmManager();
 
       resetSystemClock();
 
@@ -103,8 +113,6 @@ public class TestHelpers {
       ShadowOSWebView.resetStatics();
 
       ShadowDynamicTimer.resetStatics();
-
-      ShadowOSWebView.resetStatics();
 
       OneSignalShadowPackageManager.resetStatics();
 
@@ -482,6 +490,21 @@ public class TestHelpers {
       ShadowSystemClock.setNanoTime(nano);
    }
 
+   static void setupTestWorkManager(Context context) {
+      final Configuration config = new Configuration.Builder()
+              .setMinimumLoggingLevel(Log.DEBUG)
+              .setExecutor(new SynchronousExecutor())
+              .build();
+      WorkManagerTestInitHelper.initializeTestWorkManager(context, config);
+   }
+
+   private static void resetAlarmManager() {
+      AlarmManager alarmManager = (AlarmManager) ApplicationProvider.getApplicationContext()
+              .getSystemService(Context.ALARM_SERVICE);
+      ShadowAlarmManager shadowAlarmManager = shadowOf(alarmManager);
+      shadowAlarmManager.getScheduledAlarms().clear();
+   }
+
    static void resetSystemClock() {
       SystemClock.setCurrentTimeMillis(System.currentTimeMillis());
    }
@@ -499,7 +522,7 @@ public class TestHelpers {
 
    public static @Nullable JobInfo getNextJob() {
       JobScheduler jobScheduler =
-         (JobScheduler)RuntimeEnvironment.application.getSystemService(Context.JOB_SCHEDULER_SERVICE);
+         (JobScheduler)ApplicationProvider.getApplicationContext().getSystemService(Context.JOB_SCHEDULER_SERVICE);
       List<JobInfo> jobs = jobScheduler.getAllPendingJobs();
       if (jobs.size() == 0)
          return null;


### PR DESCRIPTION
* Added `api 'androidx.work:work-runtime:[2.0.0, 2.99.99]'` for onesignal
* Added `testImplementation 'androidx.test:core:1.2.0'` for unittest
* Added `testImplementation 'androidx.work:work-testing:2.3.4'` for unittest
* Added the `TestHelper` methods for `WorkManager` and `AlarmManager` cleanup/setup
  * Added method calls `setupTestWorkManager` and `resetAlarmManager` to `beforeTestInitAndCleanup` for future usage of `Worker` and `WorkManager` class
* Also removed deprecated `RuntimeEnvironment.application` usage
  * Replaced with `ApplicationProvider.getApplicationContext`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1088)
<!-- Reviewable:end -->
