### PR TITLE
Feature/add onesignal suppress launch urls

### DIFF
--- a/Examples/OneSignalDemo/local.properties
+++ b/Examples/OneSignalDemo/local.properties
@@ -4,6 +4,6 @@
 # Location of the SDK. This is only used by Gradle.
 # For customization when using a Version Control System, please read the
 # header note.
-#Tue Jul 23 19:22:28 PDT 2019
+#Wed Jan 27 19:24:35 ART 2021
 ndk.dir=/Users/mikechoch/Library/Android/sdk/ndk-bundle
-sdk.dir=/Users/mikechoch/Library/Android/sdk
+sdk.dir=/Users/gonzalonarbaiz/Library/Android/sdk

--- a/Examples/OneSignalDemo/local.properties
+++ b/Examples/OneSignalDemo/local.properties
@@ -4,6 +4,6 @@
 # Location of the SDK. This is only used by Gradle.
 # For customization when using a Version Control System, please read the
 # header note.
-#Wed Jan 27 19:24:35 ART 2021
+#Tue Jul 23 19:22:28 PDT 2019
 ndk.dir=/Users/mikechoch/Library/Android/sdk/ndk-bundle
-sdk.dir=/Users/gonzalonarbaiz/Library/Android/sdk
+sdk.dir=/Users/mikechoch/Library/Android/sdk

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationOpenedResult.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationOpenedResult.java
@@ -58,6 +58,8 @@ public class OSNotificationOpenedResult implements OneSignal.EntryStateListener 
       // Configure 5 second timeout - max time we expect the application to call onResume
       // User can disable OneSignal application open by setting on the manifest:
       // <meta-data android:name="com.onesignal.NotificationOpened.DEFAULT" android:value="DISABLE" />
