### PR TITLE
Delay outcomes call until init

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSTaskController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSTaskController.java
@@ -33,6 +33,9 @@ class OSTaskController {
     static final String CANCEL_GROUPED_NOTIFICATIONS = "cancelGroupedNotifications()";
     static final String PAUSE_IN_APP_MESSAGES = "pauseInAppMessages()";
     static final String APP_LOST_FOCUS = "onAppLostFocus()";
+    static final String SEND_OUTCOME = "sendOutcome()";
+    static final String SEND_UNIQUE_OUTCOME = "sendUniqueOutcome()";
+    static final String SEND_OUTCOME_WITH_VALUE = "sendOutcomeWithValue()";
     static final HashSet<String> METHODS_AVAILABLE_FOR_DELAY = new HashSet<>(Arrays.asList(
             GET_TAGS,
             SYNC_HASHED_EMAIL,

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -2971,7 +2971,8 @@ public class OneSignal {
    }
 
    static void sendClickActionOutcomes(@NonNull List<OSInAppMessageOutcome> outcomes) {
-      if (outcomeEventsController == null) {
+      // This is called from IAM shouldn't need this check
+      if (outcomeEventsController == null || appId == null) {
          OneSignal.Log(LOG_LEVEL.ERROR, "Make sure OneSignal.init is called first");
          return;
       }
@@ -2983,14 +2984,23 @@ public class OneSignal {
       sendOutcome(name, null);
    }
 
-   public static void sendOutcome(@NonNull String name, OutcomeCallback callback) {
+   public static void sendOutcome(@NonNull final String name, final OutcomeCallback callback) {
       if (!isValidOutcomeEntry(name)) {
          logger.error("Make sure OneSignal initWithContext and setAppId is called first");
          return;
       }
 
-      if (outcomeEventsController == null) {
-         logger.error("Make sure OneSignal initWithContext and setAppId is called first");
+      // Outcomes needs app id, delay until init is not done
+      if (taskController.shouldQueueTaskForInit(OSTaskController.SEND_OUTCOME) || outcomeEventsController == null) {
+         logger.error("Waiting for remote params. " +
+                 "Moving " + OSTaskController.SEND_OUTCOME + " operation to a pending queue.");
+         taskController.addTaskToQueue(new Runnable() {
+            @Override
+            public void run() {
+               logger.debug("Running " + OSTaskController.HANDLE_NOTIFICATION_OPEN + " operation from pending queue.");
+               sendOutcome(name, callback);
+            }
+         });
          return;
       }
 
@@ -3001,12 +3011,21 @@ public class OneSignal {
       sendUniqueOutcome(name, null);
    }
 
-   public static void sendUniqueOutcome(@NonNull String name, OutcomeCallback callback) {
+   public static void sendUniqueOutcome(@NonNull final String name, final OutcomeCallback callback) {
       if (!isValidOutcomeEntry(name))
          return;
 
-      if (outcomeEventsController == null) {
-         logger.error("Make sure OneSignal initWithContext and setAppId is called first");
+      // Outcomes needs app id, delay until init is not done
+      if (taskController.shouldQueueTaskForInit(OSTaskController.SEND_UNIQUE_OUTCOME) || outcomeEventsController == null) {
+         logger.error("Waiting for remote params. " +
+                 "Moving " + OSTaskController.SEND_UNIQUE_OUTCOME + " operation to a pending queue.");
+         taskController.addTaskToQueue(new Runnable() {
+            @Override
+            public void run() {
+               logger.debug("Running " + OSTaskController.HANDLE_NOTIFICATION_OPEN + " operation from pending queue.");
+               sendUniqueOutcome(name, callback);
+            }
+         });
          return;
       }
 
@@ -3017,12 +3036,21 @@ public class OneSignal {
       sendOutcomeWithValue(name, value, null);
    }
 
-   public static void sendOutcomeWithValue(@NonNull String name, float value, OutcomeCallback callback) {
+   public static void sendOutcomeWithValue(@NonNull final String name, final float value, final OutcomeCallback callback) {
       if (!isValidOutcomeEntry(name) || !isValidOutcomeValue(value))
          return;
 
-      if (outcomeEventsController == null) {
-         logger.error("Make sure OneSignal.init is called first");
+      // Outcomes needs app id, delay until init is not done
+      if (taskController.shouldQueueTaskForInit(OSTaskController.SEND_OUTCOME_WITH_VALUE) || outcomeEventsController == null) {
+         logger.error("Waiting for remote params. " +
+                 "Moving " + OSTaskController.SEND_OUTCOME_WITH_VALUE + " operation to a pending queue.");
+         taskController.addTaskToQueue(new Runnable() {
+            @Override
+            public void run() {
+               logger.debug("Running " + OSTaskController.HANDLE_NOTIFICATION_OPEN + " operation from pending queue.");
+               sendOutcomeWithValue(name, value, callback);
+            }
+         });
          return;
       }
 


### PR DESCRIPTION
* If outcomes is send before init is done then app id is not set, this makes wrappers crash
* Delay outcomes unitl init is done

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1208)
<!-- Reviewable:end -->

