### PR TITLE
Fix do not restore notification disabled by application

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotification.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotification.java
@@ -328,7 +328,7 @@ class GenerateNotification {
       }
 
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
-         return OneSignalNotificationManager.notificationChannelEnabled(currentContext, notification.getChannelId());
+         return OneSignalNotificationManager.areNotificationsEnabled(currentContext, notification.getChannelId());
       return true;
    }
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
@@ -180,7 +180,7 @@ class NotificationBundleProcessor {
         if (!notificationDisplayed) {
             // Notification channel disable or not displayed
             // save notification as dismissed to avoid user re-enabling channel and notification being displayed due to restore
-            markRestoredNotificationAsDismissed(notificationJob);
+            markNotificationAsDismissed(notificationJob);
             return;
         }
 
@@ -252,11 +252,11 @@ class NotificationBundleProcessor {
       }
    }
 
-    static void markRestoredNotificationAsDismissed(OSNotificationGenerationJob notifiJob) {
-        OneSignal.Log(OneSignal.LOG_LEVEL.DEBUG, "Marking restored notifications as dismissed: " + notifiJob.toString());
+    static void markNotificationAsDismissed(OSNotificationGenerationJob notifiJob) {
         if (notifiJob.getAndroidIdWithoutCreate() == -1)
             return;
 
+        OneSignal.Log(OneSignal.LOG_LEVEL.DEBUG, "Marking restored or disabled notifications as dismissed: " + notifiJob.toString());
         String whereStr = NotificationTable.COLUMN_NAME_ANDROID_NOTIFICATION_ID + " = " + notifiJob.getAndroidIdWithoutCreate();
 
         OneSignalDbHelper dbHelper = OneSignalDbHelper.getInstance(notifiJob.getContext());

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationController.java
@@ -105,7 +105,7 @@ public class OSNotificationController {
       if (restoring) {
          // If we are not displaying a restored notification make sure we mark it as dismissed
          // This will prevent it from being restored again
-         NotificationBundleProcessor.markRestoredNotificationAsDismissed(notificationJob);
+         NotificationBundleProcessor.markNotificationAsDismissed(notificationJob);
       } else {
          // -1 is used to note never displayed
          notificationJob.getNotification().setAndroidNotificationId(-1);

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalNotificationManager.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalNotificationManager.java
@@ -164,11 +164,16 @@ public class OneSignalNotificationManager {
     }
 
     @Nullable
-    public static boolean notificationChannelEnabled(Context context, String channelId) {
+    public static boolean areNotificationsEnabled(Context context, String channelId) {
+        boolean notificationsEnabled = NotificationManagerCompat.from(context).areNotificationsEnabled();
+        if (!notificationsEnabled)
+            return false;
+
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
             NotificationChannel channel = getNotificationManager(context).getNotificationChannel(channelId);
             return channel == null || channel.getImportance() != IMPORTANCE_NONE;
         }
+
         return true;
     }
 }


### PR DESCRIPTION
* When notifications are disabled by application, save as dismissed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1295)
<!-- Reviewable:end -->
