### PR TITLE
Always add external id auth hash

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserState.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserState.java
@@ -240,6 +240,8 @@ abstract class UserState {
                 sendJson.put("app_id", syncValues.optString("app_id"));
             if (syncValues.has("email_auth_hash"))
                 sendJson.put("email_auth_hash", syncValues.optString("email_auth_hash"));
+            if (syncValues.has("external_user_id_auth_hash"))
+                sendJson.put("external_user_id_auth_hash", syncValues.optString("external_user_id_auth_hash"));
         } catch (JSONException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
* External id auth hash should be sent in all players and on_session calls

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1221)
<!-- Reviewable:end -->

