### PR TITLE
Fix direct tracking

### DIFF
--- a/Examples/OneSignalDemo/app/src/main/AndroidManifest.xml
+++ b/Examples/OneSignalDemo/app/src/main/AndroidManifest.xml
@@ -64,8 +64,6 @@
         <meta-data android:name="com.onesignal.NotificationServiceExtension"
             android:value="com.onesignal.sdktest.notification.NotificationServiceExtension" />
 
-        <meta-data android:name="com.onesignal.NotificationOpened.DEFAULT" android:value="DISABLE" />
-
         <activity android:name=".activity.SplashActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/Examples/OneSignalDemo/app/src/main/AndroidManifest.xml
+++ b/Examples/OneSignalDemo/app/src/main/AndroidManifest.xml
@@ -64,6 +64,8 @@
         <meta-data android:name="com.onesignal.NotificationServiceExtension"
             android:value="com.onesignal.sdktest.notification.NotificationServiceExtension" />
 
+        <meta-data android:name="com.onesignal.NotificationOpened.DEFAULT" android:value="DISABLE" />
+
         <activity android:name=".activity.SplashActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationOpenedResult.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationOpenedResult.java
@@ -1,7 +1,7 @@
 /**
  * Modified MIT License
  *
- * Copyright 2016 OneSignal
+ * Copyright 2020 OneSignal
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -55,6 +55,10 @@ public class OSNotificationOpenedResult implements OneSignal.EntryStateListener 
       this.notification = notification;
       this.action = action;
 
+      // Configure 5 second timeout - max time we expect the application to call onResume
+      // User can disable OneSignal application open by setting on the manifest:
+      // <meta-data android:name="com.onesignal.NotificationOpened.DEFAULT" android:value="DISABLE" />
+      // If the user does this, we need to identify if the notification click was the way the user come back to the application (Session tracking)
       timeoutHandler = OSTimeoutHandler.getTimeoutHandler();
       timeoutRunnable = new Runnable() {
          @Override
@@ -63,13 +67,12 @@ public class OSNotificationOpenedResult implements OneSignal.EntryStateListener 
             complete(false);
          }
       };
+      // This timer is needed for tracking application coming from background or swiped away when user click on notification
       timeoutHandler.startTimeout(PROCESS_NOTIFICATION_TIMEOUT, timeoutRunnable);
    }
 
    /**
     * Method indicating OneSignal that application was opened by user.
-    * This method must be call before startActivity or equivalents are called
-    * User must call complete within 5 seconds or opened track will be handle by OneSignal.
     *
     * @param opened true if application was opened under the OSNotificationOpenedHandler handler, false otherwise
     */

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -303,6 +303,7 @@ public class OneSignal {
       // Fire with the last appEntryState that just ended.
       void onEntryStateChange(AppEntryAction appEntryState);
    }
