### PR TITLE
Fix crash when receiving IAM on android

### DIFF
--- a/OneSignalSDK/onesignal/build.gradle
+++ b/OneSignalSDK/onesignal/build.gradle
@@ -5,7 +5,7 @@ ext {
 
     androidXVersion = '[1.0.0, 1.99.99]'
     androidWorkVersion = '[2.0.0, 2.99.99]'
-    firebaseMessagingVersion = '[19.0.0, 20.99.99]'
+    firebaseMessagingVersion = '[19.0.0, 21.99.99]'
     googleGMSVersion = '[17.0.0, 17.99.99]'
 }
 


### PR DESCRIPTION
The range that we were using was causing that gradle build to use version 20.2.2 of the firebase messaging library, which was making the app crash. 
That error is fixed on later versions of the library.
This error is reported in https://firebase.google.com/support/release-notes/android#messaging_v20-2-2
## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1264)
<!-- Reviewable:end -->

