### PR TITLE
Make OSDevice a snapshot for state getters

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSDevice.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSDevice.java
@@ -1,21 +1,21 @@
 /**
  * Modified MIT License
- *
+ * <p>
  * Copyright 2020 OneSignal
- *
+ * <p>
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- *
+ * <p>
  * 1. The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- *
+ * <p>
  * 2. All copies of substantial portions of the Software may only be used in connection
  * with services provided by OneSignal.
- *
+ * <p>
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -29,59 +29,88 @@ package com.onesignal;
 
 public class OSDevice {
 
+    private final boolean notificationEnabled;
+    private final boolean userSubscribed;
+    private final boolean subscribed;
+    private final String userId;
+    private final String pushToken;
+    private final String emailUserId;
+    private final String emailAddress;
+
+    public OSDevice(OSPermissionSubscriptionState permissionSubscriptionState) {
+        OSSubscriptionState subscriptionStatus = permissionSubscriptionState.subscriptionStatus;
+        OSPermissionState permissionStatus = permissionSubscriptionState.permissionStatus;
+        OSEmailSubscriptionState emailSubscriptionStatus = permissionSubscriptionState.emailSubscriptionStatus;
+
+        notificationEnabled = permissionStatus.getEnabled();
+        userSubscribed = subscriptionStatus.getUserSubscriptionSetting();
+        subscribed = subscriptionStatus.getSubscribed();
+        userId = subscriptionStatus.getUserId();
+        pushToken = subscriptionStatus.getPushToken();
+        emailUserId = emailSubscriptionStatus.getEmailUserId();
+        emailAddress = emailSubscriptionStatus.getEmailAddress();
+    }
+
     /**
      * Get the app's notification permission
+     *
      * @return false if the user disabled notifications for the app, otherwise true
      */
     public boolean isNotificationEnabled() {
-        return OneSignal.getPermissionSubscriptionState().permissionStatus.getEnabled();
+        return notificationEnabled;
     }
 
     /**
      * Get whether the user is subscribed to OneSignal notifications or not
+     *
      * @return false if the user is not subscribed to OneSignal notifications, otherwise true
      */
     public boolean isUserSubscribed() {
-        return OneSignal.getPermissionSubscriptionState().subscriptionStatus.getUserSubscriptionSetting();
+        return userSubscribed;
     }
 
     /**
      * Get whether the user is subscribed
+     *
      * @return true if {@link #isNotificationEnabled}, {@link #isUserSubscribed}, {@link #getUserId} and {@link #getPushToken} are true, otherwise false
      */
     public boolean isSubscribed() {
-        return OneSignal.getPermissionSubscriptionState().subscriptionStatus.getSubscribed();
+        return subscribed;
     }
 
     /**
      * Get user id from registration
+     *
      * @return user id if user is registered, otherwise false
      */
     public String getUserId() {
-        return OneSignal.getPermissionSubscriptionState().subscriptionStatus.getUserId();
+        return userId;
     }
 
     /**
      * Get device push token
+     *
      * @return push token if available, otherwise null
      */
     public String getPushToken() {
-        return OneSignal.getPermissionSubscriptionState().subscriptionStatus.getPushToken();
+        return pushToken;
     }
 
     /**
      * Get the user email id
+     *
      * @return email id if user address was registered, otherwise null
      */
     public String getEmailUserId() {
-        return OneSignal.getPermissionSubscriptionState().emailSubscriptionStatus.getEmailUserId();
+        return emailUserId;
     }
 
     /**
      * Get the user email
+     *
      * @return email address if set, otherwise null
      */
     public String getEmailAddress() {
-        return OneSignal.getPermissionSubscriptionState().emailSubscriptionStatus.getEmailAddress();
+        return emailAddress;
     }
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSDeviceState.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSDeviceState.java
@@ -27,23 +27,23 @@
 
 package com.onesignal;
 
