### PR TITLE
Fix remove external id

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -1521,7 +1521,8 @@ public class OneSignal {
          return;
       }
 
-      if (getRemoteParams() != null && getRemoteParams().useUserIdAuth && (externalIdAuthHash == null || externalIdAuthHash.length() == 0)) {
+      // Empty external Id is used for remove external id, in this case auth hash will be pop from saved UserState
+      if (!externalId.isEmpty() && getRemoteParams() != null && getRemoteParams().useUserIdAuth && (externalIdAuthHash == null || externalIdAuthHash.length() == 0)) {
          String errorMessage = "External Id authentication (auth token) is set to REQUIRED for this application. Please provide an auth token from your backend server or change the setting in the OneSignal dashboard.";
          if (completionCallback != null)
             completionCallback.onFailure(new ExternalIdError(ExternalIdErrorType.REQUIRES_EXTERNAL_ID_AUTH, errorMessage));

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
@@ -4434,6 +4434,8 @@ public class MainOneSignalClassRunner {
 
    @Test
    public void shouldRemoveExternalUserIdFromPushWithAuthHash() throws Exception {
+      ShadowOneSignalRestClient.setRemoteParamsGetHtmlResponse(new JSONObject().put("require_user_id_auth", true));
+      
       String testExternalId = "test_ext_id";
       String mockExternalIdHash = new String(new char[64]).replace('\0', '0');
 


### PR DESCRIPTION
* If remote params had the require_user_id_auth with true then the remove external id was not working due to requiring token hash
* Remove token hash check when removing external id

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1249)
<!-- Reviewable:end -->

