### PR TITLE
Add null check for currentActivityName

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/InAppMessageView.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/InAppMessageView.java
@@ -600,4 +600,20 @@ class InAppMessageView {
                 endColor,
                 animCallback);
     }
+
+    @Override
+    public String toString() {
+        return "InAppMessageView{" +
+                "currentActivity=" + currentActivity +
+                ", pageWidth=" + pageWidth +
+                ", pageHeight=" + pageHeight +
+                ", dismissDuration=" + dismissDuration +
+                ", hasBackground=" + hasBackground +
+                ", shouldDismissWhenActive=" + shouldDismissWhenActive +
+                ", isDragging=" + isDragging +
+                ", disableDragDismiss=" + disableDragDismiss +
+                ", displayLocation=" + displayLocation +
+                ", webView=" + webView +
+                '}';
+    }
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageController.java
@@ -610,7 +610,7 @@ class OSInAppMessageController implements OSDynamicTriggerControllerObserver, OS
             // Make sure no message is ever added to the queue more than once
             if (!messageDisplayQueue.contains(message)) {
                 messageDisplayQueue.add(message);
-                logger.debug("In app message with id, " + message.messageId + ", added to the queue");
+                logger.debug("In app message with id: " + message.messageId + ", added to the queue");
             }
 
             attemptToShowInAppMessage();
@@ -633,7 +633,7 @@ class OSInAppMessageController implements OSDynamicTriggerControllerObserver, OS
                 return;
             }
 
-            logger.debug("In app message is currently showing or there are no IAMs left in the queue!");
+            logger.debug("In app message is currently showing or there are no IAMs left in the queue! isInAppMessageShowing: " + isInAppMessageShowing());
         }
     }
 
@@ -676,7 +676,7 @@ class OSInAppMessageController implements OSDynamicTriggerControllerObserver, OS
     }
 
     void messageWasDismissedByBackPress(@NonNull OSInAppMessage message) {
-        OneSignal.onesignalLog(OneSignal.LOG_LEVEL.DEBUG, "OSInAppMessageController messageWasDismissed by back press: " + message.toString());
+        OneSignal.onesignalLog(OneSignal.LOG_LEVEL.DEBUG, "In app message OSInAppMessageController messageWasDismissed by back press: " + message.toString());
         // IAM was not dismissed by user, will be redisplay again until user dismiss it
         dismissCurrentMessage(message);
     }
@@ -703,7 +703,7 @@ class OSInAppMessageController implements OSDynamicTriggerControllerObserver, OS
                     return;
                 } else {
                     String removedMessageId = messageDisplayQueue.remove(0).messageId;
-                    logger.debug("In app message with id, " + removedMessageId + ", dismissed (removed) from the queue!");
+                    logger.debug("In app message with id: " + removedMessageId + ", dismissed (removed) from the queue!");
                 }
             }
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/WebViewManager.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/WebViewManager.java
@@ -6,13 +6,14 @@ import android.app.Activity;
 import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import android.util.Base64;
 import android.view.View;
 import android.webkit.JavascriptInterface;
 import android.webkit.ValueCallback;
 import android.webkit.WebView;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -63,7 +64,7 @@ class WebViewManager extends ActivityLifecycleHandler.ActivityAvailableListener 
     @NonNull private Activity activity;
     @NonNull private OSInAppMessage message;
 
-    private String currentActivityName = null;
+    @Nullable private String currentActivityName = null;
     private Integer lastPageHeight = null;
 
     interface OneSignalGenericCallback {
@@ -303,6 +304,9 @@ class WebViewManager extends ActivityLifecycleHandler.ActivityAvailableListener 
         this.activity = activity;
         this.currentActivityName = activity.getLocalClassName();
 
+        OneSignal.Log(OneSignal.LOG_LEVEL.DEBUG, "In app message activity available " +
+                "currentActivityName: " + currentActivityName + " lastActivityName: " + lastActivityName );
+
         if (lastActivityName == null)
             showMessageView(null);
         else if (!lastActivityName.equals(currentActivityName)) {
@@ -310,14 +314,18 @@ class WebViewManager extends ActivityLifecycleHandler.ActivityAvailableListener 
             if (messageView != null)
                 messageView.removeAllViews();
             showMessageView(lastPageHeight);
-        } else
+        } else {
+            // Activity rotated
             calculateHeightAndShowWebViewAfterNewActivity();
+        }
     }
 
     @Override
-    void stopped(Activity activity) {
-        OneSignal.Log(OneSignal.LOG_LEVEL.DEBUG, "In app message activity stopped, cleaning views");
-        if (messageView != null && currentActivityName.equals(activity.getLocalClassName()))
+    void stopped(@NonNull Activity activity) {
+        OneSignal.Log(OneSignal.LOG_LEVEL.DEBUG, "In app message activity stopped, cleaning views, " +
+                "currentActivityName: " + currentActivityName + "\nactivity: " + this.activity + "\nmessageView: " + messageView);
+
+        if (messageView != null && activity.getLocalClassName().equals(currentActivityName))
             messageView.removeAllViews();
     }
 


### PR DESCRIPTION
* currentActivityName under WebViewManager for IAMs, might end being null
* Add log to know in which case might this field end null

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1304)
<!-- Reviewable:end -->

