### PR TITLE
Fix notification open not launching main activity by default on app cold start

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -2174,12 +2174,7 @@ public class OneSignal {
       logger.debug("startOrResumeApp from context: " + inContext + " isRoot: " + inContext.isTaskRoot() + " with launchIntent: " + launchIntent);
       // Make sure we have a launcher intent.
       if (launchIntent != null) {
-         if (inContext.isTaskRoot()) {
-            inContext.startActivity(launchIntent);
-         } else {
-            launchIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-            inContext.startActivity(launchIntent);
-         }
+         inContext.startActivity(launchIntent);
          return true;
       }
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -2178,10 +2178,11 @@ public class OneSignal {
             inContext.startActivity(launchIntent);
          } else {
             launchIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-            PendingIntent.getActivity(inContext, 0, launchIntent, 0);
+            inContext.startActivity(launchIntent);
          }
          return true;
       }
+
       return false;
    }
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -2169,16 +2169,16 @@ public class OneSignal {
       sessionManager.onDirectInfluenceFromNotificationOpen(appEntryState, notificationId);
    }
 
-   static boolean startOrResumeApp(Activity inContext) {
-      Intent launchIntent = inContext.getPackageManager().getLaunchIntentForPackage(inContext.getPackageName());
-      logger.debug("startOrResumeApp from context: " + inContext + " isRoot: " + inContext.isTaskRoot() + " with launchIntent: " + launchIntent);
-      // Make sure we have a launcher intent.
-      if (launchIntent != null) {
-         inContext.startActivity(launchIntent);
-         return true;
-      }
+   static boolean startOrResumeApp(Activity activity) {
+      Intent launchIntent = activity.getPackageManager().getLaunchIntentForPackage(activity.getPackageName());
+      logger.debug("startOrResumeApp from context: " + activity + " isRoot: " + activity.isTaskRoot() + " with launchIntent: " + launchIntent);
 
-      return false;
+      // Not all apps have a launcher intent, such as one that only provides a homescreen widget
+      if (launchIntent == null)
+         return false;
+
+      activity.startActivity(launchIntent);
+      return true;
    }
 
    /**


### PR DESCRIPTION
## Scope
### Fix
This is fixes a bug where the app would not be open when the app was completely closed when tapping on a notification.


* The app process would still be started and the NotificationOpenHandler would still fire, just the default auto launch was not happening in this case.
### Clean up
Clean up to internals of the private `startOrResumeApp` method.

## Tests
### Automated 
Normally a failing test should be added before a fix is done but since the bugged code path was completely removed it isn't needed. There is an existing test already covering the launching the main activity so all lines of code are covered in this modification.


### Manual
#### App w/ splash and single Activity (the example app in this repo)
1. In focus notifi open, no flicker, back button works
1. Notif open from cold start, back button works.
1. Notif open after backgrounding app, app resumed correctly, back button works

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1276)
<!-- Reviewable:end -->

