### PR TITLE
Add Main thread check under OSNotificationReceivedEvent

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationReceivedEvent.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationReceivedEvent.java
@@ -67,7 +67,7 @@ public class OSNotificationReceivedEvent {
     * @param notification can be null to omit displaying the notification,
     *                     or OSMutableNotification to modify the notification to display
     */
-   public synchronized void complete(@Nullable OSNotification notification) {
+   public synchronized void complete(@Nullable final OSNotification notification) {
       timeoutHandler.destroyTimeout(timeoutRunnable);
 
       if (isComplete) {
@@ -77,6 +77,20 @@ public class OSNotificationReceivedEvent {
 
       isComplete = true;
 
+      if (OSUtils.isRunningOnMainThread()) {
+         new Thread(new Runnable() {
+            @Override
+            public void run() {
+               processNotification(notification);
+            }
+         }, "OS_COMPLETE_NOTIFICATION").start();
+         return;
+      }
+
+      processNotification(notification);
+   }
+
+   private void processNotification(@Nullable OSNotification notification) {
       // Pass copies to controller, to avoid modifying objects accessed by the user
       controller.processNotification(this.notification.copy(), notification != null ? notification.copy() : null);
    }

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
+import static com.test.onesignal.TestHelpers.threadAndTaskWait;
 import static org.robolectric.Shadows.shadowOf;
 
 public class OneSignalPackagePrivateHelper {
@@ -142,12 +143,13 @@ public class OneSignalPackagePrivateHelper {
       receiver.onReceive(context, intent);
    }
 
-   public static void FCMBroadcastReceiver_onReceived_withBundle(Context context, Bundle bundle) {
+   public static void FCMBroadcastReceiver_onReceived_withBundle(Context context, Bundle bundle) throws Exception {
       FCMBroadcastReceiver receiver = new FCMBroadcastReceiver();
       Intent intent = new Intent();
       intent.setAction("com.google.android.c2dm.intent.RECEIVE");
       intent.putExtras(bundle);
       receiver.onReceive(context,intent);
+      threadAndTaskWait();
    }
 
    public static void HMSProcessor_processDataMessageReceived(final Context context, final String jsonStrPayload) {

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
@@ -1129,7 +1129,7 @@ public class GenerateNotificationRunner {
 
    @Test
    @Config(shadows = { ShadowGenerateNotification.class })
-   public void shouldSetExpireTimeCorrectlyFromGoogleTTL() {
+   public void shouldSetExpireTimeCorrectlyFromGoogleTTL() throws Exception {
       long sentTime = 1_553_035_338_000L;
       long ttl = 60L;
 
@@ -1137,6 +1137,7 @@ public class GenerateNotificationRunner {
       bundle.putLong("google.sent_time", sentTime);
       bundle.putLong("google.ttl", ttl);
       NotificationBundleProcessor_ProcessFromFCMIntentService(blankActivity, bundle);
+      threadAndTaskWait();
 
       HashMap<String, Object> notification = TestHelpers.getAllNotificationRecords(dbHelper).get(0);
       long expireTime = (Long)notification.get(NotificationTable.COLUMN_NAME_EXPIRE_TIME);
@@ -1145,8 +1146,9 @@ public class GenerateNotificationRunner {
 
    @Test
    @Config(shadows = { ShadowGenerateNotification.class })
-   public void shouldSetExpireTimeCorrectlyWhenMissingFromPayload() {
+   public void shouldSetExpireTimeCorrectlyWhenMissingFromPayload() throws Exception {
       NotificationBundleProcessor_ProcessFromFCMIntentService(blankActivity, getBaseNotifBundle());
+      threadAndTaskWait();
 
       long expireTime = (Long)TestHelpers.getAllNotificationRecords(dbHelper).get(0).get(NotificationTable.COLUMN_NAME_EXPIRE_TIME);
       assertEquals((SystemClock.currentThreadTimeMillis() / 1_000L) + 259_200, expireTime);

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/OutcomeEventIntegrationTests.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/OutcomeEventIntegrationTests.java
@@ -696,7 +696,6 @@ public class OutcomeEventIntegrationTests {
         // Receive notification
         Bundle bundle = getBaseNotifBundle(ONESIGNAL_NOTIFICATION_ID + "2");
         FCMBroadcastReceiver_onReceived_withBundle(blankActivity, bundle);
-        threadAndTaskWait();
 
         // Wait 31 seconds
         time.advanceSystemTimeBy(31);

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/TestHelpers.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/TestHelpers.java
@@ -201,7 +201,7 @@ public class TestHelpers {
    }
 
    // Run any OneSignal background threads including any pending runnables
-   static void threadAndTaskWait() throws Exception {
+   public static void threadAndTaskWait() throws Exception {
       ShadowApplication.getInstance().getForegroundThreadScheduler().runOneTask();
       // Runs Runnables posted by calling View.post() which are run on the main thread.
       Robolectric.getForegroundThreadScheduler().runOneTask();


### PR DESCRIPTION
* Flutter invoked methods are runned under MainThread, OSNotificationReceivedEvent complete method ends calling a MainThread check that crashes.
* Add MainThread check under OSNotificationReceivedEvent complete method
* If running on MainThread create a new thread to complete the notification

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1206)
<!-- Reviewable:end -->

