### PR TITLE
Fix new session triggering from 2nd init

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -692,7 +692,6 @@ public class OneSignal {
          if (notificationOpenedHandler != null)
             fireCallbackForOpenedNotifications();
          logger.debug("OneSignal SDK initialization already completed.");
-         doSessionInit();
          return;
       }
 

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
@@ -28,6 +28,8 @@ import static org.robolectric.Shadows.shadowOf;
 public class OneSignalPackagePrivateHelper {
    public static final String IN_APP_MESSAGES_JSON_KEY = com.onesignal.OSInAppMessageController.IN_APP_MESSAGES_JSON_KEY;
 
+   public static final long MIN_ON_SESSION_TIME_MILLIS = com.onesignal.OneSignal.MIN_ON_SESSION_TIME_MILLIS;
+
    private static abstract class RunnableArg<T> {
       abstract void run(T object) throws Exception;
    }

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/OneSignalInitializationIntegrationTestsRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/OneSignalInitializationIntegrationTestsRunner.java
@@ -2,6 +2,7 @@ package com.test.onesignal;
 
 import androidx.test.core.app.ApplicationProvider;
 
+import com.onesignal.MockOSTimeImpl;
 import com.onesignal.OneSignal;
 import com.onesignal.ShadowCustomTabsClient;
 import com.onesignal.ShadowCustomTabsSession;
@@ -21,7 +22,10 @@ import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowLog;
 
+import static com.onesignal.OneSignalPackagePrivateHelper.MIN_ON_SESSION_TIME_MILLIS;
+import static com.onesignal.OneSignalPackagePrivateHelper.OneSignal_setTime;
 import static com.onesignal.ShadowOneSignalRestClient.setRemoteParamsGetHtmlResponse;
+import static com.test.onesignal.RestClientAsserts.assertNumberOfOnSessions;
 import static com.test.onesignal.TestHelpers.threadAndTaskWait;
 
 @Config(
@@ -39,6 +43,7 @@ import static com.test.onesignal.TestHelpers.threadAndTaskWait;
 @RunWith(RobolectricTestRunner.class)
 public class OneSignalInitializationIntegrationTestsRunner {
     private ActivityController<BlankActivity> blankActivityController;
+    private MockOSTimeImpl time;
 
     @BeforeClass // Runs only once, before any tests
     public static void setUpClass() throws Exception {
@@ -52,11 +57,22 @@ public class OneSignalInitializationIntegrationTestsRunner {
         TestHelpers.beforeTestInitAndCleanup();
         setRemoteParamsGetHtmlResponse();
         blankActivityController = Robolectric.buildActivity(BlankActivity.class).create();
+
+        time = new MockOSTimeImpl();
+        OneSignal_setTime(time);
     }
 
+    private static final long MIN_ON_SESSION_TIME_SEC = MIN_ON_SESSION_TIME_MILLIS / 1_000L;
     private static final String APP_ID = "11111111-2222-3333-4444-55555555555";
     private static void helper_OneSignal_initWithAppContext() {
         OneSignal.initWithContext(ApplicationProvider.getApplicationContext());
+    }
+    private void helper_OneSignal_initWithActivity() {
+        OneSignal.initWithContext(blankActivityController.get());
+    }
+
+    private void helper_advanceSystemTimeToNextOnSession() {
+        time.advanceSystemAndElapsedTimeBy(MIN_ON_SESSION_TIME_SEC + 1);
     }
 
     @Test
@@ -80,6 +96,29 @@ public class OneSignalInitializationIntegrationTestsRunner {
         threadAndTaskWait();
 
         RestClientAsserts.assertRemoteParamsWasTheOnlyNetworkCall();
+    }
+
+    /**
+     * on_session calls should only be made if the user left the app for MIN_ON_SESSION_TIME_SEC or longer
+     * This test ensures that we meet the out of focus requirement, at lest through initWithContext
+     *   being called a 2nd time code path.
+     */
+    @Test
+    public void initWithContext_calledA2ndTimeAfter30OrMoreSeconds_doesNotStartNewSession() throws Exception {
+        // 1. Basic OneSignal init with Activity
+        OneSignal.setAppId(APP_ID);
+        helper_OneSignal_initWithActivity();
+        threadAndTaskWait();
+
+        // 2. Keep the app in focus for 30+ seconds, which is the time required to
+        helper_advanceSystemTimeToNextOnSession();
+
+        // 3. Developer or OneSignal internally calls OneSignal.initWithContext
+        helper_OneSignal_initWithActivity();
+        threadAndTaskWait();
+
+        // 4. Ensure we do NOT make an /players/{player_id}/on_session network call.
+        assertNumberOfOnSessions(0);
     }
 
 }

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/RestClientAsserts.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/RestClientAsserts.java
@@ -113,6 +113,18 @@ class RestClientAsserts {
       assertOnSessionUrl(request.url);
    }
 
+   static void assertNumberOfOnSessions(int number) {
+      int successfulAsserts = 0;
+      for (Request request : ShadowOneSignalRestClient.requests) {
+         try {
+            assertOnSessionUrl(request.url);
+            successfulAsserts++;
+         } catch (AssertionError ignored) { }
+      }
+
+      assertEquals(number, successfulAsserts);
+   }
+
    static void assertOnFocusAtIndex(int index, int focusTimeSec) throws JSONException {
       assertOnFocusAtIndex(index, new JSONObject().put("active_time", focusTimeSec));
    }
@@ -256,6 +268,8 @@ class RestClientAsserts {
    static void assertOnSessionUrl(String url) {
       String[] parts = url.split("/");
       assertEquals("players", parts[0]);
+      if (parts.length == 1)
+         fail("Not an on_session as player_id and on_session is missing from the URL");
       assertIsUUID(parts[1]);
       assertEquals("on_session", parts[2]);
    }


### PR DESCRIPTION
## Test Added
### Integration test for extra on_session call
* Added initWithContext_calledA2ndTimeAfter30OrMoreSeconds_doesNotStartNewSession test
  * This is a failing test to reproduce the issue.
* Added new `RestClientAsserts.assertNumberOfOnSessions` to help the ensure we have the right number of on_session calls.

## Refactoring
### Cleaned up isPastOnSessionTime logic
* Added new shouldStartNewSession method to encapsulate foreground check
* Added foreground check to attemptSessionUpgrade
* Added appEntryState logging to doSessionInit

## Fix implementation
### Removed extra doSessionInit call
* This extra doSessionInit if we init a 2nd time isn't needed and
address the issue covered in the new initWithContext_calledA2ndTimeAfter30OrMoreSeconds_doesNotStartNewSession test added in this PR.
* For reference the extra doSessionInit call was added in this commit
* 012cdb2#diff-2708f86f77e539cab647ecede9d5fcbead3bf0f954d7f9e536eafbc78ba760d6R685
* Ran `shouldSendTagsFromBackgroundOnAppKilled` test locally and it still passes after this change

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1229)
<!-- Reviewable:end -->

