### PR TITLE
Fix notification disabled by channel being restored

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotification.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotification.java
@@ -95,12 +95,12 @@ class GenerateNotification {
    }
 
    @WorkerThread
-   static void fromJsonPayload(OSNotificationGenerationJob notificationJob) {
+   static boolean displayNotificationFromJsonPayload(OSNotificationGenerationJob notificationJob) {
       setStatics(notificationJob.getContext());
 
       isRunningOnMainThreadCheck();
 
-      showNotification(notificationJob);
+      return showNotification(notificationJob);
    }
 
    /**
@@ -263,7 +263,7 @@ class GenerateNotification {
    }
 
    // Put the message into a notification and post it.
-   private static void showNotification(OSNotificationGenerationJob notificationJob) {
+   private static boolean showNotification(OSNotificationGenerationJob notificationJob) {
       int notificationId = notificationJob.getAndroidId();
       JSONObject fcmJson = notificationJob.getJsonPayload();
       String group = fcmJson.optString("grp", null);
@@ -326,6 +326,10 @@ class GenerateNotification {
          addXiaomiSettings(oneSignalNotificationBuilder, notification);
          NotificationManagerCompat.from(currentContext).notify(notificationId, notification);
       }
+
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
+         return OneSignalNotificationManager.notificationChannelEnabled(currentContext, notification.getChannelId());
+      return true;
    }
 
    private static Notification createGenericPendingIntentsForNotif(NotificationCompat.Builder notifBuilder, JSONObject gcmBundle, int notificationId) {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotification.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotification.java
@@ -328,7 +328,7 @@ class GenerateNotification {
       }
 
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
-         return OneSignalNotificationManager.notificationChannelEnabled(currentContext, notification.getChannelId());
+         return OneSignalNotificationManager.areNotificationsEnabled(currentContext, notification.getChannelId());
       return true;
    }
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
@@ -180,7 +180,7 @@ class NotificationBundleProcessor {
         if (!notificationDisplayed) {
             // Notification channel disable or not displayed
             // save notification as dismissed to avoid user re-enabling channel and notification being displayed due to restore
-            markRestoredNotificationAsDismissed(notificationJob);
+            markNotificationAsDismissed(notificationJob);
             return;
         }
 
@@ -252,11 +252,11 @@ class NotificationBundleProcessor {
       }
    }
 
-    static void markRestoredNotificationAsDismissed(OSNotificationGenerationJob notifiJob) {
-        OneSignal.Log(OneSignal.LOG_LEVEL.DEBUG, "Marking restored notifications as dismissed: " + notifiJob.toString());
+    static void markNotificationAsDismissed(OSNotificationGenerationJob notifiJob) {
         if (notifiJob.getAndroidIdWithoutCreate() == -1)
             return;
 
+        OneSignal.Log(OneSignal.LOG_LEVEL.DEBUG, "Marking restored or disabled notifications as dismissed: " + notifiJob.toString());
         String whereStr = NotificationTable.COLUMN_NAME_ANDROID_NOTIFICATION_ID + " = " + notifiJob.getAndroidIdWithoutCreate();
 
         OneSignalDbHelper dbHelper = OneSignalDbHelper.getInstance(notifiJob.getContext());

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationController.java
@@ -109,7 +109,7 @@ public class OSNotificationController {
       } else {
          // -1 is used to note never displayed
          notificationJob.getNotification().setAndroidNotificationId(-1);
-         NotificationBundleProcessor.processNotification(notificationJob, true);
+         NotificationBundleProcessor.processNotification(notificationJob, true, false);
          OneSignal.handleNotificationReceived(notificationJob);
       }
    }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationController.java
@@ -105,7 +105,7 @@ public class OSNotificationController {
       if (restoring) {
          // If we are not displaying a restored notification make sure we mark it as dismissed
          // This will prevent it from being restored again
-         NotificationBundleProcessor.markRestoredNotificationAsDismissed(notificationJob);
+         NotificationBundleProcessor.markNotificationAsDismissed(notificationJob);
       } else {
          // -1 is used to note never displayed
          notificationJob.getNotification().setAndroidNotificationId(-1);

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationRestoreWorkManager.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationRestoreWorkManager.java
@@ -2,7 +2,6 @@ package com.onesignal;
 
 import android.content.Context;
 import android.database.Cursor;
-import android.database.sqlite.SQLiteDatabase;
 import android.os.Build;
 import android.service.notification.StatusBarNotification;
 import android.text.TextUtils;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalNotificationManager.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalNotificationManager.java
@@ -164,11 +164,16 @@ public class OneSignalNotificationManager {
     }
 
     @Nullable
-    public static boolean notificationChannelEnabled(Context context, String channelId) {
+    public static boolean areNotificationsEnabled(Context context, String channelId) {
+        boolean notificationsEnabled = NotificationManagerCompat.from(context).areNotificationsEnabled();
+        if (!notificationsEnabled)
+            return false;
+
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
             NotificationChannel channel = getNotificationManager(context).getNotificationChannel(channelId);
             return channel == null || channel.getImportance() != IMPORTANCE_NONE;
         }
+
         return true;
     }
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalNotificationManager.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalNotificationManager.java
@@ -1,16 +1,21 @@
 package com.onesignal;
 
 import android.app.Notification;
+import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.content.Context;
 import android.database.Cursor;
 import android.os.Build;
 import android.service.notification.StatusBarNotification;
+
+import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 import androidx.core.app.NotificationCompat;
 import androidx.core.app.NotificationManagerCompat;
 
 import java.util.ArrayList;
+
+import static android.app.NotificationManager.IMPORTANCE_NONE;
 
 public class OneSignalNotificationManager {
 
@@ -156,5 +161,14 @@ public class OneSignalNotificationManager {
         cursor.close();
 
         return recentId;
+    }
+
+    @Nullable
+    public static boolean notificationChannelEnabled(Context context, String channelId) {
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+            NotificationChannel channel = getNotificationManager(context).getNotificationChannel(channelId);
+            return channel == null || channel.getImportance() != IMPORTANCE_NONE;
+        }
+        return true;
     }
 }

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowOneSignalNotificationManager.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowOneSignalNotificationManager.java
@@ -1,0 +1,28 @@
+package com.onesignal;
+
+import android.content.Context;
+
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+
+@Implements(OneSignalNotificationManager.class)
+public class ShadowOneSignalNotificationManager {
+
+   private static boolean notificationChannelEnabled = true;
+
+   public static void setNotificationChannelEnabled(boolean notificationChannelEnabled) {
+      ShadowOneSignalNotificationManager.notificationChannelEnabled = notificationChannelEnabled;
+   }
+
+   @Implementation
+   public static boolean notificationChannelEnabled(Context context, String channelId) {
+      return notificationChannelEnabled;
+   }
+
+   /**
+    * Reset all static values (should be called before each test)
+    */
+   public static void resetStatics() {
+      notificationChannelEnabled = true;
+   }
+}

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowOneSignalNotificationManager.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowOneSignalNotificationManager.java
@@ -15,7 +15,7 @@ public class ShadowOneSignalNotificationManager {
    }
 
    @Implementation
