### PR TITLE
Remove ExtNotificationWillShowInForegroundHandler

### DIFF
--- a/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/application/MainApplication.java
+++ b/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/application/MainApplication.java
@@ -29,7 +29,7 @@ public class MainApplication extends Application {
 
         OneSignal.setNotificationWillShowInForegroundHandler(notificationJob -> {
             OneSignal.onesignalLog(OneSignal.LOG_LEVEL.VERBOSE, "AppNotificationWillShowInForeground fired!" +
-                    " with AppNotificationWillShowInForegroundHandler: " + notificationJob.toString());
+                    " with NotificationWillShowInForegroundHandler: " + notificationJob.toString());
 
             notificationJob.setNotificationDisplayOption(OneSignal.OSNotificationDisplay.NOTIFICATION);
             notificationJob.complete();

--- a/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/notification/AppNotificationExtensionService.java
+++ b/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/notification/AppNotificationExtensionService.java
@@ -28,12 +28,12 @@ public class AppNotificationExtensionService implements
       notification.setModifiedContent(overrideSettings);
 
       // If Developer doesn't call notification.display()
-      // AppNotificationWillShowInForegroundHandler won't be call
+      // NotificationWillShowInForegroundHandler won't be call
       OSNotificationDisplayedResult notificationDisplayedResult = notification.display();
       OneSignal.onesignalLog(OneSignal.LOG_LEVEL.VERBOSE, "Android notification id: " + notificationDisplayedResult.androidNotificationId);
 
       // If complete isn't call and notification.display() was called, after 5 seconds
-      // OneSignal will continue calling AppNotificationWillShowInForegroundHandler
+      // OneSignal will continue calling NotificationWillShowInForegroundHandler
       notification.complete();
    }
 

--- a/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/notification/AppNotificationExtensionService.java
+++ b/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/notification/AppNotificationExtensionService.java
@@ -16,6 +16,8 @@ public class AppNotificationExtensionService implements
 
    @Override
    public void notificationProcessing(Context context, OSNotificationReceived notification) {
+      OneSignal.onesignalLog(OneSignal.LOG_LEVEL.VERBOSE, "NotificationProcessingHandler fired!" +
+              " with OSNotificationReceived: " + notification.toString());
       if (notification.payload.actionButtons != null) {
          for (OSNotificationPayload.ActionButton button : notification.payload.actionButtons) {
             OneSignal.onesignalLog(OneSignal.LOG_LEVEL.VERBOSE, "ActionButton: " + button.toString());

--- a/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/notification/AppNotificationExtensionService.java
+++ b/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/notification/AppNotificationExtensionService.java
@@ -4,7 +4,6 @@ import android.content.Context;
 
 import com.onesignal.OSNotificationDisplayedResult;
 import com.onesignal.OSNotificationExtender;
-import com.onesignal.OSNotificationGenerationJob.ExtNotificationGenerationJob;
 import com.onesignal.OSNotificationOpenResult;
 import com.onesignal.OSNotificationPayload;
 import com.onesignal.OSNotificationReceived;
@@ -13,7 +12,6 @@ import com.onesignal.sdktest.R;
 
 public class AppNotificationExtensionService implements
         OneSignal.NotificationProcessingHandler,
-        OneSignal.ExtNotificationWillShowInForegroundHandler,
         OneSignal.NotificationOpenedHandler {
 
    @Override
@@ -29,25 +27,14 @@ public class AppNotificationExtensionService implements
 
       notification.setModifiedContent(overrideSettings);
 
-      // If Developer doesn't call notification.display() ExtNotificationWillShowInForegroundHandler
-      // and AppNotificationWillShowInForegroundHandler won't be call
+      // If Developer doesn't call notification.display()
+      // AppNotificationWillShowInForegroundHandler won't be call
       OSNotificationDisplayedResult notificationDisplayedResult = notification.display();
       OneSignal.onesignalLog(OneSignal.LOG_LEVEL.VERBOSE, "Android notification id: " + notificationDisplayedResult.androidNotificationId);
 
       // If complete isn't call and notification.display() was called, after 5 seconds
-      // OneSignal will continue calling ExtNotificationWillShowInForegroundHandler
+      // OneSignal will continue calling AppNotificationWillShowInForegroundHandler
       notification.complete();
-   }
-
-   @Override
-   public void notificationWillShowInForeground(ExtNotificationGenerationJob notificationJob) {
-      OneSignal.onesignalLog(OneSignal.LOG_LEVEL.VERBOSE, "ExtNotificationWillShowInForeground fired! " +
-              "with ExtNotificationGenerationJob: " + notificationJob.toString());
-
-      notificationJob.setNotificationDisplayOption(OneSignal.OSNotificationDisplay.NOTIFICATION);
-
-      // If bubble set to false AppNotificationWillShowInForegroundHandler won't be called
-      notificationJob.complete(true);
    }
 
    @Override

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationExtender.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationExtender.java
@@ -188,7 +188,7 @@ public class OSNotificationExtender {
     * <br/><br/>
     * There is only one way to implement the {@link OneSignal.NotificationProcessingHandler}
     * <br/><br/>
-    * In the case of the {@link OneSignal.ExtNotificationWillShowInForegroundHandler} and the {@link OneSignal.AppNotificationWillShowInForegroundHandler}
+    * In the case of the {@link OneSignal.AppNotificationWillShowInForegroundHandler}
     *  there are also setters for these handlers. So why create this new class and implement
     *  the same handlers, won't they just overwrite each other?
     * No, the idea here is to keep track of two separate handlers and keep them both
@@ -197,7 +197,6 @@ public class OSNotificationExtender {
     * The extension handlers will always be called first and then bubble to the app handlers
     * <br/><br/>
     * @see OneSignal.NotificationProcessingHandler
-    * @see OneSignal.ExtNotificationWillShowInForegroundHandler
     */
    static void setupNotificationExtensionServiceClass() {
       String className = OSUtils.getManifestMeta(OneSignal.appContext, EXTENSION_SERVICE_META_DATA_TAG_NAME);
@@ -216,10 +215,6 @@ public class OSNotificationExtender {
          // Make sure a NotificationProcessingHandler exists and notificationProcessingHandler has not been set yet
          if (clazzInstance instanceof OneSignal.NotificationProcessingHandler && OneSignal.notificationProcessingHandler == null) {
             OneSignal.setNotificationProcessingHandler((OneSignal.NotificationProcessingHandler) clazzInstance);
-         }
-         // Make sure a ExtNotificationWillShowInForegroundHandler exists and extNotificationWillShowInForegroundHandler has not been set yet
-         if (clazzInstance instanceof OneSignal.ExtNotificationWillShowInForegroundHandler && OneSignal.extNotificationWillShowInForegroundHandler == null) {
-            OneSignal.setExtNotificationWillShowInForegroundHandler((OneSignal.ExtNotificationWillShowInForegroundHandler) clazzInstance);
          }
       } catch (IllegalAccessException e) {
          e.printStackTrace();

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationExtender.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationExtender.java
@@ -188,7 +188,7 @@ public class OSNotificationExtender {
     * <br/><br/>
     * There is only one way to implement the {@link OneSignal.NotificationProcessingHandler}
     * <br/><br/>
-    * In the case of the {@link OneSignal.AppNotificationWillShowInForegroundHandler}
+    * In the case of the {@link OneSignal.NotificationWillShowInForegroundHandler}
     *  there are also setters for these handlers. So why create this new class and implement
     *  the same handlers, won't they just overwrite each other?
     * No, the idea here is to keep track of two separate handlers and keep them both

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationGenerationJob.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationGenerationJob.java
@@ -156,7 +156,7 @@ public class OSNotificationGenerationJob {
 
     /**
      * Create a {@link AppNotificationGenerationJob} to manage the {@link OSNotificationGenerationJob}
-     *  while the {@link OneSignal.AppNotificationWillShowInForegroundHandler} is being fired
+     *  while the {@link OneSignal.NotificationWillShowInForegroundHandler} is being fired
      */
     AppNotificationGenerationJob toAppNotificationGenerationJob() {
         return new AppNotificationGenerationJob(this);
@@ -231,7 +231,7 @@ public class OSNotificationGenerationJob {
     }
 
    /**
-    * Used to modify the {@link OSNotificationGenerationJob} inside of the {@link OneSignal.AppNotificationWillShowInForegroundHandler}
+    * Used to modify the {@link OSNotificationGenerationJob} inside of the {@link OneSignal.NotificationWillShowInForegroundHandler}
     * without exposing internals publicly
     */
    public static class AppNotificationGenerationJob extends NotificationGenerationJob {
@@ -249,7 +249,7 @@ public class OSNotificationGenerationJob {
         }
 
         /**
-         * Method controlling completion from the AppNotificationWillShowInForegroundHandler
+         * Method controlling completion from the NotificationWillShowInForegroundHandler
          * If a dev does not call this at the end of the notificationWillShowInForeground implementation,
          *  a runnable will fire after a 30 second timer and complete by default
          */

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationReceived.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationReceived.java
@@ -46,6 +46,8 @@ public class OSNotificationReceived {
    public boolean isAppInFocus;
    // Used to toggle when complete is called so it can not be called more than once
    private boolean isComplete = false;
+   // Flag that differentiate user custom flow from OneSignal
+   private boolean internalComplete = false;
 
    OSNotificationReceived(Context context, int androidNotificationId, JSONObject jsonPayload,
                           boolean isRestoring, boolean isAppInFocus, long timestamp) {
@@ -112,6 +114,11 @@ public class OSNotificationReceived {
       return notificationExtender.displayNotification();
    }
 
+   synchronized void internalComplete() {
+      internalComplete = true;
+      complete();
+   }
+
    /**
     * Method controlling completion from the NotificationProcessingHandler
     * If a dev does not call this at the end of the notificationProcessing implementation,
@@ -125,7 +132,7 @@ public class OSNotificationReceived {
 
       isComplete = true;
 
-      notificationExtender.processNotification();
+      notificationExtender.processNotification(internalComplete);
    }
 
    @Override

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationWorkManager.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationWorkManager.java
@@ -85,7 +85,7 @@ class OSNotificationWorkManager {
                 } catch (Throwable t) {
                     if (!notificationReceived.displayed()) {
                         OneSignal.Log(OneSignal.LOG_LEVEL.ERROR, "onNotificationProcessing throw an exception. Displaying normal OneSignal notification.", t);
-                        notificationReceived.complete();
+                        notificationReceived.internalComplete();
                     }
                     else
                         OneSignal.Log(OneSignal.LOG_LEVEL.ERROR, "onNotificationProcessing throw an exception. Extended notification displayed but custom processing did not finish.", t);
@@ -94,7 +94,7 @@ class OSNotificationWorkManager {
                 }
             else if (!notificationReceived.displayed()) {
                 OneSignal.Log(OneSignal.LOG_LEVEL.WARN, "notificationProcessingHandler not setup, displaying normal OneSignal notification");
-                notificationReceived.complete();
+                notificationReceived.internalComplete();
             }
         }
     }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -95,12 +95,12 @@ public class OneSignal {
     * <br/><br/>
     * Used with the {@link OSNotificationGenerationJob#setNotificationDisplayOption(OSNotificationDisplay)}
     * Determines how the notification will show to the user when inside of the
-    *  {@link AppNotificationWillShowInForegroundHandler#notificationWillShowInForeground(AppNotificationGenerationJob)}
+    *  {@link NotificationWillShowInForegroundHandler#notificationWillShowInForeground(AppNotificationGenerationJob)}
     * <br/><br/>
     * Default for {@link OSNotificationGenerationJob#displayOption} is {@link OSNotificationDisplay#NOTIFICATION}
     * <br/><br/>
     * @see OSNotificationGenerationJob
-    * @see AppNotificationWillShowInForegroundHandler
+    * @see NotificationWillShowInForegroundHandler
     */
    public enum OSNotificationDisplay {
 
@@ -189,7 +189,7 @@ public class OneSignal {
    }
 
    /**
-    * Meant to be implemented with {@link OneSignal#setNotificationWillShowInForegroundHandler(AppNotificationWillShowInForegroundHandler)}
+    * Meant to be implemented with {@link OneSignal#setNotificationWillShowInForegroundHandler(NotificationWillShowInForegroundHandler)}
     * <br/><br/>
     * Call setters from the {@link AppNotificationGenerationJob} to modify the {@link OSNotificationGenerationJob}
     *    before the notification is shown on the device
@@ -199,7 +199,7 @@ public class OneSignal {
     * TODO: Update docs with new NotificationReceivedHandler
     * @see <a href="https://documentation.onesignal.com/docs/android-native-sdk#notificationreceivedhandler">NotificationReceivedHandler | OneSignal Docs</a>
     */
-   public interface AppNotificationWillShowInForegroundHandler {
+   public interface NotificationWillShowInForegroundHandler {
 
       void notificationWillShowInForeground(AppNotificationGenerationJob notificationJob);
    }
@@ -330,7 +330,7 @@ public class OneSignal {
    private static int subscribableStatus = Integer.MAX_VALUE;
 
    static NotificationProcessingHandler notificationProcessingHandler;
-   static AppNotificationWillShowInForegroundHandler appNotificationWillShowInForegroundHandler;
+   static NotificationWillShowInForegroundHandler notificationWillShowInForegroundHandler;
 
    // TODO: Start of old mInitBuilder params
    //    These should be cleaned up and managed else where maybe?
@@ -652,8 +652,8 @@ public class OneSignal {
       notificationProcessingHandler = callback;
    }
 
-   public static void setNotificationWillShowInForegroundHandler(AppNotificationWillShowInForegroundHandler callback) {
-      appNotificationWillShowInForegroundHandler = callback;
+   public static void setNotificationWillShowInForegroundHandler(NotificationWillShowInForegroundHandler callback) {
+      notificationWillShowInForegroundHandler = callback;
    }
 
    public static void setNotificationOpenedHandler(NotificationOpenedHandler callback) {
@@ -2083,9 +2083,9 @@ public class OneSignal {
 
    /**
     * Checks if the app is in the background
-    * Checks if appNotificationWillShowInForegroundHandler are setup
+    * Checks if notificationWillShowInForegroundHandler is setup
     * <br/><br/>
-    * @see OneSignal.AppNotificationWillShowInForegroundHandler
+    * @see NotificationWillShowInForegroundHandler
     */
    static boolean shouldFireForegroundHandlers() {
       if (!isInForeground()) {
@@ -2093,8 +2093,8 @@ public class OneSignal {
          return false;
       }
 
-      if (appNotificationWillShowInForegroundHandler == null) {
-         OneSignal.onesignalLog(LOG_LEVEL.INFO, "No AppNotificationWillShowInForegroundHandler setup, show notification");
+      if (notificationWillShowInForegroundHandler == null) {
+         OneSignal.onesignalLog(LOG_LEVEL.INFO, "No NotificationWillShowInForegroundHandler setup, show notification");
          return false;
       }
 
@@ -2102,17 +2102,17 @@ public class OneSignal {
    }
 
    /**
-    * Responsible for firing the appNotificationWillShowInForegroundHandler
+    * Responsible for firing the notificationWillShowInForegroundHandler
     * <br/><br/>
-    * @see OneSignal.AppNotificationWillShowInForegroundHandler
+    * @see NotificationWillShowInForegroundHandler
     */
    static void fireForegroundHandlers(OSNotificationGenerationJob notificationJob) {
-      OneSignal.onesignalLog(OneSignal.LOG_LEVEL.INFO, "Fire appNotificationWillShowInForegroundHandler");
+      OneSignal.onesignalLog(OneSignal.LOG_LEVEL.INFO, "Fire notificationWillShowInForegroundHandler");
       AppNotificationGenerationJob appnotificationJob = notificationJob.toAppNotificationGenerationJob();
       try {
-         OneSignal.appNotificationWillShowInForegroundHandler.notificationWillShowInForeground(appnotificationJob);
+         OneSignal.notificationWillShowInForegroundHandler.notificationWillShowInForeground(appnotificationJob);
       } catch (Throwable t) {
-         OneSignal.onesignalLog(LOG_LEVEL.ERROR, "Exception thrown while notification was being processed for display by appNotificationWillShowInForegroundHandler, showing notification in foreground!");
+         OneSignal.onesignalLog(LOG_LEVEL.ERROR, "Exception thrown while notification was being processed for display by notificationWillShowInForegroundHandler, showing notification in foreground!");
          appnotificationJob.complete();
          throw t;
       }
@@ -2774,7 +2774,7 @@ public class OneSignal {
    }
 
    public static void removeNotificationWillShowInForegroundHandler() {
-      OneSignal.appNotificationWillShowInForegroundHandler = null;
+      OneSignal.notificationWillShowInForegroundHandler = null;
    }
 
    public static void removeNotificationOpenedHandler() {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -649,7 +649,8 @@ public class OneSignal {
    }
 
    static void setNotificationProcessingHandler(NotificationProcessingHandler callback) {
-      notificationProcessingHandler = callback;
+      if (notificationProcessingHandler == null)
+         notificationProcessingHandler = callback;
    }
 
    public static void setNotificationWillShowInForegroundHandler(NotificationWillShowInForegroundHandler callback) {
@@ -671,6 +672,8 @@ public class OneSignal {
     * Called after setAppId and setAppContext, depending on which one is called last (order does not matter)
     */
    synchronized private static void init(Context context) {
+      OSNotificationExtender.setupNotificationExtensionServiceClass();
+
       if (requiresUserPrivacyConsent() || !remoteParamController.isRemoteParamsCallDone()) {
          if (!remoteParamController.isRemoteParamsCallDone())
             logger.verbose("OneSignal SDK initialization delayed, " +
@@ -701,8 +704,6 @@ public class OneSignal {
          logger.debug("OneSignal SDK initialization already completed.");
          return;
       }
-
-      OSNotificationExtender.setupNotificationExtensionServiceClass();
 
       handleActivityLifecycleHandler(context);
 

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowGenerateNotification.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowGenerateNotification.java
@@ -6,8 +6,19 @@ import org.robolectric.annotation.Implements;
 @Implements(GenerateNotification.class)
 public class ShadowGenerateNotification {
 
-   @Implementation
+    private static boolean runningOnMainThreadCheck = false;
+
+    @Implementation
     public static void isRunningOnMainThreadCheck() {
-      // Remove Main thread check and throw
+        // Remove Main thread check and throw
+        runningOnMainThreadCheck = true;
+    }
+
+    public static boolean isRunningOnMainThreadCheckCalled() {
+        return runningOnMainThreadCheck;
+    }
+
+    public static void resetStatics() {
+        runningOnMainThreadCheck = false;
     }
 }

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
@@ -1555,11 +1555,11 @@ public class GenerateNotificationRunner {
 
    @Test
    @Config(shadows = { ShadowGenerateNotification.class })
-   public void testAppNotificationWillShowInForegroundHandlerIsCallWhenReceivingNotificationInForeground() throws Exception {
+   public void testNotificationWillShowInForegroundHandlerIsCallWhenReceivingNotificationInForeground() throws Exception {
       // 1. Init OneSignal
       OneSignal.setAppId("b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
       OneSignal.setAppContext(blankActivity);
-      OneSignal.setNotificationWillShowInForegroundHandler(new OneSignal.AppNotificationWillShowInForegroundHandler() {
+      OneSignal.setNotificationWillShowInForegroundHandler(new OneSignal.NotificationWillShowInForegroundHandler() {
          @Override
          public void notificationWillShowInForeground(OSNotificationGenerationJob.AppNotificationGenerationJob notificationJob) {
             lastAppNotificationJob = notificationJob;
@@ -1586,11 +1586,11 @@ public class GenerateNotificationRunner {
 
    @Test
    @Config(shadows = { ShadowGenerateNotification.class })
-   public void testAppNotificationWillShowInForegroundHandler_setNotificationDisplayOptionToNotification() throws Exception {
+   public void testNotificationWillShowInForegroundHandler_setNotificationDisplayOptionToNotification() throws Exception {
       // 1. Init OneSignal
       OneSignal.setAppId("b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
       OneSignal.setAppContext(blankActivity);
-      OneSignal.setNotificationWillShowInForegroundHandler(new OneSignal.AppNotificationWillShowInForegroundHandler() {
+      OneSignal.setNotificationWillShowInForegroundHandler(new OneSignal.NotificationWillShowInForegroundHandler() {
          @Override
          public void notificationWillShowInForeground(OSNotificationGenerationJob.AppNotificationGenerationJob notificationJob) {
             notificationJob.setNotificationDisplayOption(OneSignal.OSNotificationDisplay.NOTIFICATION);
@@ -1618,11 +1618,11 @@ public class GenerateNotificationRunner {
 
    @Test
    @Config(shadows = { ShadowGenerateNotification.class })
-   public void testAppNotificationWillShowInForegroundHandler_setNotificationDisplayOptionToSilent() throws Exception {
+   public void testNotificationWillShowInForegroundHandler_setNotificationDisplayOptionToSilent() throws Exception {
       // 1. Init OneSignal
       OneSignal.setAppId("b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
       OneSignal.setAppContext(blankActivity);
-      OneSignal.setNotificationWillShowInForegroundHandler(new OneSignal.AppNotificationWillShowInForegroundHandler() {
+      OneSignal.setNotificationWillShowInForegroundHandler(new OneSignal.NotificationWillShowInForegroundHandler() {
          @Override
          public void notificationWillShowInForeground(OSNotificationGenerationJob.AppNotificationGenerationJob notificationJob) {
             notificationJob.setNotificationDisplayOption(OneSignal.OSNotificationDisplay.SILENT);
@@ -1650,7 +1650,7 @@ public class GenerateNotificationRunner {
 
    @Test
    @Config(shadows = { ShadowGenerateNotification.class })
-   public void testNotificationCompletesFlows_withNullAppNotificationWillShowInForegroundHandler() throws Exception {
+   public void testNotificationCompletesFlows_withNullNotificationWillShowInForegroundHandler() throws Exception {
       // 1. Init OneSignal
       OneSignal.setAppId("b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
       OneSignal.setAppContext(blankActivity);
@@ -1676,7 +1676,7 @@ public class GenerateNotificationRunner {
       // 1. Init OneSignal
       OneSignal.setAppId("b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
       OneSignal.setAppContext(blankActivity);
-      OneSignal.setNotificationWillShowInForegroundHandler(new OneSignal.AppNotificationWillShowInForegroundHandler() {
+      OneSignal.setNotificationWillShowInForegroundHandler(new OneSignal.NotificationWillShowInForegroundHandler() {
          @Override
          public void notificationWillShowInForeground(OSNotificationGenerationJob.AppNotificationGenerationJob notificationJob) {
             lastAppNotificationJob = notificationJob;
@@ -1707,7 +1707,7 @@ public class GenerateNotificationRunner {
       // 1. Init OneSignal
       OneSignal.setAppId("b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
       OneSignal.setAppContext(blankActivity);
-      OneSignal.setNotificationWillShowInForegroundHandler(new OneSignal.AppNotificationWillShowInForegroundHandler() {
+      OneSignal.setNotificationWillShowInForegroundHandler(new OneSignal.NotificationWillShowInForegroundHandler() {
          @Override
          public void notificationWillShowInForeground(OSNotificationGenerationJob.AppNotificationGenerationJob notificationJob) {
             callbackCounter++;
@@ -1719,7 +1719,7 @@ public class GenerateNotificationRunner {
       blankActivityController.resume();
       threadAndTaskWait();
 
-      // Mock timeout to 1, given that we are not calling complete inside AppNotificationWillShowInForegroundHandler we depend on the timeout complete
+      // Mock timeout to 1, given that we are not calling complete inside NotificationWillShowInForegroundHandler we depend on the timeout complete
       ShadowTimeoutHandler.setMockDelayMillis(1);
       // 2. Receive a notification
       FCMBroadcastReceiver_processBundle(blankActivity, getBaseNotifBundle());
@@ -1742,7 +1742,7 @@ public class GenerateNotificationRunner {
       // 1. Init OneSignal
       OneSignal.setAppId("b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
       OneSignal.setAppContext(blankActivity);
-      OneSignal.setNotificationWillShowInForegroundHandler(new OneSignal.AppNotificationWillShowInForegroundHandler() {
+      OneSignal.setNotificationWillShowInForegroundHandler(new OneSignal.NotificationWillShowInForegroundHandler() {
          @Override
          public void notificationWillShowInForeground(OSNotificationGenerationJob.AppNotificationGenerationJob notificationJob) {
             lastAppNotificationJob = notificationJob;
@@ -1795,7 +1795,7 @@ public class GenerateNotificationRunner {
       // 1. Init OneSignal
       OneSignal.setAppId("b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
       OneSignal.setAppContext(blankActivity);
-      OneSignal.setNotificationWillShowInForegroundHandler(new OneSignal.AppNotificationWillShowInForegroundHandler() {
+      OneSignal.setNotificationWillShowInForegroundHandler(new OneSignal.NotificationWillShowInForegroundHandler() {
          @Override
          public void notificationWillShowInForeground(final OSNotificationGenerationJob.AppNotificationGenerationJob notificationJob) {
             callbackCounter++;
@@ -1815,7 +1815,7 @@ public class GenerateNotificationRunner {
       blankActivityController.resume();
       threadAndTaskWait();
 
-      // Mock timeout to 1, given that we are delaying the complete inside NotificationExtensionService and AppNotificationWillShowInForegroundHandler
+      // Mock timeout to 1, given that we are delaying the complete inside NotificationExtensionService and NotificationWillShowInForegroundHandler
       // We depend on the timeout complete
       ShadowTimeoutHandler.setMockDelayMillis(1);
       // 2. Receive a notification

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
@@ -210,23 +210,11 @@ public class MainOneSignalClassRunner {
       });
    }
 
-   private static AppNotificationGenerationJob lastNotificationGenerationJob;
-   private static OneSignal.AppNotificationWillShowInForegroundHandler getAppNotificationWillShowInForegroundHandler() {
-      return new OneSignal.AppNotificationWillShowInForegroundHandler() {
-         @Override
-         public void notificationWillShowInForeground(AppNotificationGenerationJob notificationJob) {
-            lastNotificationGenerationJob = notificationJob;
-         }
-      };
-   }
-
-   private static OSNotificationOpenResult lastNotificationOpenResult;
    private static String lastNotificationOpenedBody;
    private static OneSignal.NotificationOpenedHandler getNotificationOpenedHandler() {
       return new OneSignal.NotificationOpenedHandler() {
          @Override
          public void notificationOpened(OSNotificationOpenResult openedResult) {
-            lastNotificationOpenResult = openedResult;
 
             // TODO: Double check if we should use this or not
             lastNotificationOpenedBody = openedResult.notification.payload.body;
@@ -1151,7 +1139,7 @@ public class MainOneSignalClassRunner {
       // 1. Init OneSignal
       OneSignal.setAppId(ONESIGNAL_APP_ID);
       OneSignal.setAppContext(blankActivity);
-      OneSignal.setNotificationWillShowInForegroundHandler(new OneSignal.AppNotificationWillShowInForegroundHandler() {
+      OneSignal.setNotificationWillShowInForegroundHandler(new OneSignal.NotificationWillShowInForegroundHandler() {
          @Override
          public void notificationWillShowInForeground(AppNotificationGenerationJob notificationJob) {
             androidNotificationId = notificationJob.getAndroidNotificationId();
@@ -4277,7 +4265,7 @@ public class MainOneSignalClassRunner {
       // Assert that another receive isn't trigger later when the unprocessed receives are fired
       OneSignal.setAppId(ONESIGNAL_APP_ID);
       OneSignal.setAppContext(blankActivity);
-      OneSignal.setNotificationWillShowInForegroundHandler(new OneSignal.AppNotificationWillShowInForegroundHandler() {
+      OneSignal.setNotificationWillShowInForegroundHandler(new OneSignal.NotificationWillShowInForegroundHandler() {
          @Override
          public void notificationWillShowInForeground(OSNotificationGenerationJob.AppNotificationGenerationJob notificationJob) {
 

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/TestHelpers.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/TestHelpers.java
@@ -32,6 +32,7 @@ import com.onesignal.ShadowDynamicTimer;
 import com.onesignal.ShadowFCMBroadcastReceiver;
 import com.onesignal.ShadowFirebaseAnalytics;
 import com.onesignal.ShadowFusedLocationApiWrapper;
+import com.onesignal.ShadowGenerateNotification;
 import com.onesignal.ShadowGoogleApiClientCompatProxy;
 import com.onesignal.ShadowHMSFusedLocationProviderClient;
 import com.onesignal.ShadowHmsInstanceId;
@@ -121,6 +122,7 @@ public class TestHelpers {
 
       ShadowOSUtils.resetStatics();
       ShadowTimeoutHandler.resetStatics();
+      ShadowGenerateNotification.resetStatics();
 
       lastException = null;
    }


### PR DESCRIPTION
  * There is no difference between ExtNotificationWillShowInForegroundHandler and AppNotificationWillShowInForegroundHandler
    responsibility, to avoid confusion ExtNotificationWillShowInForegroundHandler was removed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1136)
<!-- Reviewable:end -->
