### PR TITLE
getOneSignalNotificationsCount method added

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -182,7 +182,7 @@ public class OneSignal {
       void tagsAvailable(JSONObject tags);
    }
    
-   public interface GetNotificationsCountHandler {
+   public interface OSNotificationsCountHandler {
       void notificationsAvailable(int count);
    }
 
@@ -2625,12 +2625,10 @@ public class OneSignal {
       runPromptLocation.run();
    }
    
-   public static void getOneSignalNotificationsCount(final GetNotificationsCountHandler getNotificationsCountHandler) {
+   public static void getOneSignalNotificationsCount(final OSNotificationsCountHandler getNotificationsCountHandler) {
       Runnable runGetOneSignalNotificationsCount = new Runnable() {
          @Override
          public void run() {
-            NotificationManager notificationManager = OneSignalNotificationManager.getNotificationManager(appContext);
-
             OneSignalDbHelper dbHelper = OneSignalDbHelper.getInstance(appContext);
             String[] retColumn = {OneSignalDbContract.NotificationTable.COLUMN_NAME_ANDROID_NOTIFICATION_ID};
 
@@ -2644,9 +2642,8 @@ public class OneSignal {
                     null,                                                    // filter by row groups
                     null                                                     // sort order
             );
-            
-            //BadgeCountUpdater.updateCount(0, appContext);			
-			getNotificationsCountHandler.notificationsAvailable(cursor.getCount());
+            	
+            getNotificationsCountHandler.notificationsAvailable(cursor.getCount());
 
             cursor.close();
          }

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
@@ -2627,6 +2627,10 @@ public class MainOneSignalClassRunner {
       OneSignal.enableVibrate(false);
       OneSignal.enableSound(false);
       OneSignal.promptLocation();
+	  OneSignal.getOneSignalNotificationsCount(new OneSignal.OSNotificationsCountHandler() {
+		  @Override
+		  public void notificationsAvailable(int count) {}
+	  });
       OneSignal.postNotification("{}", new OneSignal.PostNotificationResponseHandler() {
          @Override
          public void onSuccess(JSONObject response) {}


### PR DESCRIPTION
getOneSignalNotificationsCount method added for Android (returns number of available notifications displayed on the app's badge)

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1211)
<!-- Reviewable:end -->

