### PR TITLE
Set up NotificationProcessingHandler before remote params call

### DIFF
--- a/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/notification/AppNotificationExtensionService.java
+++ b/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/notification/AppNotificationExtensionService.java
@@ -16,6 +16,8 @@ public class AppNotificationExtensionService implements
 
    @Override
    public void notificationProcessing(Context context, OSNotificationReceived notification) {
+      OneSignal.onesignalLog(OneSignal.LOG_LEVEL.VERBOSE, "NotificationProcessingHandler fired!" +
+              " with OSNotificationReceived: " + notification.toString());
       if (notification.payload.actionButtons != null) {
          for (OSNotificationPayload.ActionButton button : notification.payload.actionButtons) {
             OneSignal.onesignalLog(OneSignal.LOG_LEVEL.VERBOSE, "ActionButton: " + button.toString());

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -649,7 +649,8 @@ public class OneSignal {
    }
 
    static void setNotificationProcessingHandler(NotificationProcessingHandler callback) {
-      notificationProcessingHandler = callback;
+      if (notificationProcessingHandler == null)
+         notificationProcessingHandler = callback;
    }
 
    public static void setNotificationWillShowInForegroundHandler(AppNotificationWillShowInForegroundHandler callback) {
@@ -671,6 +672,8 @@ public class OneSignal {
     * Called after setAppId and setAppContext, depending on which one is called last (order does not matter)
     */
    synchronized private static void init(Context context) {
+      OSNotificationExtender.setupNotificationExtensionServiceClass();
+
       if (requiresUserPrivacyConsent() || !remoteParamController.isRemoteParamsCallDone()) {
          if (!remoteParamController.isRemoteParamsCallDone())
             logger.verbose("OneSignal SDK initialization delayed, " +
@@ -701,8 +704,6 @@ public class OneSignal {
          logger.debug("OneSignal SDK initialization already completed.");
          return;
       }
-
-      OSNotificationExtender.setupNotificationExtensionServiceClass();
 
       handleActivityLifecycleHandler(context);
 


### PR DESCRIPTION
  * setupNotificationExtensionServiceClass method must be called even if remote params aren't called, in that way the user service callback is called
  * If privacy consent isn't granted then subscription shouldn't happen then notifications will not arrive, because of that it is safe to init service even if we don't have remote params or privacy consent

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1138)
<!-- Reviewable:end -->
