### PR TITLE
NPE on notification received from BundleCompat

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/BundleCompat.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/BundleCompat.java
@@ -41,7 +41,7 @@ public interface BundleCompat<T> {
    void putLong(String key, Long value);
    void putBoolean(String key, Boolean value);
    
-   String getString(String key);
+   String getString(String key) throws OSBundleCompatException;
    Integer getInt(String key);
    Long getLong(String key);
    boolean getBoolean(String key);
@@ -87,8 +87,11 @@ class BundleCompatPersistableBundle implements BundleCompat<PersistableBundle> {
    }
    
    @Override
-   public String getString(String key) {
-      return mBundle.getString(key);
+   public String getString(String key) throws OSBundleCompatException {
+      if (mBundle != null)
+         return mBundle.getString(key);
+      else
+         throw new OSBundleCompatException("unable to get mBundle " + this.toString());
    }
    
    @Override
@@ -200,6 +203,12 @@ class BundleCompatBundle implements BundleCompat<Bundle> {
    @Override
    public boolean getBoolean(String key, boolean value) {
      return mBundle.getBoolean(key, value);
+   }
+}
+
+class OSBundleCompatException extends Exception {
+   public OSBundleCompatException(String message) {
+      super(message);
    }
 }
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/BundleCompat.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/BundleCompat.java
@@ -91,7 +91,7 @@ class BundleCompatPersistableBundle implements BundleCompat<PersistableBundle> {
       if (mBundle != null)
          return mBundle.getString(key);
       else
-         throw new OSBundleCompatException("unable to get mBundle " + this.toString());
+         throw new OSBundleCompatException("unable to get mBundle");
    }
    
    @Override

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/FCMBroadcastReceiver.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/FCMBroadcastReceiver.java
@@ -128,7 +128,12 @@ public class FCMBroadcastReceiver extends WakefulBroadcastReceiver {
       // If no remote resources have to be downloaded don't create a job which could add some delay.
       if (!NotificationBundleProcessor.hasRemoteResource(bundle)) {
          BundleCompat taskExtras = setCompatBundleForServer(bundle, BundleCompatFactory.getInstance());
-         NotificationBundleProcessor.processFromFCMIntentService(context, taskExtras);
+         try {
+            NotificationBundleProcessor.processFromFCMIntentService(context, taskExtras);
+         } catch (OSBundleCompatException e) {
+            OneSignal.Log(OneSignal.LOG_LEVEL.ERROR, "there was an error getting data from mBundle: " + bundle);
+            e.printStackTrace();
+         }
          return;
       }
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
@@ -105,6 +105,8 @@ class NotificationBundleProcessor {
             // Normally more than one notification is restored at a time.
             if (isRestoring)
                 OSUtils.sleep(100);
+        } catch (OSBundleCompatException e) {
+            e.printStackTrace();
         } catch (JSONException e) {
             e.printStackTrace();
         }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
@@ -68,7 +68,7 @@ class NotificationBundleProcessor {
 
     static final String OS_NOTIFICATION_PROCESSING_THREAD = "OS_NOTIFICATION_PROCESSING_THREAD";
 
-    static void processFromFCMIntentService(Context context, BundleCompat bundle) {
+    static void processFromFCMIntentService(Context context, BundleCompat bundle) throws OSBundleCompatException {
         OneSignal.initWithContext(context);
         try {
             String jsonStrPayload = bundle.getString("json_payload");
@@ -105,8 +105,6 @@ class NotificationBundleProcessor {
             // Normally more than one notification is restored at a time.
             if (isRestoring)
                 OSUtils.sleep(100);
-        } catch (OSBundleCompatException e) {
-            e.printStackTrace();
         } catch (JSONException e) {
             e.printStackTrace();
         }

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
@@ -159,11 +159,11 @@ public class OneSignalPackagePrivateHelper {
       return retBundle;
    }
 
-   public static void NotificationBundleProcessor_ProcessFromFCMIntentService(Context context, Bundle bundle) {
+   public static void NotificationBundleProcessor_ProcessFromFCMIntentService(Context context, Bundle bundle) throws OSBundleCompatException {
       NotificationBundleProcessor.processFromFCMIntentService(context, createInternalPayloadBundle(bundle));
    }
 
-   public static void NotificationBundleProcessor_ProcessFromFCMIntentService_NoWrap(Context context, BundleCompat bundle) {
+   public static void NotificationBundleProcessor_ProcessFromFCMIntentService_NoWrap(Context context, BundleCompat bundle) throws OSBundleCompatException {
       NotificationBundleProcessor.processFromFCMIntentService(context, bundle);
    }
 

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
@@ -568,7 +568,11 @@ public class GenerateNotificationRunner {
           bundle = getBaseNotifBundle("UUID" + i);
           bundle.putString("grp", group);
 
-          NotificationBundleProcessor_ProcessFromFCMIntentService(blankActivity, bundle);
+          try {
+             NotificationBundleProcessor_ProcessFromFCMIntentService(blankActivity, bundle);
+          } catch (Exception e) {
+             e.printStackTrace();
+          }
        }
        return bundle;
     }
@@ -699,7 +703,7 @@ public class GenerateNotificationRunner {
    
    @Test
    @Config(shadows = { ShadowGenerateNotification.class })
-   public void shouldUpdateBadgesWhenDismissingNotification() {
+   public void shouldUpdateBadgesWhenDismissingNotification() throws Exception {
       Bundle bundle = getBaseNotifBundle();
       NotificationBundleProcessor_ProcessFromFCMIntentService(blankActivity, bundle);
       assertEquals(notifMessage, ShadowRoboNotificationManager.getLastShadowNotif().getContentText());
@@ -749,7 +753,7 @@ public class GenerateNotificationRunner {
    }
    
    @Test
-   public void shouldNotShowNotificationWhenAlertIsBlankOrNull() {
+   public void shouldNotShowNotificationWhenAlertIsBlankOrNull() throws Exception {
       Bundle bundle = getBaseNotifBundle();
       bundle.remove("alert");
       NotificationBundleProcessor_ProcessFromFCMIntentService(blankActivity, bundle);
@@ -942,7 +946,7 @@ public class GenerateNotificationRunner {
    }
 
    @Test
-   public void badgeCountShouldNotIncludeOldNotifications() {
+   public void badgeCountShouldNotIncludeOldNotifications() throws Exception {
       NotificationBundleProcessor_ProcessFromFCMIntentService(blankActivity, getBaseNotifBundle());
 
       // Go forward 1 week
@@ -1094,7 +1098,7 @@ public class GenerateNotificationRunner {
 
    @Test
    @Config(shadows = { ShadowGenerateNotification.class })
-   public void shouldSetAlertnessFieldsOnNormalPriority() {
+   public void shouldSetAlertnessFieldsOnNormalPriority() throws Exception {
       Bundle bundle = getBaseNotifBundle();
       bundle.putString("pri", "5"); // Notifications from dashboard have priority 5 by default
       NotificationBundleProcessor_ProcessFromFCMIntentService(blankActivity, bundle);
@@ -1118,7 +1122,7 @@ public class GenerateNotificationRunner {
 
    @Test
    @Config(shadows = { ShadowGenerateNotification.class })
-   public void shouldSetExpireTimeCorrectlyFromGoogleTTL() {
+   public void shouldSetExpireTimeCorrectlyFromGoogleTTL() throws Exception {
       long sentTime = 1_553_035_338_000L;
       long ttl = 60L;
 
@@ -1134,7 +1138,7 @@ public class GenerateNotificationRunner {
 
    @Test
    @Config(shadows = { ShadowGenerateNotification.class })
-   public void shouldSetExpireTimeCorrectlyWhenMissingFromPayload() {
+   public void shouldSetExpireTimeCorrectlyWhenMissingFromPayload() throws Exception {
       NotificationBundleProcessor_ProcessFromFCMIntentService(blankActivity, getBaseNotifBundle());
 
       long expireTime = (Long)TestHelpers.getAllNotificationRecords(dbHelper).get(0).get(NotificationTable.COLUMN_NAME_EXPIRE_TIME);


### PR DESCRIPTION
Added exception handler to further investigate mBundle null state


* Created an exception called `OSBundleCompatException` 
* Throw it when accessing mBundle when it's null

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1173)
<!-- Reviewable:end -->

