### PR TITLE
Custom base url support added

### DIFF
--- a/OneSignalSDK/app/src/main/AndroidManifest.xml
+++ b/OneSignalSDK/app/src/main/AndroidManifest.xml
@@ -67,6 +67,7 @@
         <activity
             android:name=".BlankActivity"
             android:label="OneSignal Example"
+            android:exported="true"
             >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/OneSignalSDK/onesignal/src/debug/AndroidManifest.xml
+++ b/OneSignalSDK/onesignal/src/debug/AndroidManifest.xml
@@ -13,7 +13,8 @@
 
         <receiver
             android:name="com.onesignal.GcmBroadcastReceiver"
-            android:permission="com.google.android.c2dm.permission.SEND" >
+            android:permission="com.google.android.c2dm.permission.SEND"
+            android:exported="true" >
             <!-- High priority so OneSignal payloads can be filtered from other GCM receivers if filterOtherGCMReceivers is enabled. -->
             <intent-filter android:priority="999" >
                 <action android:name="com.google.android.c2dm.intent.RECEIVE" />

--- a/OneSignalSDK/onesignal/src/main/AndroidManifest.xml
+++ b/OneSignalSDK/onesignal/src/main/AndroidManifest.xml
@@ -72,7 +72,8 @@
         </service>
         
         <activity android:name="com.onesignal.NotificationOpenedActivityHMS"
-                  android:theme="@android:style/Theme.Translucent.NoTitleBar">
+                  android:theme="@android:style/Theme.Translucent.NoTitleBar"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
             </intent-filter>
@@ -98,13 +99,13 @@
 
         <service android:name="com.onesignal.NotificationRestoreService" />
 
-        <receiver android:name="com.onesignal.BootUpReceiver">
+        <receiver android:name="com.onesignal.BootUpReceiver" android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
                 <action android:name="android.intent.action.QUICKBOOT_POWERON" />
             </intent-filter>
         </receiver>
-        <receiver android:name="com.onesignal.UpgradeReceiver" >
+        <receiver android:name="com.onesignal.UpgradeReceiver" android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
             </intent-filter>

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -699,6 +699,11 @@ public class OneSignal {
    }
 
    public static void init(Context context, String googleProjectNumber, String oneSignalAppId, NotificationOpenedHandler notificationOpenedHandler, NotificationReceivedHandler notificationReceivedHandler) {
+      init(context, googleProjectNumber, oneSignalAppId, null, notificationOpenedHandler, null);
+   }
+
+   public static void init(Context context, String googleProjectNumber, String oneSignalAppId, String baseUrl, NotificationOpenedHandler notificationOpenedHandler, NotificationReceivedHandler notificationReceivedHandler) {
+      OneSignalRestClient.updateBaseURL(baseUrl);
       mInitBuilder = createInitBuilder(notificationOpenedHandler, notificationReceivedHandler);
       OneSignal.setAppContext(context);
       setupPrivacyConsent(context);

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalRestClient.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalRestClient.java
@@ -52,11 +52,15 @@ class OneSignalRestClient {
 
    private static final String OS_API_VERSION = "1";
    private static final String OS_ACCEPT_HEADER = "application/vnd.onesignal.v" + OS_API_VERSION + "+json";
-   private static final String BASE_URL = "https://api.onesignal.com/";
+   private static String BASE_URL = "https://api.onesignal.com/";
    
    private static final int THREAD_ID = 10000;
    private static final int TIMEOUT = 120_000;
    private static final int GET_TIMEOUT = 60_000;
+
+   public static void updateBaseURL(String baseUrl){
+      if(baseUrl != null) BASE_URL = baseUrl + (baseUrl.endsWith("/") ? "" : "/");
+   }
    
    private static int getThreadTimeout(int timeout) {
       return timeout + 5_000;

--- a/OneSignalSDK/onesignal/src/release/AndroidManifest.xml
+++ b/OneSignalSDK/onesignal/src/release/AndroidManifest.xml
@@ -11,7 +11,8 @@
 
         <receiver
             android:name="com.onesignal.GcmBroadcastReceiver"
-            android:permission="com.google.android.c2dm.permission.SEND" >
+            android:permission="com.google.android.c2dm.permission.SEND"
+            android:exported="true" >
             <!-- High priority so OneSignal payloads can be filtered from other GCM receivers if filterOtherGCMReceivers is enabled. -->
             <intent-filter android:priority="999" >
                 <action android:name="com.google.android.c2dm.intent.RECEIVE" />


### PR DESCRIPTION
This is a feature request to allow developers to opt in to use a proxy server as OneSignal api base url. It happen that OneSignal domains are blocked in some countries and by some ISPs… so I think this could be a good way to allow devs to use OneSignal.

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1152)
<!-- Reviewable:end -->

