### PR TITLE
Fix framework crash

### DIFF
--- a/OneSignalSDK/onesignal/build.gradle
+++ b/OneSignalSDK/onesignal/build.gradle
@@ -65,12 +65,12 @@ dependencies {
     //   otherwise app can get dup classes between 26 & 28 when mixing these versions.
     // Also note, firebase & gms libraries use android.support:26.
     //   - They never refer to 27 or 28
-    api 'com.android.support:cardview-v7:[26.0.0, 27.99.99]'
-    api 'com.android.support:support-fragment:[26.0.0, 27.99.99]'
-    api 'com.android.support:customtabs:[26.0.0, 27.99.99]'
+    api "androidx.cardview:cardview:1.0.0"
+    api "androidx.fragment:fragment-ktx:1.2.5"
+    api "androidx.browser:browser:1.0.0"
 
     // compileOnly as this is just for fallback code if AppCompatActivity wasn't added to the project.
-    compileOnly 'com.android.support:appcompat-v7:26.1.0'
+    compileOnly "androidx.appcompat:appcompat:1.0.0"
 }
 
 apply from: 'maven-push.gradle'

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/ActivityLifecycleHandler.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/ActivityLifecycleHandler.java
@@ -36,8 +36,9 @@ import android.os.Build;
 import android.os.Handler;
 import android.os.HandlerThread;
 import android.os.Looper;
-import android.support.annotation.NonNull;
 import android.view.ViewTreeObserver;
+
+import androidx.annotation.NonNull;
 
 import java.lang.ref.WeakReference;
 import java.util.Map;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/ActivityLifecycleListener.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/ActivityLifecycleListener.java
