### PR TITLE
Return setLocationShared and setRequiresUserPrivacyConsent methods

### DIFF
--- a/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/application/MainApplication.java
+++ b/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/application/MainApplication.java
@@ -38,6 +38,7 @@ public class MainApplication extends Application {
 
         OneSignal.unsubscribeWhenNotificationsAreDisabled(true);
         OneSignal.pauseInAppMessages(true);
+        OneSignal.setLocationShared(false);
 
         Log.d(Tag.DEBUG, Text.ONESIGNAL_SDK_INIT);
     }

--- a/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/model/MainActivityViewModel.java
+++ b/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/model/MainActivityViewModel.java
@@ -446,7 +446,7 @@ public class MainActivityViewModel implements ActivityViewModel {
         locationSharedSwitch.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
             @Override
             public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
-                // TODO remove element, was replaced by remote params
+                OneSignal.setLocationShared(isChecked);
             }
         });
     }

--- a/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/model/SplashActivityViewModel.java
+++ b/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/model/SplashActivityViewModel.java
@@ -85,8 +85,16 @@ public class SplashActivityViewModel implements ActivityViewModel {
     }
 
     private void setupOneSignalSDK() {
+        boolean privacyConsent = true;
+        OneSignal.setRequiresUserPrivacyConsent(privacyConsent);
+
+        boolean isLocationShared = OneSignalPrefs.getCachedLocationSharedStatus(context);
+        OneSignal.setLocationShared(isLocationShared);
+
         boolean isInAppMessagingPaused = OneSignalPrefs.getCachedInAppMessagingPausedStatus(context);
         OneSignal.pauseInAppMessages(isInAppMessagingPaused);
+
+        Log.d(Tag.DEBUG, Text.PRIVACY_CONSENT_REQUIRED_SET + ": " + privacyConsent);
 
         boolean isEmailCached = attemptSignIn(new EmailUpdateCallback() {
             @Override

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSRemoteParamController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSRemoteParamController.java
@@ -40,16 +40,6 @@ class OSRemoteParamController {
         );
         OneSignalPrefs.saveBool(
                 OneSignalPrefs.PREFS_ONESIGNAL,
-                OneSignalPrefs.PREFS_OS_UNSUBSCRIBE_WHEN_NOTIFICATIONS_DISABLED,
-                remoteParams.unsubscribeWhenNotificationsDisabled
-        );
-        OneSignalPrefs.saveBool(
-                OneSignalPrefs.PREFS_ONESIGNAL,
-                OneSignalPrefs.PREFS_OS_DISABLE_GMS_MISSING_PROMPT,
-                remoteParams.disableGMSMissingPrompt
-        );
-        OneSignalPrefs.saveBool(
-                OneSignalPrefs.PREFS_ONESIGNAL,
                 preferences.getOutcomesV2KeyName(),
                 remoteParams.influenceParams.outcomesV2ServiceEnabled
         );
@@ -57,9 +47,13 @@ class OSRemoteParamController {
         logger.debug("OneSignal saveInfluenceParams: " + remoteParams.influenceParams.toString());
         trackerFactory.saveInfluenceParams(remoteParams.influenceParams);
 
-        saveLocationShared(remoteParams.locationShared);
-        OneSignal.setLocationShared(remoteParams.locationShared);
-        savePrivacyConsentRequired(remoteParams.requiresUserPrivacyConsent);
+        saveGMSMissingPromptDisable(remoteParams.disableGMSMissingPrompt);
+        if (remoteParams.unsubscribeWhenNotificationsDisabled != null)
+            saveUnsubscribeWhenNotificationsAreDisabled(remoteParams.unsubscribeWhenNotificationsDisabled);
+        if (remoteParams.locationShared != null)
+            saveLocationShared(remoteParams.locationShared);
+        if (remoteParams.requiresUserPrivacyConsent != null)
+            savePrivacyConsentRequired(remoteParams.requiresUserPrivacyConsent);
     }
 
     boolean isRemoteParamsCallDone() {
@@ -68,6 +62,18 @@ class OSRemoteParamController {
 
     OneSignalRemoteParams.Params getRemoteParams() {
         return remoteParams;
+    }
+
+    boolean hasLocationKey() {
+        return remoteParams != null && remoteParams.locationShared != null;
+    }
+
+    boolean hasPrivacyConsentKey() {
+        return remoteParams != null && remoteParams.requiresUserPrivacyConsent != null;
+    }
+
+    boolean hasUnsubscribeNotificationKey() {
+        return remoteParams != null && remoteParams.unsubscribeWhenNotificationsDisabled != null;
     }
 
     void clearRemoteParams() {
@@ -95,11 +101,27 @@ class OSRemoteParamController {
                 true);
     }
 
+    void saveUnsubscribeWhenNotificationsAreDisabled(boolean unsubscribe) {
+        OneSignalPrefs.saveBool(
+                OneSignalPrefs.PREFS_ONESIGNAL,
+                OneSignalPrefs.PREFS_OS_UNSUBSCRIBE_WHEN_NOTIFICATIONS_DISABLED,
+                unsubscribe
+        );
+    }
+
     boolean isGMSMissingPromptDisable() {
         return OneSignalPrefs.getBool(
                 OneSignalPrefs.PREFS_ONESIGNAL,
                 OneSignalPrefs.PREFS_OS_DISABLE_GMS_MISSING_PROMPT,
                 false);
+    }
+
+    void saveGMSMissingPromptDisable(boolean promptDisable) {
+        OneSignalPrefs.saveBool(
+                OneSignalPrefs.PREFS_ONESIGNAL,
+                OneSignalPrefs.PREFS_OS_DISABLE_GMS_MISSING_PROMPT,
+                promptDisable
+        );
     }
 
     boolean isLocationShared() {
@@ -120,9 +142,8 @@ class OSRemoteParamController {
         return OneSignalPrefs.getBool(
                 OneSignalPrefs.PREFS_ONESIGNAL,
                 OneSignalPrefs.PREFS_OS_REQUIRES_USER_PRIVACY_CONSENT,
-                true);
+                false);
     }
-
 
     void savePrivacyConsentRequired(boolean required) {
         OneSignalPrefs.saveBool(

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSRemoteParamController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSRemoteParamController.java
@@ -58,7 +58,7 @@ class OSRemoteParamController {
         trackerFactory.saveInfluenceParams(remoteParams.influenceParams);
 
         saveLocationShared(remoteParams.locationShared);
-        OneSignal.setSharedLocation(remoteParams.locationShared);
+        OneSignal.setLocationShared(remoteParams.locationShared);
         savePrivacyConsentRequired(remoteParams.requiresUserPrivacyConsent);
     }
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSTaskController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSTaskController.java
@@ -26,6 +26,9 @@ class OSTaskController {
     static final String IDS_AVAILABLE = "idsAvailable()";
     static final String SEND_TAG = "sendTag()";
     static final String SEND_TAGS = "sendTags()";
+    static final String SET_LOCATION_SHARED = "setLocationShared()";
+    static final String SET_REQUIRES_USER_PRIVACY_CONSENT = "setRequiresUserPrivacyConsent()";
+    static final String UNSUBSCRIBE_WHEN_NOTIFICATION_ARE_DISABLED = "unsubscribeWhenNotificationsAreDisabled()";
     static final String HANDLE_NOTIFICATION_OPEN = "handleNotificationOpen()";
     static final String CANCEL_GROUPED_NOTIFICATIONS = "cancelGroupedNotifications()";
     static final HashSet<String> METHODS_AVAILABLE_FOR_DELAY = new HashSet<>(Arrays.asList(
@@ -37,6 +40,9 @@ class OSTaskController {
             IDS_AVAILABLE,
             SEND_TAG,
             SEND_TAGS,
+            SET_LOCATION_SHARED,
+            SET_REQUIRES_USER_PRIVACY_CONSENT,
+            UNSUBSCRIBE_WHEN_NOTIFICATION_ARE_DISABLED,
             HANDLE_NOTIFICATION_OPEN,
             SET_EMAIL));
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -34,6 +34,7 @@ import android.app.NotificationManager;
 import android.content.ContentValues;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
@@ -93,8 +94,7 @@ public class OneSignal {
    /**
     * A display type enum for notifications when the app receives and tries shows them.
     * <br/><br/>
-    * Used with the {@link OneSignal#setNotificationDisplayOption(OSNotificationDisplay)} and
-    *  {@link OSNotificationGenerationJob#setNotificationDisplayOption(OSNotificationDisplay)}
+    * Used with the {@link OSNotificationGenerationJob#setNotificationDisplayOption(OSNotificationDisplay)}
     * Determines how the notification will show to the user when inside of the
     *  {@link ExtNotificationWillShowInForegroundHandler#notificationWillShowInForeground(ExtNotificationGenerationJob)}
     *  {@link AppNotificationWillShowInForegroundHandler#notificationWillShowInForeground(AppNotificationGenerationJob)}
@@ -134,9 +134,9 @@ public class OneSignal {
     * The enum also helps decide the type of session the user is in an is tracked in {@link OneSignal#sessionManager}
     *  from the {@link OSSessionManager}.
     * <br/><br/>
-    * {@link AppEntryAction#NOTIFICATION_CLICK} will always lead a overridden {@link com.onesignal.OSSessionManager.Session#DIRECT}.
+    * {@link AppEntryAction#NOTIFICATION_CLICK} will always lead a overridden {@link com.onesignal.influence.domain.OSInfluenceType#DIRECT}.
     * {@link AppEntryAction#APP_OPEN} on a new session notifications within the attribution window
-    *  parameter, this will lead to a {@link com.onesignal.OSSessionManager.Session#INDIRECT}.
+    *  parameter, this will lead to a {@link com.onesignal.influence.domain.OSInfluenceType#DIRECT}.
     * <br/><br/>
     * @see OneSignal#onAppFocus
     * @see OneSignal#onAppLostFocus
@@ -366,7 +366,6 @@ public class OneSignal {
    static InAppMessageClickHandler inAppMessageClickHandler;
 
    static boolean mAutoPromptLocation;
-   static boolean mUnsubscribeWhenNotificationsAreDisabled = true;
    // TODO: End of old mInitBuilder params
 
    // Is the init() of OneSignal SDK finished yet
@@ -589,8 +588,25 @@ public class OneSignal {
     *            the default is {@code false}
     * @return the builder you called this method on
     */
-   public static void unsubscribeWhenNotificationsAreDisabled(boolean set) {
-      mUnsubscribeWhenNotificationsAreDisabled = set;
+   public static void unsubscribeWhenNotificationsAreDisabled(final boolean set) {
+      if (taskController.shouldQueueTaskForInit(OSTaskController.UNSUBSCRIBE_WHEN_NOTIFICATION_ARE_DISABLED)) {
+         logger.error("Waiting for remote params. " +
+                 "Moving " + OSTaskController.UNSUBSCRIBE_WHEN_NOTIFICATION_ARE_DISABLED + " operation to a pending task queue.");
+         taskController.addTaskToQueue(new Runnable() {
+            @Override
+            public void run() {
+               logger.debug("Running " + OSTaskController.UNSUBSCRIBE_WHEN_NOTIFICATION_ARE_DISABLED + " operation from pending task queue.");
+               unsubscribeWhenNotificationsAreDisabled(set);
+            }
+         });
+         return;
+      }
+
+      // Already set by remote params
+      if (getRemoteParamController().hasUnsubscribeNotificationKey())
+         return;
+
+      getRemoteParamController().saveUnsubscribeWhenNotificationsAreDisabled(set);
    }
 
    /**
@@ -641,6 +657,7 @@ public class OneSignal {
       boolean wasAppContextNull = (appContext == null);
       appContext = context.getApplicationContext();
       setupActivityLifecycleListener(wasAppContextNull);
+      setupPrivacyConsent(appContext);
 
       logger.verbose("setAppContext(context) finished, checking if appId has been set before proceeding...");
       if (appId == null) {
@@ -775,6 +792,19 @@ public class OneSignal {
          OneSignalPrefs.startDelayedWrite();
          // Cleans out old cached data to prevent over using the storage on devices
          OneSignalCacheCleaner.cleanOldCachedData(appContext);
+      }
+   }
+
+   private static void setupPrivacyConsent(Context context) {
+      try {
+         ApplicationInfo ai = context.getPackageManager().getApplicationInfo(context.getPackageName(), PackageManager.GET_META_DATA);
+         Bundle bundle = ai.metaData;
+
+         // Read the current privacy consent setting from AndroidManifest.xml
+         String requireSetting = bundle.getString("com.onesignal.PrivacyConsent");
+         setRequiresUserPrivacyConsent("ENABLE".equalsIgnoreCase(requireSetting));
+      } catch (Throwable t) {
+         t.printStackTrace();
       }
    }
 
@@ -1010,8 +1040,24 @@ public class OneSignal {
    /**
     * This method will be replaced by remote params set
     */
-   @Deprecated
-   public static void setRequiresUserPrivacyConsent(boolean required) {
+   public static void setRequiresUserPrivacyConsent(final boolean required) {
+      if (taskController.shouldQueueTaskForInit(OSTaskController.SET_REQUIRES_USER_PRIVACY_CONSENT)) {
+         logger.error("Waiting for remote params. " +
+                 "Moving " + OSTaskController.SET_REQUIRES_USER_PRIVACY_CONSENT + " operation to a pending task queue.");
+         taskController.addTaskToQueue(new Runnable() {
+            @Override
+            public void run() {
+               logger.debug("Running " + OSTaskController.SET_REQUIRES_USER_PRIVACY_CONSENT + " operation from pending task queue.");
+               setRequiresUserPrivacyConsent(required);
+            }
+         });
+         return;
+      }
+
+      // Already set by remote params
+      if (getRemoteParamController().hasPrivacyConsentKey())
+         return;
+
       if (requiresUserPrivacyConsent() && !required) {
          OneSignal.Log(LOG_LEVEL.ERROR, "Cannot change requiresUserPrivacyConsent() from TRUE to FALSE");
          return;
@@ -2458,16 +2504,36 @@ public class OneSignal {
    /**
     * This method will be replaced by remote params set
     */
-   @Deprecated
-   public static void setLocationShared(boolean enable) {
+   public static void setLocationShared(final boolean enable) {
+      if (taskController.shouldQueueTaskForInit(OSTaskController.SET_LOCATION_SHARED)) {
+         logger.error("Waiting for remote params. " +
+                 "Moving " + OSTaskController.SET_LOCATION_SHARED + " operation to a pending task queue.");
+         taskController.addTaskToQueue(new Runnable() {
+            @Override
+            public void run() {
+               logger.debug("Running " + OSTaskController.SET_LOCATION_SHARED + " operation from pending task queue.");
+               setLocationShared(enable);
+            }
+         });
+         return;
+      }
 
-      //if applicable, check if the user provided privacy consent
-      if (shouldLogUserPrivacyConsentErrorMessageForMethodName("setLocationShared()"))
+      // Already set by remote params
+      if (getRemoteParamController().hasLocationKey())
          return;
 
+      getRemoteParamController().saveLocationShared(enable);
       if (!enable)
-         OneSignalStateSynchronizer.clearLocation();
+         clearLocation();
       logger.debug("OneSignal is shareLocation enabled: " + enable);
+   }
+
+   private static void clearLocation() {
+      // If applicable, check if the user provided privacy consent
+      if (shouldLogUserPrivacyConsentErrorMessageForMethodName(OSTaskController.SET_LOCATION_SHARED))
+         return;
+
+      OneSignalStateSynchronizer.clearLocation();
    }
 
    /**

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -1007,6 +1007,19 @@ public class OneSignal {
       return appContext == null || isUserPrivacyConsentRequired() && !userProvidedPrivacyConsent();
    }
 
+   /**
+    * This method will be replaced by remote params set
+    */
+   @Deprecated
+   public static void setRequiresUserPrivacyConsent(boolean required) {
+      if (requiresUserPrivacyConsent() && !required) {
+         OneSignal.Log(LOG_LEVEL.ERROR, "Cannot change requiresUserPrivacyConsent() from TRUE to FALSE");
+         return;
+      }
+
+      getRemoteParamController().savePrivacyConsentRequired(required);
+   }
+
    static boolean shouldLogUserPrivacyConsentErrorMessageForMethodName(String methodName) {
       if (requiresUserPrivacyConsent()) {
          if (methodName != null)
@@ -2442,7 +2455,16 @@ public class OneSignal {
       OneSignalStateSynchronizer.setSubscription(enable);
    }
 
-   static void setSharedLocation(boolean enable) {
+   /**
+    * This method will be replaced by remote params set
+    */
+   @Deprecated
+   public static void setLocationShared(boolean enable) {
+
+      //if applicable, check if the user provided privacy consent
+      if (shouldLogUserPrivacyConsentErrorMessageForMethodName("setLocationShared()"))
+         return;
+
       if (!enable)
          OneSignalStateSynchronizer.clearLocation();
       logger.debug("OneSignal is shareLocation enabled: " + enable);

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalRemoteParams.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalRemoteParams.java
@@ -81,10 +81,10 @@ public class OneSignalRemoteParams {
       boolean restoreTTLFilter;
       boolean clearGroupOnSummaryClick;
       boolean receiveReceiptEnabled;
-      boolean unsubscribeWhenNotificationsDisabled;
       boolean disableGMSMissingPrompt;
-      boolean locationShared;
-      boolean requiresUserPrivacyConsent;
+      Boolean unsubscribeWhenNotificationsDisabled;
+      Boolean locationShared;
+      Boolean requiresUserPrivacyConsent;
       InfluenceParams influenceParams;
       FCMParams fcmParams;
    }
@@ -179,10 +179,12 @@ public class OneSignalRemoteParams {
          clearGroupOnSummaryClick = responseJson.optBoolean("clear_group_on_summary_click", true);
          receiveReceiptEnabled = responseJson.optBoolean("receive_receipts_enable", false);
 
-         unsubscribeWhenNotificationsDisabled = responseJson.optBoolean(UNSUBSCRIBE_ON_NOTIFICATION_DISABLE, true);
          disableGMSMissingPrompt = responseJson.optBoolean(DISABLE_GMS_MISSING_PROMPT, false);
-         locationShared = responseJson.optBoolean(LOCATION_SHARED, true);
-         requiresUserPrivacyConsent = responseJson.optBoolean(REQUIRES_USER_PRIVACY_CONSENT, false);
+         // Null assignation to avoid remote param override user configuration until backend is done
+         // TODO remove has check when backend has new remote params and user sets inside OneSignal.java were removed
+         unsubscribeWhenNotificationsDisabled = !responseJson.has(UNSUBSCRIBE_ON_NOTIFICATION_DISABLE) ? null : responseJson.optBoolean(UNSUBSCRIBE_ON_NOTIFICATION_DISABLE, true);
+         locationShared = !responseJson.has(LOCATION_SHARED) ? null : responseJson.optBoolean(LOCATION_SHARED, true);
+         requiresUserPrivacyConsent = !responseJson.has(REQUIRES_USER_PRIVACY_CONSENT) ? null : responseJson.optBoolean(REQUIRES_USER_PRIVACY_CONSENT, false);
 
          influenceParams = new InfluenceParams();
          // Process outcomes params

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
@@ -254,7 +254,7 @@ public class OneSignalPackagePrivateHelper {
    }
 
    public static boolean OneSignal_requiresUserPrivacyConsent() {
-      return OneSignal.isUserPrivacyConsentRequired();
+      return OneSignal.requiresUserPrivacyConsent();
    }
 
    public static boolean OneSignal_locationShared() {

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowOneSignalRestClient.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowOneSignalRestClient.java
@@ -205,6 +205,14 @@ public class ShadowOneSignalRestClient {
       remoteParamsGetHtmlResponse = remoteParams.toString();
    }
 
+   public static void setAndRemoveKeyFromRemoteParams(String key) throws JSONException {
+      JSONObject remoteParams = new JSONObject(REMOTE_PARAMS);
+      if (remoteParams.has(key)) {
+         remoteParams.remove(key);
+      }
+      remoteParamsGetHtmlResponse = remoteParams.toString();
+   }
+
    public static void setRemoteParamsGetHtmlResponse(String response) {
       remoteParamsGetHtmlResponse = response;
    }

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
@@ -2761,8 +2761,8 @@ public class MainOneSignalClassRunner {
       OneSignal.removeNotificationWillShowInForegroundHandler();
       threadAndTaskWait();
 
-      // Permission subscription wont return until OneSignal init is done
-      assertNull(OneSignal.getPermissionSubscriptionState());
+      // TODO change to assertNull(OneSignal.getPermissionSubscriptionState()); when privacy consent public set is removed
+      assertFalse(OneSignal.getPermissionSubscriptionState().getSubscriptionStatus().getSubscribed());
 
       OneSignal.setAppId(ONESIGNAL_APP_ID);
       threadAndTaskWait();

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/RemoteParamsTests.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/RemoteParamsTests.java
@@ -99,6 +99,24 @@ public class RemoteParamsTests {
     }
 
     @Test
+    public void testUserPrivacyConsentRequired_ByUser() throws Exception {
+        ShadowOneSignalRestClient.setAndRemoveKeyFromRemoteParams("requires_user_privacy_consent");
+        OneSignal.setRequiresUserPrivacyConsent(true);
+        OneSignalInit();
+        threadAndTaskWait();
+        assertTrue(OneSignal.requiresUserPrivacyConsent());
+    }
+
+    @Test
+    public void testUserPrivacyConsentNotRequired_ByUser() throws Exception {
+        ShadowOneSignalRestClient.setAndRemoveKeyFromRemoteParams("requires_user_privacy_consent");
+        OneSignal.setRequiresUserPrivacyConsent(false);
+        OneSignalInit();
+        threadAndTaskWait();
+        assertFalse(OneSignal.requiresUserPrivacyConsent());
+    }
+
+    @Test
     public void testUserPrivacyConsentRequired() throws Exception {
         JSONObject remoteParams = new JSONObject();
         remoteParams.put("requires_user_privacy_consent", true);
@@ -119,7 +137,47 @@ public class RemoteParamsTests {
     }
 
     @Test
+    public void testUserPrivacyConsentRequired_UserConfigurationOverrideByRemoteParams() throws Exception {
+        JSONObject remoteParams = new JSONObject();
+        remoteParams.put("requires_user_privacy_consent", true);
+        ShadowOneSignalRestClient.setRemoteParamsGetHtmlResponse(remoteParams);
+
+        OneSignalInit();
+        OneSignal.setRequiresUserPrivacyConsent(false);
+        threadAndTaskWait();
+        assertTrue(OneSignal.requiresUserPrivacyConsent());
+    }
+
+    @Test
+    public void testUserPrivacyConsentNotRequired_UserConfigurationOverrideByRemoteParams() throws Exception {
+        ShadowOneSignalRestClient.setRemoteParamsGetHtmlResponse();
+
+        OneSignalInit();
+        OneSignal.setRequiresUserPrivacyConsent(true);
+        threadAndTaskWait();
+        assertFalse(OneSignal.requiresUserPrivacyConsent());
+    }
+
+    @Test
+    public void testLocationSharedEnable_ByUser() throws Exception {
+        OneSignal.setLocationShared(true);
+        OneSignalInit();
+        threadAndTaskWait();
+        assertTrue(OneSignal_locationShared());
+    }
+
+    @Test
+    public void testLocationSharedDisable_ByUser() throws Exception {
+        ShadowOneSignalRestClient.setAndRemoveKeyFromRemoteParams("location_shared");
+        OneSignal.setLocationShared(false);
+        OneSignalInit();
+        threadAndTaskWait();
+        assertFalse(OneSignal_locationShared());
+    }
+
+    @Test
     public void testLocationSharedEnable() throws Exception {
+        ShadowOneSignalRestClient.setAndRemoveKeyFromRemoteParams("location_shared");
         ShadowOneSignalRestClient.setRemoteParamsGetHtmlResponse();
 
         OneSignalInit();
@@ -136,6 +194,48 @@ public class RemoteParamsTests {
         OneSignalInit();
         threadAndTaskWait();
         assertFalse(OneSignal_locationShared());
+    }
+
+    @Test
+    public void testLocationSharedEnable_UserConfigurationOverrideByRemoteParams() throws Exception {
+        ShadowOneSignalRestClient.setRemoteParamsGetHtmlResponse();
+        OneSignalInit();
+        OneSignal.setLocationShared(false);
+        threadAndTaskWait();
+        assertTrue(OneSignal_locationShared());
+    }
+
+    @Test
+    public void testLocationSharedDisable_UserConfigurationOverrideByRemoteParams() throws Exception {
+        JSONObject remoteParams = new JSONObject();
+        remoteParams.put("location_shared", false);
+        ShadowOneSignalRestClient.setRemoteParamsGetHtmlResponse(remoteParams);
+
+        OneSignalInit();
+        OneSignal.setLocationShared(true);
+        threadAndTaskWait();
+        assertFalse(OneSignal_locationShared());
+    }
+
+    @Test
+    @Config(shadows = {ShadowNotificationManagerCompat.class})
+    public void testUnsubscribeOnNotificationsDisable_EnableByUser() throws Exception {
+        ShadowNotificationManagerCompat.enabled = false;
+        OneSignal.unsubscribeWhenNotificationsAreDisabled(true);
+        OneSignalInit();
+        threadAndTaskWait();
+        assertFalse(OneSignal_areNotificationsEnabledForSubscribedState());
+    }
+
+    @Test
+    @Config(shadows = {ShadowNotificationManagerCompat.class})
+    public void testUnsubscribeOnNotificationsDisable_DisableByUser() throws Exception {
+        ShadowNotificationManagerCompat.enabled = false;
+        ShadowOneSignalRestClient.setAndRemoveKeyFromRemoteParams("unsubscribe_on_notifications_disabled");
+        OneSignal.unsubscribeWhenNotificationsAreDisabled(false);
+        OneSignalInit();
+        threadAndTaskWait();
+        assertTrue(OneSignal_areNotificationsEnabledForSubscribedState());
     }
 
     @Test
@@ -156,6 +256,30 @@ public class RemoteParamsTests {
         ShadowOneSignalRestClient.setRemoteParamsGetHtmlResponse(remoteParams);
 
         OneSignalInit();
+        threadAndTaskWait();
+        assertTrue(OneSignal_areNotificationsEnabledForSubscribedState());
+    }
+
+    @Test
+    @Config(shadows = {ShadowNotificationManagerCompat.class})
+    public void testUnsubscribeOnNotificationsDisable_Enable_UserConfigurationOverrideByRemoteParams() throws Exception {
+        ShadowNotificationManagerCompat.enabled = false;
+        ShadowOneSignalRestClient.setRemoteParamsGetHtmlResponse();
+
+        OneSignalInit();
+        OneSignal.unsubscribeWhenNotificationsAreDisabled(false);
+        threadAndTaskWait();
+        assertFalse(OneSignal_areNotificationsEnabledForSubscribedState());
+    }
+
+    @Test
+    public void testUnsubscribeOnNotificationsDisable_Disable_UserConfigurationOverrideByRemoteParams() throws Exception {
+        JSONObject remoteParams = new JSONObject();
+        remoteParams.put("unsubscribe_on_notifications_disabled", false);
+        ShadowOneSignalRestClient.setRemoteParamsGetHtmlResponse(remoteParams);
+
+        OneSignalInit();
+        OneSignal.unsubscribeWhenNotificationsAreDisabled(true);
         threadAndTaskWait();
         assertTrue(OneSignal_areNotificationsEnabledForSubscribedState());
     }


### PR DESCRIPTION
  * Keep remote param methods logic
  * Add logic to avoid user methods override remote params when available

for reference: https://github.com/OneSignal/OneSignal-iOS-SDK/pull/707
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1124)
<!-- Reviewable:end -->
