### PR TITLE
Feature app-defined language implementation

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationChannelManager.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationChannelManager.java
@@ -118,9 +118,9 @@ class NotificationChannelManager {
       JSONObject payloadWithText = channelPayload;
       if (channelPayload.has("langs")) {
          JSONObject langList = channelPayload.getJSONObject("langs");
-         String deviceLanguage = OneSignal.languageContext.getLanguage();
-         if (langList.has(deviceLanguage))
-            payloadWithText = langList.optJSONObject(deviceLanguage);
+         String language = LanguageContext.getInstance().getLanguage();
+         if (langList.has(language))
+            payloadWithText = langList.optJSONObject(language);
       }
       
       String channel_name = payloadWithText.optString("nm", "Miscellaneous");

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationChannelManager.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationChannelManager.java
@@ -40,6 +40,8 @@ import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 import androidx.core.app.NotificationManagerCompat;
 
+import com.onesignal.language.LanguageContext;
+
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -116,7 +118,7 @@ class NotificationChannelManager {
       JSONObject payloadWithText = channelPayload;
       if (channelPayload.has("langs")) {
          JSONObject langList = channelPayload.getJSONObject("langs");
-         String deviceLanguage = OSUtils.getCorrectedLanguage();
+         String deviceLanguage = OneSignal.languageContext.getLanguage();
          if (langList.has(deviceLanguage))
             payloadWithText = langList.optJSONObject(deviceLanguage);
       }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageController.java
@@ -285,7 +285,7 @@ class OSInAppMessageController extends OSBackgroundManager implements OSDynamicT
     }
 
     private @Nullable String variantIdForMessage(@NonNull OSInAppMessage message) {
-        String languageIdentifier = OSUtils.getCorrectedLanguage();
+        String languageIdentifier = OneSignal.languageContext.getLanguage();
 
         for (String variant : PREFERRED_VARIANT_ORDER) {
             if (!message.variants.containsKey(variant))

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageController.java
@@ -8,6 +8,7 @@ import androidx.annotation.Nullable;
 
 import com.onesignal.OSDynamicTriggerController.OSDynamicTriggerControllerObserver;
 import com.onesignal.OneSignalRestClient.ResponseHandler;
+import com.onesignal.language.LanguageContext;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -39,6 +40,7 @@ class OSInAppMessageController extends OSBackgroundManager implements OSDynamicT
 
     private final OSLogger logger;
     private final OSTaskController taskController;
+    private final LanguageContext languageContext;
 
     private OSSystemConditionController systemConditionController;
     private OSInAppMessageRepository inAppMessageRepository;
@@ -87,7 +89,7 @@ class OSInAppMessageController extends OSBackgroundManager implements OSDynamicT
     Date lastTimeInAppDismissed = null;
     private int htmlNetworkRequestAttemptCount = 0;
 
-    protected OSInAppMessageController(OneSignalDbHelper dbHelper, OSTaskController controller, OSLogger logger) {
+    protected OSInAppMessageController(OneSignalDbHelper dbHelper, OSTaskController controller, OSLogger logger, LanguageContext languageContext) {
         taskController = controller;
         messages = new ArrayList<>();
         dismissedMessages = OSUtils.newConcurrentSet();
@@ -97,6 +99,7 @@ class OSInAppMessageController extends OSBackgroundManager implements OSDynamicT
         clickedClickIds = OSUtils.newConcurrentSet();
         triggerController = new OSTriggerController(this);
         systemConditionController = new OSSystemConditionController(this);
+        this.languageContext = languageContext;
         this.logger = logger;
 
         Set<String> tempDismissedSet = OneSignalPrefs.getStringSet(
@@ -285,15 +288,15 @@ class OSInAppMessageController extends OSBackgroundManager implements OSDynamicT
     }
 
     private @Nullable String variantIdForMessage(@NonNull OSInAppMessage message) {
-        String languageIdentifier = OneSignal.languageContext.getLanguage();
+        String language = languageContext.getLanguage();
 
         for (String variant : PREFERRED_VARIANT_ORDER) {
             if (!message.variants.containsKey(variant))
                 continue;
 
             HashMap<String, String> variantMap = message.variants.get(variant);
-            if (variantMap.containsKey(languageIdentifier))
-                return variantMap.get(languageIdentifier);
+            if (variantMap.containsKey(language))
+                return variantMap.get(language);
             return variantMap.get("default");
         }
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageControllerFactory.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageControllerFactory.java
@@ -29,21 +29,23 @@ package com.onesignal;
 
 import android.os.Build;
 
+import com.onesignal.language.LanguageContext;
+
 class OSInAppMessageControllerFactory {
 
     private static final Object LOCK = new Object();
 
     private OSInAppMessageController controller;
 
-    public OSInAppMessageController getController(OneSignalDbHelper dbHelper, OSTaskController taskController, OSLogger logger) {
+    public OSInAppMessageController getController(OneSignalDbHelper dbHelper, OSTaskController taskController, OSLogger logger, LanguageContext languageContext) {
         if (controller == null) {
             synchronized (LOCK) {
                 if (controller == null) {
                     // Make sure only Android 4.4 devices and higher can use IAMs
                     if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.JELLY_BEAN_MR2)
-                        controller = new OSInAppMessageDummyController(null, taskController, logger);
+                        controller = new OSInAppMessageDummyController(null, taskController, logger, languageContext);
                     else
-                        controller = new OSInAppMessageController(dbHelper, taskController, logger);
+                        controller = new OSInAppMessageController(dbHelper, taskController, logger, languageContext);
                 }
             }
         }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageDummyController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageDummyController.java
@@ -3,6 +3,8 @@ package com.onesignal;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.onesignal.language.LanguageContext;
+
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -17,8 +19,8 @@ class OSInAppMessageDummyController extends OSInAppMessageController {
      * This is a dummy controller that will be used for Android 4.3 and older devices
      * All methods should be overridden and as empty as possible (few return exceptions)
      */
-    OSInAppMessageDummyController(OneSignalDbHelper dbHelper, OSTaskController taskController, OSLogger logger) {
-        super(dbHelper, taskController, logger);
+    OSInAppMessageDummyController(OneSignalDbHelper dbHelper, OSTaskController taskController, OSLogger logger, LanguageContext languageContext) {
+        super(dbHelper, taskController, logger, languageContext);
     }
 
     @Override

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSTaskRemoteController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSTaskRemoteController.java
@@ -13,6 +13,7 @@ class OSTaskRemoteController extends OSTaskController {
     static final String LOGOUT_EMAIL = "logoutEmail()";
     static final String SYNC_HASHED_EMAIL = "syncHashedEmail()";
     static final String SET_EXTERNAL_USER_ID = "setExternalUserId()";
+    static final String SET_LANGUAGE = "setLanguage()";
     static final String SET_SUBSCRIPTION = "setSubscription()";
     static final String PROMPT_LOCATION = "promptLocation()";
     static final String IDS_AVAILABLE = "idsAvailable()";
@@ -39,6 +40,7 @@ class OSTaskRemoteController extends OSTaskController {
             LOGOUT_EMAIL,
             SYNC_HASHED_EMAIL,
             SET_EXTERNAL_USER_ID,
+            SET_LANGUAGE,
             SET_SUBSCRIPTION,
             PROMPT_LOCATION,
             IDS_AVAILABLE,

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSUtils.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSUtils.java
@@ -62,7 +62,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.Locale;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -438,24 +437,6 @@ class OSUtils {
       if (bodyResId != 0)
          return resources.getString(bodyResId);
       return defaultStr;
-   }
-
-   static String getCorrectedLanguage() {
-      String lang = Locale.getDefault().getLanguage();
-
-      // https://github.com/OneSignal/OneSignal-Android-SDK/issues/64
-      if (lang.equals("iw"))
-         return "he";
-      if (lang.equals("in"))
-         return "id";
-      if (lang.equals("ji"))
-         return "yi";
-
-      // https://github.com/OneSignal/OneSignal-Android-SDK/issues/98
-      if (lang.equals("zh"))
-         return lang + "-" + Locale.getDefault().getCountry();
-
-      return lang;
    }
 
    static boolean isValidEmail(String email) {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -47,6 +47,9 @@ import androidx.core.app.NotificationCompat;
 
 import com.onesignal.influence.data.OSTrackerFactory;
 import com.onesignal.influence.domain.OSInfluence;
+import com.onesignal.language.LanguageContext;
+import com.onesignal.language.LanguageProviderAppDefined;
+import com.onesignal.language.LanguageProviderDevice;
 import com.onesignal.outcomes.data.OSOutcomeEventsFactory;
 
 import org.json.JSONArray;
@@ -367,6 +370,8 @@ public class OneSignal {
    private static String emailId = null;
    private static String smsId = null;
    private static int subscribableStatus = Integer.MAX_VALUE;
+
+   private static LanguageContext languageContext = null;
 
    static OSRemoteNotificationReceivedHandler remoteNotificationReceivedHandler;
    static OSNotificationWillShowInForegroundHandler notificationWillShowInForegroundHandler;
@@ -762,6 +767,9 @@ public class OneSignal {
             makeAndroidParamsRequest(lastAppId, getUserId(), false);
          return;
       }
+
+      // Set Language Context to null
+      languageContext = new LanguageContext();
 
       // Keep last subscribed Status if already set
       subscribableStatus = subscribableStatus != Integer.MAX_VALUE ? subscribableStatus : osUtils.initializationChecker(appContext, appId);
@@ -1651,6 +1659,11 @@ public class OneSignal {
 
       emailLogoutHandler = callback;
       OneSignalStateSynchronizer.logoutEmail();
+   }
+
+   public static void setLanguage(@NonNull final String language) {
+      languageContext.setStrategy(new LanguageProviderAppDefined());
+      //Implement the network call to store the language setting for the user
    }
 
    public static void setExternalUserId(@NonNull final String externalId) {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -370,7 +370,7 @@ public class OneSignal {
    private static String smsId = null;
    private static int subscribableStatus = Integer.MAX_VALUE;
 
-   private static LanguageContext languageContext = null;
+   public static LanguageContext languageContext = null;
 
    static OSRemoteNotificationReceivedHandler remoteNotificationReceivedHandler;
    static OSNotificationWillShowInForegroundHandler notificationWillShowInForegroundHandler;
@@ -429,7 +429,7 @@ public class OneSignal {
    private static OSTaskController taskController = new OSTaskController(logger);
    private static OSTaskRemoteController taskRemoteController = new OSTaskRemoteController(remoteParamController, logger);
    private static OneSignalAPIClient apiClient = new OneSignalRestClientWrapper();
-   private static OSSharedPreferences preferences = new OSSharedPreferencesWrapper();
+   public static OSSharedPreferences preferences = new OSSharedPreferencesWrapper();
    private static OSTrackerFactory trackerFactory = new OSTrackerFactory(preferences, logger, time);
    private static OSSessionManager sessionManager = new OSSessionManager(sessionListener, trackerFactory, logger);
    @Nullable private static OSOutcomeEventsController outcomeEventsController;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -767,9 +767,6 @@ public class OneSignal {
          return;
       }
 
-      // Set Language Context to null
-      languageContext = new LanguageContext(preferences);
-
       // Keep last subscribed Status if already set
       subscribableStatus = subscribableStatus != Integer.MAX_VALUE ? subscribableStatus : osUtils.initializationChecker(appContext, appId);
       if (isSubscriptionStatusUninitializable())
@@ -830,6 +827,9 @@ public class OneSignal {
 
       // Do work here that should only happen once or at the start of a new lifecycle
       if (wasAppContextNull) {
+         // Set Language Context to null
+         languageContext = new LanguageContext(preferences);
+
          // Prefs require a context to save
          // If the previous state of appContext was null, kick off write in-case it was waiting
          OneSignalPrefs.startDelayedWrite();
@@ -1677,11 +1677,6 @@ public class OneSignal {
       if (shouldLogUserPrivacyConsentErrorMessageForMethodName("setLanguage()"))
          return;
 
-      if (language == null) {
-         logger.warning("Language can't be null");
-         return;
-      }
-
       LanguageProviderAppDefined languageProviderAppDefined = new LanguageProviderAppDefined(preferences);
       languageProviderAppDefined.setLanguage(language);
       languageContext.setStrategy(languageProviderAppDefined);
@@ -1691,8 +1686,6 @@ public class OneSignal {
          deviceInfo.put("language", languageContext.getLanguage());
          OneSignalStateSynchronizer.updateDeviceInfo(deviceInfo);
       } catch (JSONException exception) {
-         String operation = language.equals("") ? "remove" : "set";
-         logger.error("Attempted to " + operation + " external ID but encountered a JSON exception");
          exception.printStackTrace();
       }
    }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -370,7 +370,7 @@ public class OneSignal {
    private static String smsId = null;
    private static int subscribableStatus = Integer.MAX_VALUE;
 
-   public static LanguageContext languageContext = null;
+   private static LanguageContext languageContext = null;
 
    static OSRemoteNotificationReceivedHandler remoteNotificationReceivedHandler;
    static OSNotificationWillShowInForegroundHandler notificationWillShowInForegroundHandler;
@@ -429,7 +429,7 @@ public class OneSignal {
    private static OSTaskController taskController = new OSTaskController(logger);
    private static OSTaskRemoteController taskRemoteController = new OSTaskRemoteController(remoteParamController, logger);
    private static OneSignalAPIClient apiClient = new OneSignalRestClientWrapper();
-   public static OSSharedPreferences preferences = new OSSharedPreferencesWrapper();
+   private static OSSharedPreferences preferences = new OSSharedPreferencesWrapper();
    private static OSTrackerFactory trackerFactory = new OSTrackerFactory(preferences, logger, time);
    private static OSSessionManager sessionManager = new OSSessionManager(sessionListener, trackerFactory, logger);
    @Nullable private static OSOutcomeEventsController outcomeEventsController;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -1674,7 +1674,7 @@ public class OneSignal {
          return;
       }
 
-      if (shouldLogUserPrivacyConsentErrorMessageForMethodName("setLanguage()"))
+      if (shouldLogUserPrivacyConsentErrorMessageForMethodName(OSTaskRemoteController.SET_LANGUAGE))
          return;
 
       LanguageProviderAppDefined languageProviderAppDefined = new LanguageProviderAppDefined(preferences);

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -422,7 +422,7 @@ public class OneSignal {
 
    private static OSInAppMessageControllerFactory inAppMessageControllerFactory = new OSInAppMessageControllerFactory();
    static OSInAppMessageController getInAppMessageController() {
-      return inAppMessageControllerFactory.getController(getDBHelperInstance(), taskController, getLogger());
+      return inAppMessageControllerFactory.getController(getDBHelperInstance(), taskController, getLogger(), languageContext);
    }
    private static OSTime time = new OSTimeImpl();
    private static OSRemoteParamController remoteParamController = new OSRemoteParamController();

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -768,7 +768,7 @@ public class OneSignal {
       }
 
       // Set Language Context to null
-      languageContext = new LanguageContext();
+      languageContext = new LanguageContext(preferences);
 
       // Keep last subscribed Status if already set
       subscribableStatus = subscribableStatus != Integer.MAX_VALUE ? subscribableStatus : osUtils.initializationChecker(appContext, appId);
@@ -1682,7 +1682,7 @@ public class OneSignal {
          return;
       }
 
-      LanguageProviderAppDefined languageProviderAppDefined = new LanguageProviderAppDefined();
+      LanguageProviderAppDefined languageProviderAppDefined = new LanguageProviderAppDefined(preferences);
       languageProviderAppDefined.setLanguage(language);
       languageContext.setStrategy(languageProviderAppDefined);
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/language/LanguageContext.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/language/LanguageContext.java
@@ -16,7 +16,7 @@ public class LanguageContext {
 
     public LanguageContext(OSSharedPreferences preferences) {
         instance = this;
-        if ( preferences.getString(
+        if (preferences.getString(
                 preferences.getPreferencesName(), PREFS_OS_LANGUAGE, null) != null) {
             this.strategy = new LanguageProviderAppDefined(preferences);
         }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/language/LanguageContext.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/language/LanguageContext.java
@@ -1,8 +1,6 @@
 package com.onesignal.language;
-
 import com.onesignal.OSUtils;
 import com.onesignal.OneSignalPrefs;
-
 import static com.onesignal.language.LanguageProviderAppDefined.PREFS_OS_LANGUAGE;
 
 /*
@@ -14,7 +12,7 @@ public class LanguageContext {
 
     public LanguageContext() {
         if ( OneSignalPrefs.getString(
-                OneSignalPrefs.PREFS_ONESIGNAL, PREFS_OS_LANGUAGE,"en") != null ) {
+                OneSignalPrefs.PREFS_ONESIGNAL, PREFS_OS_LANGUAGE, null) != null) {
             this.strategy = new LanguageProviderAppDefined();
         }
         else {
@@ -26,7 +24,7 @@ public class LanguageContext {
         this.strategy = strategy;
     }
 
-    public String getStrategy() {
+    public String getLanguage() {
         return strategy.getLanguage();
     }
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/language/LanguageContext.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/language/LanguageContext.java
@@ -1,0 +1,32 @@
+package com.onesignal.language;
+
+import com.onesignal.OSUtils;
+import com.onesignal.OneSignalPrefs;
+
+import static com.onesignal.language.LanguageProviderAppDefined.PREFS_OS_LANGUAGE;
+
+/*
+The Interface implements a getter and setter for the Language Provider.
+It defaults to the device defined Language unless a language override is set.
+ */
+public class LanguageContext {
+    private LanguageProvider strategy;
+
+    public LanguageContext() {
+        if ( OneSignalPrefs.getString(
+                OneSignalPrefs.PREFS_ONESIGNAL, PREFS_OS_LANGUAGE,"en") != null ) {
+            this.strategy = new LanguageProviderAppDefined();
+        }
+        else {
+            this.strategy = new LanguageProviderDevice();
+        }
+    }
+
+    public void setStrategy(LanguageProvider strategy) {
+        this.strategy = strategy;
+    }
+
+    public String getStrategy() {
+        return strategy.getLanguage();
+    }
+}

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/language/LanguageContext.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/language/LanguageContext.java
@@ -1,6 +1,5 @@
 package com.onesignal.language;
-import com.onesignal.OSUtils;
-import com.onesignal.OneSignalPrefs;
+import com.onesignal.OneSignal;
 import static com.onesignal.language.LanguageProviderAppDefined.PREFS_OS_LANGUAGE;
 
 /*
@@ -11,8 +10,8 @@ public class LanguageContext {
     private LanguageProvider strategy;
 
     public LanguageContext() {
-        if ( OneSignalPrefs.getString(
-                OneSignalPrefs.PREFS_ONESIGNAL, PREFS_OS_LANGUAGE, null) != null) {
+        if ( OneSignal.preferences.getString(
+                OneSignal.preferences.getPreferencesName(), PREFS_OS_LANGUAGE, null) != null) {
             this.strategy = new LanguageProviderAppDefined();
         }
         else {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/language/LanguageContext.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/language/LanguageContext.java
@@ -1,5 +1,9 @@
 package com.onesignal.language;
+
+import androidx.annotation.NonNull;
+
 import com.onesignal.OSSharedPreferences;
+
 import static com.onesignal.language.LanguageProviderAppDefined.PREFS_OS_LANGUAGE;
 
 /*
@@ -29,6 +33,7 @@ public class LanguageContext {
         this.strategy = strategy;
     }
 
+    @NonNull
     public String getLanguage() {
         return strategy.getLanguage();
     }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/language/LanguageContext.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/language/LanguageContext.java
@@ -20,8 +20,8 @@ public class LanguageContext {
 
     public LanguageContext(OSSharedPreferences preferences) {
         instance = this;
-        if (preferences.getString(
-                preferences.getPreferencesName(), PREFS_OS_LANGUAGE, null) != null) {
+        String languageAppDefined = preferences.getString(preferences.getPreferencesName(), PREFS_OS_LANGUAGE, null);
+        if (languageAppDefined != null) {
             this.strategy = new LanguageProviderAppDefined(preferences);
         }
         else {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/language/LanguageContext.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/language/LanguageContext.java
@@ -1,5 +1,5 @@
 package com.onesignal.language;
-import com.onesignal.OneSignal;
+import com.onesignal.OSSharedPreferences;
 import static com.onesignal.language.LanguageProviderAppDefined.PREFS_OS_LANGUAGE;
 
 /*
@@ -8,11 +8,17 @@ It defaults to the device defined Language unless a language override is set.
  */
 public class LanguageContext {
     private LanguageProvider strategy;
+    private static LanguageContext instance = null;
 
-    public LanguageContext() {
-        if ( OneSignal.preferences.getString(
-                OneSignal.preferences.getPreferencesName(), PREFS_OS_LANGUAGE, null) != null) {
-            this.strategy = new LanguageProviderAppDefined();
+    public static LanguageContext getInstance() {
+        return instance;
+    }
+
+    public LanguageContext(OSSharedPreferences preferences) {
+        instance = this;
+        if ( preferences.getString(
+                preferences.getPreferencesName(), PREFS_OS_LANGUAGE, null) != null) {
+            this.strategy = new LanguageProviderAppDefined(preferences);
         }
         else {
             this.strategy = new LanguageProviderDevice();

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/language/LanguageProvider.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/language/LanguageProvider.java
@@ -1,0 +1,8 @@
+package com.onesignal.language;
+
+import androidx.annotation.NonNull;
+
+public interface LanguageProvider {
+    @NonNull
+    String getLanguage();
+}

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/language/LanguageProviderAppDefined.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/language/LanguageProviderAppDefined.java
@@ -1,0 +1,21 @@
+package com.onesignal.language;
+
+import com.onesignal.OSUtils;
+import com.onesignal.OneSignal;
+import com.onesignal.OneSignalPrefs;
+
+public class LanguageProviderAppDefined implements LanguageProvider{
+    public static final String PREFS_OS_LANGUAGE = "PREFS_OS_LANGUAGE";
+
+    public void setLanguage(String language) {
+        OneSignalPrefs.saveString(
+                OneSignalPrefs.PREFS_ONESIGNAL,
+                PREFS_OS_LANGUAGE,
+                language);
+    }
+
+    public String getLanguage() {
+        return OneSignalPrefs.getString(
+                OneSignalPrefs.PREFS_ONESIGNAL, PREFS_OS_LANGUAGE,"en");
+    }
+}

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/language/LanguageProviderAppDefined.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/language/LanguageProviderAppDefined.java
@@ -1,18 +1,23 @@
 package com.onesignal.language;
-import com.onesignal.OneSignal;
+import com.onesignal.OSSharedPreferences;
 
 public class LanguageProviderAppDefined implements LanguageProvider{
     public static final String PREFS_OS_LANGUAGE = "PREFS_OS_LANGUAGE";
+    private OSSharedPreferences preferences;
+
+    public LanguageProviderAppDefined(OSSharedPreferences preferences) {
+        this.preferences = preferences;
+    }
 
     public void setLanguage(String language) {
-        OneSignal.preferences.saveString(
-                OneSignal.preferences.getPreferencesName(),
+        preferences.saveString(
+                preferences.getPreferencesName(),
                 PREFS_OS_LANGUAGE,
                 language);
     }
 
     public String getLanguage() {
-        return OneSignal.preferences.getString(
-                OneSignal.preferences.getPreferencesName(), PREFS_OS_LANGUAGE, "en");
+        return preferences.getString(
+                preferences.getPreferencesName(), PREFS_OS_LANGUAGE, "en");
     }
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/language/LanguageProviderAppDefined.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/language/LanguageProviderAppDefined.java
@@ -5,7 +5,9 @@ import com.onesignal.OSSharedPreferences;
 
 public class LanguageProviderAppDefined implements LanguageProvider {
     public static final String PREFS_OS_LANGUAGE = "PREFS_OS_LANGUAGE";
-    private OSSharedPreferences preferences;
+
+    private static final String DEFAULT_LANGUAGE = "en";
+    private final OSSharedPreferences preferences;
 
     public LanguageProviderAppDefined(OSSharedPreferences preferences) {
         this.preferences = preferences;
@@ -21,6 +23,6 @@ public class LanguageProviderAppDefined implements LanguageProvider {
     @NonNull
     public String getLanguage() {
         return preferences.getString(
-                preferences.getPreferencesName(), PREFS_OS_LANGUAGE, "en");
+                preferences.getPreferencesName(), PREFS_OS_LANGUAGE, DEFAULT_LANGUAGE);
     }
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/language/LanguageProviderAppDefined.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/language/LanguageProviderAppDefined.java
@@ -1,21 +1,18 @@
 package com.onesignal.language;
-
-import com.onesignal.OSUtils;
 import com.onesignal.OneSignal;
-import com.onesignal.OneSignalPrefs;
 
 public class LanguageProviderAppDefined implements LanguageProvider{
     public static final String PREFS_OS_LANGUAGE = "PREFS_OS_LANGUAGE";
 
     public void setLanguage(String language) {
-        OneSignalPrefs.saveString(
-                OneSignalPrefs.PREFS_ONESIGNAL,
+        OneSignal.preferences.saveString(
+                OneSignal.preferences.getPreferencesName(),
                 PREFS_OS_LANGUAGE,
                 language);
     }
 
     public String getLanguage() {
-        return OneSignalPrefs.getString(
-                OneSignalPrefs.PREFS_ONESIGNAL, PREFS_OS_LANGUAGE,"en");
+        return OneSignal.preferences.getString(
+                OneSignal.preferences.getPreferencesName(), PREFS_OS_LANGUAGE, "en");
     }
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/language/LanguageProviderAppDefined.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/language/LanguageProviderAppDefined.java
@@ -1,4 +1,6 @@
 package com.onesignal.language;
+import androidx.annotation.NonNull;
+
 import com.onesignal.OSSharedPreferences;
 
 public class LanguageProviderAppDefined implements LanguageProvider {
@@ -16,6 +18,7 @@ public class LanguageProviderAppDefined implements LanguageProvider {
                 language);
     }
 
+    @NonNull
     public String getLanguage() {
         return preferences.getString(
                 preferences.getPreferencesName(), PREFS_OS_LANGUAGE, "en");

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/language/LanguageProviderAppDefined.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/language/LanguageProviderAppDefined.java
@@ -1,7 +1,7 @@
 package com.onesignal.language;
 import com.onesignal.OSSharedPreferences;
 
-public class LanguageProviderAppDefined implements LanguageProvider{
+public class LanguageProviderAppDefined implements LanguageProvider {
     public static final String PREFS_OS_LANGUAGE = "PREFS_OS_LANGUAGE";
     private OSSharedPreferences preferences;
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/language/LanguageProviderDevice.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/language/LanguageProviderDevice.java
@@ -1,0 +1,9 @@
+package com.onesignal.language;
+
+import com.onesignal.OSUtils;
+
+public class LanguageProviderDevice implements LanguageProvider{
+    public String getLanguage() {
+        return OSUtils.getCorrectedLanguage();
+    }
+}

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/language/LanguageProviderDevice.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/language/LanguageProviderDevice.java
@@ -5,22 +5,31 @@ import androidx.annotation.NonNull;
 import java.util.Locale;
 
 public class LanguageProviderDevice implements LanguageProvider {
-    public String getLanguage() {
-        String lang = Locale.getDefault().getLanguage();
+    private static final String HEBREW_INCORRECT = "iw";
+    private static final String HEBREW_CORRECTED = "he";
+    private static final String INDONESIAN_INCORRECT = "in";
+    private static final String INDONESIAN_CORRECTED = "id";
+    private static final String YIDDISH_INCORRECT = "ji";
+    private static final String YIDDISH_CORRECTED = "yi";
+    private static final String CHINESE = "zh";
 
-        // https://github.com/OneSignal/OneSignal-Android-SDK/issues/64
-        if (lang.equals("iw"))
-            return "he";
-        if (lang.equals("in"))
-            return "id";
-        if (lang.equals("ji"))
-            return "yi";
-
-        // https://github.com/OneSignal/OneSignal-Android-SDK/issues/98
-        if (lang.equals("zh"))
-            return lang + "-" + Locale.getDefault().getCountry();
     @NonNull
+    public String getLanguage() {
+        String language = Locale.getDefault().getLanguage();
 
-        return lang;
+        switch (language) {
+            // https://github.com/OneSignal/OneSignal-Android-SDK/issues/64
+            case HEBREW_INCORRECT:
+                return HEBREW_CORRECTED;
+            case INDONESIAN_INCORRECT:
+                return INDONESIAN_CORRECTED;
+            case YIDDISH_INCORRECT:
+                return YIDDISH_CORRECTED;
+            // https://github.com/OneSignal/OneSignal-Android-SDK/issues/98
+            case CHINESE:
+                return language + "-" + Locale.getDefault().getCountry();
+            default:
+                return language;
+        }
     }
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/language/LanguageProviderDevice.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/language/LanguageProviderDevice.java
@@ -1,9 +1,23 @@
 package com.onesignal.language;
 
-import com.onesignal.OSUtils;
+import java.util.Locale;
 
 public class LanguageProviderDevice implements LanguageProvider{
     public String getLanguage() {
-        return OSUtils.getCorrectedLanguage();
+        String lang = Locale.getDefault().getLanguage();
+
+        // https://github.com/OneSignal/OneSignal-Android-SDK/issues/64
+        if (lang.equals("iw"))
+            return "he";
+        if (lang.equals("in"))
+            return "id";
+        if (lang.equals("ji"))
+            return "yi";
+
+        // https://github.com/OneSignal/OneSignal-Android-SDK/issues/98
+        if (lang.equals("zh"))
+            return lang + "-" + Locale.getDefault().getCountry();
+
+        return lang;
     }
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/language/LanguageProviderDevice.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/language/LanguageProviderDevice.java
@@ -1,5 +1,7 @@
 package com.onesignal.language;
 
+import androidx.annotation.NonNull;
+
 import java.util.Locale;
 
 public class LanguageProviderDevice implements LanguageProvider {
@@ -17,6 +19,7 @@ public class LanguageProviderDevice implements LanguageProvider {
         // https://github.com/OneSignal/OneSignal-Android-SDK/issues/98
         if (lang.equals("zh"))
             return lang + "-" + Locale.getDefault().getCountry();
+    @NonNull
 
         return lang;
     }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/language/LanguageProviderDevice.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/language/LanguageProviderDevice.java
@@ -2,7 +2,7 @@ package com.onesignal.language;
 
 import java.util.Locale;
 
-public class LanguageProviderDevice implements LanguageProvider{
+public class LanguageProviderDevice implements LanguageProvider {
     public String getLanguage() {
         String lang = Locale.getDefault().getLanguage();
 

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
@@ -2857,6 +2857,43 @@ public class MainOneSignalClassRunner {
 
    // ####### End GetTags Tests ########
 
+   @Test
+   public void testSetLanguageOnPlayerCreate() throws Exception {
+      OneSignalInit();
+      OneSignal.setLanguage("fr");
+      threadAndTaskWait();
+
+      ShadowOneSignalRestClient.Request lastRequest = ShadowOneSignalRestClient.requests.get(1);
+
+      assertEquals("fr", lastRequest.payload.getString("language"));
+   }
+
+   @Test
+   public void testSetLanguagePUTRequest() throws Exception {
+      OneSignalInit();
+      threadAndTaskWait();
+      OneSignal.setLanguage("fr");
+      threadAndTaskWait();
+
+      ShadowOneSignalRestClient.Request lastRequest = ShadowOneSignalRestClient.requests.get(2);
+      assertEquals("fr", lastRequest.payload.getString("language"));
+   }
+
+   @Test
+   public void testSetLanguageOnSession() throws Exception {
+      OneSignalInit();
+      threadAndTaskWait();
+
+      restartAppAndElapseTimeToNextSession(time);
+
+      OneSignalInit();
+      OneSignal.setLanguage("fr");
+      threadAndTaskWait();
+
+      ShadowOneSignalRestClient.Request lastRequest = ShadowOneSignalRestClient.requests.get(3);
+      assertEquals("fr", lastRequest.payload.getString("language"));
+   }
+
    /**
     * Similar workflow to testLocationPermissionPromptWithPrivacyConsent()
     * We want to provide consent but make sure that session time tracking works properly

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/NotificationChannelManagerRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/NotificationChannelManagerRunner.java
@@ -6,6 +6,7 @@ import android.app.NotificationChannelGroup;
 import android.app.NotificationManager;
 import android.content.Context;
 
+import com.onesignal.OneSignal;
 import com.onesignal.ShadowOSUtils;
 import com.onesignal.ShadowOneSignal;
 import com.onesignal.ShadowRoboNotificationManager;
@@ -28,6 +29,7 @@ import java.math.BigInteger;
 
 import static com.onesignal.OneSignalPackagePrivateHelper.NotificationChannelManager_createNotificationChannel;
 import static com.onesignal.OneSignalPackagePrivateHelper.NotificationChannelManager_processChannelList;
+import static com.test.onesignal.TestHelpers.threadAndTaskWait;
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -206,6 +208,9 @@ public class NotificationChannelManagerRunner {
    // Top level keys under no language key are considered the default language.
    @Test
    public void processChannelListWithMultiLanguage() throws Exception {
+      OneSignal.initWithContext(blankActivity);
+      threadAndTaskWait();
+
       JSONObject payload = createBasicChannelListPayload();
    
       JSONObject channelItem = (JSONObject)payload.optJSONArray("chnl_lst").get(0);


### PR DESCRIPTION
# Description

## Line Summary
Add feature app-defined language implementation. A user can define their own language setting to be used by OneSignal-SDK

## Details
* Add `LanguageContext`, `LanguageProviderAppDefined` and `LanguageProviderDevice` class
* `LanguageContext` uses strategy pattern to retrieve either app-defined or device language
* `LanguageProviderAppDefined` retrieves app-defined language
* `LanguageProviderDevice` retrieves device language
* Add `LanguageProvider` interface that defines method getLanguage
* Add network call to `OneSignal.setLanguage` method that saves app-defined language to `OneSignal.preferences`
* Remove `OSUtils.getCorrectedLanguage` method
* Replace `LanguageProviderDevice.getLanguage` method with implementation from `OSUtils.getCorrectedLanguage`
* Add `OSSharedPreferences` dependency injection to `LanguageContext` and `LanguageProviderAppDefined` constructors
* Inject `OneSignal.preferences` into `LanguageContext` initialization
* Add `LanguageContext` dependency injection in `OSInAppMessageController`, `OSInAppMessageControllerFactory` and `OSInAppMessageDummyController` constructors
* Add `LanguageContext.getLanguage` to `OSInAppMessageController.variantIdForMessage`
* Add singleton pattern to `LanguageContext` class
* Add `getLanguage` method to `NotificationChannelManager.createChannel` using `LanguageContext` instance

## Test
* Add `MainOneSignalClassRunner` `testSetLanguageOnPlayerCreate`, `testSetLanguagePUTRequest`, `testSetLanguageOnSession` unit tests
* Test device using button click to call `OneSignal.setLanguage` to set it to language different from language defined by the device. OneSignal app dashboard reflects the language set using `OneSignal.setLanguage`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1334)
<!-- Reviewable:end -->
