### PR TITLE
Fix Roboelectric looper shadowing

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotification.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotification.java
@@ -105,7 +105,7 @@ class GenerateNotification {
          notificationOpenedClass = NotificationOpenedActivity.class;
    }
 
-   static void fromJsonPayload(final OSNotificationGenerationJob notifJob) {
+   static void fromJsonPayload(OSNotificationGenerationJob notifJob) {
       setStatics(notifJob.context);
 
       if (notifJob.displayOption.isSilent())

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotification.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotification.java
@@ -47,6 +47,7 @@ import android.text.style.StyleSpan;
 import android.widget.RemoteViews;
 
 import androidx.annotation.RequiresApi;
+import androidx.annotation.WorkerThread;
 import androidx.core.app.NotificationCompat;
 import androidx.core.app.NotificationManagerCompat;
 
@@ -105,6 +106,7 @@ class GenerateNotification {
          notificationOpenedClass = NotificationOpenedActivity.class;
    }
 
+   @WorkerThread
    static void fromJsonPayload(OSNotificationGenerationJob notifJob) {
       setStatics(notifJob.context);
 
@@ -607,7 +609,7 @@ class GenerateNotification {
             inboxStyle.addLine(spannableString);
          }
 
-         for(SpannableString line : summaryList)
+         for (SpannableString line : summaryList)
             inboxStyle.addLine(line);
          inboxStyle.setBigContentTitle(summaryMessage);
          summaryBuilder.setStyle(inboxStyle);

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
@@ -38,6 +38,7 @@ import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.WorkerThread;
 
 import com.onesignal.OneSignalDbContract.NotificationTable;
 
@@ -114,10 +115,12 @@ class NotificationBundleProcessor {
      * Only use the {@link NotificationBundleProcessor#processJobForDisplay(OSNotificationGenerationJob, boolean, boolean)}
      *  in the event where you want to mark a notification as opened or displayed different than the defaults
      */
+    @WorkerThread
     static int processJobForDisplay(OSNotificationGenerationJob notifJob) {
         return processJobForDisplay(notifJob, false, true);
     }
 
+    @WorkerThread
     static int processJobForDisplay(OSNotificationGenerationJob notifJob, boolean opened, boolean displayed) {
         processCollapseKey(notifJob);
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationSummaryManager.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationSummaryManager.java
@@ -6,10 +6,10 @@ import android.content.Context;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 
+import com.onesignal.OneSignalDbContract.NotificationTable;
+
 import org.json.JSONException;
 import org.json.JSONObject;
-
-import com.onesignal.OneSignalDbContract.NotificationTable;
 
 class NotificationSummaryManager {
    
@@ -20,16 +20,16 @@ class NotificationSummaryManager {
           new String[] { NotificationTable.COLUMN_NAME_GROUP_ID }, // retColumn
           NotificationTable.COLUMN_NAME_ANDROID_NOTIFICATION_ID + " = " + androidNotificationId,
           null, null, null, null);
-      
+
       if (cursor.moveToFirst()) {
          String group = cursor.getString(cursor.getColumnIndex(NotificationTable.COLUMN_NAME_GROUP_ID));
          cursor.close();
-         
+
          if (group != null)
             updateSummaryNotificationAfterChildRemoved(context, writableDb, group, true);
-      }
-      else
+      } else {
          cursor.close();
+      }
    }
    
    // Called from an opened / dismissed / cancel event of a single notification to update it's parent the summary notification.
@@ -162,19 +162,19 @@ class NotificationSummaryManager {
               NotificationTable.COLUMN_NAME_DISMISSED + " = 0 AND " +
               NotificationTable.COLUMN_NAME_OPENED + " = 0 AND " +
               NotificationTable.COLUMN_NAME_IS_SUMMARY + " = 1";
-      String[] whereArgs = new String[] { group };
+      String[] whereArgs = new String[]{group};
 
       try {
          // Get the Android Notification ID of the summary notification
          cursor = writableDb.query(
-             NotificationTable.TABLE_NAME,
-                 new String[] { NotificationTable.COLUMN_NAME_ANDROID_NOTIFICATION_ID }, // retColumn
+                 NotificationTable.TABLE_NAME,
+                 new String[]{NotificationTable.COLUMN_NAME_ANDROID_NOTIFICATION_ID}, // retColumn
                  whereStr,
                  whereArgs,
                  null,
                  null,
                  null);
-      
+
          boolean hasRecord = cursor.moveToFirst();
          if (!hasRecord) {
             cursor.close();

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationDisplayedResult.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationDisplayedResult.java
@@ -29,4 +29,11 @@ package com.onesignal;
 
 public class OSNotificationDisplayedResult {
    public int androidNotificationId;
+
+   @Override
+   public String toString() {
+      return "OSNotificationDisplayedResult{" +
+              "androidNotificationId=" + androidNotificationId +
+              '}';
+   }
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationExtender.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationExtender.java
@@ -57,6 +57,14 @@ public class OSNotificationExtender {
          if (overrideSettings.extender != null)
             extender = overrideSettings.extender;
       }
+
+      @Override
+      public String toString() {
+         return "OverrideSettings{" +
+                 "extender=" + extender +
+                 ", androidNotificationId=" + androidNotificationId +
+                 '}';
+      }
    }
 
    private Context context;
@@ -220,5 +228,18 @@ public class OSNotificationExtender {
       } catch (ClassNotFoundException e) {
          e.printStackTrace();
       }
+   }
+
+   @Override
+   public String toString() {
+      return "OSNotificationExtender{" +
+              "context=" + context +
+              ", jsonPayload=" + jsonPayload +
+              ", isRestoring=" + isRestoring +
+              ", timestamp=" + timestamp +
+              ", currentBaseOverrideSettings=" + currentBaseOverrideSettings +
+              ", notificationDisplayedResult=" + notificationDisplayedResult +
+              ", developerProcessed=" + developerProcessed +
+              '}';
    }
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationGenerationJob.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationGenerationJob.java
@@ -27,7 +27,6 @@
 
 package com.onesignal;
 
-
 import android.content.Context;
 import android.net.Uri;
 
@@ -43,10 +42,10 @@ public class OSNotificationGenerationJob {
     // Timeout in seconds before applying defaults
     private static final long SHOW_NOTIFICATION_TIMEOUT = 25 * 1_000L;
 
-    private final String TITLE_PAYLOAD_PARAM = "title";
-    private final String ALERT_PAYLOAD_PARAM = "alert";
-    private final String CUSTOM_PAYLOAD_PARAM = "custom";
-    private final String ADDITIONAL_DATA_PAYLOAD_PARAM = "a";
+    private static final String TITLE_PAYLOAD_PARAM = "title";
+    private static final String ALERT_PAYLOAD_PARAM = "alert";
+    private static final String CUSTOM_PAYLOAD_PARAM = "custom";
+    private static final String ADDITIONAL_DATA_PAYLOAD_PARAM = "a";
 
     Context context;
     JSONObject jsonPayload;
@@ -176,21 +175,30 @@ public class OSNotificationGenerationJob {
      *    1. {@link ExtNotificationGenerationJob}
      *    2. {@link AppNotificationGenerationJob}
      */
-    static class NotificationGenerationJob extends OSTimeoutHandler {
+    static class NotificationGenerationJob {
 
         // Used to toggle when complete is called so it can not be called more than once
         boolean isComplete = false;
 
         // The actual notifJob with notification payload data
         private OSNotificationGenerationJob notifJob;
+        private OSTimeoutHandler timeoutHandler;
 
         NotificationGenerationJob(OSNotificationGenerationJob notifJob) {
             this.notifJob = notifJob;
-            setTimeout(SHOW_NOTIFICATION_TIMEOUT);
+            timeoutHandler = new OSTimeoutHandler();
         }
 
         OSNotificationGenerationJob getNotifJob() {
             return notifJob;
+        }
+
+        protected void startTimeout(Runnable runnable) {
+            timeoutHandler.startTimeout(SHOW_NOTIFICATION_TIMEOUT, runnable);
+        }
+
+        protected void destroyTimeout() {
+            timeoutHandler.destroyTimeout();
         }
 
         public String getApiNotificationId() {
@@ -220,6 +228,14 @@ public class OSNotificationGenerationJob {
         public void setNotificationDisplayOption(OSNotificationDisplay displayOption) {
             notifJob.setNotificationDisplayOption(displayOption);
         }
+
+        @Override
+        public String toString() {
+            return "NotificationGenerationJob{" +
+                    "isComplete=" + isComplete +
+                    ", notifJob=" + notifJob +
+                    '}';
+        }
     }
 
     /**
@@ -234,9 +250,16 @@ public class OSNotificationGenerationJob {
             startTimeout(new Runnable() {
                 @Override
                 public void run() {
-                    ExtNotificationGenerationJob.this.complete(true);
+                    completeJob(true);
                 }
             });
+        }
+
+        /**
+         * For shadow testing purpose
+         */
+        void completeJob(boolean bubble) {
+            complete(bubble);
         }
 
         /**
@@ -299,4 +322,21 @@ public class OSNotificationGenerationJob {
         }
     }
 
+    @Override
+    public String toString() {
+        return "OSNotificationGenerationJob{" +
+                "jsonPayload=" + jsonPayload +
+                ", isRestoring=" + isRestoring +
+                ", isIamPreview=" + isIamPreview +
+                ", displayOption=" + displayOption +
+                ", shownTimeStamp=" + shownTimeStamp +
+                ", overriddenBodyFromExtender=" + overriddenBodyFromExtender +
+                ", overriddenTitleFromExtender=" + overriddenTitleFromExtender +
+                ", overriddenSound=" + overriddenSound +
+                ", overriddenFlags=" + overriddenFlags +
+                ", orgFlags=" + orgFlags +
+                ", orgSound=" + orgSound +
+                ", overrideSettings=" + overrideSettings +
+                '}';
+    }
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationWorkManager.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationWorkManager.java
@@ -1,6 +1,7 @@
 package com.onesignal;
 
 import android.content.Context;
+import android.os.Looper;
 
 import androidx.annotation.NonNull;
 import androidx.work.Data;
@@ -64,6 +65,10 @@ class OSNotificationWorkManager {
                 e.printStackTrace();
                 return Result.failure();
             }
+
+            // TODO: This line stops the Looper.loop call once the notification processing is all done
+            //  The reason for all of this is because we are firing handlers while running a background thread using the Worker
+            Looper.myLooper().quit();
             return Result.success();
         }
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSTimeoutHandler.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSTimeoutHandler.java
@@ -1,21 +1,21 @@
 /**
  * Modified MIT License
- *
+ * <p>
  * Copyright 2020 OneSignal
- *
+ * <p>
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- *
+ * <p>
  * 1. The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- *
+ * <p>
  * 2. All copies of substantial portions of the Software may only be used in connection
  * with services provided by OneSignal.
- *
+ * <p>
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -34,39 +34,40 @@ import androidx.annotation.NonNull;
 
 class OSTimeoutHandler {
 
-    private long timeout;
-
     private Handler timeoutHandler;
     private Runnable timeoutRunnable;
 
-    void setTimeout(long timeout) {
-        this.timeout = timeout;
+    public OSTimeoutHandler() {
     }
 
-    synchronized void startTimeout(@NonNull final Runnable runnable) {
+    synchronized void startTimeout(long timeout, @NonNull final Runnable runnable) {
         // If the handler or runnable isn't null we do not want to start another
-        if (timeoutHandler != null && timeoutRunnable != null)
+        if (timeoutRunnable != null)
             return;
 
         timeoutRunnable = runnable;
 
+        postDelayed(timeoutRunnable, timeout);
+    }
+
+    public void postDelayed(final Runnable runnable, final long delayMillis) {
         if (Looper.myLooper() == null)
             Looper.prepare();
 
         timeoutHandler = new Handler();
-        timeoutHandler.postDelayed(timeoutRunnable, timeout);
+        timeoutHandler.postDelayed(runnable, delayMillis);
 
-        // TODO: This line causes some UnitTests to run forever and not sure how to fix
-        //  This is required though for apps that have a no complete inside of the NotificationProcessing or NotificationWillShowInForeground handlers
         Looper.loop();
     }
 
     synchronized void destroyTimeout() {
-        if (timeoutHandler != null)
-            timeoutHandler.removeCallbacks(timeoutRunnable);
-
+        removeCallbacks(timeoutRunnable);
         timeoutHandler = null;
         timeoutRunnable = null;
     }
 
+    public void removeCallbacks(Runnable runnable) {
+        if (timeoutHandler != null)
+            timeoutHandler.removeCallbacks(runnable);
+    }
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSTimeoutHandler.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSTimeoutHandler.java
@@ -45,16 +45,20 @@ class OSTimeoutHandler {
 
     synchronized void startTimeout(@NonNull final Runnable runnable) {
         // If the handler or runnable isn't null we do not want to start another
-        if (this.timeoutHandler != null && this.timeoutRunnable != null)
+        if (timeoutHandler != null && timeoutRunnable != null)
             return;
 
-        this.timeoutRunnable = runnable;
+        timeoutRunnable = runnable;
 
         if (Looper.myLooper() == null)
             Looper.prepare();
 
         timeoutHandler = new Handler();
         timeoutHandler.postDelayed(timeoutRunnable, timeout);
+
+        // TODO: This line causes some UnitTests to run forever and not sure how to fix
+        //  This is required though for apps that have a no complete inside of the NotificationProcessing or NotificationWillShowInForeground handlers
+        Looper.loop();
     }
 
     synchronized void destroyTimeout() {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -2150,7 +2150,7 @@ public class OneSignal {
          jsonObject.put(BUNDLE_KEY_ANDROID_NOTIFICATION_ID, notifJob.getAndroidId());
 
          OSNotificationOpenResult openResult = generateOsNotificationOpenResult(newJsonArray(jsonObject), displayed);
-         if(trackFirebaseAnalytics != null && getFirebaseAnalyticsEnabled())
+         if (trackFirebaseAnalytics != null && getFirebaseAnalyticsEnabled())
             trackFirebaseAnalytics.trackReceivedEvent(openResult);
 
       } catch (JSONException e) {
@@ -2189,6 +2189,7 @@ public class OneSignal {
     * @see OneSignal.ExtNotificationWillShowInForegroundHandler
     * @see OneSignal.AppNotificationWillShowInForegroundHandler
     */
+   @WorkerThread
    static void fireForegroundHandlers(OSNotificationGenerationJob notifJob) {
       if (OneSignal.extNotificationWillShowInForegroundHandler == null) {
          OneSignal.onesignalLog(OneSignal.LOG_LEVEL.INFO, "No extNotificationWillShowInForegroundHandler setup, fire appNotificationWillShowInForegroundHandler");
@@ -2200,7 +2201,7 @@ public class OneSignal {
       fireExtNotificationWillShowInForegroundHandler(notifJob.toExtNotificationGenerationJob());
    }
 
-   static void fireExtNotificationWillShowInForegroundHandler(ExtNotificationGenerationJob extNotifJob) {
+   private static void fireExtNotificationWillShowInForegroundHandler(ExtNotificationGenerationJob extNotifJob) {
       try {
          OneSignal.extNotificationWillShowInForegroundHandler.notificationWillShowInForeground(extNotifJob);
       } catch (Throwable t) {

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
@@ -141,33 +141,128 @@ public class OneSignalPackagePrivateHelper {
       return retBundle;
    }
 
-   public static void NotificationBundleProcessor_ProcessFromFCMIntentService(Context context, Bundle bundle, OSNotificationExtender.OverrideSettings overrideSettings) {
-      NotificationBundleProcessor.processFromFCMIntentService(context, createInternalPayloadBundle(bundle), overrideSettings);
+   public static void NotificationBundleProcessor_ProcessFromFCMIntentService(final Context context, final Bundle bundle, final OSNotificationExtender.OverrideSettings overrideSettings) {
+      Thread thread = new Thread(new Runnable() {
+         @Override
+         public void run() {
+            NotificationBundleProcessor.processFromFCMIntentService(context, createInternalPayloadBundle(bundle), overrideSettings);
+         }
+      });
+      thread.start();
+      try {
+         thread.join();
+      } catch (InterruptedException e) {
+         e.printStackTrace();
+      }
    }
 
-   public static void NotificationBundleProcessor_ProcessFromFCMIntentService_NoWrap(Context context, BundleCompat bundle, OSNotificationExtender.OverrideSettings overrideSettings) {
-      NotificationBundleProcessor.processFromFCMIntentService(context, bundle, overrideSettings);
+   public static void NotificationBundleProcessor_ProcessFromFCMIntentService_NoWrap(final Context context, final BundleCompat bundle, final OSNotificationExtender.OverrideSettings overrideSettings) {
+      Thread thread = new Thread(new Runnable() {
+         @Override
+         public void run() {
+            NotificationBundleProcessor.processFromFCMIntentService(context, bundle, overrideSettings);
+         }
+      });
+      thread.start();
+      try {
+         thread.join();
+      } catch (InterruptedException e) {
+         e.printStackTrace();
+      }
    }
 
-   public static boolean FCMBroadcastReceiver_processBundle(Context context, Bundle bundle) {
-      NotificationBundleProcessor.ProcessedBundleResult processedResult = NotificationBundleProcessor.processBundleFromReceiver(context, bundle);
+   public static boolean FCMBroadcastReceiver_processBundle(final Context context, final Bundle bundle) {
+      NotificationBundleProcessor.ProcessedBundleResult processedResult = new com.onesignal.NotificationBundleProcessor.ProcessedBundleResult();
+
+      Thread thread = new Thread(new Runnable() {
+         @Override
+         public void run() {
+            NotificationBundleProcessor.processBundleFromReceiver(context, bundle);
+         }
+      });
+      thread.start();
+      try {
+         thread.join();
+      } catch (InterruptedException e) {
+         e.printStackTrace();
+      }
+
       return processedResult.processed();
    }
 
-   public static void FCMBroadcastReceiver_onReceived(Context context, Bundle bundle) {
-      FCMBroadcastReceiver receiver = new FCMBroadcastReceiver();
-      Intent intent = new Intent();
-      intent.setAction("com.google.android.c2dm.intent.RECEIVE");
-      intent.putExtras(bundle);
-      receiver.onReceive(context,intent);
+   public static void FCMBroadcastReceiver_onReceived_withIntent(final Context context, final Intent intent) {
+      Thread thread = new Thread(new Runnable() {
+         @Override
+         public void run() {
+            FCMBroadcastReceiver receiver = new FCMBroadcastReceiver();
+            intent.setAction("com.google.android.c2dm.intent.RECEIVE");
+            receiver.onReceive(context, intent);
+         }
+      });
+      thread.start();
+      try {
+         thread.join();
+      } catch (InterruptedException e) {
+         e.printStackTrace();
+      }
+   }
+
+   public static void FCMBroadcastReceiver_onReceived_withBundle(final Context context, final Bundle bundle) {
+      Thread thread = new Thread(new Runnable() {
+         @Override
+         public void run() {
+            final FCMBroadcastReceiver receiver = new FCMBroadcastReceiver();
+            Intent intent = new Intent();
+            intent.setAction("com.google.android.c2dm.intent.RECEIVE");
+            intent.putExtras(bundle);
+            receiver.onReceive(context, intent);
+         }
+      });
+      thread.start();
+      try {
+         thread.join();
+      } catch (InterruptedException e) {
+         e.printStackTrace();
+      }
+   }
+
+   public static void HMSProcessor_processDataMessageReceived(final Context context, final String jsonStrPayload) {
+      Thread thread = new Thread(new Runnable() {
+         @Override
+         public void run() {
+            NotificationPayloadProcessorHMS.processDataMessageReceived(context, jsonStrPayload);
+         }
+      });
+      thread.start();
+      try {
+         thread.join();
+      } catch (InterruptedException e) {
+         e.printStackTrace();
+      }
    }
 
    public static int NotificationBundleProcessor_Process(Context context, boolean restoring, JSONObject jsonPayload, OSNotificationExtender.OverrideSettings overrideSettings) {
-      OSNotificationGenerationJob notifJob = new OSNotificationGenerationJob(context);
+      final OSNotificationGenerationJob notifJob = new OSNotificationGenerationJob(context);
       notifJob.jsonPayload = jsonPayload;
       notifJob.overrideSettings = overrideSettings;
       notifJob.isRestoring = restoring;
-      return NotificationBundleProcessor.processJobForDisplay(notifJob);
+
+      int androidNotificationId = 0;
+      // processJobForDisplay leads to a MainThread check and must be run from a new Thread to pass
+      Thread thread = new Thread(new Runnable() {
+         @Override
+         public void run() {
+            NotificationBundleProcessor.processJobForDisplay(notifJob);
+         }
+      });
+      thread.start();
+      try {
+         thread.join();
+      } catch (InterruptedException e) {
+         e.printStackTrace();
+      }
+
+      return androidNotificationId;
    }
 
    public static class NotificationTable extends OneSignalDbContract.NotificationTable { }

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
@@ -6,6 +6,7 @@ import android.content.Intent;
 import android.database.sqlite.SQLiteDatabase;
 import android.os.Bundle;
 import android.os.Looper;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -142,127 +143,42 @@ public class OneSignalPackagePrivateHelper {
    }
 
    public static void NotificationBundleProcessor_ProcessFromFCMIntentService(final Context context, final Bundle bundle, final OSNotificationExtender.OverrideSettings overrideSettings) {
-      Thread thread = new Thread(new Runnable() {
-         @Override
-         public void run() {
-            NotificationBundleProcessor.processFromFCMIntentService(context, createInternalPayloadBundle(bundle), overrideSettings);
-         }
-      });
-      thread.start();
-      try {
-         thread.join();
-      } catch (InterruptedException e) {
-         e.printStackTrace();
-      }
+      NotificationBundleProcessor.processFromFCMIntentService(context, createInternalPayloadBundle(bundle), overrideSettings);
    }
 
    public static void NotificationBundleProcessor_ProcessFromFCMIntentService_NoWrap(final Context context, final BundleCompat bundle, final OSNotificationExtender.OverrideSettings overrideSettings) {
-      Thread thread = new Thread(new Runnable() {
-         @Override
-         public void run() {
-            NotificationBundleProcessor.processFromFCMIntentService(context, bundle, overrideSettings);
-         }
-      });
-      thread.start();
-      try {
-         thread.join();
-      } catch (InterruptedException e) {
-         e.printStackTrace();
-      }
+      NotificationBundleProcessor.processFromFCMIntentService(context, bundle, overrideSettings);
    }
 
    public static boolean FCMBroadcastReceiver_processBundle(final Context context, final Bundle bundle) {
-      NotificationBundleProcessor.ProcessedBundleResult processedResult = new com.onesignal.NotificationBundleProcessor.ProcessedBundleResult();
-
-      Thread thread = new Thread(new Runnable() {
-         @Override
-         public void run() {
-            NotificationBundleProcessor.processBundleFromReceiver(context, bundle);
-         }
-      });
-      thread.start();
-      try {
-         thread.join();
-      } catch (InterruptedException e) {
-         e.printStackTrace();
-      }
-
+      NotificationBundleProcessor.ProcessedBundleResult processedResult = NotificationBundleProcessor.processBundleFromReceiver(context, bundle);
       return processedResult.processed();
    }
 
    public static void FCMBroadcastReceiver_onReceived_withIntent(final Context context, final Intent intent) {
-      Thread thread = new Thread(new Runnable() {
-         @Override
-         public void run() {
-            FCMBroadcastReceiver receiver = new FCMBroadcastReceiver();
-            intent.setAction("com.google.android.c2dm.intent.RECEIVE");
-            receiver.onReceive(context, intent);
-         }
-      });
-      thread.start();
-      try {
-         thread.join();
-      } catch (InterruptedException e) {
-         e.printStackTrace();
-      }
+      FCMBroadcastReceiver receiver = new FCMBroadcastReceiver();
+      intent.setAction("com.google.android.c2dm.intent.RECEIVE");
+      receiver.onReceive(context, intent);
    }
 
    public static void FCMBroadcastReceiver_onReceived_withBundle(final Context context, final Bundle bundle) {
-      Thread thread = new Thread(new Runnable() {
-         @Override
-         public void run() {
-            final FCMBroadcastReceiver receiver = new FCMBroadcastReceiver();
-            Intent intent = new Intent();
-            intent.setAction("com.google.android.c2dm.intent.RECEIVE");
-            intent.putExtras(bundle);
-            receiver.onReceive(context, intent);
-         }
-      });
-      thread.start();
-      try {
-         thread.join();
-      } catch (InterruptedException e) {
-         e.printStackTrace();
-      }
+      final FCMBroadcastReceiver receiver = new FCMBroadcastReceiver();
+      Intent intent = new Intent();
+      intent.setAction("com.google.android.c2dm.intent.RECEIVE");
+      intent.putExtras(bundle);
+      receiver.onReceive(context, intent);
    }
 
    public static void HMSProcessor_processDataMessageReceived(final Context context, final String jsonStrPayload) {
-      Thread thread = new Thread(new Runnable() {
-         @Override
-         public void run() {
-            NotificationPayloadProcessorHMS.processDataMessageReceived(context, jsonStrPayload);
-         }
-      });
-      thread.start();
-      try {
-         thread.join();
-      } catch (InterruptedException e) {
-         e.printStackTrace();
-      }
+      NotificationPayloadProcessorHMS.processDataMessageReceived(context, jsonStrPayload);
    }
 
    public static int NotificationBundleProcessor_Process(Context context, boolean restoring, JSONObject jsonPayload, OSNotificationExtender.OverrideSettings overrideSettings) {
-      final OSNotificationGenerationJob notifJob = new OSNotificationGenerationJob(context);
+      OSNotificationGenerationJob notifJob = new OSNotificationGenerationJob(context);
       notifJob.jsonPayload = jsonPayload;
       notifJob.overrideSettings = overrideSettings;
       notifJob.isRestoring = restoring;
-
-      int androidNotificationId = 0;
-      // processJobForDisplay leads to a MainThread check and must be run from a new Thread to pass
-      Thread thread = new Thread(new Runnable() {
-         @Override
-         public void run() {
-            NotificationBundleProcessor.processJobForDisplay(notifJob);
-         }
-      });
-      thread.start();
-      try {
-         thread.join();
-      } catch (InterruptedException e) {
-         e.printStackTrace();
-      }
-
-      return androidNotificationId;
+      return NotificationBundleProcessor.processJobForDisplay(notifJob);
    }
 
    public static class NotificationTable extends OneSignalDbContract.NotificationTable { }

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowExtNotificationGenerationJob.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowExtNotificationGenerationJob.java
@@ -1,0 +1,22 @@
+package com.onesignal;
+
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+import org.robolectric.annotation.RealObject;
+
+@Implements(OSNotificationGenerationJob.ExtNotificationGenerationJob.class)
+public class ShadowExtNotificationGenerationJob {
+
+    @RealObject
+    private OSNotificationGenerationJob.ExtNotificationGenerationJob generationJob;
+
+    @Implementation
+    public void completeJob(boolean bubble) {
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                generationJob.complete(true);
+            }
+        }, "OS_EXT_NOTIFICATION_GENERATION_JOB").start();
+    }
+}

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowNotificationReceived.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowNotificationReceived.java
@@ -1,0 +1,26 @@
+package com.onesignal;
+
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+@Implements(OSNotificationReceived.class)
+public class ShadowNotificationReceived {
+
+    private ScheduledThreadPoolExecutor executor = null;
+
+    @Implementation
+    public void startCompleteTimeOut(long timeout, Runnable runnable) {
+        executor = new ScheduledThreadPoolExecutor(1);
+        executor.schedule(runnable, timeout, TimeUnit.MILLISECONDS);
+    }
+
+    @Implementation
+    public void destroyTimeout() {
+        if (executor != null) {
+            executor.shutdownNow();
+        }
+    }
+}

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowNotificationWorker.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowNotificationWorker.java
@@ -1,0 +1,48 @@
+package com.onesignal;
+
+import android.content.Context;
+
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+
+/**
+ * Shadow class for OSNotificationWorkManager.NotificationWorker methods.
+ * These method will always run inside a worker, but given that Roboelectric runs everything under MainThread
+ * we need to shadow them and emulate the background thread.
+ */
+@Implements(OSNotificationWorkManager.NotificationWorker.class)
+public class ShadowNotificationWorker {
+
+    public static boolean callProcessingHandlerUnderThread = true;
+    public static boolean completeWorkUnderThread = true;
+
+    @Implementation
+    public void callProcessingHandler(final Context context, final OSNotificationReceived notificationReceived) {
+        if (callProcessingHandlerUnderThread)
+            new Thread(new Runnable() {
+                public void run() {
+                    OneSignal.notificationProcessingHandler.notificationProcessing(context, notificationReceived);
+                }
+            }, "OS_NOTIFICATION_RECEIVED_COMPLETE").start();
+        else
+            OneSignal.notificationProcessingHandler.notificationProcessing(context, notificationReceived);
+    }
+
+    @Implementation
+    public void completeWork(final OSNotificationReceived notificationReceived) {
+        if (completeWorkUnderThread) {
+            new Thread(new Runnable() {
+                public void run() {
+                    notificationReceived.complete();
+                }
+            }, "OS_NOTIFICATION_RECEIVED_COMPLETE").start();
+        } else {
+            notificationReceived.complete();
+        }
+    }
+
+    public static void resetStatics() {
+        callProcessingHandlerUnderThread = true;
+        completeWorkUnderThread = true;
+    }
+}

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowTimeoutHandler.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowTimeoutHandler.java
@@ -1,0 +1,51 @@
+package com.onesignal;
+
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+
+import java.util.HashMap;
+import java.util.TimerTask;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Shadow class to emulate handler post delay work, Roboelectric runs everything under a custom MainThread
+ * it also shadows its Loopers under a ShadowLooper.class, if we use looper outside Roboelectric custom thread
+ * handler and looper will end disconnected and will end on a deadlock.
+ * To solve this problem, for cases were we run Loopers under a custom thread, we shadow the TimeoutHandler
+ * to emulate the same behaviour
+ */
+@Implements(OSTimeoutHandler.class)
+public class ShadowTimeoutHandler {
+
+    private static boolean mockDelay = false;
+    private static long mockDelayMillis = 1;
+
+    private HashMap<Runnable, ScheduledThreadPoolExecutor> executorHashMap = new HashMap<>();
+
+    public static void setMockDelayMillis(long mockDelayMillis) {
+        mockDelay = true;
+        ShadowTimeoutHandler.mockDelayMillis = mockDelayMillis;
+    }
+
+    @Implementation
+    public boolean postDelayed(final Runnable runnable, final long delayMillis) {
+        ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(1);
+        executor.schedule(runnable, mockDelay ? mockDelayMillis : delayMillis, TimeUnit.MILLISECONDS);
+        executorHashMap.put(runnable, executor);
+        return true;
+    }
+
+    @Implementation
+    public void removeCallbacks(Runnable runnable) {
+        ScheduledThreadPoolExecutor executor = executorHashMap.get(runnable);
+        if (executor != null) {
+            executor.shutdownNow();
+        }
+    }
+
+    public static void resetStatics() {
+        mockDelay = false;
+        mockDelayMillis = 1;
+    }
+}

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/HMSDataMessageReceivedIntegrationTestsRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/HMSDataMessageReceivedIntegrationTestsRunner.java
@@ -25,6 +25,7 @@ import org.robolectric.shadows.ShadowLog;
 
 import java.util.UUID;
 
+import static com.onesignal.OneSignalPackagePrivateHelper.HMSProcessor_processDataMessageReceived;
 import static com.onesignal.OneSignalPackagePrivateHelper.OSNotificationFormatHelper.PAYLOAD_OS_NOTIFICATION_ID;
 import static com.onesignal.OneSignalPackagePrivateHelper.OSNotificationFormatHelper.PAYLOAD_OS_ROOT_CUSTOM;
 import static com.test.onesignal.TestHelpers.threadAndTaskWait;
@@ -88,7 +89,7 @@ public class HMSDataMessageReceivedIntegrationTestsRunner {
     @Test
     public void basicPayload_shouldDisplayNotification() throws Exception {
         blankActivityController.pause();
-        NotificationPayloadProcessorHMS.processDataMessageReceived(blankActivity, helperBasicOSPayload());
+        HMSProcessor_processDataMessageReceived(blankActivity, helperBasicOSPayload());
         threadAndTaskWait();
 
         assertEquals(ALERT_TEST_MESSAGE_BODY, ShadowRoboNotificationManager.getLastShadowNotif().getBigText());

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/HMSDataMessageReceivedIntegrationTestsRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/HMSDataMessageReceivedIntegrationTestsRunner.java
@@ -5,6 +5,7 @@ import android.app.Activity;
 
 import com.onesignal.OneSignalPackagePrivateHelper.NotificationPayloadProcessorHMS;
 import com.onesignal.ShadowNotificationManagerCompat;
+import com.onesignal.ShadowNotificationWorker;
 import com.onesignal.ShadowOSUtils;
 import com.onesignal.ShadowRoboNotificationManager;
 import com.onesignal.StaticResetHelper;
@@ -87,6 +88,7 @@ public class HMSDataMessageReceivedIntegrationTestsRunner {
     }
 
     @Test
+    @Config(shadows = { ShadowNotificationWorker.class })
     public void basicPayload_shouldDisplayNotification() throws Exception {
         blankActivityController.pause();
         HMSProcessor_processDataMessageReceived(blankActivity, helperBasicOSPayload());

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
@@ -151,6 +151,7 @@ import static com.test.onesignal.TestHelpers.flushBufferedSharedPrefs;
 import static com.test.onesignal.TestHelpers.getNextJob;
 import static com.test.onesignal.TestHelpers.restartAppAndElapseTimeToNextSession;
 import static com.test.onesignal.TestHelpers.runNextJob;
+import static com.test.onesignal.TestHelpers.runOSThreads;
 import static com.test.onesignal.TestHelpers.threadAndTaskWait;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertFalse;
@@ -1134,12 +1135,12 @@ public class MainOneSignalClassRunner {
 
       Bundle bundle = getBaseNotifBundle();
       boolean processResult = FCMBroadcastReceiver_processBundle(blankActivity, bundle);
-      threadAndTaskWait();
 
       assertTrue(processResult);
       assertNull(lastNotificationOpenedBody);
 
       NotificationBundleProcessor_Process(blankActivity, false, bundleAsJSONObject(bundle), null);
+
       assertEquals("Robo test message", notificationReceivedBody);
       assertNotEquals(0, androidNotificationId);
 
@@ -1148,7 +1149,7 @@ public class MainOneSignalClassRunner {
       notificationReceivedBody = null;
 
       FCMBroadcastReceiver_processBundle(blankActivity, bundle);
-      threadAndTaskWait();
+
       assertNull(lastNotificationOpenedBody);
       assertNull(notificationReceivedBody);
 
@@ -1157,9 +1158,8 @@ public class MainOneSignalClassRunner {
 
       // Test that only NotificationReceivedHandler fires
       bundle = getBaseNotifBundle("UUID2");
-
       FCMBroadcastReceiver_processBundle(blankActivity, bundle);
-      threadAndTaskWait();
+
       assertNull(lastNotificationOpenedBody);
       assertEquals("Robo test message", notificationReceivedBody);
    }

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/NotificationLimitManagerRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/NotificationLimitManagerRunner.java
@@ -2,6 +2,7 @@ package com.test.onesignal;
 
 import android.app.NotificationManager;
 import android.content.Context;
+
 import androidx.core.app.NotificationCompat;
 import androidx.core.app.NotificationManagerCompat;
 
@@ -11,6 +12,7 @@ import com.onesignal.ShadowAdvertisingIdProviderGPS;
 import com.onesignal.ShadowCustomTabsClient;
 import com.onesignal.ShadowCustomTabsSession;
 import com.onesignal.ShadowNotificationLimitManager;
+import com.onesignal.ShadowNotificationWorker;
 import com.onesignal.ShadowOSUtils;
 import com.onesignal.ShadowOneSignalRestClient;
 import com.onesignal.ShadowPushRegistratorFCM;
@@ -120,6 +122,7 @@ public class NotificationLimitManagerRunner {
    }
 
    @Test
+   @Config(shadows = { ShadowNotificationWorker.class })
    public void clearFallbackMakingRoomForOneWhenAtLimit() throws Exception {
       NotificationBundleProcessor_ProcessFromFCMIntentService(blankActivity,  getBaseNotifBundle("UUID1"), null);
       threadAndTaskWait();
@@ -132,6 +135,7 @@ public class NotificationLimitManagerRunner {
    }
 
    @Test
+   @Config(shadows = { ShadowNotificationWorker.class })
    public void clearFallbackShouldNotCancelAnyNotificationsWhenUnderLimit() throws Exception {
       NotificationBundleProcessor_ProcessFromFCMIntentService(blankActivity,  getBaseNotifBundle("UUID1"), null);
       threadAndTaskWait();

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/OutcomeEventIntegrationTests.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/OutcomeEventIntegrationTests.java
@@ -21,6 +21,7 @@ import com.onesignal.ShadowCustomTabsSession;
 import com.onesignal.ShadowGMSLocationController;
 import com.onesignal.ShadowJobService;
 import com.onesignal.ShadowNotificationManagerCompat;
+import com.onesignal.ShadowNotificationWorker;
 import com.onesignal.ShadowOSUtils;
 import com.onesignal.ShadowOneSignalRestClient;
 import com.onesignal.ShadowPushRegistratorFCM;
@@ -160,6 +161,7 @@ public class OutcomeEventIntegrationTests {
     }
 
     @Test
+    @Config(shadows = { ShadowNotificationWorker.class })
     public void testAppSessions_beforeOnSessionCalls() throws Exception {
         foregroundAppAfterReceivingNotification();
 
@@ -190,6 +192,7 @@ public class OutcomeEventIntegrationTests {
     }
 
     @Test
+    @Config(shadows = { ShadowNotificationWorker.class })
     public void testAppSessions_afterOnSessionCalls() throws Exception {
         foregroundAppAfterReceivingNotification();
 
@@ -221,6 +224,7 @@ public class OutcomeEventIntegrationTests {
     }
 
     @Test
+    @Config(shadows = { ShadowNotificationWorker.class })
     public void testIndirectAttributionWindow_withNoNotifications() throws Exception {
         foregroundAppAfterReceivingNotification();
 
@@ -294,6 +298,7 @@ public class OutcomeEventIntegrationTests {
     }
 
     @Test
+    @Config(shadows = { ShadowNotificationWorker.class })
     public void testUniqueOutcomeMeasureOnlySentOncePerNotification_whenSendingMultipleUniqueOutcomes_inIndirectSessions() throws Exception {
         foregroundAppAfterReceivingNotification();
 
@@ -326,6 +331,7 @@ public class OutcomeEventIntegrationTests {
         // Receive notification
         Bundle bundle = getBaseNotifBundle(ONESIGNAL_NOTIFICATION_ID + "2");
         FCMBroadcastReceiver_onReceived_withBundle(blankActivity, bundle);
+        threadAndTaskWait();
 
         // Wait 31 seconds to start new session
         advanceSystemTimeBy(31);
@@ -349,6 +355,7 @@ public class OutcomeEventIntegrationTests {
     }
 
     @Test
+    @Config(shadows = { ShadowNotificationWorker.class })
     public void testOnV2UniqueOutcomeMeasureOnlySentOncePerNotification_whenSendingMultipleUniqueOutcomes_inIndirectSessions() throws Exception {
         // Enable IAM v2
         preferences = new MockOSSharedPreferences();
@@ -387,6 +394,7 @@ public class OutcomeEventIntegrationTests {
         // Receive notification
         Bundle bundle = getBaseNotifBundle(ONESIGNAL_NOTIFICATION_ID + "2");
         FCMBroadcastReceiver_onReceived_withBundle(blankActivity, bundle);
+        threadAndTaskWait();
 
         // Wait 31 seconds to start new session
         advanceSystemTimeBy(31);
@@ -626,6 +634,7 @@ public class OutcomeEventIntegrationTests {
     }
 
     @Test
+    @Config(shadows = { ShadowNotificationWorker.class })
     public void testDirectSession_willOverrideIndirectSession_whenAppIsInBackground() throws Exception {
         foregroundAppAfterReceivingNotification();
 
@@ -687,6 +696,7 @@ public class OutcomeEventIntegrationTests {
     }
 
     @Test
+    @Config(shadows = { ShadowNotificationWorker.class })
     public void testIndirectSession_fromDirectSession_afterNewSession() throws Exception {
         foregroundAppAfterClickingNotification();
 
@@ -750,6 +760,7 @@ public class OutcomeEventIntegrationTests {
     }
 
     @Test
+    @Config(shadows = { ShadowNotificationWorker.class })
     public void testIndirectSession_wontOverrideIndirectSession_beforeNewSession() throws Exception {
         foregroundAppAfterReceivingNotification();
 
@@ -776,6 +787,7 @@ public class OutcomeEventIntegrationTests {
     }
 
     @Test
+    @Config(shadows = { ShadowNotificationWorker.class })
     public void testIndirectSession_sendsOnFocusFromSyncJob_after10SecondSession() throws Exception {
         foregroundAppAfterReceivingNotification();
 
@@ -798,6 +810,7 @@ public class OutcomeEventIntegrationTests {
     }
 
     @Test
+    @Config(shadows = { ShadowNotificationWorker.class })
     public void testIndirectSession_sendsOnFocusFromSyncJob_evenAfterKillingApp_after10SecondSession() throws Exception {
         foregroundAppAfterReceivingNotification();
 
@@ -822,6 +835,7 @@ public class OutcomeEventIntegrationTests {
     }
 
     @Test
+    @Config(shadows = { ShadowNotificationWorker.class })
     public void testIndirectSession_sendsOnFocusAttributionForPushPlayer_butNotEmailPlayer() throws Exception {
         OneSignal.setEmail("test@test.com");
         foregroundAppAfterReceivingNotification();
@@ -852,6 +866,7 @@ public class OutcomeEventIntegrationTests {
     }
 
     @Test
+    @Config(shadows = { ShadowNotificationWorker.class })
     public void testIndirectSessionNotificationsUpdated_onNewIndirectSession() throws Exception {
         foregroundAppAfterReceivingNotification();
 
@@ -866,7 +881,7 @@ public class OutcomeEventIntegrationTests {
         // Receive notification
         Bundle bundle = getBaseNotifBundle(ONESIGNAL_NOTIFICATION_ID + "2");
         FCMBroadcastReceiver_onReceived_withBundle(blankActivity, bundle);
-        indirectNotificationIds.put(ONESIGNAL_NOTIFICATION_ID + "2");
+        threadAndTaskWait();
 
         // App in background for 31 seconds to trigger new session
         advanceSystemTimeBy(31);
@@ -875,6 +890,7 @@ public class OutcomeEventIntegrationTests {
         blankActivityController.resume();
         threadAndTaskWait();
 
+        indirectNotificationIds.put(ONESIGNAL_NOTIFICATION_ID + "2");
         // Make sure indirectNotificationIds are updated and correct
         assertEquals(indirectNotificationIds, trackerFactory.getNotificationChannelTracker().getIndirectIds());
 
@@ -887,6 +903,7 @@ public class OutcomeEventIntegrationTests {
     }
 
     @Test
+    @Config(shadows = { ShadowNotificationWorker.class })
     public void testCleaningCachedNotifications_after7Days_willAlsoCleanUniqueOutcomeNotifications() throws Exception {
         foregroundAppAfterReceivingNotification();
 
@@ -914,6 +931,7 @@ public class OutcomeEventIntegrationTests {
         // Receive notification
         Bundle bundle = getBaseNotifBundle(ONESIGNAL_NOTIFICATION_ID + "2");
         FCMBroadcastReceiver_onReceived_withBundle(blankActivity, bundle);
+        threadAndTaskWait();
 
         // Foreground app through icon
         blankActivityController.resume();
@@ -1007,6 +1025,7 @@ public class OutcomeEventIntegrationTests {
         // Receive notification
         Bundle bundle = getBaseNotifBundle(ONESIGNAL_NOTIFICATION_ID + "1");
         FCMBroadcastReceiver_onReceived_withBundle(blankActivity, bundle);
+        threadAndTaskWait();
 
         // Check notification was saved
         assertEquals(1, trackerFactory.getNotificationChannelTracker().getLastReceivedIds().length());

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/OutcomeEventIntegrationTests.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/OutcomeEventIntegrationTests.java
@@ -49,7 +49,7 @@ import org.robolectric.shadows.ShadowLog;
 import java.util.Arrays;
 import java.util.List;
 
-import static com.onesignal.OneSignalPackagePrivateHelper.FCMBroadcastReceiver_onReceived;
+import static com.onesignal.OneSignalPackagePrivateHelper.FCMBroadcastReceiver_onReceived_withBundle;
 import static com.onesignal.OneSignalPackagePrivateHelper.OneSignal_getSessionListener;
 import static com.onesignal.OneSignalPackagePrivateHelper.OneSignal_setSessionManager;
 import static com.onesignal.OneSignalPackagePrivateHelper.OneSignal_setSharedPreferences;
@@ -325,7 +325,7 @@ public class OutcomeEventIntegrationTests {
 
         // Receive notification
         Bundle bundle = getBaseNotifBundle(ONESIGNAL_NOTIFICATION_ID + "2");
-        FCMBroadcastReceiver_onReceived(blankActivity, bundle);
+        FCMBroadcastReceiver_onReceived_withBundle(blankActivity, bundle);
 
         // Wait 31 seconds to start new session
         advanceSystemTimeBy(31);
@@ -386,7 +386,7 @@ public class OutcomeEventIntegrationTests {
 
         // Receive notification
         Bundle bundle = getBaseNotifBundle(ONESIGNAL_NOTIFICATION_ID + "2");
-        FCMBroadcastReceiver_onReceived(blankActivity, bundle);
+        FCMBroadcastReceiver_onReceived_withBundle(blankActivity, bundle);
 
         // Wait 31 seconds to start new session
         advanceSystemTimeBy(31);
@@ -615,7 +615,7 @@ public class OutcomeEventIntegrationTests {
 
         // Receive notification
         Bundle bundle = getBaseNotifBundle(ONESIGNAL_NOTIFICATION_ID);
-        FCMBroadcastReceiver_onReceived(blankActivity, bundle);
+        FCMBroadcastReceiver_onReceived_withBundle(blankActivity, bundle);
 
         // Make sure notification influence is not INDIRECT
         assertFalse(trackerFactory.getNotificationChannelTracker().getInfluenceType().isIndirect());
@@ -696,7 +696,7 @@ public class OutcomeEventIntegrationTests {
 
         // Receive notification
         Bundle bundle = getBaseNotifBundle(ONESIGNAL_NOTIFICATION_ID + "2");
-        FCMBroadcastReceiver_onReceived(blankActivity, bundle);
+        FCMBroadcastReceiver_onReceived_withBundle(blankActivity, bundle);
         threadAndTaskWait();
 
         // Wait 31 seconds
@@ -733,7 +733,7 @@ public class OutcomeEventIntegrationTests {
 
         // Receive notification
         Bundle bundle = getBaseNotifBundle(ONESIGNAL_NOTIFICATION_ID + "2");
-        FCMBroadcastReceiver_onReceived(blankActivity, bundle);
+        FCMBroadcastReceiver_onReceived_withBundle(blankActivity, bundle);
 
         // Foreground app through icon before new session
         blankActivityController.resume();
@@ -759,7 +759,7 @@ public class OutcomeEventIntegrationTests {
 
         // Receive another notification
         Bundle bundle = getBaseNotifBundle(ONESIGNAL_NOTIFICATION_ID + "2");
-        FCMBroadcastReceiver_onReceived(blankActivity, bundle);
+        FCMBroadcastReceiver_onReceived_withBundle(blankActivity, bundle);
 
         // Foreground app through icon before new session
         blankActivityController.resume();
@@ -865,7 +865,7 @@ public class OutcomeEventIntegrationTests {
 
         // Receive notification
         Bundle bundle = getBaseNotifBundle(ONESIGNAL_NOTIFICATION_ID + "2");
-        FCMBroadcastReceiver_onReceived(blankActivity, bundle);
+        FCMBroadcastReceiver_onReceived_withBundle(blankActivity, bundle);
         indirectNotificationIds.put(ONESIGNAL_NOTIFICATION_ID + "2");
 
         // App in background for 31 seconds to trigger new session
@@ -913,7 +913,7 @@ public class OutcomeEventIntegrationTests {
 
         // Receive notification
         Bundle bundle = getBaseNotifBundle(ONESIGNAL_NOTIFICATION_ID + "2");
-        FCMBroadcastReceiver_onReceived(blankActivity, bundle);
+        FCMBroadcastReceiver_onReceived_withBundle(blankActivity, bundle);
 
         // Foreground app through icon
         blankActivityController.resume();
@@ -1006,7 +1006,7 @@ public class OutcomeEventIntegrationTests {
         String notificationID = ONESIGNAL_NOTIFICATION_ID + "1";
         // Receive notification
         Bundle bundle = getBaseNotifBundle(ONESIGNAL_NOTIFICATION_ID + "1");
-        FCMBroadcastReceiver_onReceived(blankActivity, bundle);
+        FCMBroadcastReceiver_onReceived_withBundle(blankActivity, bundle);
 
         // Check notification was saved
         assertEquals(1, trackerFactory.getNotificationChannelTracker().getLastReceivedIds().length());

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/TestHelpers.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/TestHelpers.java
@@ -1,7 +1,6 @@
 package com.test.onesignal;
 
 import android.app.AlarmManager;
-import android.app.Application;
 import android.app.job.JobInfo;
 import android.app.job.JobScheduler;
 import android.app.job.JobService;

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/TestHelpers.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/TestHelpers.java
@@ -34,6 +34,7 @@ import com.onesignal.ShadowGoogleApiClientCompatProxy;
 import com.onesignal.ShadowHMSFusedLocationProviderClient;
 import com.onesignal.ShadowHmsInstanceId;
 import com.onesignal.ShadowNotificationManagerCompat;
+import com.onesignal.ShadowNotificationWorker;
 import com.onesignal.ShadowOSUtils;
 import com.onesignal.ShadowOSWebView;
 import com.onesignal.ShadowOneSignalDbHelper;
@@ -42,6 +43,7 @@ import com.onesignal.ShadowOneSignalRestClientWithMockConnection;
 import com.onesignal.ShadowPushRegistratorADM;
 import com.onesignal.ShadowPushRegistratorFCM;
 import com.onesignal.ShadowPushRegistratorHMS;
+import com.onesignal.ShadowTimeoutHandler;
 import com.onesignal.StaticResetHelper;
 import com.onesignal.influence.model.OSInfluenceType;
 import com.onesignal.outcomes.MockOSCachedUniqueOutcomeTable;
@@ -117,6 +119,8 @@ public class TestHelpers {
       OneSignalShadowPackageManager.resetStatics();
 
       ShadowOSUtils.resetStatics();
+      ShadowTimeoutHandler.resetStatics();
+      ShadowNotificationWorker.resetStatics();
 
       lastException = null;
    }


### PR DESCRIPTION
  * Shadow methods that will run over workers and run them under a thread
  * Shadow TimerHandler to avoid deadlock under Loopers being shadowed by roboelectric

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1118)
<!-- Reviewable:end -->
