### PR TITLE
Fix InterruptedException, email id log, and focus attribution

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/FocusTimeController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/FocusTimeController.java
@@ -50,7 +50,7 @@ class FocusTimeController {
    }
 
    void appBackgrounded() {
-      giveProcessorsValidFocusTime(OneSignal.getSessionManager().getInfluences(), FocusEventType.BACKGROUND);
+      giveProcessorsValidFocusTime(OneSignal.getSessionManager().getSessionInfluences(), FocusEventType.BACKGROUND);
       timeFocusedAtMs = null;
    }
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSSessionManager.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSSessionManager.java
@@ -115,6 +115,11 @@ public class OSSessionManager {
         return trackerFactory.getInfluences();
     }
 
+    @NonNull
+    List<OSInfluence> getSessionInfluences() {
+        return trackerFactory.getSessionInfluences();
+    }
+
     /**
      * Attempt to override the current session before the 30 second session minimum
      * This should only be done in a upward direction:

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -684,7 +684,8 @@ public class OneSignal {
          if (sender_id != null && sender_id.length() > 4)
             sender_id = sender_id.substring(4);
 
-         OneSignal.init(context, sender_id, bundle.getString("onesignal_app_id"), mInitBuilder.mNotificationOpenedHandler, mInitBuilder.mNotificationReceivedHandler);
+         String appId = bundle.getString("onesignal_app_id");
+         OneSignal.init(context, sender_id, appId, mInitBuilder.mNotificationOpenedHandler, mInitBuilder.mNotificationReceivedHandler);
       } catch (Throwable t) {
          t.printStackTrace();
       }
@@ -2287,7 +2288,6 @@ public class OneSignal {
    static String getUserId() {
       if (userId == null && appContext != null)
          userId = getSavedUserId(appContext);
-
       return userId;
    }
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalRestClient.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalRestClient.java
@@ -115,6 +115,7 @@ class OneSignalRestClient {
       
       // getResponseCode() can hang past it's timeout setting so join it's thread to ensure it is timing out.
       try {
+         // Sequentially wait for connectionThread to execute
          connectionThread.join(getThreadTimeout(timeout));
          if (connectionThread.getState() != Thread.State.TERMINATED)
             connectionThread.interrupt();

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/SyncJobService.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/SyncJobService.java
@@ -48,8 +48,8 @@ public class SyncJobService extends JobService {
 
    @Override
    public boolean onStopJob(JobParameters jobParameters) {
-      OneSignal.Log(OneSignal.LOG_LEVEL.DEBUG, "SyncJobService onStopJob called, system conditions not available");
       boolean reschedule = OneSignalSyncServiceUtils.stopSyncBgThread();
+      OneSignal.Log(OneSignal.LOG_LEVEL.DEBUG, "SyncJobService onStopJob called, system conditions not available reschedule: " + reschedule);
       return reschedule;
    }
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/SyncJobService.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/SyncJobService.java
@@ -29,6 +29,8 @@ package com.onesignal;
 
 import android.app.job.JobParameters;
 import android.app.job.JobService;
+import android.content.Context;
+import android.net.ConnectivityManager;
 import android.os.Build;
 import android.support.annotation.RequiresApi;
 
@@ -46,6 +48,7 @@ public class SyncJobService extends JobService {
 
    @Override
    public boolean onStopJob(JobParameters jobParameters) {
+      OneSignal.Log(OneSignal.LOG_LEVEL.DEBUG, "SyncJobService onStopJob called, system conditions not available");
       boolean reschedule = OneSignalSyncServiceUtils.stopSyncBgThread();
       return reschedule;
    }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStateEmailSynchronizer.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStateEmailSynchronizer.java
@@ -18,6 +18,11 @@ class UserStateEmailSynchronizer extends UserStateSynchronizer {
         return new UserStateEmail(inPersistKey, load);
     }
 
+    @Override
+    protected OneSignal.LOG_LEVEL getLogLevel() {
+        return OneSignal.LOG_LEVEL.INFO;
+    }
+
     // Email subscription not readable from SDK
     @Override
     boolean getSubscribed() {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStatePushSynchronizer.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStatePushSynchronizer.java
@@ -19,6 +19,11 @@ class UserStatePushSynchronizer extends UserStateSynchronizer {
     }
 
     @Override
+    protected OneSignal.LOG_LEVEL getLogLevel() {
+        return OneSignal.LOG_LEVEL.ERROR;
+    }
+
+    @Override
     boolean getSubscribed() {
         return getToSyncUserState().isSubscribed();
     }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStateSynchronizer.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStateSynchronizer.java
@@ -197,6 +197,7 @@ abstract class UserStateSynchronizer {
         return false;
     }
 
+    protected abstract OneSignal.LOG_LEVEL getLogLevel();
     protected abstract String getId();
 
     private boolean isSessionCall() {
@@ -306,7 +307,7 @@ abstract class UserStateSynchronizer {
 
     private void doPutSync(String userId, final JSONObject jsonBody, final JSONObject dependDiff) {
         if (userId == null) {
-            OneSignal.onesignalLog(OneSignal.LOG_LEVEL.ERROR, "Error updating the user record because of the null user id");
+            OneSignal.onesignalLog(getLogLevel(), "Error updating the user record because of the null user id");
             sendTagsHandlersPerformOnFailure(new SendTagsError(-1, "Unable to update tags: the current user is not registered with OneSignal"));
             externalUserIdUpdateHandlersPerformOnFailure();
             return;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/influence/OSTrackerFactory.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/influence/OSTrackerFactory.java
@@ -57,6 +57,17 @@ public class OSTrackerFactory {
         return influences;
     }
 
+    public List<OSInfluence> getSessionInfluences() {
+        List<OSInfluence> influences = new ArrayList<>();
+        for (OSChannelTracker tracker : trackers.values()) {
+            // IAM doesn't influence session calls
+            if (tracker instanceof OSInAppMessageTracker)
+                continue;
+            influences.add(tracker.getCurrentSessionInfluence());
+        }
+        return influences;
+    }
+
     public OSChannelTracker getIAMChannelTracker() {
         return trackers.get(OSInAppMessageTracker.TAG);
     }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/influence/model/OSInfluence.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/influence/model/OSInfluence.java
@@ -31,7 +31,7 @@ public class OSInfluence {
         String ids = jsonObject.getString(INFLUENCE_IDS);
         this.influenceChannel = OSInfluenceChannel.fromString(channel);
         this.influenceType = OSInfluenceType.fromString(type);
-        this.ids = ids != null ? new JSONArray(ids) : null;
+        this.ids = ids.isEmpty() ? null : new JSONArray(ids);
     }
 
     OSInfluence(@NonNull OSInfluence.Builder builder) {
@@ -108,7 +108,7 @@ public class OSInfluence {
         JSONObject jsonObject = new JSONObject();
         jsonObject.put(INFLUENCE_CHANNEL, influenceChannel.toString());
         jsonObject.put(INFLUENCE_TYPE, influenceType.toString());
-        jsonObject.put(INFLUENCE_IDS, ids != null ? ids.toString() : null);
+        jsonObject.put(INFLUENCE_IDS, ids != null ? ids.toString() : "");
         return jsonObject.toString();
     }
 


### PR DESCRIPTION
   * InterruptedException was due to a circular initialization of the JobScheduler,
     this was making the job scheduler to stop and interrump the thread
   * Email id can be null, downgrade log to Info, keep Error lvl for User id
   * Focus attribution was being init as attributed by IAM, attribution in session can only be by notification

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1089)
<!-- Reviewable:end -->
