### PR TITLE
Fix sms logout

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalStateSynchronizer.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalStateSynchronizer.java
@@ -241,8 +241,8 @@ class OneSignalStateSynchronizer {
    }
 
    static void logoutSMS() {
-      getPushStateSynchronizer().logoutSMS();
       getSMSStateSynchronizer().logoutChannel();
+      getPushStateSynchronizer().logoutSMS();
    }
 
    static void setExternalUserId(String externalId, String externalIdAuthHash, final OneSignal.OSExternalUserIdUpdateCompletionHandler completionHandler) throws JSONException {


### PR DESCRIPTION
* On non UnitTest enviroment push channel ends too quickly and recreats sms uses
* Call SMS channel first

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1286)
<!-- Reviewable:end -->

