### PR TITLE
Fix foreground check when calling initWithContext with Activity

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/ActivityLifecycleListener.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/ActivityLifecycleListener.java
@@ -27,18 +27,24 @@
 
 package com.onesignal;
 
+import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.Application;
 import android.content.ComponentCallbacks;
 import android.content.res.Configuration;
 import android.os.Bundle;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 class ActivityLifecycleListener implements Application.ActivityLifecycleCallbacks {
 
    @Nullable private static ActivityLifecycleListener instance;
+   @SuppressLint("StaticFieldLeak")
+   @Nullable
+   private static ActivityLifecycleHandler activityLifecycleHandler;
    @Nullable private static ComponentCallbacks configuration;
+
    static void registerActivityLifecycleCallbacks(@NonNull final Application application) {
       // Activity lifecycle listener setup
       if (instance == null) {
@@ -46,12 +52,16 @@ class ActivityLifecycleListener implements Application.ActivityLifecycleCallback
          application.registerActivityLifecycleCallbacks(instance);
       }
 
+      if (activityLifecycleHandler == null) {
+         activityLifecycleHandler = new ActivityLifecycleHandler();
+      }
+
       // Configuration change listener setup
       if (configuration == null) {
          configuration = new ComponentCallbacks() {
             @Override
             public void onConfigurationChanged(Configuration newConfig) {
-               ActivityLifecycleHandler.onConfigurationChanged(newConfig);
+               activityLifecycleHandler.onConfigurationChanged(newConfig);
             }
 
             @Override
@@ -65,34 +75,46 @@ class ActivityLifecycleListener implements Application.ActivityLifecycleCallback
 
    @Override
    public void onActivityCreated(Activity activity, Bundle savedInstanceState) {
-      ActivityLifecycleHandler.onActivityCreated(activity);
+      if (activityLifecycleHandler != null)
+         activityLifecycleHandler.onActivityCreated(activity);
    }
 
    @Override
    public void onActivityStarted(Activity activity) {
-      ActivityLifecycleHandler.onActivityStarted(activity);
+      if (activityLifecycleHandler != null)
+         activityLifecycleHandler.onActivityStarted(activity);
    }
 
    @Override
    public void onActivityResumed(Activity activity) {
-      ActivityLifecycleHandler.onActivityResumed(activity);
+      if (activityLifecycleHandler != null)
+         activityLifecycleHandler.onActivityResumed(activity);
    }
 
    @Override
    public void onActivityPaused(Activity activity) {
-      ActivityLifecycleHandler.onActivityPaused(activity);
+      if (activityLifecycleHandler != null)
+         activityLifecycleHandler.onActivityPaused(activity);
    }
 
    @Override
    public void onActivityStopped(Activity activity) {
-      ActivityLifecycleHandler.onActivityStopped(activity);
+      if (activityLifecycleHandler != null)
+         activityLifecycleHandler.onActivityStopped(activity);
    }
 
    @Override
-   public void onActivitySaveInstanceState(Activity activity, Bundle outState) {}
+   public void onActivitySaveInstanceState(Activity activity, Bundle outState) {
+   }
 
    @Override
    public void onActivityDestroyed(Activity activity) {
-      ActivityLifecycleHandler.onActivityDestroyed(activity);
+      if (activityLifecycleHandler != null)
+         activityLifecycleHandler.onActivityDestroyed(activity);
+   }
+
+   @Nullable
+   public static ActivityLifecycleHandler getActivityLifecycleHandler() {
+      return activityLifecycleHandler;
    }
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/GooglePlayServicesUpgradePrompt.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/GooglePlayServicesUpgradePrompt.java
@@ -43,7 +43,7 @@ class GooglePlayServicesUpgradePrompt {
       OSUtils.runOnMainUIThread(new Runnable() {
          @Override
          public void run() {
-            final Activity activity = ActivityLifecycleHandler.curActivity;
+            final Activity activity = OneSignal.getCurrentActivity();
             if (activity == null)
                return;
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageController.java
@@ -349,7 +349,7 @@ class OSInAppMessageController implements OSDynamicTriggerControllerObserver, OS
     private void showAlertDialogMessage(final OSInAppMessage inAppMessage, final List<OSInAppMessagePrompt> prompts) {
         final String messageTitle = OneSignal.appContext.getString(R.string.location_not_available_title);
         final String message = OneSignal.appContext.getString(R.string.location_not_available_message);
-        new AlertDialog.Builder(ActivityLifecycleHandler.curActivity)
+        new AlertDialog.Builder(OneSignal.getCurrentActivity())
                 .setTitle(messageTitle)
                 .setMessage(message)
                 .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSSystemConditionController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSSystemConditionController.java
@@ -18,6 +18,10 @@ class OSSystemConditionController {
         void systemConditionChanged();
     }
 
+    interface OSSystemConditionHandler {
+        void removeSystemConditionObserver(@NonNull String key, @NonNull ActivityLifecycleHandler.KeyboardListener listener);
+    }
+
     private static final String TAG = OSSystemConditionController.class.getCanonicalName();
     private final OSSystemConditionObserver systemConditionObserver;
 
@@ -26,13 +30,13 @@ class OSSystemConditionController {
     }
 
     boolean systemConditionsAvailable() {
-        if (ActivityLifecycleHandler.curActivity == null) {
+        if (OneSignal.getCurrentActivity() == null) {
             OneSignal.onesignalLog(OneSignal.LOG_LEVEL.WARN, "OSSystemConditionObserver curActivity null");
             return false;
         }
 
         try {
-            if (isDialogFragmentShowing(ActivityLifecycleHandler.curActivity)) {
+            if (isDialogFragmentShowing(OneSignal.getCurrentActivity())) {
                 OneSignal.onesignalLog(OneSignal.LOG_LEVEL.WARN, "OSSystemConditionObserver dialog fragment detected");
                 return false;
             }
@@ -40,9 +44,11 @@ class OSSystemConditionController {
             OneSignal.onesignalLog(OneSignal.LOG_LEVEL.INFO, "AppCompatActivity is not used in this app, skipping 'isDialogFragmentShowing' check: " + exception);
         }
 
-        boolean keyboardUp = OSViewUtils.isKeyboardUp(new WeakReference<>(ActivityLifecycleHandler.curActivity));
-        if (keyboardUp) {
-            ActivityLifecycleHandler.setSystemConditionObserver(TAG, systemConditionObserver);
+        ActivityLifecycleHandler activityLifecycleHandler = ActivityLifecycleListener.getActivityLifecycleHandler();
+        boolean keyboardUp = OSViewUtils.isKeyboardUp(new WeakReference<>(OneSignal.getCurrentActivity()));
+
+        if (keyboardUp && activityLifecycleHandler != null) {
+            activityLifecycleHandler.addSystemConditionObserver(TAG, systemConditionObserver);
             OneSignal.onesignalLog(OneSignal.LOG_LEVEL.WARN, "OSSystemConditionObserver keyboard up detected");
         }
         return !keyboardUp;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSViewUtils.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSViewUtils.java
@@ -52,16 +52,19 @@ class OSViewUtils {
         activity.getWindow().getDecorView().post(new Runnable() {
             @Override
             public void run() {
-                ActivityLifecycleHandler.setActivityAvailableListener(listenerKey, new ActivityLifecycleHandler.ActivityAvailableListener() {
-                    @Override
-                    void available(@NonNull Activity currentActivity) {
-                        ActivityLifecycleHandler.removeActivityAvailableListener(listenerKey);
-                        if (isActivityFullyReady(currentActivity))
-                            runnable.run();
-                        else
-                            decorViewReady(currentActivity, runnable);
-                    }
-                });
+                final ActivityLifecycleHandler activityLifecycleHandler = ActivityLifecycleListener.getActivityLifecycleHandler();
+                if (activityLifecycleHandler!= null) {
+                    activityLifecycleHandler.addActivityAvailableListener(listenerKey, new ActivityLifecycleHandler.ActivityAvailableListener() {
+                        @Override
+                        void available(@NonNull Activity currentActivity) {
+                            activityLifecycleHandler.removeActivityAvailableListener(listenerKey);
+                            if (isActivityFullyReady(currentActivity))
+                                runnable.run();
+                            else
+                                decorViewReady(currentActivity, runnable);
+                        }
+                    });
+                }
             }
         });
     }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -811,9 +811,8 @@ public class OneSignal {
    }
 
    private static void handleActivityLifecycleHandler(Context context) {
-      inForeground = isContextActivity(context);
+      inForeground = ActivityLifecycleHandler.curActivity != null;
       if (inForeground) {
-         ActivityLifecycleHandler.curActivity = (Activity) context;
          OSNotificationRestoreWorkManager.beginEnqueueingWork(context, false);
          FocusTimeController.getInstance().appForegrounded();
       }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -322,6 +322,12 @@ public class OneSignal {
    static String appId;
    static String googleProjectNumber;
 
+   @Nullable
+   static Activity getCurrentActivity() {
+      ActivityLifecycleHandler activityLifecycleHandler = ActivityLifecycleListener.getActivityLifecycleHandler();
+      return activityLifecycleHandler != null ? activityLifecycleHandler.getCurActivity() : null;
+   }
+
    private static LOG_LEVEL visualLogLevel = LOG_LEVEL.NONE;
    private static LOG_LEVEL logCatLevel = LOG_LEVEL.WARN;
 
@@ -811,13 +817,16 @@ public class OneSignal {
    }
 
    private static void handleActivityLifecycleHandler(Context context) {
-      inForeground = ActivityLifecycleHandler.curActivity != null;
+      ActivityLifecycleHandler activityLifecycleHandler = ActivityLifecycleListener.getActivityLifecycleHandler();
+      inForeground = OneSignal.getCurrentActivity() != null;
+      logger.debug("OneSignal handleActivityLifecycleHandler inForeground: " + inForeground);
+
       if (inForeground) {
          OSNotificationRestoreWorkManager.beginEnqueueingWork(context, false);
          FocusTimeController.getInstance().appForegrounded();
+      } else if (activityLifecycleHandler != null) {
+         activityLifecycleHandler.setNextResumeIsFirstActivity(true);
       }
-      else
-         ActivityLifecycleHandler.nextResumeIsFirstActivity = true;
    }
 
    private static void handleAmazonPurchase() {
@@ -1124,7 +1133,7 @@ public class OneSignal {
             Log.e(TAG, message, throwable);
       }
 
-      if (level.compareTo(visualLogLevel) < 1 && ActivityLifecycleHandler.curActivity != null) {
+      if (level.compareTo(visualLogLevel) < 1 && OneSignal.getCurrentActivity() != null) {
          try {
             String fullMessage = message + "\n";
             if (throwable != null) {
@@ -1139,8 +1148,8 @@ public class OneSignal {
             OSUtils.runOnMainUIThread(new Runnable() {
                @Override
                public void run() {
-                  if (ActivityLifecycleHandler.curActivity != null)
-                     new AlertDialog.Builder(ActivityLifecycleHandler.curActivity)
+                  if (OneSignal.getCurrentActivity() != null)
+                     new AlertDialog.Builder(OneSignal.getCurrentActivity())
                          .setTitle(level.toString())
                          .setMessage(finalFullMessage)
                          .show();

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/PermissionsActivity.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/PermissionsActivity.java
@@ -119,7 +119,9 @@ public class PermissionsActivity extends Activity {
             }
          }, DELAY_TIME_CALLBACK_CALL);
       }
-      ActivityLifecycleHandler.removeActivityAvailableListener(TAG);
+      ActivityLifecycleHandler activityLifecycleHandler = ActivityLifecycleListener.getActivityLifecycleHandler();
+      if (activityLifecycleHandler != null)
+         activityLifecycleHandler.removeActivityAvailableListener(TAG);
       finish();
       overridePendingTransition(R.anim.onesignal_fade_in, R.anim.onesignal_fade_out);
    }
@@ -132,7 +134,7 @@ public class PermissionsActivity extends Activity {
    }
 
    private void showLocationPermissionSettings() {
-      new AlertDialog.Builder(ActivityLifecycleHandler.curActivity)
+      new AlertDialog.Builder(OneSignal.getCurrentActivity())
               .setTitle(R.string.location_not_available_title)
               .setMessage(R.string.location_not_available_open_settings_message)
               .setPositiveButton(R.string.location_not_available_open_settings_option, new DialogInterface.OnClickListener() {
@@ -169,6 +171,8 @@ public class PermissionsActivity extends Activity {
          }
       };
 
-      ActivityLifecycleHandler.setActivityAvailableListener(TAG, activityAvailableListener);
+      ActivityLifecycleHandler activityLifecycleHandler = ActivityLifecycleListener.getActivityLifecycleHandler();
+      if (activityLifecycleHandler != null)
+         activityLifecycleHandler.addActivityAvailableListener(TAG, activityAvailableListener);
    }
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/WebViewManager.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/WebViewManager.java
@@ -83,7 +83,7 @@ class WebViewManager extends ActivityLifecycleHandler.ActivityAvailableListener 
      * @param htmlStr the html to display on the WebView
      */
     static void showHTMLString(@NonNull final OSInAppMessage message, @NonNull final String htmlStr) {
-        final Activity currentActivity = ActivityLifecycleHandler.curActivity;
+        final Activity currentActivity = OneSignal.getCurrentActivity();
         /* IMPORTANT
          * This is the starting route for grabbing the current Activity and passing it to InAppMessageView */
         if (currentActivity != null) {
@@ -339,6 +339,7 @@ class WebViewManager extends ActivityLifecycleHandler.ActivityAvailableListener 
     }
 
     private void createNewInAppMessageView(@NonNull Position displayLocation, int pageHeight) {
+        final ActivityLifecycleHandler activityLifecycleHandler = ActivityLifecycleListener.getActivityLifecycleHandler();
         messageView = new InAppMessageView(webView, displayLocation, pageHeight, message.getDisplayDuration());
         messageView.setMessageController(new InAppMessageView.InAppMessageViewListener() {
             @Override
@@ -350,12 +351,14 @@ class WebViewManager extends ActivityLifecycleHandler.ActivityAvailableListener 
             @Override
             public void onMessageWasDismissed() {
                 OSInAppMessageController.getController(OneSignal.getLogger()).messageWasDismissed(message);
-                ActivityLifecycleHandler.removeActivityAvailableListener(TAG + message.messageId);
+                if (activityLifecycleHandler != null)
+                    activityLifecycleHandler.removeActivityAvailableListener(TAG + message.messageId);
             }
         });
 
         // Fires event if available, which will call messageView.showInAppMessageView() for us.
-        ActivityLifecycleHandler.setActivityAvailableListener(TAG + message.messageId, this);
+        if (activityLifecycleHandler != null)
+            activityLifecycleHandler.addActivityAvailableListener(TAG + message.messageId, this);
     }
 
     // Allow Chrome Remote Debugging if OneSignal.LOG_LEVEL.DEBUG or higher

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
@@ -71,7 +71,8 @@ public class OneSignalPackagePrivateHelper {
    }
 
    public static boolean runFocusRunnables() throws Exception {
-      Looper looper = ActivityLifecycleHandler.focusHandlerThread.getHandlerLooper();
+      ActivityLifecycleHandler activityLifecycleHandler = ActivityLifecycleListener.getActivityLifecycleHandler();
+      Looper looper = activityLifecycleHandler != null ? activityLifecycleHandler.getFocusHandlerThread().getHandlerLooper() : null;
       if (looper == null)
          return false;
 

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
@@ -273,6 +273,10 @@ public class OneSignalPackagePrivateHelper {
       return OneSignal.appId;
    }
 
+   public static boolean OneSignal_isInForeground() {
+      return OneSignal.isInForeground();
+   }
+
    static public class OSSharedPreferencesWrapper extends com.onesignal.OSSharedPreferencesWrapper {}
 
    static public class RemoteOutcomeParams extends OneSignalRemoteParams.InfluenceParams {

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/StaticResetHelper.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/StaticResetHelper.java
@@ -2,6 +2,8 @@
 
 package com.onesignal;
 
+import android.util.Log;
+
 import org.json.JSONArray;
 
 import java.lang.reflect.Field;
@@ -11,38 +13,34 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class StaticResetHelper {
 
    private static Collection<ClassState> classes = new ArrayList<>();
 
    public static void load() {
-      classes.add(new ClassState(OneSignal.class, new OtherFieldHandler() {
-         @Override
-         public boolean onOtherField(Field field) throws Exception {
-            if (field.getName().equals("unprocessedOpenedNotifis")) {
-               field.set(null, new ArrayList<JSONArray>());
-               return true;
-            } else if (field.getName().equals("remoteParamController")) {
-               field.set(null, new OSRemoteParamController());
-               return true;
-            } else if (field.getName().equals("taskController")) {
-               field.set(null, new OSTaskController(OneSignal.getRemoteParamController(), new OSLogWrapper()));
-               return true;
-            }
-            return false;
+      classes.add(new ClassState(OneSignal.class, field -> {
+         if (field.getName().equals("unprocessedOpenedNotifis")) {
+            field.set(null, new ArrayList<JSONArray>());
+            return true;
+         } else if (field.getName().equals("remoteParamController")) {
+            field.set(null, new OSRemoteParamController());
+            return true;
+         } else if (field.getName().equals("taskController")) {
+            field.set(null, new OSTaskController(OneSignal.getRemoteParamController(), new OSLogWrapper()));
+            return true;
          }
+         return false;
       }));
 
-      classes.add(new ClassState(OneSignalStateSynchronizer.class, new OtherFieldHandler() {
-         @Override
-         public boolean onOtherField(Field field) throws Exception {
-            if (field.getName().equals("userStatePushSynchronizer") || field.getName().equals("userStateEmailSynchronizer")) {
-               field.set(null, null);
-               return true;
-            }
-            return false;
+      classes.add(new ClassState(OneSignalStateSynchronizer.class, field
+              -> {
+         if (field.getName().equals("userStatePushSynchronizer") || field.getName().equals("userStateEmailSynchronizer")) {
+            field.set(null, null);
+            return true;
          }
+         return false;
       }));
       
       classes.add(new ClassState(OneSignalChromeTabAndroidFrame.class, null));
@@ -50,15 +48,12 @@ public class StaticResetHelper {
       classes.add(new ClassState(LocationController.class, null));
       classes.add(new ClassState(OSInAppMessageController.class, null));
       classes.add(new ClassState(ActivityLifecycleListener.class, null));
-      classes.add(new ClassState(OSDynamicTriggerController.class, new OtherFieldHandler() {
-         @Override
-         public boolean onOtherField(Field field) throws Exception {
-            if (field.getName().equals("sessionLaunchTime")) {
-               field.set(null, new Date());
-               return true;
-            }
-            return false;
+      classes.add(new ClassState(OSDynamicTriggerController.class, field -> {
+         if (field.getName().equals("sessionLaunchTime")) {
+            field.set(null, new Date());
+            return true;
          }
+         return false;
       }));
       classes.add(new ClassState(FocusTimeController.class, null));
       classes.add(new ClassState(OSSessionManager.class, null));

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
@@ -4863,7 +4863,7 @@ public class MainOneSignalClassRunner {
    }
 
    private void OneSignalInit() {
-      OneSignal.setLogLevel(OneSignal.LOG_LEVEL.DEBUG, OneSignal.LOG_LEVEL.NONE);
+      OneSignal.setLogLevel(OneSignal.LOG_LEVEL.VERBOSE, OneSignal.LOG_LEVEL.NONE);
       ShadowOSUtils.subscribableStatus = 1;
       OneSignal_setTime(time);
       OneSignal_setTrackerFactory(trackerFactory);

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
@@ -134,6 +134,7 @@ import static com.onesignal.OneSignalPackagePrivateHelper.FCMBroadcastReceiver_p
 import static com.onesignal.OneSignalPackagePrivateHelper.NotificationBundleProcessor_Process;
 import static com.onesignal.OneSignalPackagePrivateHelper.NotificationOpenedProcessor_processFromContext;
 import static com.onesignal.OneSignalPackagePrivateHelper.OneSignal_getSessionListener;
+import static com.onesignal.OneSignalPackagePrivateHelper.OneSignal_isInForeground;
 import static com.onesignal.OneSignalPackagePrivateHelper.OneSignal_setSessionManager;
 import static com.onesignal.OneSignalPackagePrivateHelper.OneSignal_setTime;
 import static com.onesignal.OneSignalPackagePrivateHelper.OneSignal_setTrackerFactory;
@@ -800,6 +801,46 @@ public class MainOneSignalClassRunner {
       assertRemoteParamsAtIndex(0);
       assertPlayerCreatePushAtIndex(1);
       assertRestCalls(2);
+   }
+
+   @Test
+   public void testInitWithContext_Activity() throws Exception {
+      OneSignal.setLogLevel(OneSignal.LOG_LEVEL.VERBOSE, OneSignal.LOG_LEVEL.NONE);
+      ShadowOSUtils.subscribableStatus = 1;
+
+      OneSignal.initWithContext(blankActivity);
+      OneSignal.setAppId(ONESIGNAL_APP_ID);
+      blankActivityController.resume();
+      threadAndTaskWait();
+
+      assertTrue(OneSignal_isInForeground());
+   }
+
+   @Test
+   public void testInitWithContext_ActivityResumedBeforeInit() throws Exception {
+      OneSignal.setLogLevel(OneSignal.LOG_LEVEL.VERBOSE, OneSignal.LOG_LEVEL.NONE);
+      ShadowOSUtils.subscribableStatus = 1;
+
+      OneSignal.initWithContext(blankActivity);
+      blankActivityController.resume();
+
+      OneSignal.setAppId(ONESIGNAL_APP_ID);
+      threadAndTaskWait();
+
+      assertTrue(OneSignal_isInForeground());
+   }
+
+   @Test
+   public void testInitWithContext_Application() throws Exception {
+      OneSignal.setLogLevel(OneSignal.LOG_LEVEL.DEBUG, OneSignal.LOG_LEVEL.NONE);
+      ShadowOSUtils.subscribableStatus = 1;
+
+      OneSignal.initWithContext(blankActivity.getApplicationContext());
+      OneSignal.setAppId(ONESIGNAL_APP_ID);
+      blankActivityController.resume();
+      threadAndTaskWait();
+
+      assertTrue(OneSignal_isInForeground());
    }
 
    @Test

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/NotificationOpenedActivityHMSIntegrationTestsRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/NotificationOpenedActivityHMSIntegrationTestsRunner.java
@@ -45,6 +45,7 @@ import static com.test.onesignal.RestClientAsserts.assertNotificationOpenAtIndex
 import static com.test.onesignal.TestHelpers.fastColdRestartApp;
 import static com.test.onesignal.TestHelpers.threadAndTaskWait;
 import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNotNull;
 import static org.robolectric.Shadows.shadowOf;
 
 @Config(
@@ -142,6 +143,7 @@ public class NotificationOpenedActivityHMSIntegrationTestsRunner {
         helper_initSDKAndFireHMSNotificationBarebonesOSOpenIntent();
 
         Intent startedActivity = shadowOf((Application) ApplicationProvider.getApplicationContext()).getNextStartedActivity();
+        assertNotNull(startedActivity);
         assertEquals(startedActivity.getComponent().getClassName(), BlankActivity.class.getName());
     }
 

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/TestHelpers.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/TestHelpers.java
@@ -245,7 +245,7 @@ public class TestHelpers {
       stopAllOSThreads();
       flushBufferedSharedPrefs();
       StaticResetHelper.restSetStaticFields();
-      Log.d(TAG, "fastColdRestartApp finished");
+      Log.d(TAG, "************ FAST COLD RESTART FINISHED! ************");
    }
 
    static void restartAppAndElapseTimeToNextSession(MockOSTimeImpl time) throws Exception {
@@ -253,7 +253,7 @@ public class TestHelpers {
       flushBufferedSharedPrefs();
       StaticResetHelper.restSetStaticFields();
       time.advanceSystemAndElapsedTimeBy(31);
-      Log.d(TAG, "restartAppAndElapseTimeToNextSession finished");
+      Log.d(TAG, "************ restartAppAndElapseTimeToNextSession finished ************");
    }
 
    static ArrayList<HashMap<String, Object>> getAllNotificationRecords(OneSignalDb db) {


### PR DESCRIPTION
* Since appContext is always init with Application Context, handleActivityLifecycleHandler is neveer initializing inForeground
* Check for Activity lifecycle activity for foreground status

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1151)
<!-- Reviewable:end -->

