### PR TITLE
Fix Displaying IAMs past end time

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessage.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessage.java
@@ -96,7 +96,7 @@ class OSInAppMessage {
             return null;
         }
 
-        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US);
+        SimpleDateFormat format = OneSignalSimpleDateFormat.iso8601Format();
         try {
             Date date = format.parse(endTimeString);
             return date;
@@ -179,7 +179,7 @@ class OSInAppMessage {
             json.put(IAM_TRIGGERS, orConditions);
 
             if (this.endTime != null) {
-                SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US);
+                SimpleDateFormat format = OneSignalSimpleDateFormat.iso8601Format();
                 String endTimeString = format.format(this.endTime);
                 json.put(END_TIME, endTimeString);
             }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageController.java
@@ -202,7 +202,7 @@ class OSInAppMessageController implements OSDynamicTriggerControllerObserver, OS
             if (triggerController.evaluateMessageTriggers(message)) {
                 setDataForRedisplay(message);
 
-                if (!dismissedMessages.contains(message.messageId)) {
+                if (!dismissedMessages.contains(message.messageId) && !message.isFinished()) {
                     queueMessageForDisplay(message);
                 }
             }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalSimpleDateFormat.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalSimpleDateFormat.java
@@ -1,0 +1,36 @@
+/**
+ * Modified MIT License
+ *
+ * Copyright 2020 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.onesignal;
+
+import java.text.SimpleDateFormat;
+import java.util.Locale;
+
+class OneSignalSimpleDateFormat {
+    static SimpleDateFormat iso8601Format() {
+        return new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US);
+    }
+}

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/InAppMessagingHelpers.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/InAppMessagingHelpers.java
@@ -108,6 +108,17 @@ public class InAppMessagingHelpers {
         return new OSTestInAppMessage(basicIAMJSONObject(triggerJson));
     }
 
+    public static OSTestInAppMessage buildTestMessageWithEndTime(final OSTriggerKind kind, final String key, final String operator, final Object value, final boolean pastEndTime) throws JSONException {
+        JSONArray triggerJson = basicTrigger(kind, key, operator, value);
+        JSONObject json = basicIAMJSONObject(triggerJson);
+        if (pastEndTime) {
+            json.put("end_time", "1960-01-01T00:00:00.000Z");
+        } else {
+            json.put("end_time", "2200-01-01T00:00:00.000Z");
+        }
+        return new OSTestInAppMessage(json);
+    }
+
     public static OSTestInAppMessage buildTestMessageWithMultipleTriggers(ArrayList<ArrayList<OSTestTrigger>> triggers) throws JSONException {
         JSONArray ors = buildTriggers(triggers);
         return buildTestMessage(ors);

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/InAppMessageIntegrationTests.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/InAppMessageIntegrationTests.java
@@ -190,6 +190,46 @@ public class InAppMessageIntegrationTests {
         assertTrue(OneSignal.isInAppMessagingPaused());
     }
 
+    @Test
+    public void testMessagesDoNotDisplayPastEndTime() throws Exception {
+        final OSTestInAppMessage message = InAppMessagingHelpers.buildTestMessageWithEndTime(OSTriggerKind.CUSTOM, "test_key", OSTestTrigger.OSTriggerOperator.EQUAL_TO.toString(), 3, true);
+        setMockRegistrationResponseWithMessages(new ArrayList<OSTestInAppMessage>() {{
+            add(message);
+        }});
+
+        // the SDK should read the message from registration JSON, set up a timer, and once
+        // the timer fires the message should get shown.
+        OneSignalInit();
+        threadAndTaskWait();
+
+        // We will set the trigger. However, since the end time is in the past the message should not be shown
+        OneSignal.addTrigger("test_key", 3);
+        // Make no IAMs are in the display queue
+        assertEquals(0, OneSignalPackagePrivateHelper.getInAppMessageDisplayQueue().size());
+        // Make sure no IAM is showing
+        assertFalse(OneSignalPackagePrivateHelper.isInAppMessageShowing());
+    }
+
+    @Test
+    public void testMessagesDoDisplayBeforeEndTime() throws Exception {
+        final OSTestInAppMessage message = InAppMessagingHelpers.buildTestMessageWithEndTime(OSTriggerKind.CUSTOM, "test_key", OSTestTrigger.OSTriggerOperator.EQUAL_TO.toString(), 3, false);
+        setMockRegistrationResponseWithMessages(new ArrayList<OSTestInAppMessage>() {{
+            add(message);
+        }});
+
+        // the SDK should read the message from registration JSON, set up a timer, and once
+        // the timer fires the message should get shown.
+        OneSignalInit();
+        threadAndTaskWait();
+
+        // We will set the trigger. However, since the end time is in the past the message should not be shown
+        OneSignal.addTrigger("test_key", 3);
+        // Make no IAMs are in the display queue
+        assertEquals(1, OneSignalPackagePrivateHelper.getInAppMessageDisplayQueue().size());
+        // Make sure no IAM is showing
+        assertTrue(OneSignalPackagePrivateHelper.isInAppMessageShowing());
+    }
+
     /**
      * Since it is possible for multiple in-app messages to be valid at the same time, we've implemented
      * a queue so that the SDK does not try to display both messages at the same time.


### PR DESCRIPTION
This change involves reading in end_time from JSON when creating an IAM
so that we can decide to not show the IAM (Cached case) if the IAM
should be finished. The date comes in iso8601 format.

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1246)
<!-- Reviewable:end -->

