### PR TITLE
Fix NPE under UserState

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStateSynchronizer.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStateSynchronizer.java
@@ -221,7 +221,8 @@ abstract class UserStateSynchronizer {
     boolean persist() {
         if (toSyncUserState != null) {
             synchronized (LOCK) {
-                boolean unSynced = currentUserState.generateJsonDiff(toSyncUserState, isSessionCall()) != null;
+                // In case current state is being clean in background, save toSyncUserState for next player sync
+                boolean unSynced = getCurrentUserState().generateJsonDiff(toSyncUserState, isSessionCall()) != null;
                 toSyncUserState.persistState();
                 return unSynced;
             }


### PR DESCRIPTION
* currentUserState might be null when application goes to background
* Replace currentUserState with getCurrentUserState() to avoid NPE

Fixes

https://github.com/OneSignal/OneSignal-Android-SDK/issues/1279

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1323)
<!-- Reviewable:end -->
