### PR TITLE
Fix equal trigger when using number

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSTriggerController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSTriggerController.java
@@ -5,6 +5,7 @@ import androidx.annotation.Nullable;
 
 import com.onesignal.OSDynamicTriggerController.OSDynamicTriggerControllerObserver;
 
+import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
@@ -116,8 +117,16 @@ class OSTriggerController {
             return false;
 
         // If operator is equal or not equals ignore type by comparing on toString values
-        if (operator.checksEquality())
-            return triggerMatchesStringValue(triggerValue.toString(), deviceValue.toString(), operator);
+        if (operator.checksEquality()) {
+            String triggerValueString = triggerValue.toString();
+            String deviceValueString = deviceValue.toString();
+            if (deviceValue instanceof Number) {
+                // User may have an input text that converts 5 to 5.0, we only care about the raw value on equals
+                DecimalFormat format = new DecimalFormat("0.#");
+                deviceValueString = format.format(deviceValue);
+            }
+            return triggerMatchesStringValue(triggerValueString, deviceValueString, operator);
+        }
 
         if (deviceValue instanceof String &&
             triggerValue instanceof Number)

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/InAppMessageIntegrationTests.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/InAppMessageIntegrationTests.java
@@ -66,6 +66,7 @@ import static com.onesignal.OneSignalPackagePrivateHelper.OneSignal_setSessionMa
 import static com.onesignal.OneSignalPackagePrivateHelper.OneSignal_setSharedPreferences;
 import static com.onesignal.OneSignalPackagePrivateHelper.OneSignal_setTime;
 import static com.onesignal.OneSignalPackagePrivateHelper.OneSignal_setTrackerFactory;
+import static com.onesignal.OneSignalPackagePrivateHelper.dismissCurrentMessage;
 import static com.onesignal.ShadowOneSignalRestClient.setRemoteParamsGetHtmlResponse;
 import static com.test.onesignal.RestClientAsserts.assertMeasureOnV2AtIndex;
 import static com.test.onesignal.TestHelpers.assertMainThread;
@@ -396,6 +397,55 @@ public class InAppMessageIntegrationTests {
         // the message should now have been displayed
         assertEquals(1, OneSignalPackagePrivateHelper.getInAppMessageDisplayQueue().size());
         assertFalse(ShadowDynamicTimer.hasScheduledTimer);
+    }
+
+    @Test
+    public void testMessageDisplayedAfterAddTriggerEqualWithStringVsNumber() throws Exception {
+        // Set IAM with EQUAL trigger with number value as string
+        final OSTestInAppMessage message =
+                InAppMessagingHelpers.buildTestMessageWithSingleTrigger(OSTriggerKind.CUSTOM, "test", OSTestTrigger.OSTriggerOperator.EQUAL_TO.toString(), "5");
+
+        setMockRegistrationResponseWithMessages(new ArrayList<OSTestInAppMessage>() {{
+            add(message);
+        }});
+
+        OneSignalInit();
+        threadAndTaskWait();
+
+        assertEquals(0, OneSignalPackagePrivateHelper.getInAppMessageDisplayQueue().size());
+
+        // after setting this trigger the message should be displayed immediately
+        OneSignal.addTrigger("test", 5.0);
+        threadAndTaskWait();
+
+        // the message should now have been displayed
+        assertEquals(1, OneSignalPackagePrivateHelper.getInAppMessageDisplayQueue().size());
+        dismissCurrentMessage();
+    }
+
+
+    @Test
+    public void testMessageDisplayedAfterAddTriggerEqualWithStringVsNumberFloat() throws Exception {
+        // Set IAM with EQUAL trigger with number value as string
+        final OSTestInAppMessage message =
+                InAppMessagingHelpers.buildTestMessageWithSingleTrigger(OSTriggerKind.CUSTOM, "test", OSTestTrigger.OSTriggerOperator.EQUAL_TO.toString(), "5.5");
+
+        setMockRegistrationResponseWithMessages(new ArrayList<OSTestInAppMessage>() {{
+            add(message);
+        }});
+
+        OneSignalInit();
+        threadAndTaskWait();
+
+        assertEquals(0, OneSignalPackagePrivateHelper.getInAppMessageDisplayQueue().size());
+
+        // after setting this trigger the message should be displayed immediately
+        OneSignal.addTrigger("test", 5.50);
+        threadAndTaskWait();
+
+        // the message should now have been displayed
+        assertEquals(1, OneSignalPackagePrivateHelper.getInAppMessageDisplayQueue().size());
+        dismissCurrentMessage();
     }
 
     @Test


### PR DESCRIPTION
* Trim ceros for string equal matching

Use case:

Is user value is coming from an edit text that always returns a double. If the user puts 1, edit text if configure with decimals the result will be 1.0 , then equals between "1.0" and "1" won't match

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1150)
<!-- Reviewable:end -->

