### PR TITLE
Fixes IAM NPE with getDisplayPosition

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/WebViewManager.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/WebViewManager.java
@@ -239,6 +239,9 @@ class WebViewManager extends ActivityLifecycleHandler.ActivityAvailableListener 
     // Every time an Activity is shown we update the height of the WebView since the available
     //   screen size may have changed. (Expect for Fullscreen)
     private void calculateHeightAndShowWebViewAfterNewActivity() {
+        if (messageView == null)
+            return;
+
         // Don't need a CSS / HTML height update for fullscreen
         if (messageView.getDisplayPosition() == Position.FULL_SCREEN) {
             showMessageView(null);

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/InAppMessageIntegrationTests.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/InAppMessageIntegrationTests.java
@@ -242,6 +242,26 @@ public class InAppMessageIntegrationTests {
         assertTrue(OneSignalPackagePrivateHelper.isInAppMessageShowing());
     }
 
+    // This test reproduces https://github.com/OneSignal/OneSignal-Android-SDK/issues/1000
+    @Test
+    public void testMessageDismissingWhileNewActivityIsBeingStarted() throws Exception {
+        initializeSdkWithMultiplePendingMessages();
+
+        // 1. Add trigger to show IAM
+        OneSignal.addTriggers(new HashMap<String, Object>() {{
+            put("test_2", 2);
+        }});
+
+        // 2. Activity IAM is displaying over is dismissed
+        blankActivityController.stop();
+
+        // 3. IAM is dismissed before a new Activity is shown
+        OneSignalPackagePrivateHelper.WebViewManager.callDismissAndAwaitNextMessage();
+
+        // 4. An Activity put in to focus, successful we don't throw.
+        blankActivityController.resume();
+    }
+
 
     private void nextResponseMultiplePendingMessages() throws JSONException {
         final OSTestInAppMessage testFirstMessage = InAppMessagingHelpers.buildTestMessageWithSingleTrigger(OSTriggerKind.CUSTOM, "test_1", OSTestTrigger.OSTriggerOperator.EQUAL_TO.toString(), 3);


### PR DESCRIPTION
* It is possible for messageView to become null if you dismissed the IAM
then closed the Activity before the IAM animation finishes. Then if the IAM
animation finishes before the next Activity is shown.
* Fixed by adding a null check to calculateHeightAndShowWebViewAfterNewActivity
as it is not require now that an IAM is no longer showing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1119)
<!-- Reviewable:end -->