+
    private static List<EntryStateListener> entryStateListeners = new ArrayList<>();
    static void callEntryStateListeners(AppEntryAction appEntryState) {
       List<EntryStateListener> entryStateListeners = new ArrayList<>(OneSignal.entryStateListeners);

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -299,6 +299,28 @@ public class OneSignal {
       void onFailure(JSONObject response);
    }
 
+   interface EntryStateListener {
+      // Fire with the last appEntryState that just ended.
+      void onEntryStateChange(AppEntryAction appEntryState);
+   }
+   private static List<EntryStateListener> entryStateListeners = new ArrayList<>();
+   static void callEntryStateListeners(AppEntryAction appEntryState) {
+      List<EntryStateListener> entryStateListeners = new ArrayList<>(OneSignal.entryStateListeners);
+      for (EntryStateListener sessionListener : entryStateListeners) {
+         sessionListener.onEntryStateChange(appEntryState);
+      }
+   }
+
+   static void addEntryStateListener(EntryStateListener sessionListener, AppEntryAction appEntryState) {
+      // We only care for open and close changes
+      if (!appEntryState.equals(AppEntryAction.NOTIFICATION_CLICK))
+         entryStateListeners.add(sessionListener);
+   }
+
+   static void removeEntryStateListener(EntryStateListener sessionListener) {
+      entryStateListeners.remove(sessionListener);
+   }
+
    static Context appContext;
    static WeakReference<Activity> appActivity;
    static String appId;
@@ -1226,8 +1248,12 @@ public class OneSignal {
       setInForeground(true);
 
       // If the app gains focus and has not been set to NOTIFICATION_CLICK yet we can assume this is a normal app open
-      if (!appEntryState.equals(AppEntryAction.NOTIFICATION_CLICK))
-         appEntryState = AppEntryAction.APP_OPEN;
+      if (!appEntryState.equals(AppEntryAction.NOTIFICATION_CLICK)) {
+         callEntryStateListeners(appEntryState);
+         // Check again because listeners might have changed the appEntryState
+         if (!appEntryState.equals(AppEntryAction.NOTIFICATION_CLICK))
+            appEntryState = AppEntryAction.APP_OPEN;
+      }
 
       LocationController.onFocusChange();
 
@@ -1979,7 +2005,9 @@ public class OneSignal {
          return;
       }
 
-      fireNotificationOpenedHandler(generateNotificationOpenedResult(dataArray));
+      OSNotificationOpenedResult openedResult = generateNotificationOpenedResult(dataArray);
+      addEntryStateListener(openedResult, appEntryState);
+      fireNotificationOpenedHandler(openedResult);
    }
 
    // Also called for received but OSNotification is extracted from it.
@@ -2126,12 +2154,16 @@ public class OneSignal {
       logger.debug("handleNotificationOpen from context: " + context + " with fromAlert: " + fromAlert + " urlOpened: " + urlOpened + " and defaultOpenActionDisabled: " + defaultOpenActionDisabled);
       // Check if the notification click should lead to a DIRECT session
       if (shouldInitDirectSessionFromNotificationOpen(context, fromAlert, urlOpened, defaultOpenActionDisabled)) {
-         // We want to set the app entry state to NOTIFICATION_CLICK when coming from background
-         appEntryState = AppEntryAction.NOTIFICATION_CLICK;
-         sessionManager.onDirectInfluenceFromNotificationOpen(appEntryState, notificationId);
+         applicationOpenedByNotification(notificationId);
       }
 
       runNotificationOpenedCallback(data);
+   }
+
+   static void applicationOpenedByNotification(@Nullable final String notificationId) {
+      // We want to set the app entry state to NOTIFICATION_CLICK when coming from background
+      appEntryState = AppEntryAction.NOTIFICATION_CLICK;
+      sessionManager.onDirectInfluenceFromNotificationOpen(appEntryState, notificationId);
    }
 
    static boolean startOrResumeApp(Activity inContext) {

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
@@ -996,6 +996,14 @@ public class MainOneSignalClassRunner {
    }
 
    @Test
+   public void testAndroidParamsProjectNumberOverridesLocal() throws Exception {
+      OneSignalInit();
+      threadAndTaskWait();
+
+      assertThat(ShadowPushRegistratorFCM.lastProjectNumber, not("123456789"));
+   }
+
+   @Test
    @Config(shadows = {ShadowOneSignal.class})
    public void testOpenFromNotificationWhenAppIsDead() throws Exception {
       OneSignal.initWithContext(blankActivity);
@@ -1008,14 +1016,6 @@ public class MainOneSignalClassRunner {
       threadAndTaskWait();
 
       assertEquals("Robo test message", lastNotificationOpenedBody);
-   }
-
-   @Test
-   public void testAndroidParamsProjectNumberOverridesLocal() throws Exception {
-      OneSignalInit();
-      threadAndTaskWait();
-
-      assertThat(ShadowPushRegistratorFCM.lastProjectNumber, not("123456789"));
    }
 
    @Test


### PR DESCRIPTION
* Direct session tracking is not working when OneSignal opening application is disabled on the manifest. If the user opens the application on the open handler callback no direct session is being tracked
* Create a complete method under OSNotificationOpenedResult to track direct opening by notification click

To achieve the fix we have a timeout handler of 5 seconds, this time is the max time that the application will wait for the application to start. This way we can track that the app was started by a notification click activity open handle by the user, this will able Session DIRECT tracking

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1244)
<!-- Reviewable:end -->

