### PR TITLE
Fix IAM redisplay multiple times

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessage.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessage.java
@@ -222,9 +222,13 @@ class OSInAppMessage {
     public String toString() {
         return "OSInAppMessage{" +
                 "messageId='" + messageId + '\'' +
+                ", variants=" + variants +
                 ", triggers=" + triggers +
                 ", clickedClickIds=" + clickedClickIds +
-                ", displayStats=" + redisplayStats +
+                ", redisplayStats=" + redisplayStats +
+                ", displayDuration=" + displayDuration +
+                ", displayedInSession=" + displayedInSession +
+                ", triggerChanged=" + triggerChanged +
                 ", actionTaken=" + actionTaken +
                 ", isPreview=" + isPreview +
                 '}';

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSTriggerController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSTriggerController.java
@@ -201,6 +201,26 @@ class OSTriggerController {
     }
 
     /**
+     * Part of redisplay logic
+     *
+     * If message has only dynamic trigger return true, otherwise false
+     * */
+    boolean messageHasOnlyDynamicTriggers(OSInAppMessage message) {
+        if (message.triggers == null || message.triggers.isEmpty())
+            return false;
+
+        for (ArrayList<OSTrigger> andConditions : message.triggers) {
+            for (OSTrigger trigger : andConditions) {
+                if (trigger.kind == OSTrigger.OSTriggerKind.CUSTOM || trigger.kind == OSTrigger.OSTriggerKind.UNKNOWN)
+                    // At least one trigger is not dynamic
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
      * Trigger Set/Delete/Persist Logic
      */
     void addTriggers(Map<String, Object> newTriggers) {


### PR DESCRIPTION
* When IAM only has dynamic triggers it can end redisplaying multiple times on the same session
* Limit IAM with only dynamic trigger to display once per session
* Add test for scenario

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1240)
<!-- Reviewable:end -->

