### PR TITLE
Removing ad_id from player create

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -433,14 +433,6 @@ public class OneSignal {
    @Nullable private static OSNotificationDataController notificationDataController;
 
    @Nullable private static AdvertisingIdentifierProvider adIdProvider;
-   private static synchronized @Nullable AdvertisingIdentifierProvider getAdIdProvider() {
-      if (adIdProvider == null) {
-         if (OSUtils.isAndroidDeviceType())
-            adIdProvider = new AdvertisingIdProviderGPS();
-      }
-
-      return adIdProvider;
-   }
 
    @SuppressWarnings("WeakerAccess")
    public static String sdkType = "native";
@@ -1422,11 +1414,6 @@ public class OneSignal {
 
       deviceInfo.put("app_id", getSavedAppId());
 
-      if (getAdIdProvider() != null) {
-         String adId = getAdIdProvider().getIdentifier(appContext);
-         if (adId != null)
-            deviceInfo.put("ad_id", adId);
-      }
       deviceInfo.put("device_os", Build.VERSION.RELEASE);
       deviceInfo.put("timezone", getTimeZoneOffset());
       deviceInfo.put("timezone_id", getTimeZoneId());

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
@@ -315,6 +315,23 @@ public class MainOneSignalClassRunner {
    }
 
    @Test
+   public void testAndroidDoesNotGetAdId() throws Exception {
+      // 2. Init OneSignal so the app id is cached
+      OneSignalInit();
+      threadAndTaskWait();
+
+      // 3. Make sure device_type is Amazon (2) in player create
+      assertAndroidPlayerCreateAtIndex(1);
+
+      // 4. Assert Player Create does NOT have an ad_id
+      ShadowOneSignalRestClient.Request request = ShadowOneSignalRestClient.requests.get(1);
+      JsonAsserts.doesNotContainKeys(request.payload, new ArrayList<String>() {{ add("ad_id"); }});
+
+      // 5. Assert we did NOT try to get a Google Ad id
+      assertFalse(ShadowAdvertisingIdProviderGPS.calledGetIdentifier);
+   }
+
+   @Test
    public void testDeviceTypeIsAmazon_forPlayerCreate() throws Exception {
       // 1. Mock Amazon device type for this test
       ShadowOSUtils.supportsADM = true;


### PR DESCRIPTION
We will no longer use ad_id on Android in the player create request, meaning that all new installs will result in a new OneSignal Player ID. 

This behavior now matches iOS

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1313)
<!-- Reviewable:end -->

