### PR TITLE
Added runtime check before showing a notification

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotification.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotification.java
@@ -111,6 +111,10 @@ class GenerateNotification {
       if (notifJob.displayOption.isSilent())
          return;
 
+      // Runtime check against showing the notification from the main thread
+      if (OSUtils.isRunningOnMainThread())
+         throw new OSThrowable.OSMainThreadException("Process for showing a notification should never been done on Main Thread!");
+
       showNotification(notifJob);
    }
    

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotification.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotification.java
@@ -47,6 +47,7 @@ import android.text.style.StyleSpan;
 import android.widget.RemoteViews;
 
 import androidx.annotation.RequiresApi;
+import androidx.annotation.WorkerThread;
 import androidx.core.app.NotificationCompat;
 import androidx.core.app.NotificationManagerCompat;
 
@@ -105,17 +106,25 @@ class GenerateNotification {
          notificationOpenedClass = NotificationOpenedActivity.class;
    }
 
-   static void fromJsonPayload(final OSNotificationGenerationJob notifJob) {
+   @WorkerThread
+   static void fromJsonPayload(OSNotificationGenerationJob notifJob) {
       setStatics(notifJob.context);
 
       if (notifJob.displayOption.isSilent())
          return;
 
+      isRunningOnMainThreadCheck();
+
+      showNotification(notifJob);
+   }
+
+   /**
+    * For shadow test purpose
+    */
+   static void isRunningOnMainThreadCheck() {
       // Runtime check against showing the notification from the main thread
       if (OSUtils.isRunningOnMainThread())
          throw new OSThrowable.OSMainThreadException("Process for showing a notification should never been done on Main Thread!");
-
-      showNotification(notifJob);
    }
    
    private static CharSequence getTitle(JSONObject fcmJson) {
@@ -607,7 +616,7 @@ class GenerateNotification {
             inboxStyle.addLine(spannableString);
          }
 
-         for(SpannableString line : summaryList)
+         for (SpannableString line : summaryList)
             inboxStyle.addLine(line);
          inboxStyle.setBigContentTitle(summaryMessage);
          summaryBuilder.setStyle(inboxStyle);

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
@@ -38,6 +38,7 @@ import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.WorkerThread;
 
 import com.onesignal.OneSignalDbContract.NotificationTable;
 
@@ -114,10 +115,12 @@ class NotificationBundleProcessor {
      * Only use the {@link NotificationBundleProcessor#processJobForDisplay(OSNotificationGenerationJob, boolean, boolean)}
      *  in the event where you want to mark a notification as opened or displayed different than the defaults
      */
+    @WorkerThread
     static int processJobForDisplay(OSNotificationGenerationJob notifJob) {
         return processJobForDisplay(notifJob, false, true);
     }
 
+    @WorkerThread
     static int processJobForDisplay(OSNotificationGenerationJob notifJob, boolean opened, boolean displayed) {
         processCollapseKey(notifJob);
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationDisplayedResult.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationDisplayedResult.java
@@ -29,4 +29,11 @@ package com.onesignal;
 
 public class OSNotificationDisplayedResult {
    public int androidNotificationId;
+
+   @Override
+   public String toString() {
+      return "OSNotificationDisplayedResult{" +
+              "androidNotificationId=" + androidNotificationId +
+              '}';
+   }
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationExtender.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationExtender.java
@@ -57,6 +57,14 @@ public class OSNotificationExtender {
          if (overrideSettings.extender != null)
             extender = overrideSettings.extender;
       }
+
+      @Override
+      public String toString() {
+         return "OverrideSettings{" +
+                 "extender=" + extender +
+                 ", androidNotificationId=" + androidNotificationId +
+                 '}';
+      }
    }
 
    private Context context;
@@ -220,5 +228,18 @@ public class OSNotificationExtender {
       } catch (ClassNotFoundException e) {
          e.printStackTrace();
       }
+   }
+
+   @Override
+   public String toString() {
+      return "OSNotificationExtender{" +
+              "context=" + context +
+              ", jsonPayload=" + jsonPayload +
+              ", isRestoring=" + isRestoring +
+              ", timestamp=" + timestamp +
+              ", currentBaseOverrideSettings=" + currentBaseOverrideSettings +
+              ", notificationDisplayedResult=" + notificationDisplayedResult +
+              ", developerProcessed=" + developerProcessed +
+              '}';
    }
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationGenerationJob.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationGenerationJob.java
@@ -43,10 +43,10 @@ public class OSNotificationGenerationJob {
     // Timeout in seconds before applying defaults
     private static final long SHOW_NOTIFICATION_TIMEOUT = 25 * 1_000L;
 
-    private final String TITLE_PAYLOAD_PARAM = "title";
-    private final String ALERT_PAYLOAD_PARAM = "alert";
-    private final String CUSTOM_PAYLOAD_PARAM = "custom";
-    private final String ADDITIONAL_DATA_PAYLOAD_PARAM = "a";
+    private static final String TITLE_PAYLOAD_PARAM = "title";
+    private static final String ALERT_PAYLOAD_PARAM = "alert";
+    private static final String CUSTOM_PAYLOAD_PARAM = "custom";
+    private static final String ADDITIONAL_DATA_PAYLOAD_PARAM = "a";
 
     Context context;
     JSONObject jsonPayload;
@@ -176,21 +176,30 @@ public class OSNotificationGenerationJob {
      *    1. {@link ExtNotificationGenerationJob}
      *    2. {@link AppNotificationGenerationJob}
      */
-    static class NotificationGenerationJob extends OSTimeoutHandler {
+    static class NotificationGenerationJob {
 
         // Used to toggle when complete is called so it can not be called more than once
         boolean isComplete = false;
 
+        private final OSTimeoutHandler timeoutHandler;
         // The actual notifJob with notification payload data
         private OSNotificationGenerationJob notifJob;
 
         NotificationGenerationJob(OSNotificationGenerationJob notifJob) {
             this.notifJob = notifJob;
-            setTimeout(SHOW_NOTIFICATION_TIMEOUT);
+            timeoutHandler = new OSTimeoutHandler();
         }
 
         OSNotificationGenerationJob getNotifJob() {
             return notifJob;
+        }
+
+        protected void startTimeout(Runnable runnable) {
+            timeoutHandler.startTimeout(SHOW_NOTIFICATION_TIMEOUT, runnable);
+        }
+
+        protected void destroyTimeout() {
+            timeoutHandler.destroyTimeout();
         }
 
         public String getApiNotificationId() {
@@ -219,6 +228,14 @@ public class OSNotificationGenerationJob {
 
         public void setNotificationDisplayOption(OSNotificationDisplay displayOption) {
             notifJob.setNotificationDisplayOption(displayOption);
+        }
+
+        @Override
+        public String toString() {
+            return "NotificationGenerationJob{" +
+                    "isComplete=" + isComplete +
+                    ", notifJob=" + notifJob +
+                    '}';
         }
     }
 
@@ -299,4 +316,21 @@ public class OSNotificationGenerationJob {
         }
     }
 
+    @Override
+    public String toString() {
+        return "OSNotificationGenerationJob{" +
+                "jsonPayload=" + jsonPayload +
+                ", isRestoring=" + isRestoring +
+                ", isIamPreview=" + isIamPreview +
+                ", displayOption=" + displayOption +
+                ", shownTimeStamp=" + shownTimeStamp +
+                ", overriddenBodyFromExtender=" + overriddenBodyFromExtender +
+                ", overriddenTitleFromExtender=" + overriddenTitleFromExtender +
+                ", overriddenSound=" + overriddenSound +
+                ", overriddenFlags=" + overriddenFlags +
+                ", orgFlags=" + orgFlags +
+                ", orgSound=" + orgSound +
+                ", overrideSettings=" + overrideSettings +
+                '}';
+    }
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationGenerationJob.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationGenerationJob.java
@@ -274,7 +274,6 @@ public class OSNotificationGenerationJob {
         AppNotificationGenerationJob(OSNotificationGenerationJob notifJob) {
             super(notifJob);
 
-
             startTimeout(new Runnable() {
                 @Override
                 public void run() {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationWorkManager.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationWorkManager.java
@@ -1,6 +1,7 @@
 package com.onesignal;
 
 import android.content.Context;
+import android.os.Looper;
 
 import androidx.annotation.NonNull;
 import androidx.work.Data;
@@ -64,6 +65,11 @@ class OSNotificationWorkManager {
                 e.printStackTrace();
                 return Result.failure();
             }
+
+            // TODO: This line stops the Looper.loop call once the notification processing is all done
+            //  The reason for all of this is because we are firing handlers while running a background thread using the Worker
+            if (!OSUtils.isRunningOnMainThread())
+                Looper.myLooper().quit();
             return Result.success();
         }
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSThrowable.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSThrowable.java
@@ -27,42 +27,11 @@
 
 package com.onesignal;
 
-import android.os.Handler;
-import android.os.Looper;
+class OSThrowable {
 
-import androidx.annotation.NonNull;
-
-class OSTimeoutHandler {
-
-    private long timeout;
-
-    private Handler timeoutHandler;
-    private Runnable timeoutRunnable;
-
-    void setTimeout(long timeout) {
-        this.timeout = timeout;
+    static class OSMainThreadException extends RuntimeException {
+        public OSMainThreadException(String message) {
+            super(message);
+        }
     }
-
-    synchronized void startTimeout(@NonNull final Runnable runnable) {
-        // If the handler or runnable isn't null we do not want to start another
-        if (this.timeoutHandler != null && this.timeoutRunnable != null)
-            return;
-
-        this.timeoutRunnable = runnable;
-
-        if (Looper.myLooper() == null)
-            Looper.prepare();
-
-        timeoutHandler = new Handler();
-        timeoutHandler.postDelayed(timeoutRunnable, timeout);
-    }
-
-    synchronized void destroyTimeout() {
-        if (timeoutHandler != null)
-            timeoutHandler.removeCallbacks(timeoutRunnable);
-
-        timeoutHandler = null;
-        timeoutRunnable = null;
-    }
-
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSTimeoutHandler.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSTimeoutHandler.java
@@ -1,21 +1,21 @@
 /**
  * Modified MIT License
- *
+ * <p>
  * Copyright 2020 OneSignal
- *
+ * <p>
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- *
+ * <p>
  * 1. The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- *
+ * <p>
  * 2. All copies of substantial portions of the Software may only be used in connection
  * with services provided by OneSignal.
- *
+ * <p>
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -34,35 +34,40 @@ import androidx.annotation.NonNull;
 
 class OSTimeoutHandler {
 
-    private long timeout;
-
     private Handler timeoutHandler;
     private Runnable timeoutRunnable;
 
-    void setTimeout(long timeout) {
-        this.timeout = timeout;
+    public OSTimeoutHandler() {
     }
 
-    synchronized void startTimeout(@NonNull final Runnable runnable) {
+    synchronized void startTimeout(long timeout, @NonNull final Runnable runnable) {
         // If the handler or runnable isn't null we do not want to start another
-        if (this.timeoutHandler != null && this.timeoutRunnable != null)
+        if (timeoutRunnable != null)
             return;
 
-        this.timeoutRunnable = runnable;
+        timeoutRunnable = runnable;
 
+        postDelayed(timeoutRunnable, timeout);
+    }
+
+    public void postDelayed(final Runnable runnable, final long delayMillis) {
         if (Looper.myLooper() == null)
             Looper.prepare();
 
         timeoutHandler = new Handler();
-        timeoutHandler.postDelayed(timeoutRunnable, timeout);
+        timeoutHandler.postDelayed(runnable, delayMillis);
+
+        Looper.loop();
     }
 
     synchronized void destroyTimeout() {
-        if (timeoutHandler != null)
-            timeoutHandler.removeCallbacks(timeoutRunnable);
-
+        removeCallbacks(timeoutRunnable);
         timeoutHandler = null;
         timeoutRunnable = null;
     }
 
+    public void removeCallbacks(Runnable runnable) {
+        if (timeoutHandler != null)
+            timeoutHandler.removeCallbacks(runnable);
+    }
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -192,7 +192,6 @@ public class OneSignal {
     * Finally, to notify the SDK that the processing work is done, call {@link OSNotificationReceived#complete()}
     * <br/><br/>
     * TODO: Update docs with new NotificationProcessingHandler, this would be replacing the old NotificationExtenderService
-    * @see <a href="https://documentation.onesignal.com/docs/android-native-sdk#notificationreceivedhandler">NotificationReceivedHandler | OneSignal Docs</a>
     */
    public interface NotificationProcessingHandler {
 
@@ -243,7 +242,6 @@ public class OneSignal {
     * Set this during OneSignal init in
     * {@link OneSignal#setNotificationOpenedHandler(NotificationOpenedHandler)}
     * <br/><br/>
-    * TODO: Update docs with new NotificationOpenedHandler
     * @see <a href="https://documentation.onesignal.com/docs/android-native-sdk#notificationopenedhandler">NotificationOpenedHandler | OneSignal Docs</a>
     */
    public interface NotificationOpenedHandler {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalRestClient.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalRestClient.java
@@ -101,7 +101,7 @@ class OneSignalRestClient {
    
    private static void makeRequest(final String url, final String method, final JSONObject jsonBody, final ResponseHandler responseHandler, final int timeout, final String cacheKey) {
       if (OSUtils.isRunningOnMainThread())
-         throw new OneSignalNetworkCallException("Method: " + method + " was called from the Main Thread!");
+         throw new OSThrowable.OSMainThreadException("Method: " + method + " was called from the Main Thread!");
 
       // If not a GET request, check if the user provided privacy consent if the application is set to require user privacy consent
       if (method != null && OneSignal.shouldLogUserPrivacyConsentErrorMessageForMethodName(null))
@@ -291,11 +291,5 @@ class OneSignalRestClient {
 
    private static HttpURLConnection newHttpURLConnection(String url) throws IOException {
       return (HttpURLConnection)new URL(BASE_URL + url).openConnection();
-   }
-
-   private static class OneSignalNetworkCallException extends RuntimeException {
-      public OneSignalNetworkCallException(String message) {
-         super(message);
-      }
    }
 }

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
@@ -154,12 +154,22 @@ public class OneSignalPackagePrivateHelper {
       return processedResult.processed();
    }
 
-   public static void FCMBroadcastReceiver_onReceived(Context context, Bundle bundle) {
+   public static void FCMBroadcastReceiver_onReceived_withIntent(Context context, Intent intent) {
+      FCMBroadcastReceiver receiver = new FCMBroadcastReceiver();
+      intent.setAction("com.google.android.c2dm.intent.RECEIVE");
+      receiver.onReceive(context, intent);
+   }
+
+   public static void FCMBroadcastReceiver_onReceived_withBundle(Context context, Bundle bundle) {
       FCMBroadcastReceiver receiver = new FCMBroadcastReceiver();
       Intent intent = new Intent();
       intent.setAction("com.google.android.c2dm.intent.RECEIVE");
       intent.putExtras(bundle);
       receiver.onReceive(context,intent);
+   }
+
+   public static void HMSProcessor_processDataMessageReceived(final Context context, final String jsonStrPayload) {
+      NotificationPayloadProcessorHMS.processDataMessageReceived(context, jsonStrPayload);
    }
 
    public static int NotificationBundleProcessor_Process(Context context, boolean restoring, JSONObject jsonPayload, OSNotificationExtender.OverrideSettings overrideSettings) {

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowGenerateNotification.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowGenerateNotification.java
@@ -1,0 +1,13 @@
+package com.onesignal;
+
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+
+@Implements(GenerateNotification.class)
+public class ShadowGenerateNotification {
+
+   @Implementation
+    public static void isRunningOnMainThreadCheck() {
+      // Remove Main thread check and throw
+    }
+}

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowOSUtils.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowOSUtils.java
@@ -7,14 +7,8 @@ import org.robolectric.annotation.Implements;
 @Implements(OSUtils.class)
 public class ShadowOSUtils {
 
-   public static boolean isRunningOnMainThread;
-
    public static String carrierName;
    public static int subscribableStatus;
-
-   public static boolean isRunningOnMainThread() {
-      return isRunningOnMainThread;
-   }
 
    // FireOS: ADM
    public static boolean supportsADM;
@@ -78,7 +72,6 @@ public class ShadowOSUtils {
       carrierName = "test1";
       subscribableStatus = 1;
 
-      isRunningOnMainThread = false;
       supportsADM = false;
       hasFCMLibrary = false;
       isGMSInstalledAndEnabled = false;

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowOSUtils.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowOSUtils.java
@@ -7,8 +7,14 @@ import org.robolectric.annotation.Implements;
 @Implements(OSUtils.class)
 public class ShadowOSUtils {
 
+   public static boolean isRunningOnMainThread;
+
    public static String carrierName;
    public static int subscribableStatus;
+
+   public static boolean isRunningOnMainThread() {
+      return isRunningOnMainThread;
+   }
 
    // FireOS: ADM
    public static boolean supportsADM;
@@ -72,6 +78,7 @@ public class ShadowOSUtils {
       carrierName = "test1";
       subscribableStatus = 1;
 
+      isRunningOnMainThread = false;
       supportsADM = false;
       hasFCMLibrary = false;
       isGMSInstalledAndEnabled = false;
@@ -79,7 +86,6 @@ public class ShadowOSUtils {
       hasHMSPushKitLibrary = false;
       hasHMSAGConnectLibrary = false;
       isHMSCoreInstalledAndEnabled = false;
-
    }
 
    public String getCarrierName() {

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowTimeoutHandler.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowTimeoutHandler.java
@@ -1,0 +1,51 @@
+package com.onesignal;
+
+
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+
+import java.util.HashMap;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Shadow class to emulate handler post delay work, Roboelectric runs everything under a custom MainThread
+ * it also shadows its Loopers under a ShadowLooper.class, if we use looper outside Roboelectric custom thread
+ * handler and looper will end disconnected and will end on a deadlock.
+ * To solve this problem, for cases were we run Loopers under a custom thread, we shadow the TimeoutHandler
+ * to emulate the same behaviour
+ */
+@Implements(OSTimeoutHandler.class)
+public class ShadowTimeoutHandler {
+
+    private static boolean mockDelay = false;
+    private static long mockDelayMillis = 1;
+
+    private HashMap<Runnable, ScheduledThreadPoolExecutor> executorHashMap = new HashMap<>();
+
+    public static void setMockDelayMillis(long mockDelayMillis) {
+        mockDelay = true;
+        ShadowTimeoutHandler.mockDelayMillis = mockDelayMillis;
+    }
+
+    @Implementation
+    public boolean postDelayed(final Runnable runnable, final long delayMillis) {
+        ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(1);
+        executor.schedule(runnable, mockDelay ? mockDelayMillis : delayMillis, TimeUnit.MILLISECONDS);
+        executorHashMap.put(runnable, executor);
+        return true;
+    }
+
+    @Implementation
+    public void removeCallbacks(Runnable runnable) {
+        ScheduledThreadPoolExecutor executor = executorHashMap.get(runnable);
+        if (executor != null) {
+            executor.shutdownNow();
+        }
+    }
+
+    public static void resetStatics() {
+        mockDelay = false;
+        mockDelayMillis = 1;
+    }
+}

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
@@ -176,9 +176,6 @@ public class GenerateNotificationRunner {
       lastExtNotifJob = null;
       lastAppNotifJob = null;
 
-      OneSignalShadowPackageManager.resetStatics();
-
-      TestHelpers.setupTestWorkManager(blankActivity);
       TestHelpers.beforeTestInitAndCleanup();
 
       setClearGroupSummaryClick(true);

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
@@ -68,6 +68,7 @@ import com.onesignal.ShadowBadgeCountUpdater;
 import com.onesignal.ShadowCustomTabsClient;
 import com.onesignal.ShadowCustomTabsSession;
 import com.onesignal.ShadowFCMBroadcastReceiver;
+import com.onesignal.ShadowGenerateNotification;
 import com.onesignal.ShadowNotificationManagerCompat;
 import com.onesignal.ShadowOSUtils;
 import com.onesignal.ShadowOSViewUtils;
@@ -77,6 +78,7 @@ import com.onesignal.ShadowOneSignalRestClient;
 import com.onesignal.ShadowReceiveReceiptController;
 import com.onesignal.ShadowRoboNotificationManager;
 import com.onesignal.ShadowRoboNotificationManager.PostedNotification;
+import com.onesignal.ShadowTimeoutHandler;
 import com.onesignal.StaticResetHelper;
 import com.onesignal.example.BlankActivity;
 
@@ -101,6 +103,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
+import static com.onesignal.OneSignalPackagePrivateHelper.FCMBroadcastReceiver_onReceived_withIntent;
 import static com.onesignal.OneSignalPackagePrivateHelper.FCMBroadcastReceiver_processBundle;
 import static com.onesignal.OneSignalPackagePrivateHelper.GenerateNotification.BUNDLE_KEY_ACTION_ID;
 import static com.onesignal.OneSignalPackagePrivateHelper.GenerateNotification.BUNDLE_KEY_ANDROID_NOTIFICATION_ID;
@@ -213,7 +216,7 @@ public class GenerateNotificationRunner {
    }
    
    @Test
-   @Config (sdk = 22)
+   @Config (sdk = 22, shadows = { ShadowGenerateNotification.class })
    public void shouldSetTitleCorrectly() throws Exception {
       // Should use app's Title by default
       Bundle bundle = getBaseNotifBundle();
@@ -232,7 +235,7 @@ public class GenerateNotificationRunner {
    }
    
    @Test
-   @Config (sdk = 22)
+   @Config (sdk = 22, shadows = { ShadowGenerateNotification.class })
    public void shouldProcessRestore() throws Exception {
       BundleCompat bundle = createInternalPayloadBundle(getBaseNotifBundle());
       bundle.putInt("android_notif_id", 0);
@@ -266,6 +269,7 @@ public class GenerateNotificationRunner {
    private static OSNotificationOpenResult lastOpenResult;
    
    @Test
+   @Config(shadows = { ShadowGenerateNotification.class })
    public void shouldContainPayloadWhenOldSummaryNotificationIsOpened() throws Exception {
       OneSignal.setAppId("b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
       OneSignal.setAppContext(blankActivity);
@@ -306,6 +310,7 @@ public class GenerateNotificationRunner {
    }
 
    @Test
+   @Config(shadows = { ShadowGenerateNotification.class })
    public void shouldSetCorrectNumberOfButtonsOnSummaryNotification() throws Exception {
       // Setup - Init
       OneSignal.setAppId("b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
@@ -328,6 +333,7 @@ public class GenerateNotificationRunner {
    }
    
    @Test
+   @Config(shadows = { ShadowGenerateNotification.class })
    public void shouldCancelAllNotificationsPartOfAGroup() throws Exception {
       // Setup - Init
       OneSignal.setAppId("b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
@@ -357,7 +363,7 @@ public class GenerateNotificationRunner {
 
 
    @Test
-   @Config(sdk = Build.VERSION_CODES.N)
+   @Config(sdk = Build.VERSION_CODES.N, shadows = { ShadowGenerateNotification.class })
    public void testFourNotificationsUseProvidedGroup() throws Exception {
       OneSignal.setAppId("b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
       OneSignal.setAppContext(blankActivity.getApplicationContext());
@@ -371,7 +377,7 @@ public class GenerateNotificationRunner {
    }
 
    @Test
-   @Config(sdk = Build.VERSION_CODES.N)
+   @Config(sdk = Build.VERSION_CODES.N, shadows = { ShadowGenerateNotification.class })
    public void testFourGrouplessNotificationsUseDefaultGroup() throws Exception {
       OneSignal.setAppId("b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
       OneSignal.setAppContext(blankActivity.getApplicationContext());
@@ -385,7 +391,7 @@ public class GenerateNotificationRunner {
    }
 
     @Test
-    @Config(sdk = Build.VERSION_CODES.LOLLIPOP)
+    @Config(sdk = Build.VERSION_CODES.LOLLIPOP, shadows = { ShadowGenerateNotification.class })
     public void testNotifDismissAllOnGroupSummaryClickForAndroidUnderM() throws Exception {
         OneSignal.setAppId("b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
         OneSignal.setAppContext(blankActivity);
@@ -401,7 +407,7 @@ public class GenerateNotificationRunner {
     }
 
     @Test
-    @Config(sdk = Build.VERSION_CODES.LOLLIPOP)
+    @Config(sdk = Build.VERSION_CODES.LOLLIPOP, shadows = { ShadowGenerateNotification.class })
     public void testNotifDismissRecentOnGroupSummaryClickForAndroidUnderM() throws Exception {
         OneSignal.setAppId("b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
         OneSignal.setAppContext(blankActivity);
@@ -417,7 +423,7 @@ public class GenerateNotificationRunner {
     }
 
    @Test
-   @Config(sdk = Build.VERSION_CODES.N)
+   @Config(sdk = Build.VERSION_CODES.N, shadows = { ShadowGenerateNotification.class })
    public void testNotifDismissAllOnGroupSummaryClick() throws Exception {
       OneSignal.setAppId("b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
       OneSignal.setAppContext(blankActivity);
@@ -433,7 +439,7 @@ public class GenerateNotificationRunner {
    }
 
    @Test
-   @Config(sdk = Build.VERSION_CODES.N)
+   @Config(sdk = Build.VERSION_CODES.N, shadows = { ShadowGenerateNotification.class })
    public void testNotifDismissRecentOnGroupSummaryClick() throws Exception {
       OneSignal.setAppId("b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
       OneSignal.setAppContext(blankActivity);
@@ -451,7 +457,7 @@ public class GenerateNotificationRunner {
    }
 
    @Test
-   @Config(sdk = Build.VERSION_CODES.N)
+   @Config(sdk = Build.VERSION_CODES.N, shadows = { ShadowGenerateNotification.class })
    public void testNotifDismissAllOnGrouplessSummaryClick() throws Exception {
       OneSignal.setAppId("b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
       OneSignal.setAppContext(blankActivity);
@@ -467,7 +473,7 @@ public class GenerateNotificationRunner {
    }
 
    @Test
-   @Config(sdk = Build.VERSION_CODES.N)
+   @Config(sdk = Build.VERSION_CODES.N, shadows = { ShadowGenerateNotification.class })
    public void testNotifDismissRecentOnGrouplessSummaryClick() throws Exception {
       OneSignal.setAppId("b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
       OneSignal.setAppContext(blankActivity);
@@ -509,7 +515,7 @@ public class GenerateNotificationRunner {
    }
 
    @Test
-   @Config(sdk = Build.VERSION_CODES.N)
+   @Config(sdk = Build.VERSION_CODES.N, shadows = { ShadowGenerateNotification.class, ShadowGenerateNotification.class })
    public void testGrouplessSummaryKeyReassignmentAtFourOrMoreNotification() throws Exception {
       OneSignal.setAppId("b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
       OneSignal.setAppContext(blankActivity);
@@ -581,6 +587,9 @@ public class GenerateNotificationRunner {
    }
 
    @Test
+   // We need ShadowTimeoutHandler because RestoreJobService run under an AsyncTask, in that way we can avoid deadlock due to Roboelectric tying to shadow
+   // Handlers under AsyncTask, and Roboelectric doesn't support handler outside it's custom Main Thread
+   @Config(shadows = { ShadowGenerateNotification.class, ShadowTimeoutHandler.class })
    public void shouldCancelNotificationAndUpdateSummary() throws Exception {
       // Setup - Init
       OneSignal.setAppId("b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
@@ -609,7 +618,6 @@ public class GenerateNotificationRunner {
       
       // Test - 3 notifis + 1 summary
       assertEquals(4, postedNotifs.size());
-      
       
       // Test - First notification should be the summary
       PostedNotification postedSummaryNotification = postedNotifsIterator.next().getValue();
@@ -672,6 +680,7 @@ public class GenerateNotificationRunner {
    }
    
    @Test
+   @Config(shadows = { ShadowGenerateNotification.class })
    public void shouldUpdateBadgesWhenDismissingNotification() {
       Bundle bundle = getBaseNotifBundle();
       NotificationBundleProcessor_ProcessFromFCMIntentService(blankActivity, bundle, null);
@@ -700,6 +709,7 @@ public class GenerateNotificationRunner {
    }
 
    @Test
+   @Config(shadows = { ShadowGenerateNotification.class })
    public void shouldSetBadgesWhenRestoringNotifications() {
       NotificationBundleProcessor_ProcessFromFCMIntentService(blankActivity, getBaseNotifBundle(), null);
       ShadowBadgeCountUpdater.lastCount = 0;
@@ -736,6 +746,7 @@ public class GenerateNotificationRunner {
    }
    
    @Test
+   @Config(shadows = { ShadowGenerateNotification.class })
    public void shouldUpdateNormalNotificationDisplayWhenReplacingANotification() throws Exception {
       // Setup - init
       OneSignal.setAppId("b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
@@ -782,6 +793,7 @@ public class GenerateNotificationRunner {
    }
 
    @Test
+   @Config(shadows = { ShadowGenerateNotification.class })
    public void shouldHandleBasicNotifications() throws Exception {
       // Make sure the notification got posted and the content is correct.
       Bundle bundle = getBaseNotifBundle();
@@ -841,6 +853,7 @@ public class GenerateNotificationRunner {
    }
 
    @Test
+   @Config(shadows = { ShadowGenerateNotification.class })
    public void shouldRestoreNotifications() {
       NotificationRestorer.restore(blankActivity); NotificationRestorer.restored = false;
 
@@ -892,11 +905,13 @@ public class GenerateNotificationRunner {
    }
 
    @Test
+   @Config(shadows = { ShadowGenerateNotification.class })
    public void doNotRestoreNotificationsPastExpireTime() {
       helperShouldRestoreNotificationsPastExpireTime(false);
    }
 
    @Test
+   @Config(shadows = { ShadowGenerateNotification.class })
    public void restoreNotificationsPastExpireTimeIfSettingIsDisabled() {
       TestOneSignalPrefs.saveBool(TestOneSignalPrefs.PREFS_ONESIGNAL, TestOneSignalPrefs.PREFS_OS_RESTORE_TTL_FILTER, false);
       helperShouldRestoreNotificationsPastExpireTime(true);
@@ -916,6 +931,7 @@ public class GenerateNotificationRunner {
    }
 
    @Test
+   @Config(shadows = { ShadowGenerateNotification.class })
    public void shouldGenerate2BasicGroupNotifications() throws Exception {
       // Make sure the notification got posted and the content is correct.
       Bundle bundle = getBaseNotifBundle();
@@ -1008,17 +1024,16 @@ public class GenerateNotificationRunner {
    }
 
    @Test
-   @Config(shadows = {ShadowFCMBroadcastReceiver.class})
+   @Config(shadows = {ShadowFCMBroadcastReceiver.class, ShadowGenerateNotification.class })
    public void shouldSetButtonsCorrectly() throws Exception {
-      Intent intent = new Intent();
+      final Intent intent = new Intent();
       intent.setAction("com.google.android.c2dm.intent.RECEIVE");
       intent.putExtra("message_type", "gcm");
       Bundle bundle = getBaseNotifBundle();
       addButtonsToReceivedPayload(bundle);
       intent.putExtras(bundle);
 
-      FCMBroadcastReceiver broadcastReceiver = new FCMBroadcastReceiver();
-      broadcastReceiver.onReceive(blankActivity, intent);
+      FCMBroadcastReceiver_onReceived_withIntent(blankActivity, intent);
       threadAndTaskWait();
       
       // Normal notifications should be generated right from the BroadcastReceiver
@@ -1035,6 +1050,7 @@ public class GenerateNotificationRunner {
    }
 
    @Test
+   @Config(shadows = { ShadowGenerateNotification.class })
    public void shouldSetAlertnessFieldsOnNormalPriority() {
       Bundle bundle = getBaseNotifBundle();
       bundle.putString("pri", "5"); // Notifications from dashboard have priority 5 by default
@@ -1046,6 +1062,7 @@ public class GenerateNotificationRunner {
    }
 
    @Test
+   @Config(shadows = { ShadowGenerateNotification.class })
    public void shouldNotSetAlertnessFieldsOnLowPriority() throws Exception {
       Bundle bundle = getBaseNotifBundle();
       bundle.putString("pri", "4");
@@ -1057,6 +1074,7 @@ public class GenerateNotificationRunner {
    }
 
    @Test
+   @Config(shadows = { ShadowGenerateNotification.class })
    public void shouldSetExpireTimeCorrectlyFromGoogleTTL() {
       long sentTime = 1_553_035_338_000L;
       long ttl = 60L;
@@ -1072,6 +1090,7 @@ public class GenerateNotificationRunner {
    }
 
    @Test
+   @Config(shadows = { ShadowGenerateNotification.class })
    public void shouldSetExpireTimeCorrectlyWhenMissingFromPayload() {
       NotificationBundleProcessor_ProcessFromFCMIntentService(blankActivity, getBaseNotifBundle(), null);
 
@@ -1152,7 +1171,7 @@ public class GenerateNotificationRunner {
    }
 
    @Test
-   @Config(shadows = { ShadowReceiveReceiptController.class })
+   @Config(shadows = { ShadowReceiveReceiptController.class, ShadowGenerateNotification.class })
    public void shouldSendReceivedReceiptWhenEnabled() throws Exception {
       String appId = "b2f7f966-d8cc-11e4-bed1-df8f05be55ba";
       OneSignal.setAppId(appId);
@@ -1182,7 +1201,7 @@ public class GenerateNotificationRunner {
    }
 
    @Test
-   @Config(sdk = 17)
+   @Config(sdk = 17, shadows = { ShadowGenerateNotification.class })
    public void testNotificationExtensionServiceOverridePropertiesWithSummaryApi17() throws Exception {
       // 1. Setup notification extension service as well as notifications to receive
       setupNotificationExtensionServiceOverridePropertiesWithSummary();
@@ -1200,7 +1219,7 @@ public class GenerateNotificationRunner {
    }
 
    @Test
-   @Config(sdk = 21)
+   @Config(sdk = 21, shadows = { ShadowGenerateNotification.class })
    public void testNotificationExtensionServiceOverridePropertiesWithSummary() throws Exception {
       // 1. Setup notification extension service as well as received notifications/summary
       setupNotificationExtensionServiceOverridePropertiesWithSummary();
@@ -1308,7 +1327,7 @@ public class GenerateNotificationRunner {
    }
 
    @Test
-   @Config(shadows = {ShadowOneSignal.class})
+   @Config(shadows = { ShadowOneSignal.class, ShadowGenerateNotification.class })
    public void testNotificationExtensionService_notificationProcessingProperties() throws Exception {
       // 1. Setup correct notification extension service class
       startNotificationExtensionService("com.test.onesignal.GenerateNotificationRunner$" +
@@ -1407,6 +1426,7 @@ public class GenerateNotificationRunner {
    }
 
    @Test
+   @Config(shadows = { ShadowGenerateNotification.class })
    public void testNotificationProcessing_twoNotificationsWithSameOverrideAndroidNotificationId() throws Exception {
       // 1. Setup correct notification extension service class
       startNotificationExtensionService("com.test.onesignal.GenerateNotificationRunner$" +
@@ -1481,6 +1501,7 @@ public class GenerateNotificationRunner {
    }
 
    @Test
+   @Config(shadows = { ShadowGenerateNotification.class })
    public void testExtNotificationWillShowInForegroundHandler_setNotificationDisplayOptionToNotification() throws Exception {
       // 1. Setup correct notification extension service class
       startNotificationExtensionService("com.test.onesignal.GenerateNotificationRunner$" +
@@ -1595,6 +1616,7 @@ public class GenerateNotificationRunner {
    }
 
    @Test
+   @Config(shadows = { ShadowGenerateNotification.class })
    public void testExtNotificationWillShowInForegroundHandler_setNotificationDisplayOptionToSilent_andThenToNotification() throws Exception {
       // 1. Setup correct notification extension service class
       startNotificationExtensionService("com.test.onesignal.GenerateNotificationRunner$" +
@@ -1643,6 +1665,7 @@ public class GenerateNotificationRunner {
    }
 
    @Test
+   @Config(shadows = { ShadowGenerateNotification.class })
    public void testExtNotificationWillShowInForegroundHandler_completeBubbles_toAppNotificationWillShowInForegroundHandler() throws Exception {
       // 1. Setup correct notification extension service class
       startNotificationExtensionService("com.test.onesignal.GenerateNotificationRunner$" +
@@ -1675,6 +1698,7 @@ public class GenerateNotificationRunner {
    }
 
    @Test
+   @Config(shadows = { ShadowGenerateNotification.class })
    public void testExtNotificationWillShowInForegroundHandler_completeBubbles_withNullAppNotificationWillShowInForegroundHandler() throws Exception {
       // 1. Setup correct notification extension service class
       startNotificationExtensionService("com.test.onesignal.GenerateNotificationRunner$" +
@@ -1699,6 +1723,7 @@ public class GenerateNotificationRunner {
    }
 
    @Test
+   @Config(shadows = { ShadowGenerateNotification.class })
    public void testNotificationWillShowInForegroundHandler_doesNotFireWhenAppBackgrounded() throws Exception {
       // 1. Setup correct notification extension service class
       startNotificationExtensionService("com.test.onesignal.GenerateNotificationRunner$" +
@@ -1748,6 +1773,7 @@ public class GenerateNotificationRunner {
    }
 
    @Test
+   @Config(shadows = { ShadowGenerateNotification.class })
    public void testExtNotificationWillShowInForegroundHandler_completeDoesNotBubble_toAppNotificationWillShowInForegroundHandler() throws Exception {
       // 1. Setup correct notification extension service class
       startNotificationExtensionService("com.test.onesignal.GenerateNotificationRunner$" +
@@ -1780,6 +1806,7 @@ public class GenerateNotificationRunner {
    }
 
    @Test
+   @Config(shadows = { ShadowGenerateNotification.class })
    public void testExtNotificationWillShowInForegroundHandler_completeDoesNotBubble_toNullAppNotificationWillShowInForegroundHandler() throws Exception {
       // 1. Setup correct notification extension service class
       startNotificationExtensionService("com.test.onesignal.GenerateNotificationRunner$" +
@@ -1817,6 +1844,7 @@ public class GenerateNotificationRunner {
    }
 
    @Test
+   @Config(shadows = { ShadowGenerateNotification.class })
    public void testNotificationWillShowInForegroundHandler_bubbles30SecondTimeout_forExtAndAppHandlers() throws Exception {
       // 1. Setup correct notification extension service class
       startNotificationExtensionService("com.test.onesignal.GenerateNotificationRunner$" +
@@ -1828,6 +1856,7 @@ public class GenerateNotificationRunner {
       OneSignal.setNotificationWillShowInForegroundHandler(new OneSignal.AppNotificationWillShowInForegroundHandler() {
          @Override
          public void notificationWillShowInForeground(OSNotificationGenerationJob.AppNotificationGenerationJob notifJob) {
+            callbackCounter++;
             lastAppNotifJob = notifJob;
             // Call complete to end without waiting default 30 second timeout
             notifJob.complete();
@@ -1837,18 +1866,22 @@ public class GenerateNotificationRunner {
 
       // 3. Receive a notification
       FCMBroadcastReceiver_processBundle(blankActivity, getBaseNotifBundle());
-      // threadTaskAndWait(); is inside of the ExtNotificationWillShowInForegroundHandler implementation
+      threadAndTaskWait();
 
       // 4. Make sure the ExtNotifJob is not null and AppNotifJob is not null
       assertNotNull(lastExtNotifJob);
       assertNotNull(lastAppNotifJob);
       assertEquals(OneSignal.OSNotificationDisplay.NOTIFICATION, lastAppNotifJob.getNotificationDisplayOption());
 
-      // 5. Make sure 1 notification exists in DB
+      // 5. Make sure the callback counter is only fired twice, once for both Ext and App NotificationWillShowInForegroundHandler
+      assertEquals(2, callbackCounter);
+
+      // 6. Make sure 1 notification exists in DB
       assertNotificationDbRecords(1);
    }
 
    @Test
+   @Config(shadows = { ShadowGenerateNotification.class })
    public void testExtNotificationWillShowInForegroundHandler_bubblesAfter30SecondTimeout_withNullAppNotificationWillShowInForegroundHandler() throws Exception {
       // 1. Setup correct notification extension service class
       startNotificationExtensionService("com.test.onesignal.GenerateNotificationRunner$" +
@@ -1861,19 +1894,23 @@ public class GenerateNotificationRunner {
 
       // 3. Receive a notification
       FCMBroadcastReceiver_processBundle(blankActivity, getBaseNotifBundle());
-      // threadTaskAndWait(); is inside of the ExtNotificationWillShowInForegroundHandler implementation
+      threadAndTaskWait();
 
       // 4. Make sure the ExtNotifJob is not null and AppNotifJob is null
       assertNotNull(lastExtNotifJob);
       assertEquals(OneSignal.OSNotificationDisplay.NOTIFICATION, lastExtNotifJob.getNotificationDisplayOption());
       assertNull(lastAppNotifJob);
 
-      // 5. Make sure 1 notification exists in DB
+      // 5. Make sure the callback counter is only fired once for the Ext NotificationWillShowInForegroundHandler
+      assertEquals(1, callbackCounter);
+
+      // 6. Make sure 1 notification exists in DB
       assertNotificationDbRecords(1);
    }
 
    @Test
-   public void testExtNotificationWillShowInForegroundHandler_bubblesAfter30SecondTimeout_toAppNotificationWillShowInForegroundHandler() {
+   @Config(shadows = { ShadowGenerateNotification.class })
+   public void testExtNotificationWillShowInForegroundHandler_bubblesAfter30SecondTimeout_toAppNotificationWillShowInForegroundHandler() throws Exception {
       // 1. Setup correct notification extension service class
       startNotificationExtensionService("com.test.onesignal.GenerateNotificationRunner$" +
               "NotificationExtensionService_bubblesAfter30SecondTimeout_toAppNotificationWillShowInForegroundHandler");
@@ -1884,26 +1921,26 @@ public class GenerateNotificationRunner {
       OneSignal.setNotificationWillShowInForegroundHandler(new OneSignal.AppNotificationWillShowInForegroundHandler() {
          @Override
          public void notificationWillShowInForeground(OSNotificationGenerationJob.AppNotificationGenerationJob notifJob) {
+            callbackCounter++;
             lastAppNotifJob = notifJob;
             // Complete is not called, so we rely on 30 second timeout until bubbling by default out of the AppNotificationWillShowInForegroundHandler
-            try {
-               threadAndTaskWait();
-            } catch (Exception e) {
-               e.printStackTrace();
-            }
          }
       });
+      threadAndTaskWait();
 
       // 3. Receive a notification
       FCMBroadcastReceiver_processBundle(blankActivity, getBaseNotifBundle());
-      // threadTaskAndWait(); is inside of the ExtNotificationWillShowInForegroundHandler and  implementation
+      threadAndTaskWait();
 
       // 4. Make sure the ExtNotifJob is not null and AppNotifJob is not null
       assertNotNull(lastExtNotifJob);
       assertNotNull(lastAppNotifJob);
       assertEquals(OneSignal.OSNotificationDisplay.NOTIFICATION, lastAppNotifJob.getNotificationDisplayOption());
 
-      // 5. Make sure 1 notification exists in DB
+      // 5. Make sure the callback counter is only fired twice, once for both Ext and App NotificationWillShowInForegroundHandler
+      assertEquals(2, callbackCounter);
+
+      // 6. Make sure 1 notification exists in DB
       assertNotificationDbRecords(1);
    }
 
@@ -1915,17 +1952,14 @@ public class GenerateNotificationRunner {
    public static class NotificationExtensionService_bubblesAfter30SecondTimeout_toAppNotificationWillShowInForegroundHandler implements OneSignal.ExtNotificationWillShowInForegroundHandler {
       @Override
       public void notificationWillShowInForeground(OSNotificationGenerationJob.ExtNotificationGenerationJob notifJob) {
+         callbackCounter++;
          lastExtNotifJob = notifJob;
          // Complete is not called, so we rely on 30 second timeout until bubbling by default to the AppNotificationWillShowInForegroundHandler
-         try {
-            threadAndTaskWait();
-         } catch (Exception e) {
-            e.printStackTrace();
-         }
       }
    }
 
    @Test
+   @Config(shadows = { ShadowGenerateNotification.class })
    public void testNotificationWillShowInForegroundHandler_notifJobPayload() throws Exception {
       // 1. Setup correct notification extension service class
       startNotificationExtensionService("com.test.onesignal.GenerateNotificationRunner$" +
@@ -2071,6 +2105,7 @@ public class GenerateNotificationRunner {
    }
 
    @Test
+   @Config(shadows = { ShadowGenerateNotification.class })
    public void testNullExtAndAppNotificationWillShowInForegroundHandlers() throws Exception {
       // 1. Init OneSignal
       OneSignal.setAppId("b2f7f966-d8cc-11e4-bed1-df8f05be55ba");

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/HMSDataMessageReceivedIntegrationTestsRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/HMSDataMessageReceivedIntegrationTestsRunner.java
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint;
 import android.app.Activity;
 
 import com.onesignal.OneSignalPackagePrivateHelper.NotificationPayloadProcessorHMS;
+import com.onesignal.ShadowGenerateNotification;
 import com.onesignal.ShadowNotificationManagerCompat;
 import com.onesignal.ShadowOSUtils;
 import com.onesignal.ShadowRoboNotificationManager;
@@ -25,6 +26,7 @@ import org.robolectric.shadows.ShadowLog;
 
 import java.util.UUID;
 
+import static com.onesignal.OneSignalPackagePrivateHelper.HMSProcessor_processDataMessageReceived;
 import static com.onesignal.OneSignalPackagePrivateHelper.OSNotificationFormatHelper.PAYLOAD_OS_NOTIFICATION_ID;
 import static com.onesignal.OneSignalPackagePrivateHelper.OSNotificationFormatHelper.PAYLOAD_OS_ROOT_CUSTOM;
 import static com.test.onesignal.TestHelpers.threadAndTaskWait;
@@ -35,7 +37,6 @@ import static junit.framework.Assert.assertEquals;
     instrumentedPackages = { "com.onesignal" },
     packageName = "com.onesignal.example",
     shadows = {
-        ShadowOSUtils.class,
         ShadowRoboNotificationManager.class,
         ShadowNotificationManagerCompat.class
     },
@@ -86,9 +87,10 @@ public class HMSDataMessageReceivedIntegrationTestsRunner {
     }
 
     @Test
+    @Config(shadows = { ShadowGenerateNotification.class })
     public void basicPayload_shouldDisplayNotification() throws Exception {
         blankActivityController.pause();
-        NotificationPayloadProcessorHMS.processDataMessageReceived(blankActivity, helperBasicOSPayload());
+        HMSProcessor_processDataMessageReceived(blankActivity, helperBasicOSPayload());
         threadAndTaskWait();
 
         assertEquals(ALERT_TEST_MESSAGE_BODY, ShadowRoboNotificationManager.getLastShadowNotif().getBigText());

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/HMSDataMessageReceivedIntegrationTestsRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/HMSDataMessageReceivedIntegrationTestsRunner.java
@@ -35,6 +35,7 @@ import static junit.framework.Assert.assertEquals;
     instrumentedPackages = { "com.onesignal" },
     packageName = "com.onesignal.example",
     shadows = {
+        ShadowOSUtils.class,
         ShadowRoboNotificationManager.class,
         ShadowNotificationManagerCompat.class
     },

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
@@ -76,6 +76,7 @@ import com.onesignal.ShadowFirebaseAnalytics;
 import com.onesignal.ShadowFusedLocationApiWrapper;
 import com.onesignal.ShadowGMSLocationController;
 import com.onesignal.ShadowGMSLocationUpdateListener;
+import com.onesignal.ShadowGenerateNotification;
 import com.onesignal.ShadowGoogleApiClientBuilder;
 import com.onesignal.ShadowGoogleApiClientCompatProxy;
 import com.onesignal.ShadowHMSFusedLocationProviderClient;
@@ -151,6 +152,7 @@ import static com.test.onesignal.TestHelpers.flushBufferedSharedPrefs;
 import static com.test.onesignal.TestHelpers.getNextJob;
 import static com.test.onesignal.TestHelpers.restartAppAndElapseTimeToNextSession;
 import static com.test.onesignal.TestHelpers.runNextJob;
+import static com.test.onesignal.TestHelpers.runOSThreads;
 import static com.test.onesignal.TestHelpers.threadAndTaskWait;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertFalse;
@@ -1134,12 +1136,12 @@ public class MainOneSignalClassRunner {
 
       Bundle bundle = getBaseNotifBundle();
       boolean processResult = FCMBroadcastReceiver_processBundle(blankActivity, bundle);
-      threadAndTaskWait();
 
       assertTrue(processResult);
       assertNull(lastNotificationOpenedBody);
 
       NotificationBundleProcessor_Process(blankActivity, false, bundleAsJSONObject(bundle), null);
+
       assertEquals("Robo test message", notificationReceivedBody);
       assertNotEquals(0, androidNotificationId);
 
@@ -1148,7 +1150,7 @@ public class MainOneSignalClassRunner {
       notificationReceivedBody = null;
 
       FCMBroadcastReceiver_processBundle(blankActivity, bundle);
-      threadAndTaskWait();
+
       assertNull(lastNotificationOpenedBody);
       assertNull(notificationReceivedBody);
 
@@ -1157,9 +1159,8 @@ public class MainOneSignalClassRunner {
 
       // Test that only NotificationReceivedHandler fires
       bundle = getBaseNotifBundle("UUID2");
-
       FCMBroadcastReceiver_processBundle(blankActivity, bundle);
-      threadAndTaskWait();
+
       assertNull(lastNotificationOpenedBody);
       assertEquals("Robo test message", notificationReceivedBody);
    }
@@ -3761,7 +3762,7 @@ public class MainOneSignalClassRunner {
 
 
    @Test
-   @Config(shadows = { ShadowRoboNotificationManager.class, ShadowBadgeCountUpdater.class })
+   @Config(shadows = { ShadowRoboNotificationManager.class, ShadowBadgeCountUpdater.class, ShadowGenerateNotification.class })
    public void shouldCancelAndClearNotifications() throws Exception {
       ShadowRoboNotificationManager.notifications.clear();
       OneSignal.setAppId(ONESIGNAL_APP_ID);
@@ -4201,7 +4202,7 @@ public class MainOneSignalClassRunner {
    }
 
    @Test
-   @Config(shadows = { ShadowFirebaseAnalytics.class })
+   @Config(shadows = { ShadowFirebaseAnalytics.class, ShadowGenerateNotification.class })
    public void shouldSendFirebaseAnalyticsNotificationReceived() throws Exception {
       ShadowOneSignalRestClient.paramExtras = new JSONObject().put("fba", true);
       OneSignalInit();

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/NotificationLimitManagerRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/NotificationLimitManagerRunner.java
@@ -10,6 +10,7 @@ import com.onesignal.OneSignalPackagePrivateHelper.NotificationLimitManager;
 import com.onesignal.ShadowAdvertisingIdProviderGPS;
 import com.onesignal.ShadowCustomTabsClient;
 import com.onesignal.ShadowCustomTabsSession;
+import com.onesignal.ShadowGenerateNotification;
 import com.onesignal.ShadowNotificationLimitManager;
 import com.onesignal.ShadowOSUtils;
 import com.onesignal.ShadowOneSignalRestClient;
@@ -120,6 +121,7 @@ public class NotificationLimitManagerRunner {
    }
 
    @Test
+   @Config(shadows = { ShadowGenerateNotification.class })
    public void clearFallbackMakingRoomForOneWhenAtLimit() throws Exception {
       NotificationBundleProcessor_ProcessFromFCMIntentService(blankActivity,  getBaseNotifBundle("UUID1"), null);
       threadAndTaskWait();
@@ -132,6 +134,7 @@ public class NotificationLimitManagerRunner {
    }
 
    @Test
+   @Config(shadows = { ShadowGenerateNotification.class })
    public void clearFallbackShouldNotCancelAnyNotificationsWhenUnderLimit() throws Exception {
       NotificationBundleProcessor_ProcessFromFCMIntentService(blankActivity,  getBaseNotifBundle("UUID1"), null);
       threadAndTaskWait();

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/OutcomeEventIntegrationTests.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/OutcomeEventIntegrationTests.java
@@ -19,6 +19,7 @@ import com.onesignal.ShadowAdvertisingIdProviderGPS;
 import com.onesignal.ShadowCustomTabsClient;
 import com.onesignal.ShadowCustomTabsSession;
 import com.onesignal.ShadowGMSLocationController;
+import com.onesignal.ShadowGenerateNotification;
 import com.onesignal.ShadowJobService;
 import com.onesignal.ShadowNotificationManagerCompat;
 import com.onesignal.ShadowOSUtils;
@@ -49,7 +50,7 @@ import org.robolectric.shadows.ShadowLog;
 import java.util.Arrays;
 import java.util.List;
 
-import static com.onesignal.OneSignalPackagePrivateHelper.FCMBroadcastReceiver_onReceived;
+import static com.onesignal.OneSignalPackagePrivateHelper.FCMBroadcastReceiver_onReceived_withBundle;
 import static com.onesignal.OneSignalPackagePrivateHelper.OneSignal_getSessionListener;
 import static com.onesignal.OneSignalPackagePrivateHelper.OneSignal_setSessionManager;
 import static com.onesignal.OneSignalPackagePrivateHelper.OneSignal_setSharedPreferences;
@@ -160,6 +161,7 @@ public class OutcomeEventIntegrationTests {
     }
 
     @Test
+    @Config(shadows = { ShadowGenerateNotification.class })
     public void testAppSessions_beforeOnSessionCalls() throws Exception {
         foregroundAppAfterReceivingNotification();
 
@@ -190,6 +192,7 @@ public class OutcomeEventIntegrationTests {
     }
 
     @Test
+    @Config(shadows = { ShadowGenerateNotification.class })
     public void testAppSessions_afterOnSessionCalls() throws Exception {
         foregroundAppAfterReceivingNotification();
 
@@ -221,6 +224,7 @@ public class OutcomeEventIntegrationTests {
     }
 
     @Test
+    @Config(shadows = { ShadowGenerateNotification.class })
     public void testIndirectAttributionWindow_withNoNotifications() throws Exception {
         foregroundAppAfterReceivingNotification();
 
@@ -294,6 +298,7 @@ public class OutcomeEventIntegrationTests {
     }
 
     @Test
+    @Config(shadows = { ShadowGenerateNotification.class })
     public void testUniqueOutcomeMeasureOnlySentOncePerNotification_whenSendingMultipleUniqueOutcomes_inIndirectSessions() throws Exception {
         foregroundAppAfterReceivingNotification();
 
@@ -325,7 +330,7 @@ public class OutcomeEventIntegrationTests {
 
         // Receive notification
         Bundle bundle = getBaseNotifBundle(ONESIGNAL_NOTIFICATION_ID + "2");
-        FCMBroadcastReceiver_onReceived(blankActivity, bundle);
+        FCMBroadcastReceiver_onReceived_withBundle(blankActivity, bundle);
 
         // Wait 31 seconds to start new session
         advanceSystemTimeBy(31);
@@ -349,6 +354,7 @@ public class OutcomeEventIntegrationTests {
     }
 
     @Test
+    @Config(shadows = { ShadowGenerateNotification.class })
     public void testOnV2UniqueOutcomeMeasureOnlySentOncePerNotification_whenSendingMultipleUniqueOutcomes_inIndirectSessions() throws Exception {
         // Enable IAM v2
         preferences = new MockOSSharedPreferences();
@@ -386,7 +392,7 @@ public class OutcomeEventIntegrationTests {
 
         // Receive notification
         Bundle bundle = getBaseNotifBundle(ONESIGNAL_NOTIFICATION_ID + "2");
-        FCMBroadcastReceiver_onReceived(blankActivity, bundle);
+        FCMBroadcastReceiver_onReceived_withBundle(blankActivity, bundle);
 
         // Wait 31 seconds to start new session
         advanceSystemTimeBy(31);
@@ -615,7 +621,7 @@ public class OutcomeEventIntegrationTests {
 
         // Receive notification
         Bundle bundle = getBaseNotifBundle(ONESIGNAL_NOTIFICATION_ID);
-        FCMBroadcastReceiver_onReceived(blankActivity, bundle);
+        FCMBroadcastReceiver_onReceived_withBundle(blankActivity, bundle);
 
         // Make sure notification influence is not INDIRECT
         assertFalse(trackerFactory.getNotificationChannelTracker().getInfluenceType().isIndirect());
@@ -626,6 +632,7 @@ public class OutcomeEventIntegrationTests {
     }
 
     @Test
+    @Config(shadows = { ShadowGenerateNotification.class })
     public void testDirectSession_willOverrideIndirectSession_whenAppIsInBackground() throws Exception {
         foregroundAppAfterReceivingNotification();
 
@@ -687,6 +694,7 @@ public class OutcomeEventIntegrationTests {
     }
 
     @Test
+    @Config(shadows = { ShadowGenerateNotification.class })
     public void testIndirectSession_fromDirectSession_afterNewSession() throws Exception {
         foregroundAppAfterClickingNotification();
 
@@ -696,7 +704,7 @@ public class OutcomeEventIntegrationTests {
 
         // Receive notification
         Bundle bundle = getBaseNotifBundle(ONESIGNAL_NOTIFICATION_ID + "2");
-        FCMBroadcastReceiver_onReceived(blankActivity, bundle);
+        FCMBroadcastReceiver_onReceived_withBundle(blankActivity, bundle);
         threadAndTaskWait();
 
         // Wait 31 seconds
@@ -733,7 +741,7 @@ public class OutcomeEventIntegrationTests {
 
         // Receive notification
         Bundle bundle = getBaseNotifBundle(ONESIGNAL_NOTIFICATION_ID + "2");
-        FCMBroadcastReceiver_onReceived(blankActivity, bundle);
+        FCMBroadcastReceiver_onReceived_withBundle(blankActivity, bundle);
 
         // Foreground app through icon before new session
         blankActivityController.resume();
@@ -750,6 +758,7 @@ public class OutcomeEventIntegrationTests {
     }
 
     @Test
+    @Config(shadows = { ShadowGenerateNotification.class })
     public void testIndirectSession_wontOverrideIndirectSession_beforeNewSession() throws Exception {
         foregroundAppAfterReceivingNotification();
 
@@ -759,7 +768,7 @@ public class OutcomeEventIntegrationTests {
 
         // Receive another notification
         Bundle bundle = getBaseNotifBundle(ONESIGNAL_NOTIFICATION_ID + "2");
-        FCMBroadcastReceiver_onReceived(blankActivity, bundle);
+        FCMBroadcastReceiver_onReceived_withBundle(blankActivity, bundle);
 
         // Foreground app through icon before new session
         blankActivityController.resume();
@@ -776,6 +785,7 @@ public class OutcomeEventIntegrationTests {
     }
 
     @Test
+    @Config(shadows = { ShadowGenerateNotification.class })
     public void testIndirectSession_sendsOnFocusFromSyncJob_after10SecondSession() throws Exception {
         foregroundAppAfterReceivingNotification();
 
@@ -798,6 +808,7 @@ public class OutcomeEventIntegrationTests {
     }
 
     @Test
+    @Config(shadows = { ShadowGenerateNotification.class })
     public void testIndirectSession_sendsOnFocusFromSyncJob_evenAfterKillingApp_after10SecondSession() throws Exception {
         foregroundAppAfterReceivingNotification();
 
@@ -822,6 +833,7 @@ public class OutcomeEventIntegrationTests {
     }
 
     @Test
+    @Config(shadows = { ShadowGenerateNotification.class })
     public void testIndirectSession_sendsOnFocusAttributionForPushPlayer_butNotEmailPlayer() throws Exception {
         OneSignal.setEmail("test@test.com");
         foregroundAppAfterReceivingNotification();
@@ -852,6 +864,7 @@ public class OutcomeEventIntegrationTests {
     }
 
     @Test
+    @Config(shadows = { ShadowGenerateNotification.class })
     public void testIndirectSessionNotificationsUpdated_onNewIndirectSession() throws Exception {
         foregroundAppAfterReceivingNotification();
 
@@ -865,7 +878,7 @@ public class OutcomeEventIntegrationTests {
 
         // Receive notification
         Bundle bundle = getBaseNotifBundle(ONESIGNAL_NOTIFICATION_ID + "2");
-        FCMBroadcastReceiver_onReceived(blankActivity, bundle);
+        FCMBroadcastReceiver_onReceived_withBundle(blankActivity, bundle);
         indirectNotificationIds.put(ONESIGNAL_NOTIFICATION_ID + "2");
 
         // App in background for 31 seconds to trigger new session
@@ -887,6 +900,7 @@ public class OutcomeEventIntegrationTests {
     }
 
     @Test
+    @Config(shadows = { ShadowGenerateNotification.class })
     public void testCleaningCachedNotifications_after7Days_willAlsoCleanUniqueOutcomeNotifications() throws Exception {
         foregroundAppAfterReceivingNotification();
 
@@ -913,7 +927,7 @@ public class OutcomeEventIntegrationTests {
 
         // Receive notification
         Bundle bundle = getBaseNotifBundle(ONESIGNAL_NOTIFICATION_ID + "2");
-        FCMBroadcastReceiver_onReceived(blankActivity, bundle);
+        FCMBroadcastReceiver_onReceived_withBundle(blankActivity, bundle);
 
         // Foreground app through icon
         blankActivityController.resume();
@@ -1006,7 +1020,7 @@ public class OutcomeEventIntegrationTests {
         String notificationID = ONESIGNAL_NOTIFICATION_ID + "1";
         // Receive notification
         Bundle bundle = getBaseNotifBundle(ONESIGNAL_NOTIFICATION_ID + "1");
-        FCMBroadcastReceiver_onReceived(blankActivity, bundle);
+        FCMBroadcastReceiver_onReceived_withBundle(blankActivity, bundle);
 
         // Check notification was saved
         assertEquals(1, trackerFactory.getNotificationChannelTracker().getLastReceivedIds().length());

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/TestHelpers.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/TestHelpers.java
@@ -1,7 +1,6 @@
 package com.test.onesignal;
 
 import android.app.AlarmManager;
-import android.app.Application;
 import android.app.job.JobInfo;
 import android.app.job.JobScheduler;
 import android.app.job.JobService;
@@ -43,6 +42,7 @@ import com.onesignal.ShadowOneSignalRestClientWithMockConnection;
 import com.onesignal.ShadowPushRegistratorADM;
 import com.onesignal.ShadowPushRegistratorFCM;
 import com.onesignal.ShadowPushRegistratorHMS;
+import com.onesignal.ShadowTimeoutHandler;
 import com.onesignal.StaticResetHelper;
 import com.onesignal.influence.model.OSInfluenceType;
 import com.onesignal.outcomes.MockOSCachedUniqueOutcomeTable;
@@ -118,6 +118,7 @@ public class TestHelpers {
       OneSignalShadowPackageManager.resetStatics();
 
       ShadowOSUtils.resetStatics();
+      ShadowTimeoutHandler.resetStatics();
 
       lastException = null;
    }


### PR DESCRIPTION
* Notification should never be processed for display from the Main Thread
  * This can cause an `ANR` if work is taking too long before showing the notification
* Created a `OSThrowable` class with a `OSMainThreadException`
* Fixed `UnitTests` thinking they were on the Main Thread
  * Added a shadow in `ShadowOSUtils` for `isRunningOnMainThread` method

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1110)
<!-- Reviewable:end -->