-public class OSDevice {
+public class OSDeviceState {
 
     private final boolean notificationEnabled;
-    private final boolean userSubscribed;
+    private final boolean pushDisabled;
     private final boolean subscribed;
     private final String userId;
     private final String pushToken;
     private final String emailUserId;
     private final String emailAddress;
 
-    public OSDevice(OSPermissionSubscriptionState permissionSubscriptionState) {
+    public OSDeviceState(OSPermissionSubscriptionState permissionSubscriptionState) {
         OSSubscriptionState subscriptionStatus = permissionSubscriptionState.subscriptionStatus;
         OSPermissionState permissionStatus = permissionSubscriptionState.permissionStatus;
         OSEmailSubscriptionState emailSubscriptionStatus = permissionSubscriptionState.emailSubscriptionStatus;
 
         notificationEnabled = permissionStatus.getEnabled();
-        userSubscribed = subscriptionStatus.getUserSubscriptionSetting();
+        pushDisabled = !subscriptionStatus.getUserSubscriptionSetting();
         subscribed = subscriptionStatus.getSubscribed();
         userId = subscriptionStatus.getUserId();
         pushToken = subscriptionStatus.getPushToken();
@@ -56,7 +56,7 @@ public class OSDevice {
      *
      * @return false if the user disabled notifications for the app, otherwise true
      */
-    public boolean isNotificationEnabled() {
+    public boolean areNotificationsEnabled() {
         return notificationEnabled;
     }
 
@@ -65,14 +65,14 @@ public class OSDevice {
      *
      * @return false if the user is not subscribed to OneSignal notifications, otherwise true
      */
-    public boolean isUserSubscribed() {
-        return userSubscribed;
+    public boolean isPushDisabled() {
+        return pushDisabled;
     }
 
     /**
      * Get whether the user is subscribed
      *
-     * @return true if {@link #isNotificationEnabled}, {@link #isUserSubscribed}, {@link #getUserId} and {@link #getPushToken} are true, otherwise false
+     * @return true if {@link #areNotificationsEnabled}, {@link #isPushDisabled}, {@link #getUserId} and {@link #getPushToken} are true, otherwise false
      */
     public boolean isSubscribed() {
         return subscribed;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -517,10 +517,10 @@ public class OneSignal {
    // End EmailSubscriptionState
 
    @Nullable
-   public static OSDevice getUserDevice() {
+   public static OSDeviceState getDeviceState() {
       if (getPermissionSubscriptionState() == null)
          return null;
-      return new OSDevice(getPermissionSubscriptionState());
+      return new OSDeviceState(getPermissionSubscriptionState());
    }
 
    private static class IAPUpdateJob {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -516,12 +516,11 @@ public class OneSignal {
    }
    // End EmailSubscriptionState
 
-   private static OSDevice userDevice;
+   @Nullable
    public static OSDevice getUserDevice() {
-      if (userDevice == null)
-         userDevice = new OSDevice();
-
-      return userDevice;
+      if (getPermissionSubscriptionState() == null)
+         return null;
+      return new OSDevice(getPermissionSubscriptionState());
    }
 
    private static class IAPUpdateJob {
@@ -2900,7 +2899,7 @@ public class OneSignal {
     */
    public static OSPermissionSubscriptionState getPermissionSubscriptionState() {
 
-      //if applicable, check if the user provided privacy consent
+      // If applicable, check if the user provided privacy consent
       if (shouldLogUserPrivacyConsentErrorMessageForMethodName("getPermissionSubscriptionState()"))
          return null;
 

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
@@ -49,7 +49,7 @@ import com.onesignal.MockOSSharedPreferences;
 import com.onesignal.MockOSTimeImpl;
 import com.onesignal.MockOneSignalDBHelper;
 import com.onesignal.MockSessionManager;
-import com.onesignal.OSDevice;
+import com.onesignal.OSDeviceState;
 import com.onesignal.OSEmailSubscriptionObserver;
 import com.onesignal.OSEmailSubscriptionState;
 import com.onesignal.OSEmailSubscriptionStateChanges;
@@ -4589,15 +4589,15 @@ public class MainOneSignalClassRunner {
    }
 
    @Test
-   public void testOSDeviceHasEmailAddress() throws Exception {
+   public void testDeviceStateHasEmailAddress() throws Exception {
       String testEmail = "test@onesignal.com";
 
-      assertNull(OneSignal.getUserDevice());
+      assertNull(OneSignal.getDeviceState());
 
       OneSignalInit();
       threadAndTaskWait();
 
-      OSDevice device = OneSignal.getUserDevice();
+      OSDeviceState device = OneSignal.getDeviceState();
       assertNull(device.getEmailAddress());
 
       OneSignal.setEmail(testEmail);
@@ -4606,19 +4606,19 @@ public class MainOneSignalClassRunner {
       // Device is a snapshot, last value should not change
       assertNull(device.getEmailAddress());
       // Retrieve new user device
-      assertEquals(testEmail, OneSignal.getUserDevice().getEmailAddress());
+      assertEquals(testEmail, OneSignal.getDeviceState().getEmailAddress());
    }
 
    @Test
-   public void testOSDeviceHasEmailId() throws Exception {
+   public void testDeviceStateHasEmailId() throws Exception {
       String testEmail = "test@onesignal.com";
 
-      assertNull(OneSignal.getUserDevice());
+      assertNull(OneSignal.getDeviceState());
 
       OneSignalInit();
       threadAndTaskWait();
 
-      OSDevice device = OneSignal.getUserDevice();
+      OSDeviceState device = OneSignal.getDeviceState();
       assertNull(device.getEmailUserId());
 
       OneSignal.setEmail(testEmail);
@@ -4627,38 +4627,38 @@ public class MainOneSignalClassRunner {
       // Device is a snapshot, last value should not change
       assertNull(device.getEmailUserId());
       // Retrieve new user device
-      assertNotNull(OneSignal.getUserDevice().getEmailUserId());
+      assertNotNull(OneSignal.getDeviceState().getEmailUserId());
    }
 
    @Test
-   public void testOSDeviceHasUserId() throws Exception {
-      assertNull(OneSignal.getUserDevice());
+   public void testDeviceStateHasUserId() throws Exception {
+      assertNull(OneSignal.getDeviceState());
 
       OneSignalInit();
       threadAndTaskWait();
 
-      assertNotNull(OneSignal.getUserDevice().getUserId());
+      assertNotNull(OneSignal.getDeviceState().getUserId());
    }
 
    @Test
-   public void testOSDeviceHasPushToken() throws Exception {
-      assertNull(OneSignal.getUserDevice());
+   public void testDeviceStateHasPushToken() throws Exception {
+      assertNull(OneSignal.getDeviceState());
 
       OneSignalInit();
       threadAndTaskWait();
 
-      assertNotNull(OneSignal.getUserDevice().getPushToken());
+      assertNotNull(OneSignal.getDeviceState().getPushToken());
    }
 
    @Test
-   public void testOSDeviceNotificationPermission() throws Exception {
-      assertNull(OneSignal.getUserDevice());
+   public void testDeviceStateAreNotificationsEnabled() throws Exception {
+      assertNull(OneSignal.getDeviceState());
 
       OneSignalInit();
       threadAndTaskWait();
 
-      OSDevice device = OneSignal.getUserDevice();
-      assertTrue(device.isNotificationEnabled());
+      OSDeviceState device = OneSignal.getDeviceState();
+      assertTrue(device.areNotificationsEnabled());
 
       fastColdRestartApp();
 
@@ -4668,29 +4668,29 @@ public class MainOneSignalClassRunner {
       threadAndTaskWait();
 
       // Device is a snapshot, last value should not change
-      assertTrue(device.isNotificationEnabled());
+      assertTrue(device.areNotificationsEnabled());
       // Retrieve new user device
-      assertFalse(OneSignal.getUserDevice().isNotificationEnabled());
+      assertFalse(OneSignal.getDeviceState().areNotificationsEnabled());
    }
 
    @Test
-   public void testOSDeviceUserSubscriptionSetting() throws Exception {
-      assertNull(OneSignal.getUserDevice());
+   public void testDeviceStateIsPushDisabled() throws Exception {
+      assertNull(OneSignal.getDeviceState());
 
       OneSignalInit();
       threadAndTaskWait();
 
-      assertTrue(OneSignal.getUserDevice().isUserSubscribed());
+      assertFalse(OneSignal.getDeviceState().isPushDisabled());
    }
 
    @Test
-   public void testOSDeviceSubscribed() throws Exception {
-      assertNull(OneSignal.getUserDevice());
+   public void testDeviceStateIsSubscribed() throws Exception {
+      assertNull(OneSignal.getDeviceState());
 
       OneSignalInit();
       threadAndTaskWait();
 
-      OSDevice device = OneSignal.getUserDevice();
+      OSDeviceState device = OneSignal.getDeviceState();
       assertTrue(device.isSubscribed());
 
       fastColdRestartApp();
@@ -4703,7 +4703,7 @@ public class MainOneSignalClassRunner {
       // Device is a snapshot, last value should not change
       assertTrue(device.isSubscribed());
       // Retrieve new user device
-      assertFalse(OneSignal.getUserDevice().isSubscribed());
+      assertFalse(OneSignal.getDeviceState().isSubscribed());
    }
 
    @Test

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
@@ -49,6 +49,7 @@ import com.onesignal.MockOSSharedPreferences;
 import com.onesignal.MockOSTimeImpl;
 import com.onesignal.MockOneSignalDBHelper;
 import com.onesignal.MockSessionManager;
+import com.onesignal.OSDevice;
 import com.onesignal.OSEmailSubscriptionObserver;
 import com.onesignal.OSEmailSubscriptionState;
 import com.onesignal.OSEmailSubscriptionStateChanges;
@@ -4591,14 +4592,20 @@ public class MainOneSignalClassRunner {
    public void testOSDeviceHasEmailAddress() throws Exception {
       String testEmail = "test@onesignal.com";
 
+      assertNull(OneSignal.getUserDevice());
+
       OneSignalInit();
       threadAndTaskWait();
 
-      assertNull(OneSignal.getUserDevice().getEmailAddress());
+      OSDevice device = OneSignal.getUserDevice();
+      assertNull(device.getEmailAddress());
 
       OneSignal.setEmail(testEmail);
       threadAndTaskWait();
 
+      // Device is a snapshot, last value should not change
+      assertNull(device.getEmailAddress());
+      // Retrieve new user device
       assertEquals(testEmail, OneSignal.getUserDevice().getEmailAddress());
    }
 
@@ -4606,20 +4613,27 @@ public class MainOneSignalClassRunner {
    public void testOSDeviceHasEmailId() throws Exception {
       String testEmail = "test@onesignal.com";
 
+      assertNull(OneSignal.getUserDevice());
 
       OneSignalInit();
       threadAndTaskWait();
 
-      assertNull(OneSignal.getUserDevice().getEmailUserId());
+      OSDevice device = OneSignal.getUserDevice();
+      assertNull(device.getEmailUserId());
 
       OneSignal.setEmail(testEmail);
       threadAndTaskWait();
 
+      // Device is a snapshot, last value should not change
+      assertNull(device.getEmailUserId());
+      // Retrieve new user device
       assertNotNull(OneSignal.getUserDevice().getEmailUserId());
    }
 
    @Test
    public void testOSDeviceHasUserId() throws Exception {
+      assertNull(OneSignal.getUserDevice());
+
       OneSignalInit();
       threadAndTaskWait();
 
@@ -4628,6 +4642,8 @@ public class MainOneSignalClassRunner {
 
    @Test
    public void testOSDeviceHasPushToken() throws Exception {
+      assertNull(OneSignal.getUserDevice());
+
       OneSignalInit();
       threadAndTaskWait();
 
@@ -4636,14 +4652,31 @@ public class MainOneSignalClassRunner {
 
    @Test
    public void testOSDeviceNotificationPermission() throws Exception {
+      assertNull(OneSignal.getUserDevice());
+
       OneSignalInit();
       threadAndTaskWait();
 
-      assertTrue(OneSignal.getUserDevice().isNotificationEnabled());
+      OSDevice device = OneSignal.getUserDevice();
+      assertTrue(device.isNotificationEnabled());
+
+      fastColdRestartApp();
+
+      ShadowNotificationManagerCompat.enabled = false;
+
+      OneSignalInit();
+      threadAndTaskWait();
+
+      // Device is a snapshot, last value should not change
+      assertTrue(device.isNotificationEnabled());
+      // Retrieve new user device
+      assertFalse(OneSignal.getUserDevice().isNotificationEnabled());
    }
 
    @Test
    public void testOSDeviceUserSubscriptionSetting() throws Exception {
+      assertNull(OneSignal.getUserDevice());
+
       OneSignalInit();
       threadAndTaskWait();
 
@@ -4652,10 +4685,25 @@ public class MainOneSignalClassRunner {
 
    @Test
    public void testOSDeviceSubscribed() throws Exception {
+      assertNull(OneSignal.getUserDevice());
+
       OneSignalInit();
       threadAndTaskWait();
 
-      assertTrue(OneSignal.getUserDevice().isSubscribed());
+      OSDevice device = OneSignal.getUserDevice();
+      assertTrue(device.isSubscribed());
+
+      fastColdRestartApp();
+
+      ShadowNotificationManagerCompat.enabled = false;
+
+      OneSignalInit();
+      threadAndTaskWait();
+
+      // Device is a snapshot, last value should not change
+      assertTrue(device.isSubscribed());
+      // Retrieve new user device
+      assertFalse(OneSignal.getUserDevice().isSubscribed());
    }
 
    @Test


### PR DESCRIPTION
  * Create a new OSDevice on every getter
  * Make OSDevice depend on current OSPermissionSubscriptionState
 
Rename OSDevice to OSDeviceState

  * Rename isNotificationEnabled to areNotificationsEnabled
  * Rename isUserSubscribed to isPushDisabled and change logic

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1134)
<!-- Reviewable:end -->
