### PR TITLE
Disabling scrolling if dragToDismissDisabled is true in the rendering_complete event

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/DraggableRelativeLayout.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/DraggableRelativeLayout.java
@@ -28,6 +28,7 @@ class DraggableRelativeLayout extends RelativeLayout {
    private DraggableListener mListener;
    private ViewDragHelper mDragHelper;
    private boolean dismissing;
+   private boolean draggingDisabled;
 
    static class Params {
       static final int DRAGGABLE_DIRECTION_UP = 0;
@@ -40,6 +41,8 @@ class DraggableRelativeLayout extends RelativeLayout {
       int height;
       int messageHeight;
       int dragDirection;
+
+      boolean draggingDisabled;
 
       private int dismissingYVelocity;
       private int offScreenYPos;
@@ -85,6 +88,9 @@ class DraggableRelativeLayout extends RelativeLayout {
 
          @Override
          public int clampViewPositionVertical(@NonNull View child, int top, int dy) {
+            if (params.draggingDisabled) {
+               return params.maxYPos;
+            }
             lastYPos = top;
             if (params.dragDirection == Params.DRAGGABLE_DIRECTION_DOWN) {
                // Dragging down

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/InAppMessageView.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/InAppMessageView.java
@@ -72,6 +72,7 @@ class InAppMessageView {
     private boolean hasBackground;
     private boolean shouldDismissWhenActive = false;
     private boolean isDragging = false;
+    private boolean disableDragDismiss = false;
     @NonNull private WebViewManager.Position displayLocation;
     private WebView webView;
     private RelativeLayout parentRelativeLayout;
@@ -79,13 +80,14 @@ class InAppMessageView {
     private InAppMessageViewListener messageController;
     private Runnable scheduleDismissRunnable;
 
-    InAppMessageView(@NonNull WebView webView, @NonNull WebViewManager.Position displayLocation, int pageHeight, double dismissDuration) {
+    InAppMessageView(@NonNull WebView webView, @NonNull WebViewManager.Position displayLocation, int pageHeight, double dismissDuration, boolean disableDragDismiss) {
         this.webView = webView;
         this.displayLocation = displayLocation;
         this.pageHeight = pageHeight;
         this.pageWidth = ViewGroup.LayoutParams.MATCH_PARENT;
         this.dismissDuration = Double.isNaN(dismissDuration) ? 0 : dismissDuration;
         this.hasBackground = !displayLocation.isBanner();
+        this.disableDragDismiss = disableDragDismiss;
     }
 
     void setWebView(WebView webView) {
@@ -140,7 +142,7 @@ class InAppMessageView {
                 // When preparing the IAM, the correct height will be set and handle this job, so
                 //  all bases are covered and the draggableRelativeLayout will never have the wrong height
                 if (draggableRelativeLayout != null)
-                    draggableRelativeLayout.setParams(createDraggableLayoutParams(pageHeight, displayLocation));
+                    draggableRelativeLayout.setParams(createDraggableLayoutParams(pageHeight, displayLocation, disableDragDismiss));
             }
         });
     }
@@ -162,7 +164,7 @@ class InAppMessageView {
                 displayLocation,
                 webViewLayoutParams,
                 linearLayoutParams,
-                createDraggableLayoutParams(pageHeight, displayLocation)
+                createDraggableLayoutParams(pageHeight, displayLocation, disableDragDismiss)
         );
     }
 
@@ -188,11 +190,11 @@ class InAppMessageView {
         return linearLayoutParams;
     }
 
-    private DraggableRelativeLayout.Params createDraggableLayoutParams(int pageHeight, WebViewManager.Position displayLocation) {
+    private DraggableRelativeLayout.Params createDraggableLayoutParams(int pageHeight, WebViewManager.Position displayLocation, boolean disableDragging) {
         DraggableRelativeLayout.Params draggableParams = new DraggableRelativeLayout.Params();
         draggableParams.maxXPos = MARGIN_PX_SIZE;
         draggableParams.maxYPos = MARGIN_PX_SIZE;
-
+        draggableParams.draggingDisabled = disableDragging;
         draggableParams.messageHeight = pageHeight;
         draggableParams.height = getDisplayYSize();
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/WebViewManager.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/WebViewManager.java
@@ -158,6 +158,7 @@ class WebViewManager extends ActivityLifecycleHandler.ActivityAvailableListener 
 
         static final String IAM_DISPLAY_LOCATION_KEY = "displayLocation";
         static final String IAM_PAGE_META_DATA_KEY = "pageMetaData";
+        static final String IAM_DRAG_TO_DISMISS_DISABLED_KEY = "dragToDismissDisabled";
 
         @JavascriptInterface
         public void postMessage(String message) {
@@ -181,7 +182,8 @@ class WebViewManager extends ActivityLifecycleHandler.ActivityAvailableListener 
         private void handleRenderComplete(JSONObject jsonObject) {
             Position displayType = getDisplayLocation(jsonObject);
             int pageHeight = displayType == Position.FULL_SCREEN ? -1 : getPageHeightData(jsonObject);
-            createNewInAppMessageView(displayType, pageHeight);
+            boolean dragToDismissDisabled = getDragToDismissDisabled(jsonObject);
+            createNewInAppMessageView(displayType, pageHeight, dragToDismissDisabled);
         }
 
         private int getPageHeightData(JSONObject jsonObject) {
@@ -201,6 +203,14 @@ class WebViewManager extends ActivityLifecycleHandler.ActivityAvailableListener 
                 e.printStackTrace();
             }
             return displayLocation;
+        }
+
+        private boolean getDragToDismissDisabled(JSONObject jsonObject) {
+            try {
+                return jsonObject.getBoolean(IAM_DRAG_TO_DISMISS_DISABLED_KEY);
+            } catch (JSONException e) {
+                return false;
+            }
         }
 
         private void handleActionTaken(JSONObject jsonObject) throws JSONException {
@@ -352,8 +362,8 @@ class WebViewManager extends ActivityLifecycleHandler.ActivityAvailableListener 
         webView.layout(0,0, getWebViewMaxSizeX(activity), getWebViewMaxSizeY(activity));
     }
 
-    private void createNewInAppMessageView(@NonNull Position displayLocation, int pageHeight) {
-        messageView = new InAppMessageView(webView, displayLocation, pageHeight, message.getDisplayDuration());
+    private void createNewInAppMessageView(@NonNull Position displayLocation, int pageHeight, boolean dragToDismissDisabled) {
+        messageView = new InAppMessageView(webView, displayLocation, pageHeight, message.getDisplayDuration(), dragToDismissDisabled);
         messageView.setMessageController(new InAppMessageView.InAppMessageViewListener() {
             @Override
             public void onMessageWasShown() {


### PR DESCRIPTION
This PR is intended to disable drag to dismiss for IAM carousel. This change is agnostic to carousel in case we want to disable scrolling for other reasons in the future

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1199)
<!-- Reviewable:end -->