@@ -33,12 +33,14 @@ import android.app.Application;
 import android.content.ComponentCallbacks;
 import android.content.res.Configuration;
 import android.os.Bundle;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 class ActivityLifecycleListener implements Application.ActivityLifecycleCallbacks {
 
-   @Nullable private static ActivityLifecycleListener instance;
+   @Nullable
+   private static ActivityLifecycleListener instance;
    @SuppressLint("StaticFieldLeak")
    @Nullable
    private static ActivityLifecycleHandler activityLifecycleHandler;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/AndroidSupportV4Compat.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/AndroidSupportV4Compat.java
@@ -34,9 +34,9 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.pm.PackageManager;
 import android.os.Build;
-import android.support.annotation.NonNull;
-import android.support.v4.app.ActivityCompat;
 import android.util.Log;
+
+import androidx.annotation.NonNull;
 
 // Designed as a compat for use of Android Support v4 revision 23.+ methods when an older revision of the library is included with the app developer's project.
 class AndroidSupportV4Compat {
@@ -84,7 +84,7 @@ class AndroidSupportV4Compat {
       }
 
       static boolean shouldShowRequestPermissionRationale(Activity activity, String permission) {
-         return android.support.v4.app.ActivityCompat.shouldShowRequestPermissionRationale(activity, permission);
+         return ActivityCompat.shouldShowRequestPermissionRationale(activity, permission);
       }
    }
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/BadgeCountUpdater.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/BadgeCountUpdater.java
@@ -34,7 +34,8 @@ import android.database.Cursor;
 import android.os.Build;
 import android.os.Bundle;
 import android.service.notification.StatusBarNotification;
-import android.support.annotation.RequiresApi;
+
+import androidx.annotation.RequiresApi;
 
 import com.onesignal.OneSignalDbContract.NotificationTable;
 import com.onesignal.shortcutbadger.ShortcutBadgeException;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/BundleCompat.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/BundleCompat.java
@@ -33,7 +33,8 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.Parcelable;
 import android.os.PersistableBundle;
-import android.support.annotation.RequiresApi;
+
+import androidx.annotation.RequiresApi;
 
 public interface BundleCompat<T> {
    void putString(String key, String value);

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/DraggableRelativeLayout.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/DraggableRelativeLayout.java
@@ -2,12 +2,13 @@ package com.onesignal;
 
 import android.content.Context;
 import android.content.res.Resources;
-import android.support.annotation.NonNull;
-import android.support.v4.view.ViewCompat;
-import android.support.v4.widget.ViewDragHelper;
 import android.view.MotionEvent;
 import android.view.View;
 import android.widget.RelativeLayout;
+
+import androidx.annotation.NonNull;
+import androidx.core.view.ViewCompat;
+import androidx.customview.widget.ViewDragHelper;
 
 import static com.onesignal.OSViewUtils.dpToPx;
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/FocusTimeController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/FocusTimeController.java
@@ -1,9 +1,10 @@
 package com.onesignal;
 
 import android.os.SystemClock;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.annotation.WorkerThread;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.WorkerThread;
 
 import com.onesignal.influence.model.OSInfluence;
 
@@ -203,7 +204,8 @@ class FocusTimeController {
       protected abstract void sendTime(@NonNull FocusEventType focusType);
       protected abstract void saveInfluences(List<OSInfluence> influences);
 
-      @Nullable private Long unsentActiveTime = null;
+      @Nullable
+      private Long unsentActiveTime = null;
 
       private long getUnsentActiveTime() {
          if (unsentActiveTime == null) {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/GMSLocationController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/GMSLocationController.java
@@ -29,7 +29,8 @@ package com.onesignal;
 
 import android.location.Location;
 import android.os.Bundle;
-import android.support.annotation.NonNull;
+
+import androidx.annotation.NonNull;
 
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.api.GoogleApiClient;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/GcmBroadcastReceiver.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/GcmBroadcastReceiver.java
@@ -35,9 +35,9 @@ import android.content.Intent;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Parcelable;
-import android.os.PersistableBundle;
-import android.support.annotation.Nullable;
-import android.support.v4.content.WakefulBroadcastReceiver;
+
+import androidx.annotation.Nullable;
+import androidx.legacy.content.WakefulBroadcastReceiver;
 
 import com.onesignal.NotificationBundleProcessor.ProcessedBundleResult;
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/GcmIntentJobService.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/GcmIntentJobService.java
@@ -3,8 +3,9 @@ package com.onesignal;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Build;
-import android.support.annotation.NonNull;
-import android.support.annotation.RequiresApi;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
 
 // Uses modified JobIntentService class that's part of the onesignal package
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotification.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotification.java
@@ -44,12 +44,13 @@ import android.graphics.BitmapFactory;
 import android.net.Uri;
 import android.os.Build;
 import android.service.notification.StatusBarNotification;
-import android.support.annotation.RequiresApi;
-import android.support.v4.app.NotificationCompat;
-import android.support.v4.app.NotificationManagerCompat;
 import android.text.SpannableString;
 import android.text.style.StyleSpan;
 import android.widget.RemoteViews;
+
+import androidx.annotation.RequiresApi;
+import androidx.core.app.NotificationCompat;
+import androidx.core.app.NotificationManagerCompat;
 
 import com.onesignal.OneSignalDbContract.NotificationTable;
 
@@ -685,7 +686,10 @@ class GenerateNotification {
          // We are re-using the notifBuilder from the normal notification so if a developer as an
          //    extender setup all the settings will carry over.
          // Note: However their buttons will not carry over as we need to be setup with this new summaryNotificationId.
-         summaryBuilder.mActions.clear();
+         try {
+            summaryBuilder.mActions.clear();
+         } catch (Exception ex) {
+         }
          addNotificationActionButtons(gcmBundle, summaryBuilder, summaryNotificationId, group);
 
          summaryBuilder.setContentIntent(summaryContentIntent)

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/InAppMessageView.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/InAppMessageView.java
@@ -9,10 +9,6 @@ import android.graphics.Color;
 import android.graphics.drawable.ColorDrawable;
 import android.os.Build;
 import android.os.Handler;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.v4.widget.PopupWindowCompat;
-import android.support.v7.widget.CardView;
 import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
@@ -22,6 +18,11 @@ import android.webkit.WebView;
 import android.widget.LinearLayout;
 import android.widget.PopupWindow;
 import android.widget.RelativeLayout;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.cardview.widget.CardView;
+import androidx.core.widget.PopupWindowCompat;
 
 import static com.onesignal.OSViewUtils.dpToPx;
 
@@ -72,7 +73,8 @@ class InAppMessageView {
     private boolean hasBackground;
     private boolean shouldDismissWhenActive = false;
     private boolean isDragging = false;
-    @NonNull private WebViewManager.Position displayLocation;
+    @NonNull
+    private WebViewManager.Position displayLocation;
     private WebView webView;
     private RelativeLayout parentRelativeLayout;
     private DraggableRelativeLayout draggableRelativeLayout;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/JSONUtils.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/JSONUtils.java
@@ -1,7 +1,8 @@
 package com.onesignal;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import org.json.JSONArray;
 import org.json.JSONException;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/JobIntentService.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/JobIntentService.java
@@ -43,10 +43,11 @@ import android.os.AsyncTask;
 import android.os.Build;
 import android.os.IBinder;
 import android.os.PowerManager;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.annotation.RequiresApi;
 import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
@@ -111,19 +111,24 @@ class NotificationBundleProcessor {
       notifJob.showAsAlert = OneSignal.getInAppAlertNotificationEnabled() && OneSignal.isAppActive();
       processCollapseKey(notifJob);
 
-      boolean doDisplay = shouldDisplayNotif(notifJob);
-      if (doDisplay)
-         GenerateNotification.fromJsonPayload(notifJob);
+      try {
+         boolean doDisplay = shouldDisplayNotif(notifJob);
+         if (doDisplay)
+            GenerateNotification.fromJsonPayload(notifJob);
 
-      if (!notifJob.restoring && !notifJob.isInAppPreviewPush) {
-         processNotification(notifJob, false);
-         try {
-            JSONObject jsonObject = new JSONObject(notifJob.jsonPayload.toString());
-            jsonObject.put(BUNDLE_KEY_ANDROID_NOTIFICATION_ID, notifJob.getAndroidId());
-            OneSignal.handleNotificationReceived(newJsonArray(jsonObject), true, notifJob.showAsAlert);
-         } catch (JSONException t) {
-            t.printStackTrace();
+         if (!notifJob.restoring && !notifJob.isInAppPreviewPush) {
+            processNotification(notifJob, false);
+            try {
+               JSONObject jsonObject = new JSONObject(notifJob.jsonPayload.toString());
+               jsonObject.put(BUNDLE_KEY_ANDROID_NOTIFICATION_ID, notifJob.getAndroidId());
+               OneSignal.handleNotificationReceived(newJsonArray(jsonObject), true, notifJob.showAsAlert);
+            } catch (JSONException t) {
+               t.printStackTrace();
+            }
          }
+         // we could receive DeadSystemException/RuntimeException on android 5/8
+      } catch(Throwable ex) {
+         ex.printStackTrace();
       }
 
       return notifJob.getAndroidId();

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
@@ -34,8 +34,9 @@ import android.database.Cursor;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.SystemClock;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.onesignal.OneSignalDbContract.NotificationTable;
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationChannelManager.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationChannelManager.java
@@ -34,10 +34,11 @@ import android.app.NotificationManager;
 import android.content.Context;
 import android.net.Uri;
 import android.os.Build;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.annotation.RequiresApi;
-import android.support.v4.app.NotificationManagerCompat;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
+import androidx.core.app.NotificationManagerCompat;
 
 import org.json.JSONArray;
 import org.json.JSONException;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationExtenderService.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationExtenderService.java
@@ -33,7 +33,8 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.os.Bundle;
-import android.support.v4.app.NotificationCompat;
+
+import androidx.core.app.NotificationCompat;
 
 import org.json.JSONException;
 import org.json.JSONObject;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationGenerationJob.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationGenerationJob.java
@@ -30,7 +30,8 @@ package com.onesignal;
 
 import android.content.Context;
 import android.net.Uri;
-import android.support.annotation.Nullable;
+
+import androidx.annotation.Nullable;
 
 import org.json.JSONObject;
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationLimitManager.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationLimitManager.java
@@ -5,7 +5,8 @@ import android.content.Context;
 import android.database.Cursor;
 import android.os.Build;
 import android.service.notification.StatusBarNotification;
-import android.support.annotation.RequiresApi;
+
+import androidx.annotation.RequiresApi;
 
 import com.onesignal.OneSignalDbContract.NotificationTable;
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationOpenedActivityHMS.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationOpenedActivityHMS.java
@@ -30,7 +30,8 @@ package com.onesignal;
 import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
-import android.support.annotation.Nullable;
+
+import androidx.annotation.Nullable;
 
 // HMS Core creates a notification with an Intent when opened to start this Activity.
 //   Intent is defined via OneSignal's backend and is sent to HMS.

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationOpenedProcessor.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationOpenedProcessor.java
@@ -33,8 +33,9 @@ import android.content.Context;
 import android.content.Intent;
 import android.database.Cursor;
 import android.os.Build;
-import android.support.annotation.NonNull;
-import android.support.v4.app.NotificationManagerCompat;
+
+import androidx.annotation.NonNull;
+import androidx.core.app.NotificationManagerCompat;
 
 import com.onesignal.OneSignalDbContract.NotificationTable;
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationPayloadProcessorHMS.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationPayloadProcessorHMS.java
@@ -4,8 +4,9 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import org.json.JSONArray;
 import org.json.JSONException;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationRestoreService.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationRestoreService.java
@@ -29,7 +29,8 @@ package com.onesignal;
 
 import android.app.IntentService;
 import android.content.Intent;
-import android.support.v4.content.WakefulBroadcastReceiver;
+
+import androidx.legacy.content.WakefulBroadcastReceiver;
 
 public class NotificationRestoreService extends IntentService {
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationRestorer.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationRestorer.java
@@ -38,8 +38,9 @@ import android.database.Cursor;
 import android.os.Build;
 import android.os.Process;
 import android.service.notification.StatusBarNotification;
-import android.support.annotation.WorkerThread;
 import android.text.TextUtils;
+
+import androidx.annotation.WorkerThread;
 
 import com.onesignal.OneSignalDbContract.NotificationTable;
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSEmailSubscriptionState.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSEmailSubscriptionState.java
@@ -27,7 +27,7 @@
 
 package com.onesignal;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import org.json.JSONObject;
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessage.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessage.java
@@ -1,6 +1,7 @@
 package com.onesignal;
 
-import android.support.annotation.NonNull;
+
+import androidx.annotation.NonNull;
 
 import org.json.JSONArray;
 import org.json.JSONException;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageAction.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageAction.java
@@ -1,7 +1,7 @@
 package com.onesignal;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import org.json.JSONArray;
 import org.json.JSONException;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageController.java
@@ -4,8 +4,9 @@ import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.DialogInterface;
 import android.os.Process;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.onesignal.OSDynamicTriggerController.OSDynamicTriggerControllerObserver;
 import com.onesignal.OneSignalRestClient.ResponseHandler;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageDummyController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageDummyController.java
@@ -1,7 +1,8 @@
 package com.onesignal;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import org.json.JSONArray;
 import org.json.JSONException;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageOutcome.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageOutcome.java
@@ -1,6 +1,7 @@
 package com.onesignal;
 
-import android.support.annotation.NonNull;
+
+import androidx.annotation.NonNull;
 
 import org.json.JSONException;
 import org.json.JSONObject;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageRepository.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageRepository.java
@@ -2,7 +2,8 @@ package com.onesignal;
 
 import android.content.ContentValues;
 import android.database.Cursor;
-import android.support.annotation.WorkerThread;
+
+import androidx.annotation.WorkerThread;
 
 import org.json.JSONArray;
 import org.json.JSONException;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageTag.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageTag.java
@@ -1,6 +1,6 @@
 package com.onesignal;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import org.json.JSONArray;
 import org.json.JSONException;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSLogWrapper.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSLogWrapper.java
@@ -1,7 +1,8 @@
 package com.onesignal;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 class OSLogWrapper implements OSLogger {
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSLogger.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSLogger.java
@@ -1,7 +1,8 @@
 package com.onesignal;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 public interface OSLogger {
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationFormatHelper.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationFormatHelper.java
@@ -2,7 +2,8 @@ package com.onesignal;
 
 import android.content.Intent;
 import android.os.Bundle;
-import android.support.annotation.Nullable;
+
+import androidx.annotation.Nullable;
 
 import org.json.JSONException;
 import org.json.JSONObject;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSOutcomeEventsController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSOutcomeEventsController.java
@@ -1,8 +1,9 @@
 package com.onesignal;
 
 import android.os.Process;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.onesignal.influence.model.OSInfluence;
 import com.onesignal.influence.model.OSInfluenceType;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSReceiveReceiptController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSReceiveReceiptController.java
@@ -27,7 +27,8 @@
 
 package com.onesignal;
 
-import android.support.annotation.NonNull;
+
+import androidx.annotation.NonNull;
 
 class OSReceiveReceiptController {
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSReceiveReceiptRepository.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSReceiveReceiptRepository.java
@@ -27,7 +27,7 @@
 
 package com.onesignal;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import org.json.JSONException;
 import org.json.JSONObject;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSSessionManager.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSSessionManager.java
@@ -1,8 +1,9 @@
 package com.onesignal;
 
 import android.os.Process;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.onesignal.influence.OSChannelTracker;
 import com.onesignal.influence.OSTrackerFactory;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSSharedPreferences.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSSharedPreferences.java
@@ -1,7 +1,7 @@
 package com.onesignal;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import java.util.Set;
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSSharedPreferencesWrapper.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSSharedPreferencesWrapper.java
@@ -1,7 +1,8 @@
 package com.onesignal;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import java.util.Set;
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSSubscriptionState.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSSubscriptionState.java
@@ -28,7 +28,7 @@
 package com.onesignal;
 
 
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import org.json.JSONException;
 import org.json.JSONObject;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSSystemConditionController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSSystemConditionController.java
@@ -1,11 +1,12 @@
 package com.onesignal;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
-import android.support.v4.app.DialogFragment;
-import android.support.v4.app.Fragment;
-import android.support.v4.app.FragmentManager;
-import android.support.v7.app.AppCompatActivity;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.fragment.app.DialogFragment;
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentManager;
 
 import java.lang.ref.WeakReference;
 import java.util.List;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSTrigger.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSTrigger.java
@@ -1,7 +1,7 @@
 package com.onesignal;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import org.json.JSONException;
 import org.json.JSONObject;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSTriggerController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSTriggerController.java
@@ -1,7 +1,7 @@
 package com.onesignal;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.onesignal.OSDynamicTriggerController.OSDynamicTriggerControllerObserver;
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSUtils.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSUtils.java
@@ -42,10 +42,12 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.v4.app.NotificationManagerCompat;
 import android.telephony.TelephonyManager;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.app.NotificationManagerCompat;
+import androidx.legacy.content.WakefulBroadcastReceiver;
 
 import com.google.android.gms.common.GoogleApiAvailability;
 import com.huawei.hms.api.HuaweiApiAvailability;
@@ -229,7 +231,7 @@ class OSUtils {
    private static boolean hasWakefulBroadcastReceiver() {
       try {
          // noinspection ConstantConditions
-         return android.support.v4.content.WakefulBroadcastReceiver.class != null;
+         return WakefulBroadcastReceiver.class != null;
       } catch (Throwable e) {
          return false;
       }
@@ -238,7 +240,7 @@ class OSUtils {
    private static boolean hasNotificationManagerCompat() {
       try {
          // noinspection ConstantConditions
-         return android.support.v4.app.NotificationManagerCompat.class != null;
+         return NotificationManagerCompat.class != null;
       } catch (Throwable e) {
          return false;
       }
@@ -247,7 +249,7 @@ class OSUtils {
    private static boolean hasJobIntentService() {
       try {
          // noinspection ConstantConditions
-         return android.support.v4.app.JobIntentService.class != null;
+         return JobIntentService.class != null;
       } catch (Throwable e) {
          return false;
       }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSViewUtils.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSViewUtils.java
@@ -7,11 +7,12 @@ import android.content.res.Resources;
 import android.graphics.Point;
 import android.graphics.Rect;
 import android.os.Build;
-import android.support.annotation.NonNull;
 import android.util.DisplayMetrics;
 import android.view.View;
 import android.view.Window;
 import android.view.WindowInsets;
+
+import androidx.annotation.NonNull;
 
 import java.lang.ref.WeakReference;
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -39,11 +39,12 @@ import android.content.pm.PackageManager;
 import android.database.Cursor;
 import android.os.Build;
 import android.os.Bundle;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.annotation.WorkerThread;
 import android.text.TextUtils;
 import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.WorkerThread;
 
 import com.onesignal.OneSignalDbContract.NotificationTable;
 import com.onesignal.influence.OSTrackerFactory;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalAPIClient.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalAPIClient.java
@@ -27,7 +27,7 @@ package com.onesignal;
  * THE SOFTWARE.
  */
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import org.json.JSONObject;
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalCacheCleaner.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalCacheCleaner.java
@@ -2,7 +2,8 @@ package com.onesignal;
 
 import android.content.Context;
 import android.os.Process;
-import android.support.annotation.WorkerThread;
+
+import androidx.annotation.WorkerThread;
 
 import com.onesignal.OneSignalDbContract.NotificationTable;
 import com.onesignal.influence.model.OSInfluenceChannel;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalChromeTab.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalChromeTab.java
@@ -31,18 +31,19 @@ import android.content.ComponentName;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Build;
-import android.support.annotation.NonNull;
-import android.support.customtabs.CustomTabsClient;
-import android.support.customtabs.CustomTabsIntent;
-import android.support.customtabs.CustomTabsServiceConnection;
-import android.support.customtabs.CustomTabsSession;
+
+import androidx.annotation.NonNull;
+import androidx.browser.customtabs.CustomTabsClient;
+import androidx.browser.customtabs.CustomTabsIntent;
+import androidx.browser.customtabs.CustomTabsServiceConnection;
+import androidx.browser.customtabs.CustomTabsSession;
 
 class OneSignalChromeTab {
 
    private static boolean hasChromeTabLibrary() {
       try {
          // noinspection ConstantConditions
-         return android.support.customtabs.CustomTabsServiceConnection.class != null;
+         return CustomTabsServiceConnection.class != null;
       } catch (Throwable e) {
          return false;
       }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalDb.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalDb.java
@@ -3,8 +3,9 @@ package com.onesignal;
 import android.content.ContentValues;
 import android.database.Cursor;
 import android.database.SQLException;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 public interface OneSignalDb {
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalDbHelper.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalDbHelper.java
@@ -37,8 +37,9 @@ import android.database.sqlite.SQLiteDatabaseLockedException;
 import android.database.sqlite.SQLiteException;
 import android.database.sqlite.SQLiteOpenHelper;
 import android.os.SystemClock;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.onesignal.OneSignalDbContract.InAppMessageTable;
 import com.onesignal.OneSignalDbContract.NotificationTable;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalHmsEventBridge.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalHmsEventBridge.java
@@ -1,7 +1,8 @@
 package com.onesignal;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
+
+import androidx.annotation.NonNull;
 
 import com.huawei.hms.push.RemoteMessage;
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalJobServiceBase.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalJobServiceBase.java
@@ -3,7 +3,8 @@ package com.onesignal;
 import android.app.job.JobParameters;
 import android.app.job.JobService;
 import android.os.Build;
-import android.support.annotation.RequiresApi;
+
+import androidx.annotation.RequiresApi;
 
 @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
 abstract class OneSignalJobServiceBase extends JobService {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalNotificationManager.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalNotificationManager.java
@@ -6,9 +6,10 @@ import android.content.Context;
 import android.database.Cursor;
 import android.os.Build;
 import android.service.notification.StatusBarNotification;
-import android.support.annotation.RequiresApi;
-import android.support.v4.app.NotificationCompat;
-import android.support.v4.app.NotificationManagerCompat;
+
+import androidx.annotation.RequiresApi;
+import androidx.core.app.NotificationCompat;
+import androidx.core.app.NotificationManagerCompat;
 
 import java.util.ArrayList;
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalPrefs.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalPrefs.java
@@ -32,8 +32,9 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Handler;
 import android.os.HandlerThread;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import java.util.HashMap;
 import java.util.Set;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalRemoteParams.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalRemoteParams.java
@@ -1,7 +1,7 @@
 package com.onesignal;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -12,7 +12,8 @@ import java.net.HttpURLConnection;
 public class OneSignalRemoteParams {
 
    static class FCMParams {
-      @Nullable String projectId;
+      @Nullable
+      String projectId;
       @Nullable String appId;
       @Nullable String apiKey;
    }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalRestClient.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalRestClient.java
@@ -29,8 +29,9 @@ package com.onesignal;
 
 import android.net.TrafficStats;
 import android.os.Build;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalRestClientWrapper.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalRestClientWrapper.java
@@ -1,6 +1,7 @@
 package com.onesignal;
 
-import android.support.annotation.NonNull;
+
+import androidx.annotation.NonNull;
 
 import org.json.JSONObject;
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalStateSynchronizer.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalStateSynchronizer.java
@@ -27,7 +27,7 @@
 
 package com.onesignal;
 
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import org.json.JSONException;
 import org.json.JSONObject;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalSyncServiceUtils.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalSyncServiceUtils.java
@@ -39,7 +39,8 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.os.Build;
-import android.support.annotation.RequiresApi;
+
+import androidx.annotation.RequiresApi;
 
 import com.onesignal.AndroidSupportV4Compat.ContextCompat;
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OutcomeEvent.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OutcomeEvent.java
@@ -1,7 +1,7 @@
 package com.onesignal;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.onesignal.influence.model.OSInfluenceType;
 import com.onesignal.outcomes.model.OSOutcomeEventParams;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/PermissionsActivity.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/PermissionsActivity.java
@@ -36,7 +36,8 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
-import android.support.annotation.NonNull;
+
+import androidx.annotation.NonNull;
 
 import com.onesignal.AndroidSupportV4Compat.ActivityCompat;
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/PushRegistratorFCM.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/PushRegistratorFCM.java
@@ -32,7 +32,7 @@ import android.content.Context;
 import android.content.pm.PackageManager;
 import android.util.Base64;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/PushRegistratorHMS.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/PushRegistratorHMS.java
@@ -1,9 +1,10 @@
 package com.onesignal;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.text.TextUtils;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.huawei.agconnect.config.AGConnectServicesConfig;
 import com.huawei.hms.aaid.HmsInstanceId;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/RestoreKickoffJobService.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/RestoreKickoffJobService.java
@@ -4,7 +4,8 @@ import android.app.job.JobParameters;
 import android.app.job.JobService;
 import android.os.Build;
 import android.os.Process;
-import android.support.annotation.RequiresApi;
+
+import androidx.annotation.RequiresApi;
 
 @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
 public class RestoreKickoffJobService extends OneSignalJobServiceBase {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/SyncJobService.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/SyncJobService.java
@@ -32,7 +32,8 @@ import android.app.job.JobService;
 import android.content.Context;
 import android.net.ConnectivityManager;
 import android.os.Build;
-import android.support.annotation.RequiresApi;
+
+import androidx.annotation.RequiresApi;
 
 @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
 public class SyncJobService extends JobService {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/SyncService.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/SyncService.java
@@ -30,7 +30,8 @@ package com.onesignal;
 import android.app.Service;
 import android.content.Intent;
 import android.os.IBinder;
-import android.support.annotation.Nullable;
+
+import androidx.annotation.Nullable;
 
 public class SyncService extends Service {
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStateEmailSynchronizer.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStateEmailSynchronizer.java
@@ -1,6 +1,7 @@
 package com.onesignal;
 
-import android.support.annotation.Nullable;
+
+import androidx.annotation.Nullable;
 
 import com.onesignal.OneSignalStateSynchronizer.UserStateSynchronizerType;
 
@@ -40,7 +41,8 @@ class UserStateEmailSynchronizer extends UserStateSynchronizer {
 
     // Email external id not readable from SDK
     @Override
-    @Nullable String getExternalId(boolean fromServer) {
+    @Nullable
+    String getExternalId(boolean fromServer) {
         return null;
     }
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStatePushSynchronizer.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStatePushSynchronizer.java
@@ -1,6 +1,6 @@
 package com.onesignal;
 
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import com.onesignal.OneSignalStateSynchronizer.UserStateSynchronizerType;
 
@@ -77,7 +77,8 @@ class UserStatePushSynchronizer extends UserStateSynchronizer {
     }
 
     @Override
-    @Nullable String getExternalId(boolean fromServer) {
+    @Nullable
+    String getExternalId(boolean fromServer) {
         synchronized(LOCK) {
             return toSyncUserState.getSyncValues().optString("external_user_id", null);
         }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStateSynchronizer.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStateSynchronizer.java
@@ -2,7 +2,8 @@ package com.onesignal;
 
 import android.os.Handler;
 import android.os.HandlerThread;
-import android.support.annotation.Nullable;
+
+import androidx.annotation.Nullable;
 
 import com.onesignal.OneSignalStateSynchronizer.UserStateSynchronizerType;
 import com.onesignal.OneSignal.ChangeTagsUpdateHandler;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/WebViewManager.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/WebViewManager.java
@@ -6,13 +6,14 @@ import android.app.Activity;
 import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.util.Base64;
 import android.view.View;
 import android.webkit.JavascriptInterface;
 import android.webkit.ValueCallback;
 import android.webkit.WebView;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -55,12 +56,14 @@ class WebViewManager extends ActivityLifecycleHandler.ActivityAvailableListener 
         }
     }
 
-    @Nullable private OSWebView webView;
+    @Nullable
+    private OSWebView webView;
     @Nullable private InAppMessageView messageView;
 
     @Nullable protected static WebViewManager lastInstance = null;
 
-    @NonNull private Activity activity;
+    @NonNull
+    private Activity activity;
     @NonNull private OSInAppMessage message;
 
     private String currentActivityName = null;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/influence/OSChannelTracker.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/influence/OSChannelTracker.java
@@ -1,7 +1,7 @@
 package com.onesignal.influence;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.onesignal.OSLogger;
 import com.onesignal.influence.model.OSInfluence;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/influence/OSInAppMessageTracker.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/influence/OSInAppMessageTracker.java
@@ -1,6 +1,7 @@
 package com.onesignal.influence;
 
-import android.support.annotation.NonNull;
+
+import androidx.annotation.NonNull;
 
 import com.onesignal.OSLogger;
 import com.onesignal.influence.model.OSInfluence;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/influence/OSInfluenceDataRepository.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/influence/OSInfluenceDataRepository.java
@@ -1,7 +1,7 @@
 package com.onesignal.influence;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.onesignal.OSSharedPreferences;
 import com.onesignal.OneSignalRemoteParams;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/influence/OSNotificationTracker.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/influence/OSNotificationTracker.java
@@ -1,6 +1,7 @@
 package com.onesignal.influence;
 
-import android.support.annotation.NonNull;
+
+import androidx.annotation.NonNull;
 
 import com.onesignal.OSLogger;
 import com.onesignal.influence.model.OSInfluence;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/influence/OSTrackerFactory.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/influence/OSTrackerFactory.java
@@ -1,7 +1,7 @@
 package com.onesignal.influence;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.onesignal.OSLogger;
 import com.onesignal.OSSharedPreferences;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/influence/model/OSInfluence.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/influence/model/OSInfluence.java
@@ -1,7 +1,8 @@
 package com.onesignal.influence.model;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import org.json.JSONArray;
 import org.json.JSONException;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/influence/model/OSInfluenceChannel.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/influence/model/OSInfluenceChannel.java
@@ -1,6 +1,7 @@
 package com.onesignal.influence.model;
 
-import android.support.annotation.NonNull;
+
+import androidx.annotation.NonNull;
 
 public enum OSInfluenceChannel {
     IAM("iam"),

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/influence/model/OSInfluenceType.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/influence/model/OSInfluenceType.java
@@ -1,6 +1,6 @@
 package com.onesignal.influence.model;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 public enum OSInfluenceType {
     DIRECT,

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/outcomes/OSOutcomeEventsCache.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/outcomes/OSOutcomeEventsCache.java
@@ -2,8 +2,9 @@ package com.onesignal.outcomes;
 
 import android.content.ContentValues;
 import android.database.Cursor;
-import android.support.annotation.NonNull;
-import android.support.annotation.WorkerThread;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.WorkerThread;
 
 import com.onesignal.OSLogger;
 import com.onesignal.OSSharedPreferences;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/outcomes/model/OSOutcomeEventParams.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/outcomes/model/OSOutcomeEventParams.java
@@ -1,7 +1,8 @@
 package com.onesignal.outcomes.model;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import org.json.JSONException;
 import org.json.JSONObject;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/outcomes/model/OSOutcomeSource.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/outcomes/model/OSOutcomeSource.java
@@ -1,6 +1,7 @@
 package com.onesignal.outcomes.model;
 
-import android.support.annotation.Nullable;
+
+import androidx.annotation.Nullable;
 
 import org.json.JSONException;
 import org.json.JSONObject;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/outcomes/model/OSOutcomeSourceBody.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/outcomes/model/OSOutcomeSourceBody.java
@@ -1,6 +1,7 @@
 package com.onesignal.outcomes.model;
 
-import android.support.annotation.Nullable;
+
+import androidx.annotation.Nullable;
 
 import org.json.JSONArray;
 import org.json.JSONException;


### PR DESCRIPTION
## RootCause / 原因
https://17media.atlassian.net/browse/TECH-1033
notification cause framework crash by DeadSystemException/RuntimeException (maybe caused by image size?)

## Solution / 方法
catch exception in **NotificationBundleProcessor.ProcessJobForDisplay()** since we don't know if it caused by image size or framework bug

## Risk / 風險 (Optional)
medium

## Sphere of influence / 影響範圍 (Optional)


## JIRA
https://17media.atlassian.net/browse/TECH-1033

## Screenshot (Optional)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1305)
<!-- Reviewable:end -->
