### PR TITLE
Avoid printing stacktrace when parsing "null"

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessage.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessage.java
@@ -96,10 +96,12 @@ class OSInAppMessage {
             return null;
         }
 
-        SimpleDateFormat format = OneSignalSimpleDateFormat.iso8601Format();
+        if (endTimeString.equals("null"))
+            return null;
+
         try {
-            Date date = format.parse(endTimeString);
-            return date;
+            SimpleDateFormat format = OneSignalSimpleDateFormat.iso8601Format();
+            return format.parse(endTimeString);
         } catch (ParseException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
* Endtime data might come as "null", getString will return "null" and is not a datetime format. Skipp parsing this data

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1256)
<!-- Reviewable:end -->

