### PR TITLE
Fix HMS register crash on old Huawei Devices

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/PushRegistratorHMS.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/PushRegistratorHMS.java
@@ -7,7 +7,9 @@ import android.text.TextUtils;
 
 import com.huawei.agconnect.config.AGConnectServicesConfig;
 import com.huawei.hms.aaid.HmsInstanceId;
+import com.huawei.hms.common.ApiException;
 import com.huawei.hms.push.HmsMessaging;
+import com.huawei.hms.support.api.entity.core.CommonCode;
 
 import static com.onesignal.OneSignal.LOG_LEVEL;
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/PushRegistratorHMS.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/PushRegistratorHMS.java
@@ -7,9 +7,7 @@ import android.text.TextUtils;
 
 import com.huawei.agconnect.config.AGConnectServicesConfig;
 import com.huawei.hms.aaid.HmsInstanceId;
-import com.huawei.hms.common.ApiException;
 import com.huawei.hms.push.HmsMessaging;
-import com.huawei.hms.support.api.entity.core.CommonCode;
 
 import static com.onesignal.OneSignal.LOG_LEVEL;
 
@@ -20,7 +18,8 @@ class PushRegistratorHMS implements PushRegistrator {
     private static final int NEW_TOKEN_TIMEOUT_MS = 30_000;
 
     private static boolean callbackSuccessful;
-    private @Nullable static RegisteredHandler registeredHandler;
+    private @Nullable
+    static RegisteredHandler registeredHandler;
 
     static void fireCallback(String token) {
         if (registeredHandler == null)
@@ -35,24 +34,12 @@ class PushRegistratorHMS implements PushRegistrator {
         new Thread(new Runnable() {
             @Override
             public void run() {
-                try {
-                    getHMSTokenTask(context, callback);
-                } catch (ApiException e) {
-                    OneSignal.Log(LOG_LEVEL.ERROR, "HMS ApiException getting Huawei push token!", e);
-
-                    int pushStatus;
-                    if (e.getStatusCode() == CommonCode.ErrorCode.ARGUMENTS_INVALID)
-                        pushStatus = UserState.PUSH_STATUS_HMS_ARGUMENTS_INVALID;
-                    else
-                        pushStatus = UserState.PUSH_STATUS_HMS_API_EXCEPTION_OTHER;
-
-                    callback.complete(null, pushStatus);
-                }
+                getHMSTokenTask(context, callback);
             }
         }, "OS_HMS_GET_TOKEN").start();
     }
 
-    private synchronized void getHMSTokenTask(@NonNull Context context, @NonNull RegisteredHandler callback) throws ApiException {
+    private synchronized void getHMSTokenTask(@NonNull Context context, @NonNull RegisteredHandler callback) {
         // Check required to prevent AGConnectServicesConfig or HmsInstanceId used below
         //   from throwing a ClassNotFoundException
         if (!OSUtils.hasAllHMSLibrariesForPushKit()) {
@@ -63,14 +50,26 @@ class PushRegistratorHMS implements PushRegistrator {
         String appId = AGConnectServicesConfig.fromContext(context).getString(HMS_CLIENT_APP_ID);
         HmsInstanceId hmsInstanceId = HmsInstanceId.getInstance(context);
 
-        String pushToken = hmsInstanceId.getToken(appId, HmsMessaging.DEFAULT_TOKEN_SCOPE);
+        try {
+            String pushToken = hmsInstanceId.getToken(appId, HmsMessaging.DEFAULT_TOKEN_SCOPE);
 
-        if (!TextUtils.isEmpty(pushToken)) {
-            OneSignal.Log(LOG_LEVEL.INFO, "Device registered for HMS, push token = " + pushToken);
-            callback.complete(pushToken, UserState.PUSH_STATUS_SUBSCRIBED);
+            if (!TextUtils.isEmpty(pushToken)) {
+                OneSignal.Log(LOG_LEVEL.INFO, "Device registered for HMS, push token = " + pushToken);
+                callback.complete(pushToken, UserState.PUSH_STATUS_SUBSCRIBED);
+            } else {
+                waitForOnNewPushTokenEvent(callback);
+            }
+        } catch (ApiException e) {
+            OneSignal.Log(LOG_LEVEL.ERROR, "HMS ApiException getting Huawei push token!", e);
+
+            int pushStatus;
+            if (e.getStatusCode() == CommonCode.ErrorCode.ARGUMENTS_INVALID)
+                pushStatus = UserState.PUSH_STATUS_HMS_ARGUMENTS_INVALID;
+            else
+                pushStatus = UserState.PUSH_STATUS_HMS_API_EXCEPTION_OTHER;
+
+            callback.complete(null, pushStatus);
         }
-        else
-            waitForOnNewPushTokenEvent(callback);
     }
 
     private static void doTimeOutWait() {


### PR DESCRIPTION
After updating to the recent version of OneSignalSDK, we have some issues on old Huawei phones. I found the problem and reason for the error is that you have ApiException before checking HMS libraries on device. Thus I moved this part of code, and the error has resolved.

For reproducing the crash call this method directly on old Huawei devices(Without HMS).

```
new PushRegistratorHMS().registerForPush(this, "123", new PushRegistrator.RegisteredHandler() {
        @Override
    public void complete(String id, int status) {

    }
});
```

> com.onesignal.PushRegistratorHMS.registerForPush (PushRegistratorHMS.java:35)
> com.onesignal.OneSignal.registerForPushToken (OneSignal.java:1002)
> com.onesignal.OneSignal.access$1800 (OneSignal.java:86)
> com.onesignal.OneSignal$5.complete (OneSignal.java:1075)
> com.onesignal.OneSignalRemoteParams.processJson (OneSignalRemoteParams.java:188)
> com.onesignal.OneSignalRemoteParams.access$100 (OneSignalRemoteParams.java:12)
> com.onesignal.OneSignalRemoteParams$1.onSuccess (OneSignalRemoteParams.java:140)
> com.onesignal.OneSignalRestClient$5.run (OneSignalRestClient.java:270)
> java.lang.Thread.run (Thread.java:841)

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1167)
<!-- Reviewable:end -->

