### PR TITLE
Fix setRequiresUserPrivacyConsent race condition

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -1012,19 +1012,6 @@ public class OneSignal {
     * This method will be replaced by remote params set
     */
    public static void setRequiresUserPrivacyConsent(final boolean required) {
-      if (taskController.shouldQueueTaskForInit(OSTaskController.SET_REQUIRES_USER_PRIVACY_CONSENT)) {
-         logger.error("Waiting for remote params. " +
-                 "Moving " + OSTaskController.SET_REQUIRES_USER_PRIVACY_CONSENT + " operation to a pending task queue.");
-         taskController.addTaskToQueue(new Runnable() {
-            @Override
-            public void run() {
-               logger.debug("Running " + OSTaskController.SET_REQUIRES_USER_PRIVACY_CONSENT + " with " + required + " operation from pending task queue.");
-               setRequiresUserPrivacyConsent(required);
-            }
-         });
-         return;
-      }
-
       // Already set by remote params
       if (getRemoteParamController().hasPrivacyConsentKey()) {
          logger.warning("setRequiresUserPrivacyConsent already called by remote params!, ignoring user set");

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowOneSignalRestClient.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowOneSignalRestClient.java
@@ -110,8 +110,7 @@ public class ShadowOneSignalRestClient {
            "\"receive_receipts_enable\":false," +
            "\"unsubscribe_on_notifications_disabled\":true," +
            "\"disable_gms_missing_prompt\":true," +
-           "\"location_shared\":true," +
-           "\"requires_user_privacy_consent\":false" +
+           "\"location_shared\":true" +
            "}";
    private static final String IAM_GET_HTML_RESPONSE;
    static {

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/OneSignalInitializationIntegrationTestsRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/OneSignalInitializationIntegrationTestsRunner.java
@@ -70,4 +70,16 @@ public class OneSignalInitializationIntegrationTestsRunner {
         RestClientAsserts.assertRemoteParamsWasTheOnlyNetworkCall();
     }
 
+    @Test
+    public void setRequiresUserPrivacyConsent_withFalseAndRemoteTrue_DoesNOTCreatePlayer() throws Exception {
+        ShadowOneSignalRestClient.setRemoteParamsRequirePrivacyConsent(true);
+        OneSignal.setRequiresUserPrivacyConsent(false);
+
+        OneSignal.setAppId(APP_ID);
+        helper_OneSignal_initWithAppContext();
+        threadAndTaskWait();
+
+        RestClientAsserts.assertRemoteParamsWasTheOnlyNetworkCall();
+    }
+
 }

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/OneSignalInitializationIntegrationTestsRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/OneSignalInitializationIntegrationTestsRunner.java
@@ -21,6 +21,7 @@ import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowLog;
 
+import static com.onesignal.ShadowOneSignalRestClient.setRemoteParamsGetHtmlResponse;
 import static com.test.onesignal.TestHelpers.threadAndTaskWait;
 
 @Config(
@@ -49,6 +50,7 @@ public class OneSignalInitializationIntegrationTestsRunner {
     @Before
     public void beforeEachTest() throws Exception {
         TestHelpers.beforeTestInitAndCleanup();
+        setRemoteParamsGetHtmlResponse();
         blankActivityController = Robolectric.buildActivity(BlankActivity.class).create();
     }
 

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/OneSignalInitializationIntegrationTestsRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/OneSignalInitializationIntegrationTestsRunner.java
@@ -1,0 +1,71 @@
+package com.test.onesignal;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import com.onesignal.OneSignal;
+import com.onesignal.ShadowCustomTabsClient;
+import com.onesignal.ShadowCustomTabsSession;
+import com.onesignal.ShadowOSUtils;
+import com.onesignal.ShadowOneSignalRestClient;
+import com.onesignal.ShadowPushRegistratorFCM;
+import com.onesignal.StaticResetHelper;
+import com.onesignal.example.BlankActivity;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.android.controller.ActivityController;
+import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowLog;
+
+import static com.test.onesignal.TestHelpers.threadAndTaskWait;
+
+@Config(
+        packageName = "com.onesignal.example",
+        shadows = {
+            ShadowOSUtils.class,
+            ShadowOneSignalRestClient.class,
+            ShadowPushRegistratorFCM.class,
+            ShadowCustomTabsClient.class,
+            ShadowCustomTabsSession.class,
+        },
+        sdk = 26
+)
+
+@RunWith(RobolectricTestRunner.class)
+public class OneSignalInitializationIntegrationTestsRunner {
+    private ActivityController<BlankActivity> blankActivityController;
+
+    @BeforeClass // Runs only once, before any tests
+    public static void setUpClass() throws Exception {
+        ShadowLog.stream = System.out;
+        TestHelpers.beforeTestSuite();
+        StaticResetHelper.saveStaticValues();
+    }
+
+    @Before
+    public void beforeEachTest() throws Exception {
+        TestHelpers.beforeTestInitAndCleanup();
+        blankActivityController = Robolectric.buildActivity(BlankActivity.class).create();
+    }
+
+    private static final String APP_ID = "11111111-2222-3333-4444-55555555555";
+    private static void helper_OneSignal_initWithAppContext() {
+        OneSignal.initWithContext(ApplicationProvider.getApplicationContext());
+    }
+
+    @Test
+    public void setRequiresUserPrivacyConsent_withTrue_CalledFirst_DoesNOTCreatePlayer() throws Exception {
+        OneSignal.setRequiresUserPrivacyConsent(true);
+
+        OneSignal.setAppId(APP_ID);
+        helper_OneSignal_initWithAppContext();
+        threadAndTaskWait();
+
+        RestClientAsserts.assertRemoteParamsWasTheOnlyNetworkCall();
+    }
+
+}

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/RemoteParamsTests.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/RemoteParamsTests.java
@@ -118,9 +118,7 @@ public class RemoteParamsTests {
 
     @Test
     public void testUserPrivacyConsentRequired_ByRemoteParams() throws Exception {
-        JSONObject remoteParams = new JSONObject();
-        remoteParams.put("requires_user_privacy_consent", true);
-        ShadowOneSignalRestClient.setRemoteParamsGetHtmlResponse(remoteParams);
+        ShadowOneSignalRestClient.setRemoteParamsRequirePrivacyConsent(true);
 
         OneSignalInit();
         threadAndTaskWait();
@@ -138,9 +136,7 @@ public class RemoteParamsTests {
 
     @Test
     public void testUserPrivacyConsentRequired_UserConfigurationOverrideByRemoteParams() throws Exception {
-        JSONObject remoteParams = new JSONObject();
-        remoteParams.put("requires_user_privacy_consent", true);
-        ShadowOneSignalRestClient.setRemoteParamsGetHtmlResponse(remoteParams);
+        ShadowOneSignalRestClient.setRemoteParamsRequirePrivacyConsent(true);
 
         OneSignal.setRequiresUserPrivacyConsent(false);
         OneSignalInit();
@@ -172,9 +168,7 @@ public class RemoteParamsTests {
 
     @Test
     public void testUserPrivacyConsentNotRequired_UserConfigurationNotOverrideRemoteParams() throws Exception {
-        JSONObject remoteParams = new JSONObject();
-        remoteParams.put("requires_user_privacy_consent", false);
-        ShadowOneSignalRestClient.setRemoteParamsGetHtmlResponse(remoteParams);
+        ShadowOneSignalRestClient.setRemoteParamsRequirePrivacyConsent(false);
 
         OneSignalInit();
         threadAndTaskWait();

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/RemoteParamsTests.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/RemoteParamsTests.java
@@ -150,9 +150,7 @@ public class RemoteParamsTests {
 
     @Test
     public void testUserPrivacyConsentNotRequired_UserConfigurationOverrideByRemoteParams() throws Exception {
-        JSONObject remoteParams = new JSONObject();
-        remoteParams.put("requires_user_privacy_consent", false);
-        ShadowOneSignalRestClient.setRemoteParamsGetHtmlResponse(remoteParams);
+        ShadowOneSignalRestClient.setRemoteParamsRequirePrivacyConsent(false);
 
         OneSignal.setRequiresUserPrivacyConsent(true);
         OneSignalInit();
@@ -162,9 +160,7 @@ public class RemoteParamsTests {
 
     @Test
     public void testUserPrivacyConsentRequired_UserConfigurationNotOverrideRemoteParams() throws Exception {
-        JSONObject remoteParams = new JSONObject();
-        remoteParams.put("requires_user_privacy_consent", true);
-        ShadowOneSignalRestClient.setRemoteParamsGetHtmlResponse(remoteParams);
+        ShadowOneSignalRestClient.setRemoteParamsRequirePrivacyConsent(true);
 
         OneSignalInit();
         threadAndTaskWait();

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/RemoteParamsTests.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/RemoteParamsTests.java
@@ -150,7 +150,9 @@ public class RemoteParamsTests {
 
     @Test
     public void testUserPrivacyConsentNotRequired_UserConfigurationOverrideByRemoteParams() throws Exception {
-        ShadowOneSignalRestClient.setRemoteParamsGetHtmlResponse();
+        JSONObject remoteParams = new JSONObject();
+        remoteParams.put("requires_user_privacy_consent", false);
+        ShadowOneSignalRestClient.setRemoteParamsGetHtmlResponse(remoteParams);
 
         OneSignal.setRequiresUserPrivacyConsent(true);
         OneSignalInit();
@@ -174,7 +176,9 @@ public class RemoteParamsTests {
 
     @Test
     public void testUserPrivacyConsentNotRequired_UserConfigurationNotOverrideRemoteParams() throws Exception {
-        ShadowOneSignalRestClient.setRemoteParamsGetHtmlResponse();
+        JSONObject remoteParams = new JSONObject();
+        remoteParams.put("requires_user_privacy_consent", false);
+        ShadowOneSignalRestClient.setRemoteParamsGetHtmlResponse(remoteParams);
 
         OneSignalInit();
         threadAndTaskWait();

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/RestClientAsserts.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/RestClientAsserts.java
@@ -331,4 +331,9 @@ class RestClientAsserts {
       else
          fail("Invalid format");
    }
+
+   public static void assertRemoteParamsWasTheOnlyNetworkCall() {
+      assertRemoteParamsAtIndex(0);
+      assertRestCalls(1);
+   }
 }


### PR DESCRIPTION
Fixes issue where `setRequiresUserPrivacyConsent(true)` may not apply in time to prevent a player create from happening when called before the SDK initializes.

Recommend reviewing commit-by-commit 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1153)
<!-- Reviewable:end -->

