### PR TITLE
Fix foreground check for wrappers

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationOpenedProcessor.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationOpenedProcessor.java
@@ -55,7 +55,8 @@ class NotificationOpenedProcessor {
       if (!isOneSignalIntent(intent))
          return;
 
-      OneSignal.initWithContext(context);
+      if (context != null)
+         OneSignal.initWithContext(context.getApplicationContext());
 
       handleDismissFromActionButtonPress(context, intent);
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationPayloadProcessorHMS.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationPayloadProcessorHMS.java
@@ -16,7 +16,7 @@ import static com.onesignal.GenerateNotification.BUNDLE_KEY_ACTION_ID;
 class NotificationPayloadProcessorHMS {
 
     static void handleHMSNotificationOpenIntent(@NonNull Activity activity, @Nullable Intent intent) {
-        OneSignal.initWithContext(activity);
+        OneSignal.initWithContext(activity.getApplicationContext());
         if (intent == null)
             return;
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationRestoreWorkManager.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationRestoreWorkManager.java
@@ -61,7 +61,8 @@ class OSNotificationRestoreWorkManager {
         public Result doWork() {
             Context context = getApplicationContext();
 
-            OneSignal.initWithContext(context);
+            if (OneSignal.appContext == null)
+                OneSignal.initWithContext(context);
 
             if (!OSUtils.areNotificationsEnabled(context))
                 return Result.failure();

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -574,7 +574,7 @@ public class OneSignal {
       }
 
       if (appActivity != null && appActivity.get() != null)
-         initWithContext(appActivity.get());
+         init(appActivity.get());
       else
          init(appContext);
    }
@@ -780,8 +780,10 @@ public class OneSignal {
       logger.debug("OneSignal handleActivityLifecycleHandler inForeground: " + inForeground);
 
       if (inForeground) {
-         if (OneSignal.getCurrentActivity() == null && activityLifecycleHandler != null)
+         if (OneSignal.getCurrentActivity() == null && activityLifecycleHandler != null) {
+            activityLifecycleHandler.setCurActivity((Activity) context);
             activityLifecycleHandler.setNextResumeIsFirstActivity(true);
+         }
          OSNotificationRestoreWorkManager.beginEnqueueingWork(context, false);
          FocusTimeController.getInstance().appForegrounded();
       } else if (activityLifecycleHandler != null) {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -58,6 +58,7 @@ import org.json.JSONObject;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collection;
@@ -275,6 +276,7 @@ public class OneSignal {
    }
 
    static Context appContext;
+   static WeakReference<Activity> appActivity;
    static String appId;
    static String googleProjectNumber;
 
@@ -571,7 +573,10 @@ public class OneSignal {
          return;
       }
 
-      init(appContext);
+      if (appActivity != null && appActivity.get() != null)
+         initWithContext(appActivity.get());
+      else
+         init(appContext);
    }
 
    /**
@@ -589,6 +594,8 @@ public class OneSignal {
 
       boolean wasAppContextNull = (appContext == null);
       appContext = context.getApplicationContext();
+      if (context instanceof Activity)
+         appActivity = new WeakReference<>((Activity) context);
       setupActivityLifecycleListener(wasAppContextNull);
       setupPrivacyConsent(appContext);
 
@@ -667,6 +674,8 @@ public class OneSignal {
       }
 
       handleActivityLifecycleHandler(context);
+      // Clean saved init activity
+      appActivity = null;
 
       OneSignalStateSynchronizer.initUserState();
 
@@ -767,10 +776,12 @@ public class OneSignal {
 
    private static void handleActivityLifecycleHandler(Context context) {
       ActivityLifecycleHandler activityLifecycleHandler = ActivityLifecycleListener.getActivityLifecycleHandler();
-      inForeground = OneSignal.getCurrentActivity() != null;
+      inForeground = OneSignal.getCurrentActivity() != null || context instanceof Activity;
       logger.debug("OneSignal handleActivityLifecycleHandler inForeground: " + inForeground);
 
       if (inForeground) {
+         if (OneSignal.getCurrentActivity() == null && activityLifecycleHandler != null)
+            activityLifecycleHandler.setNextResumeIsFirstActivity(true);
          OSNotificationRestoreWorkManager.beginEnqueueingWork(context, false);
          FocusTimeController.getInstance().appForegrounded();
       } else if (activityLifecycleHandler != null) {


### PR DESCRIPTION
* If user init with activity context foreground check should work even if on resume callback is not fire

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1174)
<!-- Reviewable:end -->

