### PR TITLE
Make OSTimeoutHandler be a HandlerThread

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationGenerationJob.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationGenerationJob.java
@@ -181,13 +181,12 @@ public class OSNotificationGenerationJob {
         // Used to toggle when complete is called so it can not be called more than once
         boolean isComplete = false;
 
-        private final OSTimeoutHandler timeoutHandler;
+        private Runnable timeoutRunnable;
         // The actual notificationJob with notification payload data
         private OSNotificationGenerationJob notificationJob;
 
         NotificationGenerationJob(OSNotificationGenerationJob notificationJob) {
             this.notificationJob = notificationJob;
-            timeoutHandler = new OSTimeoutHandler();
         }
 
         OSNotificationGenerationJob getNotificationJob() {
@@ -195,11 +194,12 @@ public class OSNotificationGenerationJob {
         }
 
         protected void startTimeout(Runnable runnable) {
-            timeoutHandler.startTimeout(SHOW_NOTIFICATION_TIMEOUT, runnable);
+            timeoutRunnable = runnable;
+            OSTimeoutHandler.getTimeoutHandler().startTimeout(SHOW_NOTIFICATION_TIMEOUT, runnable);
         }
 
         protected void destroyTimeout() {
-            timeoutHandler.destroyTimeout();
+            OSTimeoutHandler.getTimeoutHandler().destroyTimeout(timeoutRunnable);
         }
 
         public String getApiNotificationId() {
@@ -251,6 +251,7 @@ public class OSNotificationGenerationJob {
             startTimeout(new Runnable() {
                 @Override
                 public void run() {
+                    OneSignal.Log(OneSignal.LOG_LEVEL.DEBUG, "Running complete from ExtNotificationGenerationJob timeout runnable!");
                     ExtNotificationGenerationJob.this.complete(true);
                 }
             });
@@ -294,6 +295,7 @@ public class OSNotificationGenerationJob {
             startTimeout(new Runnable() {
                 @Override
                 public void run() {
+                    OneSignal.Log(OneSignal.LOG_LEVEL.DEBUG, "Running complete from AppNotificationGenerationJob timeout runnable!");
                     AppNotificationGenerationJob.this.complete();
                 }
             });

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -2104,7 +2104,7 @@ public class OneSignal {
          jsonObject.put(BUNDLE_KEY_ANDROID_NOTIFICATION_ID, notificationJob.getAndroidId());
 
          OSNotificationOpenResult openResult = generateOsNotificationOpenResult(newJsonArray(jsonObject), displayed);
-         if(trackFirebaseAnalytics != null && getFirebaseAnalyticsEnabled())
+         if (trackFirebaseAnalytics != null && getFirebaseAnalyticsEnabled())
             trackFirebaseAnalytics.trackReceivedEvent(openResult);
 
       } catch (JSONException e) {

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowTimeoutHandler.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowTimeoutHandler.java
@@ -1,6 +1,8 @@
 package com.onesignal;
 
 
+import androidx.annotation.NonNull;
+
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
@@ -29,15 +31,14 @@ public class ShadowTimeoutHandler {
     }
 
     @Implementation
-    public boolean postDelayed(final Runnable runnable, final long delayMillis) {
+    public void startTimeout(long timeout, @NonNull Runnable runnable) {
         ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(1);
-        executor.schedule(runnable, mockDelay ? mockDelayMillis : delayMillis, TimeUnit.MILLISECONDS);
+        executor.schedule(runnable, mockDelay ? mockDelayMillis : timeout, TimeUnit.MILLISECONDS);
         executorHashMap.put(runnable, executor);
-        return true;
     }
 
     @Implementation
-    public void removeCallbacks(Runnable runnable) {
+    public void destroyTimeout(Runnable runnable) {
         ScheduledThreadPoolExecutor executor = executorHashMap.get(runnable);
         if (executor != null) {
             executor.shutdownNow();


### PR DESCRIPTION
  * Workers dependens on the device cores to have a pool of threads available.
  * Loopers handling are hard to debug, and maintain
  * Make a Handler Thread available for post delays runnables
  * Make OSTimeoutHandler available betweeen jobs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1127)
<!-- Reviewable:end -->
