### PR TITLE
Add task delay due to requiring consent from remote params

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/GMSLocationController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/GMSLocationController.java
@@ -64,7 +64,7 @@ class GMSLocationController extends LocationController {
                         .addApi(LocationServices.API)
                         .addConnectionCallbacks(googleApiClientListener)
                         .addOnConnectionFailedListener(googleApiClientListener)
-                        .setHandler(locationHandlerThread.mHandler)
+                        .setHandler(getLocationHandlerThread().mHandler)
                         .build();
 
                 GMSLocationController.googleApiClient = new GoogleApiClientCompatProxy(googleApiClient);

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/HMSLocationController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/HMSLocationController.java
@@ -125,7 +125,7 @@ class HMSLocationController extends LocationController {
                     .setPriority(LocationRequest.PRIORITY_BALANCED_POWER_ACCURACY);
 
             OneSignal.Log(OneSignal.LOG_LEVEL.DEBUG, "HMSLocationController Huawei LocationServices requestLocationUpdates!");
-            huaweiFusedLocationProviderClient.requestLocationUpdates(locationRequest, this, locationHandlerThread.getLooper());
+            huaweiFusedLocationProviderClient.requestLocationUpdates(locationRequest, this, getLocationHandlerThread().getLooper());
         }
 
         @Override

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/LocationController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/LocationController.java
@@ -58,7 +58,18 @@ class LocationController {
    private static boolean locationCoarse;
 
    static final Object syncLock = new Object() {};
-   static LocationHandlerThread locationHandlerThread;
+
+   private static LocationHandlerThread locationHandlerThread;
+   static LocationHandlerThread getLocationHandlerThread() {
+      if (locationHandlerThread == null) {
+         synchronized (syncLock) {
+            if (locationHandlerThread == null)
+               locationHandlerThread = new LocationHandlerThread();
+         }
+      }
+      return locationHandlerThread;
+   }
+
    static Thread fallbackFailThread;
    static Context classContext;
    static Location lastLocation;
@@ -252,9 +263,6 @@ class LocationController {
    // Started from this class or PermissionActivity
    static void startGetLocation() {
       OneSignal.Log(OneSignal.LOG_LEVEL.DEBUG, "LocationController startGetLocation with lastLocation: " + lastLocation);
-
-      if (locationHandlerThread == null)
-         locationHandlerThread = new LocationHandlerThread();
 
       try {
          if (isGooglePlayServicesAvailable()) {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationLimitManager.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationLimitManager.java
@@ -69,7 +69,7 @@ class NotificationLimitManager {
       }
 
       // Clear the oldest based on the count in notifsToClear
-      for(Map.Entry<Long, Integer> mapData : activeNotifIds.entrySet()) {
+      for (Map.Entry<Long, Integer> mapData : activeNotifIds.entrySet()) {
          OneSignal.cancelNotification(mapData.getValue());
          if (--notifsToClear <= 0)
             break;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSLogWrapper.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSLogWrapper.java
@@ -5,7 +5,6 @@ import androidx.annotation.Nullable;
 
 class OSLogWrapper implements OSLogger {
 
-
     public void verbose(@NonNull String message) {
         OneSignal.Log(OneSignal.LOG_LEVEL.VERBOSE, message);
     }
@@ -14,8 +13,18 @@ class OSLogWrapper implements OSLogger {
         OneSignal.Log(OneSignal.LOG_LEVEL.DEBUG, message);
     }
 
+    @Override
+    public void info(@NonNull String message) {
+        OneSignal.Log(OneSignal.LOG_LEVEL.INFO, message);
+    }
+
     public void warning(@NonNull String message) {
         OneSignal.Log(OneSignal.LOG_LEVEL.WARN, message);
+    }
+
+    @Override
+    public void error(@NonNull String message) {
+        OneSignal.Log(OneSignal.LOG_LEVEL.ERROR, message);
     }
 
     public void error(@NonNull String message, @Nullable Throwable throwable) {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSLogger.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSLogger.java
@@ -9,7 +9,11 @@ public interface OSLogger {
 
     void debug(@NonNull String message);
 
+    void info(@NonNull String message);
+
     void warning(@NonNull String message);
+
+    void error(@NonNull String message);
 
     void error(@NonNull String message, @Nullable Throwable throwable);
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSRemoteParamController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSRemoteParamController.java
@@ -69,6 +69,10 @@ class OSRemoteParamController {
         OneSignal.onRemoteParamSet();
     }
 
+    boolean isRemoteParamsCallDone() {
+        return remoteParams != null;
+    }
+
     OneSignalRemoteParams.Params getRemoteParams() {
         return remoteParams;
     }
@@ -95,7 +99,7 @@ class OSRemoteParamController {
         return OneSignalPrefs.getBool(
                 OneSignalPrefs.PREFS_ONESIGNAL,
                 OneSignalPrefs.PREFS_OS_UNSUBSCRIBE_WHEN_NOTIFICATIONS_DISABLED,
-                false);
+                true);
     }
 
     boolean isGMSMissingPromptDisable() {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSRemoteParamController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSRemoteParamController.java
@@ -4,10 +4,9 @@ import com.onesignal.influence.OSTrackerFactory;
 
 class OSRemoteParamController {
 
-    private OneSignalRemoteParams.Params remoteParams;
+    private OneSignalRemoteParams.Params remoteParams = null;
 
     OSRemoteParamController() {
-        this.remoteParams = null;
     }
 
     /**
@@ -65,8 +64,6 @@ class OSRemoteParamController {
 
         if (remoteParams.requiresUserPrivacyConsent != null)
             savePrivacyConsentRequired(remoteParams.requiresUserPrivacyConsent);
-
-        OneSignal.onRemoteParamSet();
     }
 
     boolean isRemoteParamsCallDone() {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSTaskController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSTaskController.java
@@ -1,0 +1,128 @@
+package com.onesignal;
+
+import androidx.annotation.NonNull;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicLong;
+
+class OSTaskController {
+
+    // the concurrent queue in which we pin pending tasks upon finishing initialization
+    static final ConcurrentLinkedQueue<Runnable> taskQueueWaitingForInit = new ConcurrentLinkedQueue<>();
+    private static final AtomicLong lastTaskId = new AtomicLong();
+    private static ExecutorService pendingTaskExecutor;
+
+    private final OSLogger logger;
+    private final OSRemoteParamController paramController;
+
+    private List<String> methodsAvailableForDelay;
+
+    OSTaskController(OSRemoteParamController paramController, OSLogger logger) {
+        this.paramController = paramController;
+        this.logger = logger;
+
+        methodsAvailableForDelay = new ArrayList<>(
+                Arrays.asList("getTags()", "SyncHashedEmail()", "setExternalUserId()", "setSubscription()",
+                        "promptLocation()", "idsAvailable()", "sendTag()", "sendTags()", "handleNotificationOpen()",
+                        "setEmail()"));
+    }
+
+    boolean shouldQueueTaskForInit(String task) {
+        return !paramController.isRemoteParamsCallDone() && methodsAvailableForDelay.contains(task);
+    }
+
+    boolean shouldRunTaskThroughQueue() {
+        if (OneSignal.isInitDone() && pendingTaskExecutor == null) {
+            // There never were any waiting tasks
+            return false;
+        }
+
+        // If init isn't finished and the pending executor hasn't been defined yet...
+        if (!OneSignal.isInitDone() && pendingTaskExecutor == null)
+            return true;
+
+        // or if the pending executor is alive and hasn't been shutdown yet...
+        return !pendingTaskExecutor.isShutdown();
+    }
+
+    void addTaskWaitingForInit(Runnable runnable) {
+        taskQueueWaitingForInit.add(runnable);
+    }
+
+    void addTaskToQueue(Runnable runnable) {
+        addTaskToQueue(new PendingTaskRunnable(this, runnable));
+    }
+
+    private void addTaskToQueue(PendingTaskRunnable task) {
+        task.taskId = lastTaskId.incrementAndGet();
+
+        if (pendingTaskExecutor == null) {
+            logger.debug("Adding a task to the pending queue with ID: " + task.taskId);
+            // The tasks haven't been executed yet...add them to the waiting queue
+            addTaskWaitingForInit(task);
+        } else if (!pendingTaskExecutor.isShutdown()) {
+            logger.debug("Executor is still running, add to the executor with ID: " + task.taskId);
+            try {
+                // If the executor isn't done with tasks, submit the task to the executor
+                pendingTaskExecutor.submit(task);
+            } catch (RejectedExecutionException e) {
+                logger.info("Executor is shutdown, running task manually with ID: " + task.taskId);
+                // Run task manually when RejectedExecutionException occurs due to the ThreadPoolExecutor.AbortPolicy
+                // The pendingTaskExecutor is already shutdown by the time it tries to run the task
+                // Issue #669
+                // https://github.com/OneSignal/OneSignal-Android-SDK/issues/669
+                task.run();
+                e.printStackTrace();
+            }
+        }
+    }
+
+    void startPendingTasks() {
+        if (!taskQueueWaitingForInit.isEmpty()) {
+            pendingTaskExecutor = Executors.newSingleThreadExecutor(new ThreadFactory() {
+                @Override
+                public Thread newThread(@NonNull Runnable runnable) {
+                    Thread newThread = new Thread(runnable);
+                    newThread.setName("OS_PENDING_EXECUTOR_" + newThread.getId());
+                    return newThread;
+                }
+            });
+
+            while (!taskQueueWaitingForInit.isEmpty()) {
+                pendingTaskExecutor.submit(taskQueueWaitingForInit.poll());
+            }
+        }
+    }
+
+    private void onTaskRan(long taskId) {
+        if (lastTaskId.get() == taskId) {
+            OneSignal.Log(OneSignal.LOG_LEVEL.INFO, "Last Pending Task has ran, shutting down");
+            pendingTaskExecutor.shutdown();
+        }
+    }
+
+    private static class PendingTaskRunnable implements Runnable {
+        private OSTaskController controller;
+        private Runnable innerTask;
+
+        private long taskId;
+
+        PendingTaskRunnable(OSTaskController controller, Runnable innerTask) {
+            this.controller = controller;
+            this.innerTask = innerTask;
+        }
+
+        @Override
+        public void run() {
+            innerTask.run();
+            controller.onTaskRan(taskId);
+        }
+    }
+}

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalRemoteParams.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalRemoteParams.java
@@ -179,7 +179,7 @@ public class OneSignalRemoteParams {
          clearGroupOnSummaryClick = responseJson.optBoolean("clear_group_on_summary_click", true);
          receiveReceiptEnabled = responseJson.optBoolean("receive_receipts_enable", false);
 
-         unsubscribeWhenNotificationsDisabled = responseJson.optBoolean(UNSUBSCRIBE_ON_NOTIFICATION_DISABLE, false);
+         unsubscribeWhenNotificationsDisabled = responseJson.optBoolean(UNSUBSCRIBE_ON_NOTIFICATION_DISABLE, true);
          disableGMSMissingPrompt = responseJson.optBoolean(DISABLE_GMS_MISSING_PROMPT, false);
 
          if (responseJson.has(LOCATION_SHARED))

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalRemoteParams.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalRemoteParams.java
@@ -89,7 +89,7 @@ public class OneSignalRemoteParams {
       FCMParams fcmParams;
    }
 
-   interface CallBack {
+   interface Callback {
       void complete(Params params);
    }
 
@@ -121,7 +121,7 @@ public class OneSignalRemoteParams {
    public static final int DEFAULT_INDIRECT_ATTRIBUTION_WINDOW = 24 * 60;
    public static final int DEFAULT_NOTIFICATION_LIMIT = 10;
 
-   static void makeAndroidParamsRequest(final String appId, final String userId, final @NonNull CallBack callback) {
+   static void makeAndroidParamsRequest(final String appId, final String userId, final @NonNull Callback callback) {
       OneSignalRestClient.ResponseHandler responseHandler = new OneSignalRestClient.ResponseHandler() {
          @Override
          void onFailure(int statusCode, String response, Throwable throwable) {
@@ -158,7 +158,7 @@ public class OneSignalRemoteParams {
       OneSignalRestClient.get(params_url, responseHandler, OneSignalRestClient.CACHE_KEY_REMOTE_PARAMS);
    }
 
-   static private void processJson(String json, final @NonNull CallBack callBack) {
+   static private void processJson(String json, final @NonNull Callback callBack) {
       final JSONObject responseJson;
       try {
          responseJson = new JSONObject(json);

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalRestClient.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalRestClient.java
@@ -63,7 +63,6 @@ class OneSignalRestClient {
    }
 
    public static void put(final String url, final JSONObject jsonBody, final ResponseHandler responseHandler) {
-
       new Thread(new Runnable() {
          public void run() {
             makeRequest(url, "PUT", jsonBody, responseHandler, TIMEOUT, null);

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/InAppMessagingHelpers.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/InAppMessagingHelpers.java
@@ -15,7 +15,7 @@ import static com.onesignal.OneSignalPackagePrivateHelper.OSTestTrigger.OSTrigge
 public class InAppMessagingHelpers {
     public static final String TEST_SPANISH_ANDROID_VARIANT_ID = "d8cc-11e4-bed1-df8f05be55ba-a4b3gj7f";
     public static final String TEST_ENGLISH_ANDROID_VARIANT_ID = "11e4-bed1-df8f05be55ba-a4b3gj7f-d8cc";
-    public static final String ONESIGNAL_APP_ID = "b2f7f966-d8cc-11e4-bed1-df8f05be55ba";
+    public static final String ONESIGNAL_APP_ID = "b4f7f966-d8cc-11e4-bed1-df8f05be55ba";
     public static final String IAM_CLICK_ID = "12345678-1234-1234-1234-123456789012";
 
     public static boolean evaluateMessage(OSInAppMessage message) {

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 import static org.robolectric.Shadows.shadowOf;
 
@@ -109,6 +110,10 @@ public class OneSignalPackagePrivateHelper {
 
    public static void OneSignal_clearRemoteParams() {
       OneSignal.getRemoteParamController().clearRemoteParams();
+   }
+
+   public static void OneSignal_savePrivacyConsentRequired(boolean required) {
+      OneSignal.getRemoteParamController().savePrivacyConsentRequired(required);
    }
 
    public static OSSessionManager.SessionListener OneSignal_getSessionListener() {
@@ -220,6 +225,10 @@ public class OneSignalPackagePrivateHelper {
 
    public static DelayedConsentInitializationParameters OneSignal_delayedInitParams() {
       return OneSignal.delayedInitParams;
+   }
+
+   public static ConcurrentLinkedQueue<Runnable> OneSignal_taskQueueWaitingForInit() {
+      return OSTaskController.taskQueueWaitingForInit;
    }
 
    public static boolean OneSignal_requiresUserPrivacyConsent() {

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
@@ -108,12 +108,12 @@ public class OneSignalPackagePrivateHelper {
       OneSignal.sendPurchases(purchases, newAsExisting, responseHandler);
    }
 
-   public static void OneSignal_clearRemoteParams() {
-      OneSignal.getRemoteParamController().clearRemoteParams();
+   public static OSRemoteParamController OneSignal_getRemoteParamController() {
+      return OneSignal.getRemoteParamController();
    }
 
    public static void OneSignal_savePrivacyConsentRequired(boolean required) {
-      OneSignal.getRemoteParamController().savePrivacyConsentRequired(required);
+      OneSignal_getRemoteParamController().savePrivacyConsentRequired(required);
    }
 
    public static OSSessionManager.SessionListener OneSignal_getSessionListener() {
@@ -228,15 +228,11 @@ public class OneSignalPackagePrivateHelper {
    }
 
    public static ConcurrentLinkedQueue<Runnable> OneSignal_taskQueueWaitingForInit() {
-      return OSTaskController.taskQueueWaitingForInit;
+      return OneSignal.getTaskController().getTaskQueueWaitingForInit();
    }
 
    public static boolean OneSignal_requiresUserPrivacyConsent() {
       return OneSignal.isUserPrivacyConsentRequired();
-   }
-
-   public static void OneSignal_setRequiresUserPrivacyConsent(boolean required) {
-      OneSignal.getRemoteParamController().savePrivacyConsentRequired(required);
    }
 
    public static boolean OneSignal_locationShared() {

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowBadgeCountUpdater.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowBadgeCountUpdater.java
@@ -29,6 +29,7 @@ package com.onesignal;
 
 import android.content.Context;
 
+import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
 @Implements(BadgeCountUpdater.class)
@@ -36,6 +37,7 @@ public class ShadowBadgeCountUpdater {
 
    public static int lastCount = 0;
 
+   @Implementation
    public static void updateCount(int count, Context context) {
       lastCount = count;
    }

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowOSUtils.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowOSUtils.java
@@ -52,6 +52,11 @@ public class ShadowOSUtils {
       return isHMSCoreInstalledAndEnabled;
    }
 
+   public static void hasAllRecommendedFCMLibraries(boolean value) {
+      isGMSInstalledAndEnabled = value;
+      hasFCMLibrary = value;
+   }
+
    public static void hasAllRecommendedHMSLibraries(boolean value) {
       // required
       hasHMSPushKitLibrary = value;

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowOSWebView.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowOSWebView.java
@@ -1,16 +1,15 @@
 package com.onesignal;
 
-import android.renderscript.Sampler;
 import android.webkit.ValueCallback;
 
+import com.onesignal.WebViewManager.OSJavaScriptInterface;
 import com.test.onesignal.TestHelpers;
 
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.shadows.ShadowWebView;
-
-import com.onesignal.WebViewManager.OSJavaScriptInterface;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -51,6 +50,7 @@ public class ShadowOSWebView extends ShadowWebView {
       MOCK_IAM_RENDERING_COMPLETE_TOP_BANNER = jsonObject.toString();
    }
 
+   @Implementation
    public void loadData(String data, String mimeType, String encoding) {
       TestHelpers.assertMainThread();
       lastData = data;

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowOneSignal.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowOneSignal.java
@@ -2,6 +2,7 @@ package com.onesignal;
 
 import android.util.Log;
 
+import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
 @Implements(OneSignal.class)
@@ -14,4 +15,8 @@ public class ShadowOneSignal {
       Log.e("", message, throwable);
    }
 
+   @Implementation
+   public static void fireNotificationOpenedHandler(final OSNotificationOpenResult openedResult) {
+      OneSignal.notificationOpenedHandler.notificationOpened(openedResult);
+   }
 }

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowOneSignalRestClient.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowOneSignalRestClient.java
@@ -77,7 +77,7 @@ public class ShadowOneSignalRestClient {
 
    public static List<String> successfulGETResponses = new ArrayList<>();
    public static ArrayList<Request> requests;
-   public static String lastUrl, failResponse, nextSuccessResponse, nextSuccessfulGETResponse, nextSuccessfulRegistrationResponse, pushUserId, emailUserId;
+   public static String lastUrl, failResponse, nextSuccessResponse, nextSuccessfulGETResponse, nextSuccessfulRegistrationResponse, pushUserId, emailUserId, failMethod;
    public static Pattern nextSuccessfulGETResponsePattern;
    public static JSONObject lastPost;
    public static boolean failNext, failNextPut, failAll, failPosts, failGetParams;
@@ -93,7 +93,7 @@ public class ShadowOneSignalRestClient {
    private static String remoteParamsGetHtmlResponse = null;
    private static final String REMOTE_PARAMS = " {" +
            "\"awl_list\":{}," +
-           "\"android_sender_id\":\"1087181915257\"," +
+           "\"android_sender_id\":\"87654321\"," +
            "\"chnl_lst\":[]," +
            "\"enterp\":false," +
            "\"outcomes\":{" +
@@ -107,7 +107,7 @@ public class ShadowOneSignalRestClient {
            "\"enabled\":true" +
            "}" +
            "}," +
-           "\"receive_receipts_enable\":true," +
+           "\"receive_receipts_enable\":false," +
            "\"unsubscribe_on_notifications_disabled\":true," +
            "\"disable_gms_missing_prompt\":true," +
            "\"location_shared\":true," +
@@ -136,6 +136,7 @@ public class ShadowOneSignalRestClient {
       nextSuccessfulGETResponse = null;
       nextSuccessfulGETResponsePattern = null;
 
+      failMethod = null;
       failResponse = "{}";
       nextSuccessfulRegistrationResponse = null;
       nextSuccessResponse = null;
@@ -204,7 +205,11 @@ public class ShadowOneSignalRestClient {
       remoteParamsGetHtmlResponse = remoteParams.toString();
    }
 
-   public static void setRemoteParamsGetHtmlResponse() throws JSONException {
+   public static void setRemoteParamsGetHtmlResponse(String response) {
+      remoteParamsGetHtmlResponse = response;
+   }
+
+   public static void setRemoteParamsGetHtmlResponse() {
       remoteParamsGetHtmlResponse = REMOTE_PARAMS;
    }
 
@@ -256,7 +261,7 @@ public class ShadowOneSignalRestClient {
    }
 
    private static boolean doFail(OneSignalRestClient.ResponseHandler responseHandler, boolean doFail) {
-      if (failNext || failAll || doFail) {
+      if (failNext || failAll || doFail || handleFailMethod(lastUrl, responseHandler)) {
          if (!suspendResponse(false, failResponse, responseHandler))
             responseHandler.onFailure(failHttpCode, failResponse, new Exception());
          failNext = failNextPut = false;
@@ -391,5 +396,9 @@ public class ShadowOneSignalRestClient {
 
       responseHandler.onSuccess(remoteParamsGetHtmlResponse);
       return true;
+   }
+
+   private static boolean handleFailMethod(final String url, final OneSignalRestClient.ResponseHandler responseHandler) {
+      return failMethod != null && url.contains(failMethod);
    }
 }

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowOneSignalRestClientWithMockConnection.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowOneSignalRestClientWithMockConnection.java
@@ -27,6 +27,7 @@
 
 package com.onesignal;
 
+import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
 import java.io.IOException;
@@ -51,6 +52,7 @@ public class ShadowOneSignalRestClientWithMockConnection {
       return 1;
    }
 
+   @Implementation
    public static HttpURLConnection newHttpURLConnection(String url) throws IOException {
       lastConnection = new MockHttpURLConnection(
          new URL("https://onesignal.com/api/v1/" + url),

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/StaticResetHelper.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/StaticResetHelper.java
@@ -12,8 +12,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
-import static com.onesignal.OneSignalPackagePrivateHelper.OneSignal_clearRemoteParams;
-
 public class StaticResetHelper {
 
    private static Collection<ClassState> classes = new ArrayList<>();
@@ -24,6 +22,12 @@ public class StaticResetHelper {
          public boolean onOtherField(Field field) throws Exception {
             if (field.getName().equals("unprocessedOpenedNotifis")) {
                field.set(null, new ArrayList<JSONArray>());
+               return true;
+            } else if (field.getName().equals("remoteParamController")) {
+               field.set(null, new OSRemoteParamController());
+               return true;
+            } else if (field.getName().equals("taskController")) {
+               field.set(null, new OSTaskController(OneSignal.getRemoteParamController(), new OSLogWrapper()));
                return true;
             }
             return false;
@@ -115,8 +119,6 @@ public class StaticResetHelper {
    }
 
    public static void restSetStaticFields() throws Exception {
-      OneSignal_clearRemoteParams();
-
       for (ClassState aClass : classes)
          aClass.restSetStaticFields();
 

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
@@ -43,6 +43,7 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.SystemClock;
+import android.util.Log;
 import android.widget.Button;
 
 import androidx.annotation.NonNull;
@@ -116,6 +117,7 @@ import static com.onesignal.OneSignalPackagePrivateHelper.NotificationBundleProc
 import static com.onesignal.OneSignalPackagePrivateHelper.NotificationOpenedProcessor_processFromContext;
 import static com.onesignal.OneSignalPackagePrivateHelper.NotificationSummaryManager_updateSummaryNotificationAfterChildRemoved;
 import static com.onesignal.OneSignalPackagePrivateHelper.createInternalPayloadBundle;
+import static com.onesignal.ShadowOneSignalRestClient.setRemoteParamsGetHtmlResponse;
 import static com.onesignal.ShadowRoboNotificationManager.getNotificationsInGroup;
 import static com.test.onesignal.RestClientAsserts.assertReportReceivedAtIndex;
 import static com.test.onesignal.RestClientAsserts.assertRestCalls;
@@ -147,7 +149,8 @@ import static org.robolectric.Shadows.shadowOf;
 )
 @RunWith(RobolectricTestRunner.class)
 public class GenerateNotificationRunner {
-   
+
+   private static final String ONESIGNAL_APP_ID = "b4f7f966-d8cc-11e4-bed1-df8f05be55ba";
    private static final String notifMessage = "Robo test message";
 
    private Activity blankActivity;
@@ -178,6 +181,9 @@ public class GenerateNotificationRunner {
       NotificationManager notificationManager = OneSignalNotificationManagerPackageHelper.getNotificationManager(blankActivity);
       notificationManager.cancelAll();
       NotificationRestorer.restored = false;
+
+      // Set remote_params GET response
+      setRemoteParamsGetHtmlResponse();
    }
 
    @AfterClass
@@ -900,7 +906,22 @@ public class GenerateNotificationRunner {
    }
 
    @Test
-   public void shouldGenerate2BasicGroupNotifications() {
+   public void shouldGenerate2BasicGroupNotifications() throws Exception {
+      ShadowOSUtils.hasAllRecommendedFCMLibraries(true);
+      // First init run for appId to be saved
+      // At least OneSignal was init once for user to be subscribed
+      // If this doesn't' happen, notifications will not arrive
+      OneSignal.setAppId(ONESIGNAL_APP_ID);
+      OneSignal.setAppContext(blankActivity);
+      threadAndTaskWait();
+      fastColdRestartApp();
+      // We only care about request post first init
+      ShadowOneSignalRestClient.resetStatics();
+
+      Log.i(GenerateNotificationRunner.class.getCanonicalName(), "****** AFTER RESET STATICS ******");
+      setRemoteParamsGetHtmlResponse();
+      ShadowOSUtils.hasAllRecommendedFCMLibraries(true);
+
       // Make sure the notification got posted and the content is correct.
       Bundle bundle = getBaseNotifBundle();
       bundle.putString("grp", "test1");
@@ -961,10 +982,14 @@ public class GenerateNotificationRunner {
       postedNotification = postedNotifsIterator.next().getValue();
       Intent intent = createOpenIntent(postedNotification.id, bundle).putExtra("summary", "test1");
       NotificationOpenedProcessor_processFromContext(blankActivity, intent);
+      // Wait for remote params call
+      threadAndTaskWait();
 
       assertEquals(0, ShadowBadgeCountUpdater.lastCount);
-      // 2 open calls should fire.
-      assertEquals(2, ShadowOneSignalRestClient.networkCallCount);
+      // 2 open calls should fire + remote params + players call
+      assertEquals(4, ShadowOneSignalRestClient.networkCallCount);
+      assertEquals("notifications/UUID2", ShadowOneSignalRestClient.requests.get(1).url);
+      assertEquals("notifications/UUID", ShadowOneSignalRestClient.requests.get(2).url);
       ShadowRoboNotificationManager.notifications.clear();
 
       // Send 3rd notification
@@ -1534,7 +1559,6 @@ public class GenerateNotificationRunner {
       
       @Override
       protected boolean onNotificationProcessing(OSNotificationReceivedResult notification) {
-         
          OverrideSettings overrideSettings = new OverrideSettings();
          overrideSettings.extender = new NotificationCompat.Extender() {
             @Override

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
@@ -345,6 +345,8 @@ public class GenerateNotificationRunner {
       assertEquals(4, ShadowRoboNotificationManager.notifications.size());
       
       OneSignal.cancelGroupedNotifications("test1");
+      threadAndTaskWait();
+
       assertEquals(1, ShadowRoboNotificationManager.notifications.size());
    }
 
@@ -609,7 +611,8 @@ public class GenerateNotificationRunner {
       // Setup - Let's cancel a child notification.
       PostedNotification postedNotification = postedNotifsIterator.next().getValue();
       OneSignal.cancelNotification(postedNotification.id);
-   
+      threadAndTaskWait();
+
       // Test - It should update summary text to say 2 notifications
       postedNotifs = ShadowRoboNotificationManager.notifications;
       assertEquals(3, postedNotifs.size());       // 2 notifis + 1 summary
@@ -621,6 +624,8 @@ public class GenerateNotificationRunner {
       // Setup - Let's cancel a 2nd child notification.
       postedNotification = postedNotifsIterator.next().getValue();
       OneSignal.cancelNotification(postedNotification.id);
+      threadAndTaskWait();
+
       runImplicitServices();
       Thread.sleep(1_000); // TODO: Service runs AsyncTask. Need to wait for this
    
@@ -638,7 +643,8 @@ public class GenerateNotificationRunner {
       
       // Setup - Let's cancel our 3rd and last child notification.
       OneSignal.cancelNotification(postedNotification.id);
-   
+      threadAndTaskWait();
+
       // Test - No more notifications! :)
       postedNotifs = ShadowRoboNotificationManager.notifications;
       assertEquals(0, postedNotifs.size());

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/InAppMessageIntegrationTests.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/InAppMessageIntegrationTests.java
@@ -64,6 +64,7 @@ import static com.onesignal.OneSignalPackagePrivateHelper.OneSignal_getSessionLi
 import static com.onesignal.OneSignalPackagePrivateHelper.OneSignal_setSessionManager;
 import static com.onesignal.OneSignalPackagePrivateHelper.OneSignal_setSharedPreferences;
 import static com.onesignal.OneSignalPackagePrivateHelper.OneSignal_setTrackerFactory;
+import static com.onesignal.ShadowOneSignalRestClient.setRemoteParamsGetHtmlResponse;
 import static com.test.onesignal.RestClientAsserts.assertMeasureOnV2AtIndex;
 import static com.test.onesignal.TestHelpers.advanceSystemTimeBy;
 import static com.test.onesignal.TestHelpers.assertMainThread;
@@ -134,6 +135,9 @@ public class InAppMessageIntegrationTests {
         blankActivity = blankActivityController.get();
         dbHelper = new MockOneSignalDBHelper(ApplicationProvider.getApplicationContext());
         TestHelpers.beforeTestInitAndCleanup();
+
+        // Set remote_params GET response
+        setRemoteParamsGetHtmlResponse();
     }
 
     @After

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/InAppMessagingUnitTests.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/InAppMessagingUnitTests.java
@@ -43,6 +43,7 @@ import java.util.UUID;
 
 import static com.onesignal.OneSignalPackagePrivateHelper.OSTestTrigger.OSTriggerKind;
 import static com.onesignal.OneSignalPackagePrivateHelper.OSTestTrigger.OSTriggerOperator;
+import static com.onesignal.ShadowOneSignalRestClient.setRemoteParamsGetHtmlResponse;
 import static com.test.onesignal.TestHelpers.advanceSystemTimeBy;
 import static com.test.onesignal.TestHelpers.assertMainThread;
 import static com.test.onesignal.TestHelpers.threadAndTaskWait;
@@ -540,12 +541,12 @@ public class InAppMessagingUnitTests {
     }
 
     private void OneSignalInit() {
+        setRemoteParamsGetHtmlResponse();
         OneSignal.setLogLevel(OneSignal.LOG_LEVEL.VERBOSE, OneSignal.LOG_LEVEL.NONE);
         OneSignal.setAppId(InAppMessagingHelpers.ONESIGNAL_APP_ID);
         OneSignal.setAppContext(blankActivity);
         blankActivityController.resume();
     }
-
 
     private static @Nullable OSInAppMessageAction lastAction;
     @Test

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
@@ -128,6 +128,7 @@ import java.util.regex.Pattern;
 import static com.onesignal.OneSignalPackagePrivateHelper.FCMBroadcastReceiver_processBundle;
 import static com.onesignal.OneSignalPackagePrivateHelper.NotificationBundleProcessor_Process;
 import static com.onesignal.OneSignalPackagePrivateHelper.NotificationOpenedProcessor_processFromContext;
+import static com.onesignal.OneSignalPackagePrivateHelper.OneSignal_getRemoteParamController;
 import static com.onesignal.OneSignalPackagePrivateHelper.OneSignal_getSessionListener;
 import static com.onesignal.OneSignalPackagePrivateHelper.OneSignal_setSessionManager;
 import static com.onesignal.OneSignalPackagePrivateHelper.OneSignal_setTrackerFactory;
@@ -2100,6 +2101,7 @@ public class MainOneSignalClassRunner {
          assertFalse(failedCurModTest);
       }
 
+      assertEquals(30000, OneSignal_taskQueueWaitingForInit().size());
       OneSignalInit();
 
       for (int a = 0; a < 10; a++) {
@@ -3355,10 +3357,7 @@ public class MainOneSignalClassRunner {
    @Test
    @Config(shadows = {ShadowOneSignal.class})
    @SuppressWarnings("unchecked") // getDeclaredMethod
-   public void testLocationTimeout() throws Exception {
-//      ShadowApplication.getInstance().grantPermissions(new String[]{"android.permission.YOUR_PERMISSION"});
-
-      OneSignalInit();
+   public void testLocationTimeout() throws Exception { OneSignalInit();
       threadAndTaskWait();
 
       Class klass = Class.forName("com.onesignal.GMSLocationController");
@@ -3803,10 +3802,12 @@ public class MainOneSignalClassRunner {
       ShadowRoboNotificationManager.PostedNotification postedNotification = postedNotifsIterator.next().getValue();
 
       OneSignal.cancelNotification(postedNotification.id);
+      threadAndTaskWait();
       assertEquals(1, ShadowBadgeCountUpdater.lastCount);
       assertEquals(1, ShadowRoboNotificationManager.notifications.size());
 
       OneSignal.clearOneSignalNotifications();
+      threadAndTaskWait();
       assertEquals(0, ShadowBadgeCountUpdater.lastCount);
       assertEquals(0, ShadowRoboNotificationManager.notifications.size());
 

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/NotificationLimitManagerRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/NotificationLimitManagerRunner.java
@@ -29,6 +29,7 @@ import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowLog;
 
 import static com.onesignal.OneSignalPackagePrivateHelper.NotificationBundleProcessor_ProcessFromFCMIntentService;
+import static com.onesignal.ShadowOneSignalRestClient.setRemoteParamsGetHtmlResponse;
 import static com.test.onesignal.GenerateNotificationRunner.getBaseNotifBundle;
 import static com.test.onesignal.TestHelpers.afterTestCleanup;
 import static com.test.onesignal.TestHelpers.threadAndTaskWait;
@@ -67,6 +68,8 @@ public class NotificationLimitManagerRunner {
       notificationManager = (NotificationManager)blankActivity.getSystemService(Context.NOTIFICATION_SERVICE);
       TestHelpers.beforeTestInitAndCleanup();
 
+      // Set remote_params GET response
+      setRemoteParamsGetHtmlResponse();
       OneSignal.setAppId("b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
       OneSignal.setAppContext(blankActivity);
       OneSignal.setInFocusDisplaying(OneSignal.OSInFocusDisplayOption.Notification);

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/NotificationLimitManagerRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/NotificationLimitManagerRunner.java
@@ -87,6 +87,7 @@ public class NotificationLimitManagerRunner {
       createNotification(blankActivity, 2);
 
       NotificationLimitManager.clearOldestOverLimitStandard(blankActivity, 1);
+      threadAndTaskWait();
 
       assertEquals(1, notificationManager.getActiveNotifications().length);
       assertEquals(2, notificationManager.getActiveNotifications()[0].getId());
@@ -97,6 +98,7 @@ public class NotificationLimitManagerRunner {
       createNotification(blankActivity, 1);
 
       NotificationLimitManager.clearOldestOverLimitStandard(blankActivity, 1);
+      threadAndTaskWait();
 
       assertEquals(1, notificationManager.getActiveNotifications().length);
    }
@@ -112,6 +114,7 @@ public class NotificationLimitManagerRunner {
       createNotification(blankActivity, 2);
 
       NotificationLimitManager.clearOldestOverLimitStandard(blankActivity, 1);
+      threadAndTaskWait();
 
       assertEquals(1 , notificationManager.getActiveNotifications()[0].getId());
    }
@@ -124,20 +127,22 @@ public class NotificationLimitManagerRunner {
    }
 
    @Test
-   public void clearFallbackMakingRoomForOneWhenAtLimit() {
+   public void clearFallbackMakingRoomForOneWhenAtLimit() throws Exception {
       NotificationBundleProcessor_ProcessFromFCMIntentService(blankActivity,  getBaseNotifBundle("UUID1"), null);
       NotificationBundleProcessor_ProcessFromFCMIntentService(blankActivity,  getBaseNotifBundle("UUID2"), null);
 
       NotificationLimitManager.clearOldestOverLimitFallback(blankActivity, 1);
+      threadAndTaskWait();
 
       assertEquals(1, notificationManager.getActiveNotifications().length);
    }
 
    @Test
-   public void clearFallbackShouldNotCancelAnyNotificationsWhenUnderLimit() {
+   public void clearFallbackShouldNotCancelAnyNotificationsWhenUnderLimit() throws Exception {
       NotificationBundleProcessor_ProcessFromFCMIntentService(blankActivity,  getBaseNotifBundle("UUID1"), null);
 
       NotificationLimitManager.clearOldestOverLimitFallback(blankActivity, 1);
+      threadAndTaskWait();
 
       assertEquals(1, notificationManager.getActiveNotifications().length);
    }

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/NotificationOpenedActivityHMSIntegrationTestsRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/NotificationOpenedActivityHMSIntegrationTestsRunner.java
@@ -30,6 +30,7 @@ import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowLog;
 
@@ -40,6 +41,7 @@ import static com.onesignal.OneSignalPackagePrivateHelper.OSNotificationFormatHe
 import static com.onesignal.OneSignalPackagePrivateHelper.OSNotificationFormatHelper.PAYLOAD_OS_NOTIFICATION_ID;
 import static com.onesignal.OneSignalPackagePrivateHelper.GenerateNotification.BUNDLE_KEY_ACTION_ID;
 import static com.onesignal.InAppMessagingHelpers.ONESIGNAL_APP_ID;
+import static com.onesignal.ShadowOneSignalRestClient.setRemoteParamsGetHtmlResponse;
 import static com.test.onesignal.RestClientAsserts.assertNotificationOpenAtIndex;
 import static com.test.onesignal.TestHelpers.fastColdRestartApp;
 import static com.test.onesignal.TestHelpers.threadAndTaskWait;
@@ -76,6 +78,8 @@ public class NotificationOpenedActivityHMSIntegrationTestsRunner {
     public void beforeEachTest() throws Exception {
         TestHelpers.beforeTestInitAndCleanup();
         ShadowOSUtils.supportsHMS(true);
+        // Set remote_params GET response
+        setRemoteParamsGetHtmlResponse();
     }
 
     private static @NonNull Intent helper_baseHMSOpenIntent() {
@@ -167,9 +171,13 @@ public class NotificationOpenedActivityHMSIntegrationTestsRunner {
 
     @Test
     public void osIAMPreview_showsPreview() throws Exception {
-        Activity activity = Robolectric.buildActivity(BlankActivity.class).create().get();
+        ActivityController<BlankActivity> blankActivityController = Robolectric.buildActivity(BlankActivity.class).create();
+        Activity blankActivity = blankActivityController.get();
         OneSignal.setAppId(ONESIGNAL_APP_ID);
-        OneSignal.setAppContext(activity);
+        OneSignal.setAppContext(blankActivity);
+        threadAndTaskWait();
+
+        blankActivityController.resume();
         threadAndTaskWait();
 
         Intent intent = helper_baseHMSOpenIntent()

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/OneSignalPrefsRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/OneSignalPrefsRunner.java
@@ -20,6 +20,8 @@ import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowLog;
 
+import static com.onesignal.ShadowOneSignalRestClient.setRemoteParamsGetHtmlResponse;
+import static com.test.onesignal.TestHelpers.threadAndTaskWait;
 import static org.junit.Assert.assertEquals;
 
 @Config(packageName = "com.onesignal.example",
@@ -29,6 +31,9 @@ import static org.junit.Assert.assertEquals;
 @RunWith(RobolectricTestRunner.class)
 public class OneSignalPrefsRunner {
 
+   private static final String ONESIGNAL_APP_ID = "b4f7f966-d8cc-11e4-bed1-df8f05be55ba";
+   private static final String KEY = "key";
+   private static final String VALUE = "value";
    private static Activity blankActivity;
 
    @BeforeClass // Runs only once, before any tests
@@ -39,10 +44,13 @@ public class OneSignalPrefsRunner {
    }
 
    @Before // Before each test
-   public void beforeEachTest() {
-      TestOneSignalPrefs.initializePool();
+   public void beforeEachTest() throws Exception {
+      TestHelpers.beforeTestInitAndCleanup();
+
       ActivityController<BlankActivity> blankActivityController = Robolectric.buildActivity(BlankActivity.class).create();
       blankActivity = blankActivityController.get();
+
+      OneSignal.setLogLevel(OneSignal.LOG_LEVEL.VERBOSE, OneSignal.LOG_LEVEL.NONE);
    }
 
    @AfterClass
@@ -52,49 +60,52 @@ public class OneSignalPrefsRunner {
 
    @Test
    public void testNullContextDoesNotCrash() {
-      TestOneSignalPrefs.saveString(TestOneSignalPrefs.PREFS_ONESIGNAL,"key", "value");
+      TestOneSignalPrefs.saveString(TestOneSignalPrefs.PREFS_ONESIGNAL, KEY, VALUE);
       TestHelpers.flushBufferedSharedPrefs();
    }
 
    @Test
-   public void tesWriteWithNullAppId_andSavesAfterSetting() {
+   public void tesWriteWithNullAppId_andSavesAfterSetting() throws Exception {
       OneSignal.setAppContext(blankActivity);
-      TestOneSignalPrefs.saveString(TestOneSignalPrefs.PREFS_ONESIGNAL,"key", "value");
+      TestOneSignalPrefs.saveString(TestOneSignalPrefs.PREFS_ONESIGNAL, KEY, VALUE);
       TestHelpers.flushBufferedSharedPrefs();
 
-      OneSignal.setAppId("b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
+      OneSignal.setAppId(ONESIGNAL_APP_ID);
+      threadAndTaskWait();
       TestHelpers.flushBufferedSharedPrefs();
 
       final SharedPreferences prefs = blankActivity.getSharedPreferences(TestOneSignalPrefs.PREFS_ONESIGNAL, Context.MODE_PRIVATE);
-      String value = prefs.getString("key", "");
-      assertEquals("value", value);
+      String value = prefs.getString(KEY, "");
+      assertEquals(VALUE, value);
    }
 
    @Test
-   public void tesWriteWithNullContext_andSavesAfterSetting() {
-      OneSignal.setAppId("b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
-      TestOneSignalPrefs.saveString(TestOneSignalPrefs.PREFS_ONESIGNAL,"key", "value");
+   public void tesWriteWithNullContext_andSavesAfterSetting() throws Exception {
+      OneSignal.setAppId(ONESIGNAL_APP_ID);
+      TestOneSignalPrefs.saveString(TestOneSignalPrefs.PREFS_ONESIGNAL, KEY, VALUE);
       TestHelpers.flushBufferedSharedPrefs();
 
       OneSignal.setAppContext(blankActivity);
+      threadAndTaskWait();
       TestHelpers.flushBufferedSharedPrefs();
 
       final SharedPreferences prefs = blankActivity.getSharedPreferences(TestOneSignalPrefs.PREFS_ONESIGNAL, Context.MODE_PRIVATE);
-      String value = prefs.getString("key", "");
-      assertEquals("value", value);
+      String value = prefs.getString(KEY, "");
+      assertEquals(VALUE, value);
    }
 
    @Test
-   public void tesWriteWithNullContextAndAppId_andSavesAfterSetting() {
-      OneSignal.setAppId("b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
-      TestOneSignalPrefs.saveString(TestOneSignalPrefs.PREFS_ONESIGNAL,"key", "value");
+   public void tesWriteWithNullContextAndAppId_andSavesAfterSetting() throws Exception {
+      OneSignal.setAppId(ONESIGNAL_APP_ID);
+      TestOneSignalPrefs.saveString(TestOneSignalPrefs.PREFS_ONESIGNAL, KEY, VALUE);
       TestHelpers.flushBufferedSharedPrefs();
 
       OneSignal.setAppContext(blankActivity);
+      threadAndTaskWait();
       TestHelpers.flushBufferedSharedPrefs();
 
       final SharedPreferences prefs = blankActivity.getSharedPreferences(TestOneSignalPrefs.PREFS_ONESIGNAL, Context.MODE_PRIVATE);
-      String value = prefs.getString("key", "");
-      assertEquals("value", value);
+      String value = prefs.getString(KEY, "");
+      assertEquals(VALUE, value);
    }
 }

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/OutcomeEventIntegrationTests.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/OutcomeEventIntegrationTests.java
@@ -54,6 +54,7 @@ import static com.onesignal.OneSignalPackagePrivateHelper.OneSignal_getSessionLi
 import static com.onesignal.OneSignalPackagePrivateHelper.OneSignal_setSessionManager;
 import static com.onesignal.OneSignalPackagePrivateHelper.OneSignal_setSharedPreferences;
 import static com.onesignal.OneSignalPackagePrivateHelper.OneSignal_setTrackerFactory;
+import static com.onesignal.ShadowOneSignalRestClient.setRemoteParamsGetHtmlResponse;
 import static com.test.onesignal.GenerateNotificationRunner.getBaseNotifBundle;
 import static com.test.onesignal.RestClientAsserts.assertMeasureAtIndex;
 import static com.test.onesignal.RestClientAsserts.assertMeasureOnV2AtIndex;
@@ -135,6 +136,8 @@ public class OutcomeEventIntegrationTests {
         notificationOpenedMessage = null;
 
         TestHelpers.beforeTestInitAndCleanup();
+        // Set remote_params GET response
+        setRemoteParamsGetHtmlResponse();
     }
 
     @Before
@@ -661,11 +664,8 @@ public class OutcomeEventIntegrationTests {
 
     @Test
     public void testDirectSession_willOverrideDirectSession_whenAppIsInBackground() throws Exception {
-        sessionManager.initSessionFromCache();
-        OneSignal_setTrackerFactory(trackerFactory);
-        OneSignal_setSessionManager(sessionManager);
-        OneSignalPackagePrivateHelper.RemoteOutcomeParams params = new OneSignalPackagePrivateHelper.RemoteOutcomeParams();
-        trackerFactory.saveInfluenceParams(params);
+        OneSignalInit();
+        threadAndTaskWait();
 
         // Background app
         blankActivityController.pause();
@@ -814,7 +814,7 @@ public class OutcomeEventIntegrationTests {
         TestHelpers.runNextJob();
         threadAndTaskWait();
 
-        assertOnFocusAtIndex(2, new JSONObject() {{
+        assertOnFocusAtIndex(3, new JSONObject() {{
             put("active_time", 10);
             put("direct", false);
             put("notification_ids", new JSONArray().put(ONESIGNAL_NOTIFICATION_ID + "1"));
@@ -1073,8 +1073,6 @@ public class OutcomeEventIntegrationTests {
         OneSignal.setAppContext(blankActivity);
         OneSignal.setNotificationOpenedHandler(getNotificationOpenedHandler());
         threadAndTaskWait();
-        // Enable influence
-        trackerFactory.saveInfluenceParams(new OneSignalPackagePrivateHelper.RemoteOutcomeParams());
         blankActivityController.resume();
     }
 
@@ -1088,8 +1086,6 @@ public class OutcomeEventIntegrationTests {
         OneSignal.setAppContext(blankActivity);
         OneSignal.setNotificationOpenedHandler(notificationOpenedHandler);
         threadAndTaskWait();
-        // Enable influence
-        trackerFactory.saveInfluenceParams(new OneSignalPackagePrivateHelper.RemoteOutcomeParams());
         blankActivityController.resume();
     }
 }

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/PushRegistratorHMSIntegrationTestsRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/PushRegistratorHMSIntegrationTestsRunner.java
@@ -29,6 +29,7 @@ import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowLog;
 
+import static com.onesignal.ShadowOneSignalRestClient.setRemoteParamsGetHtmlResponse;
 import static com.test.onesignal.RestClientAsserts.assertHuaweiPlayerCreateAtIndex;
 import static com.test.onesignal.RestClientAsserts.assertPlayerCreateNotSubscribedAtIndex;
 import static com.test.onesignal.RestClientAsserts.assertPlayerCreateSubscribedAtIndex;
@@ -70,6 +71,9 @@ public class PushRegistratorHMSIntegrationTestsRunner {
 
         blankActivityController = Robolectric.buildActivity(BlankActivity.class).create();
         blankActivity = blankActivityController.get();
+
+        // Set remote_params GET response
+        setRemoteParamsGetHtmlResponse();
     }
 
     private static void assertHuaweiSubscribe() throws JSONException {

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/RESTClientRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/RESTClientRunner.java
@@ -27,21 +27,28 @@
 
 package com.test.onesignal;
 
+import android.annotation.SuppressLint;
+import android.app.Activity;
+
 import com.onesignal.MockHttpURLConnection;
 import com.onesignal.OneSignal;
 import com.onesignal.OneSignalPackagePrivateHelper.OneSignalRestClient;
 import com.onesignal.ShadowOneSignalRestClientWithMockConnection;
 import com.onesignal.StaticResetHelper;
+import com.onesignal.example.BlankActivity;
 
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowLog;
 
+import static com.onesignal.OneSignalPackagePrivateHelper.OneSignal_savePrivacyConsentRequired;
 import static com.test.onesignal.TestHelpers.threadAndTaskWait;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNotNull;
@@ -57,6 +64,10 @@ import static junit.framework.Assert.assertTrue;
 @RunWith(RobolectricTestRunner.class)
 public class RESTClientRunner {
 
+   @SuppressLint("StaticFieldLeak")
+   private static Activity blankActivity;
+   private static ActivityController<BlankActivity> blankActivityController;
+
    @BeforeClass // Runs only once, before any tests
    public static void setUpClass() throws Exception {
       ShadowLog.stream = System.out;
@@ -67,7 +78,10 @@ public class RESTClientRunner {
    @Before // Before each test
    public void beforeEachTest() throws Exception {
       firstResponse = secondResponse = null;
+      blankActivityController = Robolectric.buildActivity(BlankActivity.class).create();
+      blankActivity = blankActivityController.get();
       TestHelpers.beforeTestInitAndCleanup();
+      OneSignal.setAppContext(blankActivity);
    }
 
    @AfterClass
@@ -99,6 +113,8 @@ public class RESTClientRunner {
 
    @Test
    public void SDKHeaderIsIncludedInPostCalls() throws Exception {
+      OneSignal_savePrivacyConsentRequired(false);
+
       OneSignalRestClient.post("URL", null, null);
       threadAndTaskWait();
 
@@ -107,6 +123,8 @@ public class RESTClientRunner {
 
    @Test
    public void SDKHeaderIsIncludedInPutCalls() throws Exception {
+      OneSignal_savePrivacyConsentRequired(false);
+
       OneSignalRestClient.put("URL", null, null);
       threadAndTaskWait();
 
@@ -192,6 +210,8 @@ public class RESTClientRunner {
 
    @Test
    public void testApiCall400Response() throws Exception {
+      OneSignal_savePrivacyConsentRequired(false);
+
       final String newMockResponse = "{\"errors\":[\"test response\"]}";
       final int statusCode = 400;
 
@@ -223,6 +243,8 @@ public class RESTClientRunner {
 
    @Test
    public void testApiCall400EmptyResponse() throws Exception {
+      OneSignal_savePrivacyConsentRequired(false);
+
       final String newMockResponse = "";
       final int statusCode = 400;
 


### PR DESCRIPTION
Add task delay due to requiring consent from remote params

   * Move task management to TaskController
   * Delay task until remote params and init is done
   * After task delayed, check again for user consent
   * Fix test, add tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1092)
<!-- Reviewable:end -->
