### PR TITLE
Fix/iam issues

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/ActivityLifecycleHandler.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/ActivityLifecycleHandler.java
@@ -50,7 +50,10 @@ class ActivityLifecycleHandler {
         void available(@NonNull Activity activity) {
         }
 
-        void stopped(WeakReference<Activity> reference) {
+        void stopped() {
+        }
+
+        void lostFocus() {
         }
     }
 
@@ -145,7 +148,7 @@ class ActivityLifecycleHandler {
         }
 
         for (Map.Entry<String, ActivityAvailableListener> entry : sActivityAvailableListeners.entrySet()) {
-            entry.getValue().stopped(new WeakReference<>(activity));
+            entry.getValue().stopped();
         }
 
         logCurActivity();
@@ -185,7 +188,7 @@ class ActivityLifecycleHandler {
         // Remove view
         handleLostFocus();
         for (Map.Entry<String, ActivityAvailableListener> entry : sActivityAvailableListeners.entrySet()) {
-            entry.getValue().stopped(new WeakReference<>(curActivity));
+            entry.getValue().stopped();
         }
 
         // Show view
@@ -260,6 +263,9 @@ class ActivityLifecycleHandler {
                 return;
 
             backgrounded = true;
+            for (Map.Entry<String, ActivityAvailableListener> entry : sActivityAvailableListeners.entrySet()) {
+                entry.getValue().lostFocus();
+            }
             OneSignal.onAppLostFocus();
             completed = true;
         }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/InAppMessageView.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/InAppMessageView.java
@@ -451,7 +451,6 @@ class InAppMessageView {
      * IAM has been fully dismissed, remove all views and call the onMessageWasDismissed callback
      */
     private void cleanupViewsAfterDismiss() {
-        OneSignal.onesignalLog(OneSignal.LOG_LEVEL.DEBUG, "InAppMessageView cleanupViewsAfterDismiss");
         removeAllViews();
         if (messageController != null)
             messageController.onMessageWasDismissed();
@@ -461,6 +460,7 @@ class InAppMessageView {
      * Remove all views and dismiss PopupWindow
      */
     void removeAllViews() {
+        OneSignal.onesignalLog(OneSignal.LOG_LEVEL.DEBUG, "InAppMessageView removing views");
         if (scheduleDismissRunnable != null) {
             // Dismissed before the dismiss delay
             handler.removeCallbacks(scheduleDismissRunnable);

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSTriggerController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSTriggerController.java
@@ -172,6 +172,9 @@ class OSTriggerController {
      * If trigger key is part of message triggers, then return true, otherwise false
      * */
     boolean isTriggerOnMessage(OSInAppMessage message, Collection<String> newTriggersKeys) {
+        if (message.triggers == null)
+            return false;
+
         for (String triggerKey : newTriggersKeys) {
             for (ArrayList<OSTrigger> andConditions : message.triggers) {
                 for (OSTrigger trigger : andConditions) {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -844,9 +844,9 @@ public class OneSignal {
    // If the app is not in the foreground yet do not make an on_session call yet.
    // If we don't have a OneSignal player_id yet make the call to create it regardless of focus
    private static void doSessionInit() {
-      getInAppMessageController().initWithCachedInAppMessages();
       // Check session time to determine whether to start a new session or not
       if (isPastOnSessionTime()) {
+         OneSignal.onesignalLog(LOG_LEVEL.DEBUG, "Starting new session");
          OneSignalStateSynchronizer.setNewSession();
          if (foreground) {
             outcomeEventsController.cleanOutcomes();
@@ -854,8 +854,10 @@ public class OneSignal {
             getInAppMessageController().resetSessionLaunchTime();
          }
       } else if (foreground) {
+         OneSignal.onesignalLog(LOG_LEVEL.DEBUG, "Continue on same session");
          sessionManager.attemptSessionUpgrade(getAppEntryState());
       }
+      getInAppMessageController().initWithCachedInAppMessages();
 
       // We still want register the user to OneSignal if the SDK was initialized
       //   in the background for the first time.

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -844,16 +844,16 @@ public class OneSignal {
    // If the app is not in the foreground yet do not make an on_session call yet.
    // If we don't have a OneSignal player_id yet make the call to create it regardless of focus
    private static void doSessionInit() {
+      getInAppMessageController().initWithCachedInAppMessages();
       // Check session time to determine whether to start a new session or not
       if (isPastOnSessionTime()) {
-          OneSignalStateSynchronizer.setNewSession();
+         OneSignalStateSynchronizer.setNewSession();
          if (foreground) {
             outcomeEventsController.cleanOutcomes();
             sessionManager.restartSessionIfNeeded(getAppEntryState());
             getInAppMessageController().resetSessionLaunchTime();
          }
       } else if (foreground) {
-         getInAppMessageController().initWithCachedInAppMessages();
          sessionManager.attemptSessionUpgrade(getAppEntryState());
       }
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/WebViewManager.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/WebViewManager.java
@@ -84,6 +84,7 @@ class WebViewManager extends ActivityLifecycleHandler.ActivityAvailableListener 
      */
     static void showHTMLString(@NonNull final OSInAppMessage message, @NonNull final String htmlStr) {
         final Activity currentActivity = ActivityLifecycleHandler.curActivity;
+        OneSignal.onesignalLog(OneSignal.LOG_LEVEL.DEBUG, "in app message showHTMLString on currentActivity: " + currentActivity);
         /* IMPORTANT
          * This is the starting route for grabbing the current Activity and passing it to InAppMessageView */
         if (currentActivity != null) {
@@ -98,9 +99,9 @@ class WebViewManager extends ActivityLifecycleHandler.ActivityAvailableListener 
                         initInAppMessage(currentActivity, message, htmlStr);
                     }
                 });
-            }
-            else
+            } else {
                 initInAppMessage(currentActivity, message, htmlStr);
+            }
             return;
         }
 
@@ -248,6 +249,8 @@ class WebViewManager extends ActivityLifecycleHandler.ActivityAvailableListener 
             return;
         }
 
+        OneSignal.Log(OneSignal.LOG_LEVEL.DEBUG, "In app message new activity, calculate height and show ");
+
        // Using post to ensure that the status bar inset is already added to the view
        OSViewUtils.decorViewReady(activity, new Runnable() {
           @Override
@@ -280,9 +283,16 @@ class WebViewManager extends ActivityLifecycleHandler.ActivityAvailableListener 
     }
 
     @Override
-    void stopped(WeakReference<Activity> reference) {
+    void stopped() {
         if (messageView != null)
             messageView.removeAllViews();
+    }
+
+    @Override
+    void lostFocus() {
+        OneSignal.getInAppMessageController().messageWasDismissedByBackPress(message);
+        removeActivityListener();
+        messageView = null;
     }
 
     private void showMessageView(@Nullable Integer newHeight) {
@@ -291,6 +301,7 @@ class WebViewManager extends ActivityLifecycleHandler.ActivityAvailableListener 
             return;
         }
 
+        OneSignal.Log(OneSignal.LOG_LEVEL.DEBUG, "In app message, showing fist one with height: " + newHeight);
         messageView.setWebView(webView);
         if (newHeight != null)
             messageView.updateHeight(newHeight);
@@ -353,7 +364,7 @@ class WebViewManager extends ActivityLifecycleHandler.ActivityAvailableListener 
             @Override
             public void onMessageWasDismissed() {
                 OneSignal.getInAppMessageController().messageWasDismissed(message);
-                ActivityLifecycleHandler.removeActivityAvailableListener(TAG + message.messageId);
+                removeActivityListener();
             }
         });
 
@@ -377,6 +388,9 @@ class WebViewManager extends ActivityLifecycleHandler.ActivityAvailableListener 
        return OSViewUtils.getWindowHeight(activity) - (MARGIN_PX_SIZE * 2);
     }
 
+    private void removeActivityListener() {
+        ActivityLifecycleHandler.removeActivityAvailableListener(TAG + message.messageId);
+    }
     /**
      * Trigger the {@link #messageView} dismiss animation flow
      */

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/InAppMessageIntegrationTests.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/InAppMessageIntegrationTests.java
@@ -466,6 +466,25 @@ public class InAppMessageIntegrationTests {
     }
 
     @Test
+    public void doNotReshowInAppUntilTriggerIfAppBackPressed() throws Exception {
+        // 1. Start app
+        initializeSdkWithMultiplePendingMessages();
+        // 2. Trigger showing In App and dismiss it
+        OneSignal.addTrigger("test_2", 2);
+        assertEquals(1, OneSignalPackagePrivateHelper.getInAppMessageDisplayQueue().size());
+        assertTrue(OneSignalPackagePrivateHelper.isInAppMessageShowing());
+        // 3. Emulate back pressing
+        blankActivityController.destroy();
+        threadAndTaskWait();
+        // 4. Put activity back to foreground
+        blankActivityController = Robolectric.buildActivity(BlankActivity.class).create();
+        OneSignalInit();
+        threadAndTaskWait();
+        assertEquals(1, OneSignalPackagePrivateHelper.getInAppMessageDisplayQueue().size());
+        assertFalse(OneSignalPackagePrivateHelper.isInAppMessageShowing());
+    }
+
+    @Test
     public void reshowInAppIfDisplayedButNeverDismissedAfterColdRestart() throws Exception {
         // 1. Start app
         initializeSdkWithMultiplePendingMessages();


### PR DESCRIPTION
Iterate over message instead of redisplay

* For better readability
* Keep message list as single source of true

Init IAM with cached IAMs on new session

* When app is closed and opened if it is a new session, the IAMs will be delayed until on_session call, this end with the idea that IAMs stop working
* Always init app with cache IAMs

Make IAM not display under splas screenh when back pressing …

* If user implements splash with a handler timer activity and back press while displaying an IAM, IAM will be displayed under splash
* Add callback for when the app lost focus, dismiss IAM but not save it as dismissed this will allow the IAM to be displayed again until the user dismiss it
* If the user back press and come too quickly to the app, focus detection won't happen, IAM will still be shown under the splash screen

Review commit by commit

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1171)
<!-- Reviewable:end -->

