### PR TITLE
Add notification duplicate check under Workers

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/FCMBroadcastReceiver.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/FCMBroadcastReceiver.java
@@ -125,8 +125,10 @@ public class FCMBroadcastReceiver extends WakefulBroadcastReceiver {
    }
 
    static void startFCMService(Context context, Bundle bundle) {
+      OneSignal.Log(OneSignal.LOG_LEVEL.DEBUG, "startFCMService from: " + context + " and bundle: " + bundle);
       // If no remote resources have to be downloaded don't create a job which could add some delay.
       if (!NotificationBundleProcessor.hasRemoteResource(bundle)) {
+         OneSignal.Log(OneSignal.LOG_LEVEL.DEBUG, "startFCMService with no remote resources, no need for services");
          BundleCompat taskExtras = setCompatBundleForServer(bundle, BundleCompatFactory.getInstance());
          NotificationBundleProcessor.processFromFCMIntentService(context, taskExtras);
          return;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
@@ -46,7 +46,7 @@ import org.json.JSONObject;
 import java.util.Set;
 
 import static com.onesignal.GenerateNotification.BUNDLE_KEY_ACTION_ID;
-import static com.onesignal.OSUtils.isStringEmpty;
+import static com.onesignal.OSUtils.isStringNotEmpty;
 
 /** Processes the Bundle received from a push.
  * This class handles both processing bundles from a BroadcastReceiver or from a Service
@@ -65,8 +65,6 @@ class NotificationBundleProcessor {
     private static final String IAM_PREVIEW_KEY = "os_in_app_message_preview_id";
     private static final String ANDROID_NOTIFICATION_ID = "android_notif_id";
     static final String DEFAULT_ACTION = "__DEFAULT__";
-
-    static final String OS_NOTIFICATION_PROCESSING_THREAD = "OS_NOTIFICATION_PROCESSING_THREAD";
 
     static void processFromFCMIntentService(Context context, BundleCompat bundle) {
         OneSignal.initWithContext(context);
@@ -88,7 +86,7 @@ class NotificationBundleProcessor {
 
             if (!isRestoring
                     && !isIamPreview
-                    && OneSignal.notValidOrDuplicated(context, jsonPayload))
+                    && OneSignal.notValidOrDuplicated(jsonPayload))
                 return;
 
             String osNotificationId = OSNotificationFormatHelper.getOSNotificationIdFromJson(jsonPayload);
@@ -167,15 +165,7 @@ class NotificationBundleProcessor {
             return false;
 
         // Otherwise, this is a normal notification and should be shown
-        return notificationJob.hasExtender() || isStringEmpty(notificationJob.getJsonPayload().optString("alert"));
-    }
-
-    private static void saveAndProcessDupNotification(Context context, Bundle bundle) {
-        JSONObject jsonPayload = bundleAsJSONObject(bundle);
-        OSNotification notification = new OSNotification(jsonPayload, -1);
-        OSNotificationGenerationJob notificationJob = new OSNotificationGenerationJob(context, notification, jsonPayload);
-
-        processNotification(notificationJob, true);
+        return notificationJob.hasExtender() || isStringNotEmpty(notificationJob.getJsonPayload().optString("alert"));
     }
 
     /**
@@ -421,7 +411,7 @@ class NotificationBundleProcessor {
         boolean isHighPriority = Integer.parseInt(bundle.getString("pri", "0")) > 9;
 
         if (!isRestoring
-                && OneSignal.notValidOrDuplicated(context, jsonPayload)) {
+                && OneSignal.notValidOrDuplicated(jsonPayload)) {
             OneSignal.Log(OneSignal.LOG_LEVEL.DEBUG, "startNotificationProcessing returning, with context: " + context + " and bundle: " + bundle);
             return false;
         }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
@@ -43,7 +43,6 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.util.ArrayList;
 import java.util.Set;
 
 import static com.onesignal.GenerateNotification.BUNDLE_KEY_ACTION_ID;
@@ -64,6 +63,7 @@ class NotificationBundleProcessor {
     public static final String PUSH_MINIFIED_BUTTON_ICON = "p";
 
     private static final String IAM_PREVIEW_KEY = "os_in_app_message_preview_id";
+    private static final String ANDROID_NOTIFICATION_ID = "android_notif_id";
     static final String DEFAULT_ACTION = "__DEFAULT__";
 
     static final String OS_NOTIFICATION_PROCESSING_THREAD = "OS_NOTIFICATION_PROCESSING_THREAD";
@@ -83,8 +83,8 @@ class NotificationBundleProcessor {
             boolean isIamPreview = inAppPreviewPushUUID(jsonPayload) != null;
 
             int androidNotificationId = 0;
-            if (bundle.containsKey("android_notif_id"))
-                androidNotificationId = bundle.getInt("android_notif_id");
+            if (bundle.containsKey(ANDROID_NOTIFICATION_ID))
+                androidNotificationId = bundle.getInt(ANDROID_NOTIFICATION_ID);
 
             if (!isRestoring
                     && !isIamPreview
@@ -128,7 +128,7 @@ class NotificationBundleProcessor {
 
     @WorkerThread
     static int processJobForDisplay(OSNotificationController notificationController, boolean opened, boolean fromBackgroundLogic) {
-        OneSignal.Log(OneSignal.LOG_LEVEL.DEBUG, "Starting processJobForDisplay");
+        OneSignal.Log(OneSignal.LOG_LEVEL.DEBUG, "Starting processJobForDisplay opened: " + opened + " fromBackgroundLogic: " + fromBackgroundLogic);
         OSNotificationGenerationJob notificationJob = notificationController.getNotificationJob();
 
         processCollapseKey(notificationJob);
@@ -149,6 +149,11 @@ class NotificationBundleProcessor {
 
         if (!notificationJob.isRestoring() && !notificationJob.isIamPreview()) {
             processNotification(notificationJob, opened);
+
+            // No need to keep notification duplicate check on memory, we have database check at this point
+            // Without removing duplicate, summary restoration might not happen
+            String osNotificationId = OSNotificationFormatHelper.getOSNotificationIdFromJson(notificationController.getNotificationJob().getJsonPayload());
+            OSNotificationWorkManager.removeNotificationIdProcessed(osNotificationId);
             OneSignal.handleNotificationReceived(notificationJob);
         }
 
@@ -357,7 +362,7 @@ class NotificationBundleProcessor {
 
     //  Process bundle passed from fcm / adm broadcast receiver.
     static @NonNull
-    ProcessedBundleResult processBundleFromReceiver(Context context, final Bundle bundle) {
+    ProcessedBundleResult processBundleFromReceiver(@NonNull Context context, final Bundle bundle) {
         ProcessedBundleResult result = new ProcessedBundleResult();
 
         // Not a OneSignal GCM message
@@ -369,44 +374,25 @@ class NotificationBundleProcessor {
 
         JSONObject pushPayloadJson = bundleAsJSONObject(bundle);
 
-      // Show In-App message preview it is in the payload & the app is in focus
-      String previewUUID = inAppPreviewPushUUID(pushPayloadJson);
-      if (previewUUID != null) {
-         // If app is in focus display the IAMs preview now
-         if (OneSignal.isAppActive()) {
-            result.inAppPreviewShown = true;
-            OneSignal.getInAppMessageController().displayPreviewMessage(previewUUID);
-         }
-         // Return early, we don't want the extender service or etc. to fire for IAM previews
-         return result;
-      }
+        // Show In-App message preview it is in the payload & the app is in focus
+        String previewUUID = inAppPreviewPushUUID(pushPayloadJson);
+        if (previewUUID != null) {
+            // If app is in focus display the IAMs preview now
+            if (OneSignal.isAppActive()) {
+                result.inAppPreviewShown = true;
+                OneSignal.getInAppMessageController().displayPreviewMessage(previewUUID);
+            }
+            // Return early, we don't want the extender service or etc. to fire for IAM previews
+            return result;
+        }
 
+        // Bundle already non null, checked under isOneSignalBundle
         if (startNotificationProcessing(context, bundle, result))
             return result;
 
-        // We already ran a getNotificationIdFromFCMBundle == null check above so this will only be true for dups
-        result.isDup = OneSignal.notValidOrDuplicated(context, pushPayloadJson);
-        if (result.isDup)
-            return result;
-
-        JSONObject payload = bundleAsJSONObject(bundle);
-        // Create new notificationJob to be processed for display
-        final OSNotificationGenerationJob notificationJob = new OSNotificationGenerationJob(context, payload);
-
-        // Save as a opened notification to prevent duplicates
-        String alert = bundle.getString("alert");
-        boolean display = isStringEmpty(alert);
-        if (!display) {
-            saveAndProcessDupNotification(context, bundle);
-            // Current thread is meant to be short lived
-            // Make a new thread to do our OneSignal work on
-            new Thread(new Runnable() {
-                public void run() {
-                    OneSignal.handleNotificationReceived(notificationJob);
-                }
-            }, OS_NOTIFICATION_PROCESSING_THREAD).start();
-        }
-
+        // We already check for bundle == null under isOneSignalBundle
+        // At this point we know notification is duplicate
+        result.isDup = true;
         return result;
     }
 
@@ -428,29 +414,23 @@ class NotificationBundleProcessor {
         return null;
     }
 
-    // NotificationExtenderService still makes additional checks such as notValidOrDuplicated
-    private static boolean startNotificationProcessing(Context context, Bundle bundle, ProcessedBundleResult result) {
-        // Service maybe triggered without extras on some Android devices on boot.
-        // https://github.com/OneSignal/OneSignal-Android-SDK/issues/99
-        if (bundle == null) {
-            OneSignal.Log(OneSignal.LOG_LEVEL.ERROR, "Notification bundle is null, not passing the notification to the work manager");
+    private static boolean startNotificationProcessing(@NonNull Context context, @NonNull Bundle bundle, @NonNull ProcessedBundleResult result) {
+        long timestamp = OneSignal.getTime().getCurrentTimeMillis() / 1000L;
+        JSONObject jsonPayload = bundleAsJSONObject(bundle);
+        boolean isRestoring = bundle.getBoolean("is_restoring", false);
+        boolean isHighPriority = Integer.parseInt(bundle.getString("pri", "0")) > 9;
+
+        if (!isRestoring
+                && OneSignal.notValidOrDuplicated(context, jsonPayload)) {
+            OneSignal.Log(OneSignal.LOG_LEVEL.DEBUG, "startNotificationProcessing returning, with context: " + context + " and bundle: " + bundle);
             return false;
         }
 
-        JSONObject jsonPayload = bundleAsJSONObject(bundle);
-        boolean isRestoring = bundle.getBoolean("is_restoring", false);
-        long timestamp = OneSignal.getTime().getCurrentTimeMillis() / 1000L;
-        boolean isHighPriority = Integer.parseInt(bundle.getString("pri", "0")) > 9;
-
-        int androidNotificationId = 0;
-        if (bundle.containsKey("android_notif_id"))
-            androidNotificationId = bundle.getInt("android_notif_id");
-
-        if (!isRestoring
-                && OneSignal.notValidOrDuplicated(context, jsonPayload))
-            return false;
-
         String osNotificationId = OSNotificationFormatHelper.getOSNotificationIdFromJson(jsonPayload);
+        int androidNotificationId = 0;
+        if (bundle.containsKey(ANDROID_NOTIFICATION_ID))
+            androidNotificationId = bundle.getInt(ANDROID_NOTIFICATION_ID);
+
         OSNotificationWorkManager.beginEnqueueingWork(
                 context,
                 osNotificationId,

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
@@ -352,7 +352,7 @@ class NotificationBundleProcessor {
 
     //  Process bundle passed from fcm / adm broadcast receiver.
     static @NonNull
-    ProcessedBundleResult processBundleFromReceiver(@NonNull Context context, final Bundle bundle) {
+    ProcessedBundleResult processBundleFromReceiver(Context context, final Bundle bundle) {
         ProcessedBundleResult result = new ProcessedBundleResult();
 
         // Not a OneSignal GCM message
@@ -404,7 +404,7 @@ class NotificationBundleProcessor {
         return null;
     }
 
-    private static boolean startNotificationProcessing(@NonNull Context context, @NonNull Bundle bundle, @NonNull ProcessedBundleResult result) {
+    private static boolean startNotificationProcessing(Context context, Bundle bundle, ProcessedBundleResult result) {
         long timestamp = OneSignal.getTime().getCurrentTimeMillis() / 1000L;
         JSONObject jsonPayload = bundleAsJSONObject(bundle);
         boolean isRestoring = bundle.getBoolean("is_restoring", false);

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationController.java
@@ -81,9 +81,9 @@ public class OSNotificationController {
     */
    void processNotification(OSNotification originalNotification, @Nullable OSNotification notification) {
       if (notification != null) {
-         // Save as processed to prevent possible duplicate calls from canonical ids
          boolean display = isStringEmpty(notification.getBody());
          if (!display) {
+            // Save as processed to prevent possible duplicate calls from canonical ids
             notDisplayNotificationLogic(originalNotification);
          } else {
             // Set modified notification

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationController.java
@@ -33,7 +33,7 @@ import androidx.annotation.Nullable;
 
 import org.json.JSONObject;
 
-import static com.onesignal.OSUtils.isStringEmpty;
+import static com.onesignal.OSUtils.isStringNotEmpty;
 
 public class OSNotificationController {
 
@@ -81,7 +81,7 @@ public class OSNotificationController {
     */
    void processNotification(OSNotification originalNotification, @Nullable OSNotification notification) {
       if (notification != null) {
-         boolean display = isStringEmpty(notification.getBody());
+         boolean display = isStringNotEmpty(notification.getBody());
          if (!display) {
             // Save as processed to prevent possible duplicate calls from canonical ids
             notDisplayNotificationLogic(originalNotification);

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSUtils.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSUtils.java
@@ -449,7 +449,7 @@ class OSUtils {
       return pattern.matcher(email).matches();
    }
 
-   static boolean isStringEmpty(String body) {
+   static boolean isStringNotEmpty(String body) {
       return !TextUtils.isEmpty(body);
    }
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -2819,7 +2819,15 @@ public class OneSignal {
 
    static boolean notValidOrDuplicated(Context context, JSONObject jsonPayload) {
       String id = OSNotificationFormatHelper.getOSNotificationIdFromJson(jsonPayload);
-      return id == null || OneSignal.isDuplicateNotification(context, id);
+      if (id == null) {
+         logger.debug("Notification notValidOrDuplicated with id null");
+         return true;
+      }
+      if (OneSignal.isDuplicateNotification(context, id)) {
+         logger.debug("Notification notValidOrDuplicated with id duplicated");
+         return true;
+      }
+      return false;
    }
 
    static String getNotificationIdFromFCMJson(@Nullable JSONObject fcmJson) {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -2789,9 +2789,12 @@ public class OneSignal {
       getInAppMessageController().setInAppMessagingEnabled(!pause);
    }
 
-   private static boolean isDuplicateNotification(Context context, String id) {
+   private static boolean isDuplicateNotification(String id) {
       if (id == null || "".equals(id))
          return false;
+
+      if (!OSNotificationWorkManager.addNotificationIdProcessed(id))
+         return true;
 
       OneSignalDbHelper dbHelper = getDBHelperInstance();
 
@@ -2817,13 +2820,13 @@ public class OneSignal {
       return false;
    }
 
-   static boolean notValidOrDuplicated(Context context, JSONObject jsonPayload) {
+   static boolean notValidOrDuplicated(JSONObject jsonPayload) {
       String id = OSNotificationFormatHelper.getOSNotificationIdFromJson(jsonPayload);
       if (id == null) {
          logger.debug("Notification notValidOrDuplicated with id null");
          return true;
       }
-      if (OneSignal.isDuplicateNotification(context, id)) {
+      if (OneSignal.isDuplicateNotification(id)) {
          logger.debug("Notification notValidOrDuplicated with id duplicated");
          return true;
       }

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/StaticResetHelper.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/StaticResetHelper.java
@@ -61,6 +61,13 @@ public class StaticResetHelper {
       classes.add(new ClassState(FocusTimeController.class, null));
       classes.add(new ClassState(OSSessionManager.class, null));
       classes.add(new ClassState(MockSessionManager.class, null));
+      classes.add(new ClassState(OSNotificationWorkManager.class,  field -> {
+         if (field.getName().equals("notificationIds")) {
+            field.set(null, OSUtils.newConcurrentSet());
+            return true;
+         }
+         return false;
+      }));
    }
 
    private interface OtherFieldHandler {

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
@@ -164,6 +164,15 @@ public class GenerateNotificationRunner {
    private static OSNotificationReceivedEvent lastServiceNotificationReceivedEvent;
    private MockOneSignalDBHelper dbHelper;
    private MockOSTimeImpl time;
+   private String notificationReceivedBody;
+   private int androidNotificationId;
+
+   private static String lastNotificationOpenedBody;
+   private static OneSignal.OSNotificationOpenedHandler getNotificationOpenedHandler() {
+      return openedResult -> {
+         lastNotificationOpenedBody = openedResult.getNotification().getBody();
+      };
+   }
 
    @BeforeClass // Runs only once, before any tests
    public static void setUpClass() throws Exception {
@@ -1987,12 +1996,9 @@ public class GenerateNotificationRunner {
       // 1. Init OneSignal
       OneSignal.setAppId("b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
       OneSignal.initWithContext(blankActivity);
-      OneSignal.setNotificationWillShowInForegroundHandler(new OneSignal.OSNotificationWillShowInForegroundHandler() {
-         @Override
-         public void notificationWillShowInForeground(OSNotificationReceivedEvent notificationReceivedEvent) {
-            callbackCounter++;
-            lastForegroundNotificationReceivedEvent = notificationReceivedEvent;
-         }
+      OneSignal.setNotificationWillShowInForegroundHandler(notificationReceivedEvent -> {
+         callbackCounter++;
+         lastForegroundNotificationReceivedEvent = notificationReceivedEvent;
       });
       threadAndTaskWait();
 
@@ -2096,30 +2102,73 @@ public class GenerateNotificationRunner {
    }
 
    @Test
+   @Config (shadows = { ShadowGenerateNotification.class })
+   public void testNotificationReceived_duplicatesInShortTime() throws Exception {
+      // 1. Init OneSignal
+      OneSignal.setAppId(ONESIGNAL_APP_ID);
+      OneSignal.initWithContext(blankActivity);
+      OneSignal.setNotificationWillShowInForegroundHandler(notificationReceivedEvent -> {
+         androidNotificationId = notificationReceivedEvent.getNotification().getAndroidNotificationId();
+         notificationReceivedBody = notificationReceivedEvent.getNotification().getBody();
+         // Not call complete to test duplicate arriving before notification processing is completed
+      });
+      OneSignal.setNotificationOpenedHandler(getNotificationOpenedHandler());
+
+      // 2. Foreground the app
+      blankActivityController.resume();
+      threadAndTaskWait();
+
+      Bundle bundle = getBaseNotifBundle();
+      boolean processResult = FCMBroadcastReceiver_processBundle(blankActivity, bundle);
+
+      assertTrue(processResult);
+      assertNull(lastNotificationOpenedBody);
+
+      assertEquals("Robo test message", notificationReceivedBody);
+      assertNotEquals(0, androidNotificationId);
+
+      // Don't fire for duplicates
+      lastNotificationOpenedBody = null;
+      notificationReceivedBody = null;
+
+      FCMBroadcastReceiver_processBundle(blankActivity, bundle);
+
+      assertNull(lastNotificationOpenedBody);
+      assertNull(notificationReceivedBody);
+
+      lastNotificationOpenedBody = null;
+      notificationReceivedBody = null;
+
+      // Test that only NotificationReceivedHandler fires
+      bundle = getBaseNotifBundle("UUID2");
+      FCMBroadcastReceiver_processBundle(blankActivity, bundle);
+
+      assertNull(lastNotificationOpenedBody);
+      assertEquals("Robo test message", notificationReceivedBody);
+   }
+
+   @Test
    @Config(shadows = { ShadowGenerateNotification.class })
    public void testNotificationWillShowInForegroundHandler_notificationJobPayload() throws Exception {
       // 1. Init OneSignal
       OneSignal.setAppId("b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
       OneSignal.initWithContext(blankActivity);
-      OneSignal.setNotificationWillShowInForegroundHandler(new OneSignal.OSNotificationWillShowInForegroundHandler() {
-         @Override
-         public void notificationWillShowInForeground(OSNotificationReceivedEvent notificationReceivedEvent) {
-            lastForegroundNotificationReceivedEvent = notificationReceivedEvent;
+      OneSignal.setNotificationWillShowInForegroundHandler(notificationReceivedEvent -> {
+         lastForegroundNotificationReceivedEvent = notificationReceivedEvent;
 
-            OSNotification notification = notificationReceivedEvent.getNotification();
-            try {
-               // Make sure all of the accessible getters have the expected values
+         OSNotification notification = notificationReceivedEvent.getNotification();
+         try {
+            // Make sure all of the accessible getters have the expected values
 //               assertEquals("UUID1", notification.getApiNotificationId());
-               assertEquals("title1", notification.getTitle());
-               assertEquals("Notif message 1", notification.getBody());
-               JsonAsserts.equals(new JSONObject("{\"myKey1\": \"myValue1\", \"myKey2\": \"myValue2\"}"), notification.getAdditionalData());
-            } catch (JSONException e) {
-               e.printStackTrace();
-            }
-
-            // Call complete to end without waiting default 30 second timeout
-            notificationReceivedEvent.complete(notification);
+            assertEquals("title1", notification.getTitle());
+            assertEquals("Notif message 1", notification.getBody());
+            JsonAsserts.equals(new JSONObject("{\"myKey1\": \"myValue1\", \"myKey2\": \"myValue2\"}"), notification.getAdditionalData());
+         } catch (JSONException e) {
+            e.printStackTrace();
          }
+
+         // Call complete to end without waiting default 30 second timeout
+         notificationReceivedEvent.complete(notification);
       });
 
       blankActivityController.resume();

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
@@ -1166,7 +1166,7 @@ public class MainOneSignalClassRunner {
       OneSignal.setNotificationWillShowInForegroundHandler(notificationReceivedEvent -> {
          androidNotificationId = notificationReceivedEvent.getNotification().getAndroidNotificationId();
          notificationReceivedBody = notificationReceivedEvent.getNotification().getBody();
-         // TODO remove this line will make test fail, we want to cover this case on the future, but it's ok for beta 1
+
          notificationReceivedEvent.complete(notificationReceivedEvent.getNotification());
       });
       OneSignal.setNotificationOpenedHandler(getNotificationOpenedHandler());
@@ -1180,8 +1180,6 @@ public class MainOneSignalClassRunner {
 
       assertTrue(processResult);
       assertNull(lastNotificationOpenedBody);
-
-      NotificationBundleProcessor_Process(blankActivity, false, bundleAsJSONObject(bundle));
 
       assertEquals("Robo test message", notificationReceivedBody);
       assertNotEquals(0, androidNotificationId);


### PR DESCRIPTION
* If the same notification arrives twice, if the first notification did not end processing, the notification will be processed twice
* Keep notificationIds in memory for short time duplicates, then we rely on databse duplicate check

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1193)
<!-- Reviewable:end -->

