### PR TITLE
Fix ANR due to on_focus call being call from MainThread

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/FocusTimeController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/FocusTimeController.java
@@ -173,8 +173,10 @@ class FocusTimeController {
       protected boolean timeTypeApplies(@NonNull List<OSInfluence> influences) {
          for (OSInfluence influence : influences) {
             // Is true is at least one channel attributed the session
-            if (influence.getInfluenceType().isAttributed())
+            if (influence.getInfluenceType().isAttributed()) {
+               OneSignal.Log(OneSignal.LOG_LEVEL.DEBUG, this.getClass().getSimpleName() + ":timeTypeApplies for influences: " + influences.toString() + " true");
                return true;
+            }
          }
          return false;
       }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSUtils.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSUtils.java
@@ -475,6 +475,10 @@ class OSUtils {
       return true;
    }
 
+   static boolean isRunningOnMainThread() {
+      return Thread.currentThread().equals(Looper.getMainLooper().getThread());
+   }
+
    static void runOnMainUIThread(Runnable runnable) {
       if (Looper.getMainLooper().getThread() == Thread.currentThread())
          runnable.run();

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -437,7 +437,7 @@ public class OneSignal {
          @Override
          public void onSessionEnding(@NonNull List<OSInfluence> lastInfluences) {
             if (outcomeEventsController == null)
-               OneSignal.Log(LOG_LEVEL.WARN, "OneSignal onSessionEnding called before initZ");
+               OneSignal.Log(LOG_LEVEL.WARN, "OneSignal onSessionEnding called before init!");
             if (outcomeEventsController != null)
                outcomeEventsController.cleanOutcomes();
             FocusTimeController.getInstance().onSessionEnded(lastInfluences);

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalRestClient.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalRestClient.java
@@ -100,10 +100,13 @@ class OneSignalRestClient {
    }
    
    private static void makeRequest(final String url, final String method, final JSONObject jsonBody, final ResponseHandler responseHandler, final int timeout, final String cacheKey) {
+      if (OSUtils.isRunningOnMainThread())
+         throw new OneSignalNetworkCallException("Method: " + method + " was called from the Main Thread!");
+
       // If not a GET request, check if the user provided privacy consent if the application is set to require user privacy consent
       if (method != null && OneSignal.shouldLogUserPrivacyConsentErrorMessageForMethodName(null))
          return;
-   
+
       final Thread[] callbackThread = new Thread[1];
       Thread connectionThread = new Thread(new Runnable() {
          public void run() {
@@ -288,5 +291,11 @@ class OneSignalRestClient {
 
    private static HttpURLConnection newHttpURLConnection(String url) throws IOException {
       return (HttpURLConnection)new URL(BASE_URL + url).openConnection();
+   }
+
+   private static class OneSignalNetworkCallException extends RuntimeException {
+      public OneSignalNetworkCallException(String message) {
+         super(message);
+      }
    }
 }

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/RESTClientRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/RESTClientRunner.java
@@ -57,7 +57,7 @@ import static junit.framework.Assert.assertTrue;
 
 @RunWith(RobolectricTestRunner.class)
 public class RESTClientRunner {
-   
+
    @BeforeClass // Runs only once, before any tests
    public static void setUpClass() throws Exception {
       ShadowLog.stream = System.out;
@@ -82,7 +82,7 @@ public class RESTClientRunner {
          mockThreadHang = true;
       }};
 
-      OneSignalRestClient.getSync("URL", null,"");
+      OneSignalRestClient.get("URL", null, "");
       threadAndTaskWait();
 
       assertTrue(ShadowOneSignalRestClientWithMockConnection.lastConnection.getDidInterruptMockHang());
@@ -92,7 +92,7 @@ public class RESTClientRunner {
 
    @Test
    public void SDKHeaderIsIncludedInGetCalls() throws Exception {
-      OneSignalRestClient.getSync("URL", null, null);
+      OneSignalRestClient.get("URL", null, null);
       threadAndTaskWait();
 
       assertEquals(SDK_VERSION_HTTP_HEADER, getLastHTTPHeaderProp("SDK-Version"));
@@ -100,7 +100,7 @@ public class RESTClientRunner {
 
    @Test
    public void SDKHeaderIsIncludedInPostCalls() throws Exception {
-      OneSignalRestClient.postSync("URL", null,null);
+      OneSignalRestClient.post("URL", null, null);
       threadAndTaskWait();
 
       assertEquals(SDK_VERSION_HTTP_HEADER, getLastHTTPHeaderProp("SDK-Version"));
@@ -108,7 +108,7 @@ public class RESTClientRunner {
 
    @Test
    public void SDKHeaderIsIncludedInPutCalls() throws Exception {
-      OneSignalRestClient.putSync("URL", null,null);
+      OneSignalRestClient.put("URL", null, null);
       threadAndTaskWait();
 
       assertEquals(SDK_VERSION_HTTP_HEADER, getLastHTTPHeaderProp("SDK-Version"));
@@ -131,7 +131,7 @@ public class RESTClientRunner {
          responseBody = "{\"key1\": \"value1\"}";
          mockProps.put("etag", MOCK_ETAG_VALUE);
       }};
-      OneSignalRestClient.getSync("URL", new OneSignalRestClient.ResponseHandler() {
+      OneSignalRestClient.get("URL", new OneSignalRestClient.ResponseHandler() {
          @Override
          public void onSuccess(String response) {
             firstResponse = response;
@@ -145,7 +145,7 @@ public class RESTClientRunner {
          status = 304;
       }};
 
-      OneSignalRestClient.getSync("URL", new OneSignalRestClient.ResponseHandler() {
+      OneSignalRestClient.get("URL", new OneSignalRestClient.ResponseHandler() {
          @Override
          public void onSuccess(String response) {
             secondResponse = response;
@@ -171,7 +171,7 @@ public class RESTClientRunner {
          responseBody = newMockResponse;
          mockProps.put("etag", "MOCK_ETAG_VALUE2");
       }};
-      OneSignalRestClient.getSync("URL", null, MOCK_CACHE_KEY);
+      OneSignalRestClient.get("URL", null, MOCK_CACHE_KEY);
       threadAndTaskWait();
       Thread.sleep(200);
 
@@ -179,7 +179,7 @@ public class RESTClientRunner {
       ShadowOneSignalRestClientWithMockConnection.mockResponse = new MockHttpURLConnection.MockResponse() {{
          status = 304;
       }};
-      OneSignalRestClient.getSync("URL", new OneSignalRestClient.ResponseHandler() {
+      OneSignalRestClient.get("URL", new OneSignalRestClient.ResponseHandler() {
          @Override
          public void onSuccess(String response) {
             secondResponse = response.replace("\u0000", "");
@@ -203,7 +203,7 @@ public class RESTClientRunner {
 
       final String[] failResponse = {null};
       final int[] statusCodeResponse = {0};
-      OneSignalRestClient.postSync("URL", null, new OneSignalRestClient.ResponseHandler() {
+      OneSignalRestClient.post("URL", null, new OneSignalRestClient.ResponseHandler() {
          @Override
          public void onSuccess(String response) {
             super.onSuccess(response);
@@ -234,7 +234,7 @@ public class RESTClientRunner {
 
       final String[] failResponse = {null};
       final int[] statusCodeResponse = {0};
-      OneSignalRestClient.postSync("URL", null, new OneSignalRestClient.ResponseHandler() {
+      OneSignalRestClient.post("URL", null, new OneSignalRestClient.ResponseHandler() {
          @Override
          public void onSuccess(String response) {
             super.onSuccess(response);

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/SessionManagerUnitTests.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/SessionManagerUnitTests.java
@@ -339,7 +339,7 @@ public class SessionManagerUnitTests {
     }
 
     @Test
-    public void testSessionUpgradeFromAppClosed() {
+    public void testSessionUpgradeFromAppClosed() throws Exception {
         trackerFactory.saveInfluenceParams(new OneSignalPackagePrivateHelper.RemoteOutcomeParams());
         sessionManager.initSessionFromCache();
 
@@ -369,6 +369,7 @@ public class SessionManagerUnitTests {
         }
 
         sessionManager.attemptSessionUpgrade(OneSignal.AppEntryAction.APP_CLOSE);
+        threadAndTaskWait();
 
         influences = sessionManager.getInfluences();
 
@@ -390,7 +391,7 @@ public class SessionManagerUnitTests {
     }
 
     @Test
-    public void testSessionUpgradeFromUnattributedToIndirect() throws JSONException {
+    public void testSessionUpgradeFromUnattributedToIndirect() throws Exception {
         trackerFactory.saveInfluenceParams(new OneSignalPackagePrivateHelper.RemoteOutcomeParams());
         sessionManager.initSessionFromCache();
 
@@ -420,6 +421,7 @@ public class SessionManagerUnitTests {
         }
 
         sessionManager.attemptSessionUpgrade(OneSignal.AppEntryAction.APP_OPEN);
+        threadAndTaskWait();
 
         influences = sessionManager.getInfluences();
 
@@ -439,7 +441,7 @@ public class SessionManagerUnitTests {
     }
 
     @Test
-    public void testSessionUpgradeFromUnattributedToDirectNotification() throws JSONException {
+    public void testSessionUpgradeFromUnattributedToDirectNotification() throws Exception {
         trackerFactory.saveInfluenceParams(new OneSignalPackagePrivateHelper.RemoteOutcomeParams());
         sessionManager.initSessionFromCache();
 
@@ -452,6 +454,7 @@ public class SessionManagerUnitTests {
         sessionManager.onNotificationReceived(GENERIC_ID);
         sessionManager.onInAppMessageReceived(GENERIC_ID);
         sessionManager.onDirectInfluenceFromNotificationOpen(GENERIC_ID);
+        threadAndTaskWait();
 
         iamInfluences = trackerFactory.getIAMChannelTracker().getCurrentSessionInfluence();
         notificationInfluences = trackerFactory.getNotificationChannelTracker().getCurrentSessionInfluence();
@@ -474,7 +477,7 @@ public class SessionManagerUnitTests {
     }
 
     @Test
-    public void testSessionUpgradeFromIndirectToDirect() throws JSONException {
+    public void testSessionUpgradeFromIndirectToDirect() throws Exception {
         trackerFactory.saveInfluenceParams(new OneSignalPackagePrivateHelper.RemoteOutcomeParams());
         sessionManager.initSessionFromCache();
 
@@ -490,6 +493,7 @@ public class SessionManagerUnitTests {
         assertEquals(GENERIC_ID, notificationInfluences.getIds().get(0));
 
         sessionManager.onDirectInfluenceFromNotificationOpen(NOTIFICATION_ID);
+        threadAndTaskWait();
 
         iamInfluences = trackerFactory.getIAMChannelTracker().getCurrentSessionInfluence();
         notificationInfluences = trackerFactory.getNotificationChannelTracker().getCurrentSessionInfluence();
@@ -513,7 +517,7 @@ public class SessionManagerUnitTests {
     }
 
     @Test
-    public void testSessionUpgradeFromDirectToDirectDifferentID() throws JSONException {
+    public void testSessionUpgradeFromDirectToDirectDifferentID() throws Exception {
         trackerFactory.saveInfluenceParams(new OneSignalPackagePrivateHelper.RemoteOutcomeParams());
         sessionManager.initSessionFromCache();
 
@@ -527,6 +531,7 @@ public class SessionManagerUnitTests {
 
         sessionManager.onNotificationReceived(NOTIFICATION_ID);
         sessionManager.onDirectInfluenceFromNotificationOpen(NOTIFICATION_ID);
+        threadAndTaskWait();
 
         notificationInfluences = trackerFactory.getNotificationChannelTracker().getCurrentSessionInfluence();
 
@@ -543,7 +548,7 @@ public class SessionManagerUnitTests {
     }
 
     @Test
-    public void testSessionUpgradeFromDirectToDirectSameID() throws JSONException {
+    public void testSessionUpgradeFromDirectToDirectSameID() throws Exception {
         trackerFactory.saveInfluenceParams(new OneSignalPackagePrivateHelper.RemoteOutcomeParams());
         sessionManager.initSessionFromCache();
 
@@ -556,6 +561,7 @@ public class SessionManagerUnitTests {
         assertEquals(GENERIC_ID, notificationInfluences.getIds().get(0));
 
         sessionManager.attemptSessionUpgrade(OneSignal.AppEntryAction.NOTIFICATION_CLICK);
+        threadAndTaskWait();
 
         notificationInfluences = trackerFactory.getNotificationChannelTracker().getCurrentSessionInfluence();
 
@@ -571,7 +577,7 @@ public class SessionManagerUnitTests {
     }
 
     @Test
-    public void testSessionUpgradeFromDirectToDirectEndChannelsDirect() throws JSONException {
+    public void testSessionUpgradeFromDirectToDirectEndChannelsDirect() throws Exception {
         trackerFactory.saveInfluenceParams(new OneSignalPackagePrivateHelper.RemoteOutcomeParams());
         sessionManager.initSessionFromCache();
 
@@ -579,6 +585,7 @@ public class SessionManagerUnitTests {
         sessionManager.onDirectInfluenceFromNotificationOpen(GENERIC_ID);
         sessionManager.onInAppMessageReceived(IAM_ID);
         sessionManager.onDirectInfluenceFromIAMClick(IAM_ID);
+        threadAndTaskWait();
 
         OSInfluence iamInfluences = trackerFactory.getIAMChannelTracker().getCurrentSessionInfluence();
         OSInfluence notificationInfluences = trackerFactory.getNotificationChannelTracker().getCurrentSessionInfluence();
@@ -589,6 +596,7 @@ public class SessionManagerUnitTests {
         assertEquals(GENERIC_ID, notificationInfluences.getIds().get(0));
 
         sessionManager.onDirectInfluenceFromNotificationOpen(NOTIFICATION_ID);
+        threadAndTaskWait();
 
         iamInfluences = trackerFactory.getIAMChannelTracker().getCurrentSessionInfluence();
         notificationInfluences = trackerFactory.getNotificationChannelTracker().getCurrentSessionInfluence();


### PR DESCRIPTION
* When attempSessionUpgrade is call, onFocus call can end being call from mainThread
* Add MainThread check on makeRequest
* Throw RuntimeException when running network calls from MainThread

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1099)
<!-- Reviewable:end -->
