### PR TITLE
Fix IAM not being redisplay by session duration

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
@@ -430,7 +430,7 @@ class NotificationBundleProcessor {
          // If app is in focus display the IAMs preview now
          if (OneSignal.isAppActive()) {
             result.inAppPreviewShown = true;
-            OSInAppMessageController.getController().displayPreviewMessage(previewUUID);
+            OneSignal.getInAppMessageController().displayPreviewMessage(previewUUID);
          }
          // Return early, we don't want the extender service or etc. to fire for IAM previews
          return result;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationOpenedProcessor.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationOpenedProcessor.java
@@ -123,7 +123,7 @@ class NotificationOpenedProcessor {
          return false;
 
       OneSignal.startOrResumeApp(context);
-      OSInAppMessageController.getController().displayPreviewMessage(previewUUID);
+      OneSignal.getInAppMessageController().displayPreviewMessage(previewUUID);
       return true;
    }
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSDynamicTriggerController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSDynamicTriggerController.java
@@ -20,10 +20,9 @@ class OSDynamicTriggerController {
     private static final double REQUIRED_ACCURACY = 0.3;
     // Assume last time an In-App Message was displayed a very very long time ago.
     private static final long DEFAULT_LAST_IN_APP_TIME_AGO = 999_999;
+    private static Date sessionLaunchTime = new Date();
 
     private final ArrayList<String> scheduledMessages;
-
-    static Date sessionLaunchTime = new Date();
 
     OSDynamicTriggerController(OSDynamicTriggerControllerObserver triggerObserver) {
         scheduledMessages = new ArrayList<>();
@@ -45,9 +44,9 @@ class OSDynamicTriggerController {
                     currentTimeInterval = new Date().getTime() - sessionLaunchTime.getTime();
                     break;
                 case TIME_SINCE_LAST_IN_APP:
-                    if (OSInAppMessageController.getController().isInAppMessageShowing())
+                    if (OneSignal.getInAppMessageController().isInAppMessageShowing())
                         return false;
-                    Date lastTimeAppDismissed = OSInAppMessageController.getController().lastTimeInAppDismissed;
+                    Date lastTimeAppDismissed = OneSignal.getInAppMessageController().lastTimeInAppDismissed;
                     if (lastTimeAppDismissed == null)
                         currentTimeInterval = DEFAULT_LAST_IN_APP_TIME_AGO;
                     else
@@ -82,6 +81,11 @@ class OSDynamicTriggerController {
         }
 
         return false;
+    }
+
+
+    static void resetSessionLaunchTime() {
+        sessionLaunchTime = new Date();
     }
 
     private static boolean evaluateTimeIntervalWithOperator(double timeInterval, double currentTimeInterval, OSTriggerOperator operator) {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSDynamicTriggerTimer.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSDynamicTriggerTimer.java
@@ -7,6 +7,7 @@ import java.util.TimerTask;
 // that schedules the timer.
 class OSDynamicTriggerTimer {
     static void scheduleTrigger(TimerTask task, String triggerId, long delay) {
+        OneSignal.onesignalLog(OneSignal.LOG_LEVEL.DEBUG, "scheduleTrigger: " + triggerId + " delay: " + delay);
         Timer timer = new Timer("trigger_timer:" + triggerId);
         timer.schedule(task, delay);
     }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageController.java
@@ -69,23 +69,6 @@ class OSInAppMessageController implements OSDynamicTriggerControllerObserver, OS
     Date lastTimeInAppDismissed = null;
     private int htmlNetworkRequestAttemptCount = 0;
 
-    @Nullable
-    private static OSInAppMessageController sharedInstance;
-
-    public static synchronized OSInAppMessageController getController() {
-        OneSignalDbHelper dbHelper = OneSignal.getDBHelperInstance();
-
-        // Make sure only Android 4.4 devices and higher can use IAMs
-        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.JELLY_BEAN_MR2) {
-            sharedInstance = new OSInAppMessageDummyController(null);
-        }
-
-        if (sharedInstance == null)
-            sharedInstance = new OSInAppMessageController(dbHelper);
-
-        return sharedInstance;
-    }
-
     protected OSInAppMessageController(OneSignalDbHelper dbHelper) {
         messages = new ArrayList<>();
         dismissedMessages = OSUtils.newConcurrentSet();
@@ -134,6 +117,10 @@ class OSInAppMessageController implements OSDynamicTriggerControllerObserver, OS
         redisplayedInAppMessages = inAppMessageRepository.getCachedInAppMessages();
 
         OneSignal.Log(OneSignal.LOG_LEVEL.DEBUG, "redisplayedInAppMessages: " + redisplayedInAppMessages.toString());
+    }
+
+    void resetSessionLaunchTime() {
+        OSDynamicTriggerController.resetSessionLaunchTime();
     }
 
     // Normally we wait until on_session call to download the latest IAMs

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageController.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -65,7 +66,7 @@ class OSInAppMessageController implements OSDynamicTriggerControllerObserver, OS
     private boolean inAppMessageShowing = false;
 
     @Nullable
-    Date lastTimeInAppDismissed;
+    Date lastTimeInAppDismissed = null;
     private int htmlNetworkRequestAttemptCount = 0;
 
     @Nullable
@@ -185,6 +186,8 @@ class OSInAppMessageController implements OSDynamicTriggerControllerObserver, OS
         for (int i = 0; i < json.length(); i++) {
             JSONObject messageJson = json.getJSONObject(i);
             OSInAppMessage message = new OSInAppMessage(messageJson);
+
+            populateRedisplayMessageTriggers(message);
             newMessages.add(message);
         }
         messages = newMessages;
@@ -192,16 +195,30 @@ class OSInAppMessageController implements OSDynamicTriggerControllerObserver, OS
         evaluateInAppMessages();
     }
 
-    private void evaluateInAppMessages() {
-        for (OSInAppMessage message : messages) {
-            setDataForRedisplay(message);
-            if (!dismissedMessages.contains(message.messageId) && triggerController.evaluateMessageTriggers(message))
-                queueMessageForDisplay(message);
+    private void populateRedisplayMessageTriggers(OSInAppMessage message) {
+        int index = redisplayedInAppMessages.indexOf(message);
+        if (index > -1) {
+            OSInAppMessage redisplayMessage = redisplayedInAppMessages.get(index);
+            redisplayMessage.triggers = message.triggers;
         }
     }
 
-    private static @Nullable
-    String variantIdForMessage(@NonNull OSInAppMessage message) {
+    private void evaluateInAppMessages() {
+        OneSignal.Log(OneSignal.LOG_LEVEL.DEBUG, "Starting evaluateInAppMessages");
+
+        for (OSInAppMessage message : messages) {
+            // Make trigger evaluation first, dynamic trigger might change "trigger changed" flag value for redisplay messages
+            if (triggerController.evaluateMessageTriggers(message)) {
+                setDataForRedisplay(message);
+
+                if (!dismissedMessages.contains(message.messageId)) {
+                    queueMessageForDisplay(message);
+                }
+            }
+        }
+    }
+
+    private static @Nullable String variantIdForMessage(@NonNull OSInAppMessage message) {
         String languageIdentifier = OSUtils.getCorrectedLanguage();
 
         for (String variant : PREFERRED_VARIANT_ORDER) {
@@ -470,17 +487,20 @@ class OSInAppMessageController implements OSDynamicTriggerControllerObserver, OS
         int index = redisplayedInAppMessages.indexOf(message);
 
         if (messageDismissed && index != -1) {
-            OneSignal.onesignalLog(OneSignal.LOG_LEVEL.DEBUG, "setDataForRedisplay: " + message.messageId);
-
             OSInAppMessage savedIAM = redisplayedInAppMessages.get(index);
             message.getRedisplayStats().setDisplayStats(savedIAM.getRedisplayStats());
 
             // Message that don't have triggers should display only once per session
-            boolean triggerHasChanged = message.isTriggerChanged() || (!savedIAM.isDisplayedInSession() && message.triggers.isEmpty());
+            boolean triggerHasChanged = savedIAM.isTriggerChanged() || (!savedIAM.isDisplayedInSession() && message.triggers.isEmpty());
+
+            OneSignal.onesignalLog(OneSignal.LOG_LEVEL.DEBUG, "setDataForRedisplay: " + message.toString() + " triggerHasChanged: " + triggerHasChanged);
+
             // Check if conditions are correct for redisplay
             if (triggerHasChanged &&
                     message.getRedisplayStats().isDelayTimeSatisfied() &&
                     message.getRedisplayStats().shouldDisplayAgain()) {
+                OneSignal.onesignalLog(OneSignal.LOG_LEVEL.DEBUG, "setDataForRedisplay message available for redisplay: " + message.messageId);
+
                 dismissedMessages.remove(message.messageId);
                 impressionedMessages.remove(message.messageId);
                 message.clearClickIds();
@@ -721,8 +741,34 @@ class OSInAppMessageController implements OSDynamicTriggerControllerObserver, OS
         }, null);
     }
 
+    /**
+     * Part of redisplay logic
+     * <p>
+     * Will update redisplay messages depending on dynamic triggers before setDataForRedisplay is called.
+     * @see OSInAppMessageController#setDataForRedisplay(OSInAppMessage)
+     *
+     * We can't depend only on messageTriggerConditionChanged, due to trigger evaluation to true before scheduling
+     * @see OSInAppMessageController#messageTriggerConditionChanged()
+     */
+    @Override
+    public void messageDynamicTriggerCompleted(String triggerId) {
+        OneSignal.onesignalLog(OneSignal.LOG_LEVEL.DEBUG, "messageDynamicTriggerCompleted called with triggerId: " + triggerId);
+        Set<String> triggerIds = new HashSet<>();
+        triggerIds.add(triggerId);
+        makeRedisplayMessagesAvailableWithTriggers(triggerIds);
+    }
+
+    /**
+     * Dynamic trigger logic
+     * <p>
+     * This will re evaluate messages due to dynamic triggers evaluating to true potentially
+     *
+     * @see OSInAppMessageController#setDataForRedisplay(OSInAppMessage)
+     */
     @Override
     public void messageTriggerConditionChanged() {
+        OneSignal.onesignalLog(OneSignal.LOG_LEVEL.DEBUG, "messageTriggerConditionChanged called");
+
         // This method is called when a time-based trigger timer fires, meaning the message can
         //  probably be shown now. So the current message conditions should be re-evaluated
         evaluateInAppMessages();
@@ -747,9 +793,8 @@ class OSInAppMessageController implements OSDynamicTriggerControllerObserver, OS
      * - At least one Trigger has changed
      */
     private void makeRedisplayMessagesAvailableWithTriggers(Collection<String> newTriggersKeys) {
-        for (OSInAppMessage message : messages) {
-            if (redisplayedInAppMessages.contains(message) &&
-                    triggerController.isTriggerOnMessage(message, newTriggersKeys)) {
+        for (OSInAppMessage message : redisplayedInAppMessages) {
+            if (!message.isTriggerChanged() && triggerController.isTriggerOnMessage(message, newTriggersKeys)) {
                 message.setTriggerChanged(true);
             }
         }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageControllerFactory.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageControllerFactory.java
@@ -1,0 +1,52 @@
+/**
+ * Modified MIT License
+ * <p>
+ * Copyright 2020 OneSignal
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * <p>
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * <p>
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ * <p>
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.onesignal;
+
+import android.os.Build;
+
+class OSInAppMessageControllerFactory {
+
+    private static final Object LOCK = new Object();
+
+    private OSInAppMessageController controller;
+
+    public OSInAppMessageController getController(OneSignalDbHelper dbHelper) {
+        if (controller == null) {
+            synchronized (LOCK) {
+                if (controller == null) {
+                    // Make sure only Android 4.4 devices and higher can use IAMs
+                    if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.JELLY_BEAN_MR2)
+                        controller = new OSInAppMessageDummyController(null);
+                    else
+                        controller = new OSInAppMessageController(dbHelper);
+                }
+            }
+        }
+        return controller;
+    }
+}

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageRedisplayStats.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageRedisplayStats.java
@@ -83,13 +83,15 @@ class OSInAppMessageRedisplayStats {
     }
 
     boolean shouldDisplayAgain() {
-        return displayQuantity < displayLimit;
+        boolean result = displayQuantity < displayLimit;
+        OneSignal.Log(OneSignal.LOG_LEVEL.DEBUG, "OSInAppMessage shouldDisplayAgain: " + result);
+        return result;
     }
 
     boolean isDelayTimeSatisfied() {
-        if (lastDisplayTime < 0) {
+        if (lastDisplayTime < 0)
             return true;
-        }
+
         long currentTimeInSeconds = System.currentTimeMillis() / 1000;
         // Calculate gap between display times
         long diffInSeconds = currentTimeInSeconds - lastDisplayTime;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSTriggerController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSTriggerController.java
@@ -175,7 +175,9 @@ class OSTriggerController {
         for (String triggerKey : newTriggersKeys) {
             for (ArrayList<OSTrigger> andConditions : message.triggers) {
                 for (OSTrigger trigger : andConditions) {
-                    if (triggerKey.equals(trigger.property)) {
+                    // Dynamic triggers depends on triggerId
+                    // Common triggers changed by user depends on property
+                    if (triggerKey.equals(trigger.property) || triggerKey.equals(trigger.triggerId)) {
                         // At least one trigger has changed
                         return true;
                     }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalCacheCleaner.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalCacheCleaner.java
@@ -57,8 +57,8 @@ class OneSignalCacheCleaner {
             public void run() {
                 Thread.currentThread().setPriority(Process.THREAD_PRIORITY_BACKGROUND);
 
-                OSInAppMessageRepository inAppMessageRepository = OSInAppMessageController
-                        .getController()
+                OSInAppMessageRepository inAppMessageRepository = OneSignal
+                        .getInAppMessageController()
                         .getInAppMessageRepository(dbHelper);
                 inAppMessageRepository.cleanCachedInAppMessages();
             }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStateSynchronizer.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStateSynchronizer.java
@@ -396,7 +396,7 @@ abstract class UserStateSynchronizer {
 
                         // List of in app messages to evaluate for the session
                         if (jsonResponse.has(IN_APP_MESSAGES_JSON_KEY))
-                            OSInAppMessageController.getController().receivedInAppMessageJson(jsonResponse.getJSONArray(IN_APP_MESSAGES_JSON_KEY));
+                            OneSignal.getInAppMessageController().receivedInAppMessageJson(jsonResponse.getJSONArray(IN_APP_MESSAGES_JSON_KEY));
 
                         onSuccessfulSync(jsonBody);
                     } catch (JSONException e) {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/WebViewManager.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/WebViewManager.java
@@ -206,9 +206,9 @@ class WebViewManager extends ActivityLifecycleHandler.ActivityAvailableListener 
             JSONObject body = jsonObject.getJSONObject("body");
             String id = body.optString("id", null);
             if (message.isPreview) {
-                OSInAppMessageController.getController().onMessageActionOccurredOnPreview(message, body);
+                OneSignal.getInAppMessageController().onMessageActionOccurredOnPreview(message, body);
             } else if (id != null) {
-                OSInAppMessageController.getController().onMessageActionOccurredOnMessage(message, body);
+                OneSignal.getInAppMessageController().onMessageActionOccurredOnMessage(message, body);
             }
 
             boolean close = body.getBoolean("close");
@@ -347,12 +347,12 @@ class WebViewManager extends ActivityLifecycleHandler.ActivityAvailableListener 
             @Override
             public void onMessageWasShown() {
                 firstShow = false;
-                OSInAppMessageController.getController().onMessageWasShown(message);
+                OneSignal.getInAppMessageController().onMessageWasShown(message);
             }
 
             @Override
             public void onMessageWasDismissed() {
-                OSInAppMessageController.getController().messageWasDismissed(message);
+                OneSignal.getInAppMessageController().messageWasDismissed(message);
                 ActivityLifecycleHandler.removeActivityAvailableListener(TAG + message.messageId);
             }
         });

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/InAppMessagingHelpers.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/InAppMessagingHelpers.java
@@ -19,20 +19,20 @@ public class InAppMessagingHelpers {
     public static final String IAM_CLICK_ID = "12345678-1234-1234-1234-123456789012";
 
     public static boolean evaluateMessage(OSInAppMessage message) {
-        return OSInAppMessageController.getController().triggerController.evaluateMessageTriggers(message);
+        return OneSignal.getInAppMessageController().triggerController.evaluateMessageTriggers(message);
     }
 
     public static boolean dynamicTriggerShouldFire(OSTrigger trigger) {
-        return OSInAppMessageController.getController().triggerController.dynamicTriggerController.dynamicTriggerShouldFire(trigger);
+        return OneSignal.getInAppMessageController().triggerController.dynamicTriggerController.dynamicTriggerShouldFire(trigger);
     }
 
     public static void resetSessionLaunchTime() {
-        OSDynamicTriggerController.sessionLaunchTime = new Date();
+        OSDynamicTriggerController.resetSessionLaunchTime();
     }
 
     public static void clearTestState() {
         OneSignal.pauseInAppMessages(false);
-        OSInAppMessageController.getController().getInAppMessageDisplayQueue().clear();
+        OneSignal.getInAppMessageController().getInAppMessageDisplayQueue().clear();
     }
 
     // Convenience method that wraps an object in a JSON Array

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
@@ -441,33 +441,33 @@ public class OneSignalPackagePrivateHelper {
    }
 
    public static void dismissCurrentMessage() {
-      com.onesignal.OSInAppMessage message = com.onesignal.OSInAppMessageController.getController().getCurrentDisplayedInAppMessage();
+      com.onesignal.OSInAppMessage message = OneSignal.getInAppMessageController().getCurrentDisplayedInAppMessage();
       if (message != null)
-         com.onesignal.OSInAppMessageController.getController().messageWasDismissed(message);
+         OneSignal.getInAppMessageController().messageWasDismissed(message);
    }
 
    public static boolean isInAppMessageShowing() {
-      return com.onesignal.OSInAppMessageController.getController().isInAppMessageShowing();
+      return OneSignal.getInAppMessageController().isInAppMessageShowing();
    }
 
    public static String getShowingInAppMessageId() {
-      return com.onesignal.OSInAppMessageController.getController().getCurrentDisplayedInAppMessage().messageId;
+      return OneSignal.getInAppMessageController().getCurrentDisplayedInAppMessage().messageId;
    }
 
    public static ArrayList<com.onesignal.OSInAppMessage> getInAppMessageDisplayQueue() {
-      return com.onesignal.OSInAppMessageController.getController().getInAppMessageDisplayQueue();
+      return OneSignal.getInAppMessageController().getInAppMessageDisplayQueue();
    }
 
    public static void onMessageActionOccurredOnMessage(@NonNull final com.onesignal.OSInAppMessage message, @NonNull final JSONObject actionJson) throws JSONException {
-      com.onesignal.OSInAppMessageController.getController().onMessageActionOccurredOnMessage(message, actionJson);
+      OneSignal.getInAppMessageController().onMessageActionOccurredOnMessage(message, actionJson);
    }
 
    public static void onMessageWasShown(@NonNull com.onesignal.OSInAppMessage message) {
-      com.onesignal.OSInAppMessageController.getController().onMessageWasShown(message);
+      OneSignal.getInAppMessageController().onMessageWasShown(message);
    }
 
    public static List<OSTestInAppMessage> getRedisplayInAppMessages() {
-      List<OSInAppMessage> messages = com.onesignal.OSInAppMessageController.getController().getRedisplayedInAppMessages();
+      List<OSInAppMessage> messages = OneSignal.getInAppMessageController().getRedisplayedInAppMessages();
       List<OSTestInAppMessage> testMessages = new ArrayList<>();
 
       for (OSInAppMessage message : messages) {

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/StaticResetHelper.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/StaticResetHelper.java
@@ -23,6 +23,9 @@ public class StaticResetHelper {
             if (field.getName().equals("unprocessedOpenedNotifis")) {
                field.set(null, new ArrayList<JSONArray>());
                return true;
+            } else if (field.getName().equals("inAppMessageControllerFactory")) {
+               field.set(null, new OSInAppMessageControllerFactory());
+               return true;
             }
             return false;
          }


### PR DESCRIPTION
* Dynamic triggers weren't being scheduled on the second pass due to !dismissedMessages.contains(message.messageId) check being call before evaluateMessageTriggers, and this is not reset until setDataForRedisplay evaluates to true. If evaluateMessageTriggers is not called then dynamic triggers aren't scheduled
* Dynamic triggers weren't calling makeRedisplayMessagesAvailableWithTriggers, so no redisplay logic was being handled
* Add better debug logging

Improvements:

populateRedisplayMessagesTriggers, to avoid iterating over messages, iterate only over redisplay messages. Redisplay messages on the worst case will be O(n)

Use Cases:

Display IAM after the user is 30 seconds on the app every day.
Display IAM 5 seconds after last IAM, every day.

Warnings:

If the user has an IAM with session duration or last IAM with a short-timer period and short redisplay delay, this might end on IAM displaying multiple times in the same session.

Reset dynamic session launch time

* If the user puts the app on the background and opens the app after 30 seconds, on a new session, the session launch time was not being reset and due to that IAM with redisplay was being shown immediately.
* When a new session is started, reset session launch time. This will make IAM with session time trigger and redisplay work properly
* Refactor IAM Controller getController to avoid static reference

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1149)
<!-- Reviewable:end -->