+      // User can also disable OneSignal from opening the url on default webview setting on the manifest:
+      // <meta-data android:name="com.onesignal.suppressLaunchURLs" android:value="true" />
       // If the user does this, we need to identify if the notification click was the way the user come back to the application (Session tracking)
       timeoutHandler = OSTimeoutHandler.getTimeoutHandler();
       timeoutRunnable = new Runnable() {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -2149,13 +2149,15 @@ public class OneSignal {
 
       boolean urlOpened = false;
       boolean defaultOpenActionDisabled = "DISABLE".equals(OSUtils.getManifestMeta(context, "com.onesignal.NotificationOpened.DEFAULT"));
+      boolean launchUrlSuppress = "true".equals(OSUtils.getManifestMeta(context, "com.onesignal.suppressLaunchURLs"));
 
-      if (!defaultOpenActionDisabled)
+      if (!defaultOpenActionDisabled && !launchUrlSuppress)
          urlOpened = openURLFromNotification(context, data);
 
-      logger.debug("handleNotificationOpen from context: " + context + " with fromAlert: " + fromAlert + " urlOpened: " + urlOpened + " and defaultOpenActionDisabled: " + defaultOpenActionDisabled);
+      logger.debug("handleNotificationOpen from context: " + context + " with fromAlert: " + fromAlert + " urlOpened: " + urlOpened + " defaultOpenActionDisabled: " + defaultOpenActionDisabled
+              + " launchUrlSuppress: " + defaultOpenActionDisabled );
       // Check if the notification click should lead to a DIRECT session
-      if (shouldInitDirectSessionFromNotificationOpen(context, fromAlert, urlOpened, defaultOpenActionDisabled)) {
+      if (shouldInitDirectSessionFromNotificationOpen(context, fromAlert, urlOpened, defaultOpenActionDisabled, launchUrlSuppress)) {
          applicationOpenedByNotification(notificationId);
       }
 
@@ -2188,13 +2190,15 @@ public class OneSignal {
     * 1. App is not an alert
     * 2. Not a URL open
     * 3. Manifest setting for com.onesignal.NotificationOpened.DEFAULT is not disabled
-    * 4. App is coming from the background
-    * 5. App open/resume intent exists
+    * 4. Manifest setting for com.onesignal.suppressLaunchURLs is not true
+    * 5. App is coming from the background
+    * 6. App open/resume intent exists
     */
-   private static boolean shouldInitDirectSessionFromNotificationOpen(Activity context, boolean fromAlert, boolean urlOpened, boolean defaultOpenActionDisabled) {
+   private static boolean shouldInitDirectSessionFromNotificationOpen(Activity context, boolean fromAlert, boolean urlOpened, boolean defaultOpenActionDisabled, boolean launchUrlSuppress) {
       return !fromAlert
               && !urlOpened
               && !defaultOpenActionDisabled
+              && !launchUrlSuppress
               && !inForeground
               && startOrResumeApp(context);
    }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -1977,6 +1977,7 @@ public class OneSignal {
       int jsonArraySize = dataArray.length();
 
       boolean urlOpened = false;
+      boolean launchUrlSuppress = "true".equals(OSUtils.getManifestMeta(context, "com.onesignal.suppressLaunchURLs"));
 
       for (int i = 0; i < jsonArraySize; i++) {
          try {
@@ -1988,7 +1989,7 @@ public class OneSignal {
 
             if (customJSON.has("u")) {
                String url = customJSON.optString("u", null);
-               if (url != null) {
+               if (url != null && !launchUrlSuppress) {
                   OSUtils.openURLInBrowser(url);
                   urlOpened = true;
                }
@@ -2149,15 +2150,13 @@ public class OneSignal {
 
       boolean urlOpened = false;
       boolean defaultOpenActionDisabled = "DISABLE".equals(OSUtils.getManifestMeta(context, "com.onesignal.NotificationOpened.DEFAULT"));
-      boolean launchUrlSuppress = "true".equals(OSUtils.getManifestMeta(context, "com.onesignal.suppressLaunchURLs"));
 
-      if (!defaultOpenActionDisabled && !launchUrlSuppress)
+      if (!defaultOpenActionDisabled)
          urlOpened = openURLFromNotification(context, data);
 
-      logger.debug("handleNotificationOpen from context: " + context + " with fromAlert: " + fromAlert + " urlOpened: " + urlOpened + " defaultOpenActionDisabled: " + defaultOpenActionDisabled
-              + " launchUrlSuppress: " + defaultOpenActionDisabled );
+      logger.debug("handleNotificationOpen from context: " + context + " with fromAlert: " + fromAlert + " urlOpened: " + urlOpened + " defaultOpenActionDisabled: " + defaultOpenActionDisabled);
       // Check if the notification click should lead to a DIRECT session
-      if (shouldInitDirectSessionFromNotificationOpen(context, fromAlert, urlOpened, defaultOpenActionDisabled, launchUrlSuppress)) {
+      if (shouldInitDirectSessionFromNotificationOpen(context, fromAlert, urlOpened, defaultOpenActionDisabled)) {
          applicationOpenedByNotification(notificationId);
       }
 
@@ -2194,11 +2193,10 @@ public class OneSignal {
     * 5. App is coming from the background
     * 6. App open/resume intent exists
     */
-   private static boolean shouldInitDirectSessionFromNotificationOpen(Activity context, boolean fromAlert, boolean urlOpened, boolean defaultOpenActionDisabled, boolean launchUrlSuppress) {
+   private static boolean shouldInitDirectSessionFromNotificationOpen(Activity context, boolean fromAlert, boolean urlOpened, boolean defaultOpenActionDisabled) {
       return !fromAlert
               && !urlOpened
               && !defaultOpenActionDisabled
-              && !launchUrlSuppress
               && !inForeground
               && startOrResumeApp(context);
    }

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
@@ -1123,7 +1123,6 @@ public class MainOneSignalClassRunner {
       // If this doesn't' happen, notifications will not arrive
       OneSignalInit();
       fastColdRestartApp();
-
       OneSignal.initWithContext(blankActivity);
       // Removes app launch
       shadowOf(blankActivity).getNextStartedActivity();
@@ -1166,6 +1165,19 @@ public class MainOneSignalClassRunner {
 
       assertNull(shadowOf(blankActivity).getNextStartedActivity());
       assertEquals("Test Msg", lastNotificationOpenedBody);
+   }
+
+   @Test
+   public void testLaunchUrlSuppressTrue() throws Exception {
+      // Add the 'com.onesignal.suppressLaunchURLs' as 'true' meta-data tag
+      OneSignalShadowPackageManager.addManifestMetaData("com.onesignal.suppressLaunchURLs", "true");
+
+      // Removes app launch
+      shadowOf(blankActivity).getNextStartedActivity();
+
+      // No OneSignal init here to test case where it is located in an Activity.
+      OneSignal_handleNotificationOpen(blankActivity, new JSONArray("[{ \"alert\": \"Test Msg\", \"custom\": { \"i\": \"UUID\", \"u\": \"http://google.com\" } }]"), false, ONESIGNAL_NOTIFICATION_ID);
+      assertNull(shadowOf(blankActivity).getNextStartedActivity());
    }
 
    private static String notificationReceivedBody;

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
@@ -1180,6 +1180,27 @@ public class MainOneSignalClassRunner {
       assertNull(shadowOf(blankActivity).getNextStartedActivity());
    }
 
+   @Test
+   public void testLaunchUrlSuppressFalse() throws Exception {
+      // Add the 'com.onesignal.suppressLaunchURLs' as 'true' meta-data tag
+      // First init run for appId to be saved
+      // At least OneSignal was init once for user to be subscribed
+      // If this doesn't' happen, notifications will not arrive
+      OneSignalInit();
+      fastColdRestartApp();
+      OneSignalShadowPackageManager.addManifestMetaData("com.onesignal.suppressLaunchURLs", "false");
+      OneSignal.initWithContext(blankActivity);
+      // Removes app launch
+      shadowOf(blankActivity).getNextStartedActivity();
+
+      // No OneSignal init here to test case where it is located in an Activity.
+      OneSignal_handleNotificationOpen(blankActivity, new JSONArray("[{ \"alert\": \"Test Msg\", \"custom\": { \"i\": \"UUID\", \"u\": \"http://google.com\" } }]"), false, ONESIGNAL_NOTIFICATION_ID);
+      Intent intent = shadowOf(blankActivity).getNextStartedActivity();
+      assertEquals("android.intent.action.VIEW", intent.getAction());
+      assertEquals("http://google.com", intent.getData().toString());
+      assertNull(shadowOf(blankActivity).getNextStartedActivity());
+   }
+
    private static String notificationReceivedBody;
    private static int androidNotificationId;
 


### PR DESCRIPTION
* Added the suppression to keep 1:1 behavior with iOS launch URL suppression. 
* added test for new metadata.

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1268)
<!-- Reviewable:end -->

