### PR TITLE
Removed public idsAvailable method

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStatePushSynchronizer.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStatePushSynchronizer.java
@@ -185,7 +185,5 @@ class UserStatePushSynchronizer extends UserStateSynchronizer {
     protected void onSuccessfulSync(JSONObject jsonFields) {
         if (jsonFields.has("email"))
             OneSignal.fireEmailUpdateSuccess();
-        if (jsonFields.has("identifier"))
-            OneSignal.fireIdsAvailableCallback();
     }
 }


### PR DESCRIPTION
Removed public idsAvailable method


* As well as it's matching OSIdsAvailableHandler
* Replaced by getDeviceState and / or addSubscriptionObserver depending
on how you were using idsAvailable.
* Removed implementation as well internal methods supporting it

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1160)
<!-- Reviewable:end -->