-   public static boolean notificationChannelEnabled(Context context, String channelId) {
+   public static boolean areNotificationsEnabled(Context context, String channelId) {
       return notificationChannelEnabled;
    }
 

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowOneSignalRestClient.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowOneSignalRestClient.java
@@ -48,6 +48,9 @@ public class ShadowOneSignalRestClient {
    public static final String PUSH_USER_ID = "a2f7f967-e8cc-11e4-bed1-118f05be4511";
    public static final String EMAIL_USER_ID = "b007f967-98cc-11e4-bed1-118f05be4522";
    public static final String SMS_USER_ID = "d007f967-98cc-11e4-bed1-118f05be4522";
+   private static final String REQUIRES_USER_PRIVACY_CONSENT = "requires_user_privacy_consent";
+   private static final String RECEIVE_RECEIPTS_ENABLE = "receive_receipts_enable";
+
    public enum REST_METHOD {
       GET, POST, PUT
    }
@@ -205,7 +208,12 @@ public class ShadowOneSignalRestClient {
    }
 
    public static void setRemoteParamsRequirePrivacyConsent(boolean requirePrivacyConsent) throws JSONException {
-      JSONObject remoteParams = new JSONObject().put("requires_user_privacy_consent", requirePrivacyConsent);
+      JSONObject remoteParams = new JSONObject().put(REQUIRES_USER_PRIVACY_CONSENT, requirePrivacyConsent);
+      ShadowOneSignalRestClient.setRemoteParamsGetHtmlResponse(remoteParams);
+   }
+
+   public static void setRemoteParamsReceiveReceiptsEnable(boolean requirePrivacyConsent) throws JSONException {
+      JSONObject remoteParams = new JSONObject().put(RECEIVE_RECEIPTS_ENABLE, requirePrivacyConsent);
       ShadowOneSignalRestClient.setRemoteParamsGetHtmlResponse(remoteParams);
    }
 

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/TestHelpers.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/TestHelpers.java
@@ -41,6 +41,7 @@ import com.onesignal.ShadowNotificationReceivedEvent;
 import com.onesignal.ShadowOSUtils;
 import com.onesignal.ShadowOSWebView;
 import com.onesignal.ShadowOneSignalDbHelper;
+import com.onesignal.ShadowOneSignalNotificationManager;
 import com.onesignal.ShadowOneSignalRestClient;
 import com.onesignal.ShadowOneSignalRestClientWithMockConnection;
 import com.onesignal.ShadowPushRegistratorADM;
@@ -130,6 +131,7 @@ public class TestHelpers {
       ShadowTimeoutHandler.resetStatics();
       ShadowGenerateNotification.resetStatics();
       ShadowNotificationReceivedEvent.resetStatics();
+      ShadowOneSignalNotificationManager.resetStatics();
 
       lastException = null;
    }


### PR DESCRIPTION
Fix notification disabled by channel being restored


* If the user disables notifications while the application is closed or in the background, then gets notifications, this notification won't display. If the user then enables notification channel previously disable, then open the application, notifications were being displayed because of restoring
* Save as dismissed a notification disable by channel

Fix notification received


* Mark as received all notification even if they are silent

This fix solves https://github.com/OneSignal/OneSignal-Android-SDK/issues/1265

Testing steps used:

Started the app so user is subscribed.
Disabled notification channel in system settings
Sent notification message to disabled channel
Enabled notification channel
Killed the app
Started the app
OneSignal SDK restored notification which was delivered when the channel was disabled

### Solution
Check if the notification channel id is disabled, if so, save notification as dismissed to avoid being restore

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1289)
<!-- Reviewable:end -->

