### PR TITLE
Avoid displaying notification if user not calls display() 

### DIFF
--- a/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/notification/AppNotificationExtensionService.java
+++ b/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/notification/AppNotificationExtensionService.java
@@ -16,6 +16,8 @@ public class AppNotificationExtensionService implements
 
    @Override
    public void notificationProcessing(Context context, OSNotificationReceived notification) {
+      OneSignal.onesignalLog(OneSignal.LOG_LEVEL.VERBOSE, "NotificationProcessingHandler fired!" +
+              " with OSNotificationReceived: " + notification.toString());
       if (notification.payload.actionButtons != null) {
          for (OSNotificationPayload.ActionButton button : notification.payload.actionButtons) {
             OneSignal.onesignalLog(OneSignal.LOG_LEVEL.VERBOSE, "ActionButton: " + button.toString());

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationReceived.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationReceived.java
@@ -46,6 +46,8 @@ public class OSNotificationReceived {
    public boolean isAppInFocus;
    // Used to toggle when complete is called so it can not be called more than once
    private boolean isComplete = false;
+   // Flag that differentiate user custom flow from OneSignal
+   private boolean internalComplete = false;
 
    OSNotificationReceived(Context context, int androidNotificationId, JSONObject jsonPayload,
                           boolean isRestoring, boolean isAppInFocus, long timestamp) {
@@ -112,6 +114,11 @@ public class OSNotificationReceived {
       return notificationExtender.displayNotification();
    }
 
+   synchronized void internalComplete() {
+      internalComplete = true;
+      complete();
+   }
+
    /**
     * Method controlling completion from the NotificationProcessingHandler
     * If a dev does not call this at the end of the notificationProcessing implementation,
@@ -125,7 +132,7 @@ public class OSNotificationReceived {
 
       isComplete = true;
 
-      notificationExtender.processNotification();
+      notificationExtender.processNotification(internalComplete);
    }
 
    @Override

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationWorkManager.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationWorkManager.java
@@ -85,7 +85,7 @@ class OSNotificationWorkManager {
                 } catch (Throwable t) {
                     if (!notificationReceived.displayed()) {
                         OneSignal.Log(OneSignal.LOG_LEVEL.ERROR, "onNotificationProcessing throw an exception. Displaying normal OneSignal notification.", t);
-                        notificationReceived.complete();
+                        notificationReceived.internalComplete();
                     }
                     else
                         OneSignal.Log(OneSignal.LOG_LEVEL.ERROR, "onNotificationProcessing throw an exception. Extended notification displayed but custom processing did not finish.", t);
@@ -94,7 +94,7 @@ class OSNotificationWorkManager {
                 }
             else if (!notificationReceived.displayed()) {
                 OneSignal.Log(OneSignal.LOG_LEVEL.WARN, "notificationProcessingHandler not setup, displaying normal OneSignal notification");
-                notificationReceived.complete();
+                notificationReceived.internalComplete();
             }
         }
     }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -649,7 +649,8 @@ public class OneSignal {
    }
 
    static void setNotificationProcessingHandler(NotificationProcessingHandler callback) {
-      notificationProcessingHandler = callback;
+      if (notificationProcessingHandler == null)
+         notificationProcessingHandler = callback;
    }
 
    public static void setNotificationWillShowInForegroundHandler(NotificationWillShowInForegroundHandler callback) {
@@ -671,6 +672,8 @@ public class OneSignal {
     * Called after setAppId and setAppContext, depending on which one is called last (order does not matter)
     */
    synchronized private static void init(Context context) {
+      OSNotificationExtender.setupNotificationExtensionServiceClass();
+
       if (requiresUserPrivacyConsent() || !remoteParamController.isRemoteParamsCallDone()) {
          if (!remoteParamController.isRemoteParamsCallDone())
             logger.verbose("OneSignal SDK initialization delayed, " +
@@ -701,8 +704,6 @@ public class OneSignal {
          logger.debug("OneSignal SDK initialization already completed.");
          return;
       }
-
-      OSNotificationExtender.setupNotificationExtensionServiceClass();
 
       handleActivityLifecycleHandler(context);
 

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowGenerateNotification.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowGenerateNotification.java
@@ -6,8 +6,19 @@ import org.robolectric.annotation.Implements;
 @Implements(GenerateNotification.class)
 public class ShadowGenerateNotification {
 
-   @Implementation
+    private static boolean runningOnMainThreadCheck = false;
+
+    @Implementation
     public static void isRunningOnMainThreadCheck() {
-      // Remove Main thread check and throw
+        // Remove Main thread check and throw
+        runningOnMainThreadCheck = true;
+    }
+
+    public static boolean isRunningOnMainThreadCheckCalled() {
+        return runningOnMainThreadCheck;
+    }
+
+    public static void resetStatics() {
+        runningOnMainThreadCheck = false;
     }
 }

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/TestHelpers.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/TestHelpers.java
@@ -32,6 +32,7 @@ import com.onesignal.ShadowDynamicTimer;
 import com.onesignal.ShadowFCMBroadcastReceiver;
 import com.onesignal.ShadowFirebaseAnalytics;
 import com.onesignal.ShadowFusedLocationApiWrapper;
+import com.onesignal.ShadowGenerateNotification;
 import com.onesignal.ShadowGoogleApiClientCompatProxy;
 import com.onesignal.ShadowHMSFusedLocationProviderClient;
 import com.onesignal.ShadowHmsInstanceId;
@@ -121,6 +122,7 @@ public class TestHelpers {
 
       ShadowOSUtils.resetStatics();
       ShadowTimeoutHandler.resetStatics();
+      ShadowGenerateNotification.resetStatics();
 
       lastException = null;
    }


### PR DESCRIPTION
  * If display() is not called on notificationProcessing under NotificationProcessingHandler service, notification should not display and the foreground handler should not be called.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1137)
<!-- Reviewable:end -->
