### PR TITLE
Fix NPE under UserState getSyncValuesCopy

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserState.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserState.java
@@ -1,5 +1,7 @@
 package com.onesignal;
 
+import androidx.annotation.NonNull;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -92,7 +94,7 @@ abstract class UserState {
         }
     }
 
-    public void setSyncValues(JSONObject syncValues) {
+    public void setSyncValues(@NonNull JSONObject syncValues) {
         synchronized (LOCK) {
             this.syncValues = syncValues;
         }
@@ -297,21 +299,20 @@ abstract class UserState {
 
         String syncValuesStr = OneSignalPrefs.getString(OneSignalPrefs.PREFS_ONESIGNAL,
                 OneSignalPrefs.PREFS_ONESIGNAL_USERSTATE_SYNCVALYES_ + persistKey,null);
+
+        JSONObject syncValues = new JSONObject();
         try {
-            JSONObject syncValues;
             if (syncValuesStr == null) {
-                syncValues = new JSONObject();
-                String gtRegistrationId = OneSignalPrefs.getString(OneSignalPrefs.PREFS_ONESIGNAL,
+                String registrationId = OneSignalPrefs.getString(OneSignalPrefs.PREFS_ONESIGNAL,
                         OneSignalPrefs.PREFS_GT_REGISTRATION_ID,null);
-                syncValues.put("identifier", gtRegistrationId);
+                syncValues.put("identifier", registrationId);
             } else {
                 syncValues = new JSONObject(syncValuesStr);
             }
-
-            setSyncValues(syncValues);
         } catch (JSONException e) {
             e.printStackTrace();
         }
+        setSyncValues(syncValues);
     }
 
     void persistState() {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStateEmail.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStateEmail.java
@@ -1,8 +1,10 @@
 package com.onesignal;
 
 class UserStateEmail extends UserState {
+    private static final String EMAIL = "email";
+
     UserStateEmail(String inPersistKey, boolean load) {
-        super("email" + inPersistKey, load);
+        super(EMAIL + inPersistKey, load);
     }
 
     @Override


### PR DESCRIPTION
* If UserState data is inited by load state and JSON parsing ends failing syncValues might end null
* Always init sync values

Fixes

https://github.com/OneSignal/OneSignal-Android-SDK/issues/1317

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1324)
<!-- Reviewable:end -->
