### PR TITLE
Moved myLooper().quit() to destroyTimeout

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationWorkManager.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationWorkManager.java
@@ -66,11 +66,6 @@ class OSNotificationWorkManager {
                 e.printStackTrace();
                 return Result.failure();
             }
-
-            // TODO: This line stops the Looper.loop call once the notification processing is all done
-            //  The reason for all of this is because we are firing handlers while running a background thread using the Worker
-            if (!OSUtils.isRunningOnMainThread())
-                Looper.myLooper().quit();
             return Result.success();
         }
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationWorkManager.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationWorkManager.java
@@ -79,23 +79,23 @@ class OSNotificationWorkManager {
                     timestamp
             );
 
-            if (OneSignal.notificationProcessingHandler != null)
+            if (OneSignal.notificationProcessingHandler != null) {
                 try {
                     OneSignal.notificationProcessingHandler.notificationProcessing(context, notificationReceived);
                 } catch (Throwable t) {
                     if (!notificationReceived.displayed()) {
                         OneSignal.Log(OneSignal.LOG_LEVEL.ERROR, "onNotificationProcessing throw an exception. Displaying normal OneSignal notification.", t);
-                        notificationReceived.complete();
-                    }
-                    else
+                    } else {
                         OneSignal.Log(OneSignal.LOG_LEVEL.ERROR, "onNotificationProcessing throw an exception. Extended notification displayed but custom processing did not finish.", t);
+                    }
+
+                    notificationReceived.complete();
 
                     throw t;
                 }
-            else if (!notificationReceived.displayed()) {
-                OneSignal.Log(OneSignal.LOG_LEVEL.WARN, "notificationProcessingHandler not setup, displaying normal OneSignal notification");
-                notificationReceived.complete();
             }
+            else
+                notificationReceived.complete();
         }
     }
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSTimeoutHandler.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSTimeoutHandler.java
@@ -64,6 +64,11 @@ class OSTimeoutHandler {
         removeCallbacks(timeoutRunnable);
         timeoutHandler = null;
         timeoutRunnable = null;
+
+        // TODO: This line stops the Looper.loop call once the notification processing is all done
+        //  The reason for all of this is because we are firing handlers while running a background thread using the Worker
+        if (!OSUtils.isRunningOnMainThread())
+            Looper.myLooper().quit();
     }
 
     public void removeCallbacks(Runnable runnable) {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSTimeoutHandler.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSTimeoutHandler.java
@@ -65,10 +65,17 @@ class OSTimeoutHandler {
         timeoutHandler = null;
         timeoutRunnable = null;
 
-        // TODO: This line stops the Looper.loop call once the notification processing is all done
-        //  The reason for all of this is because we are firing handlers while running a background thread using the Worker
+        quitLooper();
+    }
+
+    // This tear down the looper which unblocks Looper.loop()
+    private void quitLooper() {
+        Looper looper = Looper.myLooper();
+        if (looper == null)
+            return;
+
         if (!OSUtils.isRunningOnMainThread())
-            Looper.myLooper().quit();
+            looper.quit();
     }
 
     public void removeCallbacks(Runnable runnable) {


### PR DESCRIPTION
* We had `myLooper().quit()` looper at the bottom of  `doWork` however
`Looper.loop()` was blocking the thread so it would never get there.
* This fixes an issue where only the first few notifications would display
since we were hitting the max number of running workers on the WorkManager
    - This was 3 if you are testing on an emu.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1126)
<!-- Reviewable:end -->
