### PR TITLE
Fix logging typo in `showMessageView`

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/WebViewManager.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/WebViewManager.java
@@ -301,7 +301,7 @@ class WebViewManager extends ActivityLifecycleHandler.ActivityAvailableListener 
             return;
         }
 
-        OneSignal.Log(OneSignal.LOG_LEVEL.DEBUG, "In app message, showing fist one with height: " + newHeight);
+        OneSignal.Log(OneSignal.LOG_LEVEL.DEBUG, "In app message, showing first one with height: " + newHeight);
         messageView.setWebView(webView);
         if (newHeight != null)
             messageView.updateHeight(newHeight);


### PR DESCRIPTION
In app message, showing fist one with height -> 
In app message, showing fi**r**st one with height

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1220)
<!-- Reviewable:end -->

