### PR TITLE
Proguard consumer rules to keep email observers

### DIFF
--- a/OneSignalSDK/onesignal/consumer-proguard-rules.pro
+++ b/OneSignalSDK/onesignal/consumer-proguard-rules.pro
@@ -23,12 +23,20 @@
     void changed(com.onesignal.OSSubscriptionState);
 }
 
+-keep class com.onesignal.OSEmailSubscriptionChangedInternalObserver {
+    void changed(com.onesignal.OSEmailSubscriptionState);
+}
+
 -keep class ** implements com.onesignal.OSPermissionObserver {
     void onOSPermissionChanged(com.onesignal.OSPermissionStateChanges);
 }
 
 -keep class ** implements com.onesignal.OSSubscriptionObserver {
     void onOSSubscriptionChanged(com.onesignal.OSSubscriptionStateChanges);
+}
+
+-keep class ** implements com.onesignal.OSEmailSubscriptionObserver {
+    void onOSEmailSubscriptionChanged(com.onesignal.OSEmailSubscriptionStateChanges);
 }
 
 -keep class com.onesignal.shortcutbadger.impl.AdwHomeBadger { <init>(...); }


### PR DESCRIPTION
* Both internal and public observer methods
* Rules for permission and subscription observers already present

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1189)
<!-- Reviewable:end -->

