### PR TITLE
Remove OSNotificationOpenedHandler from NotificationServiceExtension

### DIFF
--- a/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/application/MainApplication.java
+++ b/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/application/MainApplication.java
@@ -4,6 +4,7 @@ import android.app.Application;
 import android.util.Log;
 
 import com.onesignal.OSNotification;
+import com.onesignal.OSNotificationOpenedResult;
 import com.onesignal.OneSignal;
 import com.onesignal.sdktest.R;
 import com.onesignal.sdktest.constant.Tag;
@@ -30,6 +31,9 @@ public class MainApplication extends Application {
         }
         OneSignal.setAppId(appId);
         OneSignal.initWithContext(this);
+
+        OneSignal.setNotificationOpenedHandler(result ->
+                OneSignal.onesignalLog(OneSignal.LOG_LEVEL.VERBOSE, "OSNotificationOpenedResult result: " + result.toString()));
 
         OneSignal.setNotificationWillShowInForegroundHandler(notificationReceivedEvent -> {
             OneSignal.onesignalLog(OneSignal.LOG_LEVEL.VERBOSE, "NotificationWillShowInForegroundHandler fired!" +

--- a/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/notification/NotificationServiceExtension.java
+++ b/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/notification/NotificationServiceExtension.java
@@ -10,8 +10,7 @@ import com.onesignal.OneSignal;
 import com.onesignal.sdktest.R;
 
 public class NotificationServiceExtension implements
-        OneSignal.OSRemoteNotificationReceivedHandler,
-        OneSignal.OSNotificationOpenedHandler {
+        OneSignal.OSRemoteNotificationReceivedHandler {
 
    @Override
    public void remoteNotificationReceived(Context context, OSNotificationReceivedEvent notificationReceivedEvent) {
@@ -33,8 +32,4 @@ public class NotificationServiceExtension implements
       notificationReceivedEvent.complete(mutableNotification);
    }
 
-   @Override
-   public void notificationOpened(OSNotificationOpenedResult result) {
-      OneSignal.onesignalLog(OneSignal.LOG_LEVEL.VERBOSE, "OSNotificationOpenedResult result: " + result.toString());
-   }
 }


### PR DESCRIPTION
Result of reviewing documentation

* Add setNotificationOpenedHandler on Example App
* Remove OSNotificationOpenedHandler from NotificationServiceExtension to avoid user confusion

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1181)
<!-- Reviewable:end -->

