### PR TITLE
Upgrade tests to Roboelectric 4.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,14 +10,14 @@ android:
             # https://github.com/travis-ci/travis-ci/issues/6193
             # Required to get the newest platform-tools.
     - platform-tools
-    - build-tools-28.0.3
-    - android-28
+    - build-tools-29.0.3
+    - android-29
   licenses:
     - '.+'
     - 'android-sdk-license-.+'
 before_install:
-    - yes | sdkmanager "platforms;android-28"
-    - yes | sdkmanager "build-tools;28.0.3"
+    - yes | sdkmanager "platforms;android-29"
+    - yes | sdkmanager "build-tools;29.0.3"
     - pwd
     - ls -la
     - cd OneSignalSDK

--- a/OneSignalSDK/build.gradle
+++ b/OneSignalSDK/build.gradle
@@ -4,7 +4,7 @@ buildscript {
 
     ext {
         buildVersions = [
-                compileSdkVersion: 28,
+                compileSdkVersion: 29,
                 targetSdkVersion: 28
         ]
         androidGradlePluginVersion = '3.6.2'

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/influence/OSInfluenceConstants.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/influence/OSInfluenceConstants.kt
@@ -13,11 +13,11 @@ internal object OSInfluenceConstants {
     const val INFLUENCE_IDS = "influence_ids"
 
     // OSInAppMessageTracker Constants
-    val IAM_TAG: String = OSInAppMessageTracker::class.java.canonicalName
+    val IAM_TAG: String = OSInAppMessageTracker::class.java.canonicalName as String
     const val IAM_ID_TAG = "iam_id"
 
     // OSNotificationTracker Constants
-    val NOTIFICATION_TAG: String = OSNotificationTracker::class.java.canonicalName
+    val NOTIFICATION_TAG: String = OSNotificationTracker::class.java.canonicalName as String
     const val DIRECT_TAG = "direct"
     const val NOTIFICATIONS_IDS = "notification_ids"
     const val NOTIFICATION_ID_TAG = "notification_id"

--- a/OneSignalSDK/unittest/build.gradle
+++ b/OneSignalSDK/unittest/build.gradle
@@ -11,7 +11,7 @@ ext {
     googlePlayServicesVersion = '17.0.0'
     jUnitVersion = '4.12'
     reflectionsVersion = '0.9.12'
-    roboelectricVersion = '4.3.1'
+    roboelectricVersion = '4.4'
 }
 
 apply plugin: 'com.android.application'

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/MockOSSharedPreferences.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/MockOSSharedPreferences.java
@@ -1,7 +1,7 @@
 package com.onesignal;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import java.util.HashMap;
 import java.util.Set;

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/MockOneSignalAPIClient.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/MockOneSignalAPIClient.java
@@ -1,6 +1,6 @@
 package com.onesignal;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import org.json.JSONObject;
 

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowHmsInstanceId.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowHmsInstanceId.java
@@ -1,7 +1,8 @@
 package com.onesignal;
 
 import android.content.Context;
-import android.support.annotation.Nullable;
+
+import androidx.annotation.Nullable;
 
 import com.huawei.hms.aaid.HmsInstanceId;
 import com.huawei.hms.common.ApiException;

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
@@ -96,6 +96,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.Shadows;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.annotation.LooperMode;
 import org.robolectric.shadows.ShadowLog;
 
 import java.lang.reflect.Field;
@@ -153,6 +154,7 @@ import static org.robolectric.Shadows.shadowOf;
         sdk = 21
 )
 @RunWith(RobolectricTestRunner.class)
+@LooperMode(LooperMode.Mode.LEGACY)
 public class GenerateNotificationRunner {
 
    private static int callbackCounter = 0;

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/InAppMessageIntegrationTests.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/InAppMessageIntegrationTests.java
@@ -47,6 +47,7 @@ import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.annotation.LooperMode;
 import org.robolectric.shadows.ShadowLog;
 
 import java.lang.reflect.Field;
@@ -92,6 +93,7 @@ import static junit.framework.Assert.assertTrue;
         sdk = 21
 )
 @RunWith(RobolectricTestRunner.class)
+@LooperMode(LooperMode.Mode.LEGACY)
 public class InAppMessageIntegrationTests {
 
     private static final String ONESIGNAL_APP_ID = "b2f7f966-d8cc-11e4-bed1-df8f05be55ba";

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/InAppMessagingUnitTests.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/InAppMessagingUnitTests.java
@@ -36,6 +36,7 @@ import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.annotation.LooperMode;
 import org.robolectric.shadows.ShadowLog;
 
 import java.util.ArrayList;
@@ -70,6 +71,7 @@ import static junit.framework.Assert.assertTrue;
         sdk = 26
 )
 @RunWith(RobolectricTestRunner.class)
+@LooperMode(LooperMode.Mode.LEGACY)
 public class InAppMessagingUnitTests {
 
     private static final String IAM_CLICK_ID = "button_id_123";

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/LocationIntegrationTests.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/LocationIntegrationTests.java
@@ -48,9 +48,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
-import org.robolectric.shadows.ShadowApplication;
+import org.robolectric.annotation.LooperMode;
 import org.robolectric.shadows.ShadowLog;
 
 import java.lang.reflect.Method;
@@ -146,7 +147,7 @@ public class LocationIntegrationTests {
     @Test
     @Config(shadows = {ShadowGoogleApiClientBuilder.class, ShadowGoogleApiClientCompatProxy.class, ShadowFusedLocationApiWrapper.class})
     public void shouldUpdateAllLocationFieldsWhenTimeStampChanges() throws Exception {
-        ShadowApplication.getInstance().grantPermissions("android.permission.ACCESS_COARSE_LOCATION");
+        shadowOf(RuntimeEnvironment.application).grantPermissions("android.permission.ACCESS_COARSE_LOCATION");
         OneSignalInit();
         threadAndTaskWait();
         assertEquals(1.0, ShadowOneSignalRestClient.lastPost.getDouble("lat"));
@@ -195,7 +196,7 @@ public class LocationIntegrationTests {
             ShadowFusedLocationApiWrapper.class },
             sdk = 19)
     public void testLocationSchedule() throws Exception {
-        ShadowApplication.getInstance().grantPermissions("android.permission.ACCESS_FINE_LOCATION");
+        shadowOf(RuntimeEnvironment.application).grantPermissions("android.permission.ACCESS_FINE_LOCATION");
         ShadowFusedLocationApiWrapper.lat = 1.0d;
         ShadowFusedLocationApiWrapper.log = 2.0d;
         ShadowFusedLocationApiWrapper.accuracy = 3.0f;
@@ -256,7 +257,7 @@ public class LocationIntegrationTests {
             ShadowFusedLocationApiWrapper.class },
             sdk = 19)
     public void testLocationFromSyncAlarm() throws Exception {
-        ShadowApplication.getInstance().grantPermissions("android.permission.ACCESS_COARSE_LOCATION");
+        shadowOf(RuntimeEnvironment.application).grantPermissions("android.permission.ACCESS_COARSE_LOCATION");
 
         ShadowFusedLocationApiWrapper.lat = 1.1d;
         ShadowFusedLocationApiWrapper.log = 2.1d;
@@ -301,7 +302,7 @@ public class LocationIntegrationTests {
     @Test
     @Config(shadows = {ShadowGoogleApiClientBuilder.class, ShadowGoogleApiClientCompatProxy.class, ShadowFusedLocationApiWrapper.class})
     public void shouldSendLocationToEmailRecord() throws Exception {
-        ShadowApplication.getInstance().grantPermissions("android.permission.ACCESS_COARSE_LOCATION");
+        shadowOf(RuntimeEnvironment.application).grantPermissions("android.permission.ACCESS_COARSE_LOCATION");
 
         OneSignalInit();
         OneSignal.setEmail("josh@onesignal.com");
@@ -318,7 +319,7 @@ public class LocationIntegrationTests {
     @Test
     @Config(shadows = {ShadowGoogleApiClientBuilder.class, ShadowGoogleApiClientCompatProxy.class, ShadowFusedLocationApiWrapper.class})
     public void shouldSendLocationToSMSRecord() throws Exception {
-        ShadowApplication.getInstance().grantPermissions("android.permission.ACCESS_COARSE_LOCATION");
+        shadowOf(RuntimeEnvironment.application).grantPermissions("android.permission.ACCESS_COARSE_LOCATION");
 
         OneSignalInit();
         OneSignal.setSMSNumber("123456789");
@@ -335,7 +336,7 @@ public class LocationIntegrationTests {
     @Test
     @Config(shadows = {ShadowGoogleApiClientBuilder.class, ShadowGoogleApiClientCompatProxy.class, ShadowFusedLocationApiWrapper.class})
     public void shouldRegisterWhenPromptingAfterInit() throws Exception {
-        ShadowApplication.getInstance().grantPermissions("android.permission.ACCESS_COARSE_LOCATION");
+        shadowOf(RuntimeEnvironment.application).grantPermissions("android.permission.ACCESS_COARSE_LOCATION");
         ShadowGoogleApiClientCompatProxy.skipOnConnected = true;
 
         // Test promptLocation right after init race condition
@@ -354,7 +355,7 @@ public class LocationIntegrationTests {
     @Test
     @Config(shadows = {ShadowGoogleApiClientBuilder.class, ShadowGoogleApiClientCompatProxy.class, ShadowFusedLocationApiWrapper.class})
     public void shouldCallOnSessionEvenIfSyncJobStarted() throws Exception {
-        ShadowApplication.getInstance().grantPermissions("android.permission.ACCESS_COARSE_LOCATION");
+        shadowOf(RuntimeEnvironment.application).grantPermissions("android.permission.ACCESS_COARSE_LOCATION");
 
         OneSignalInit();
         threadAndTaskWait();
@@ -381,7 +382,7 @@ public class LocationIntegrationTests {
     @Config(shadows = {ShadowHMSFusedLocationProviderClient.class})
     public void shouldUpdateAllLocationFieldsWhenTimeStampChanges_Huawei() throws Exception {
         ShadowOSUtils.supportsHMS(true);
-        ShadowApplication.getInstance().grantPermissions("android.permission.ACCESS_COARSE_LOCATION");
+        shadowOf(RuntimeEnvironment.application).grantPermissions("android.permission.ACCESS_COARSE_LOCATION");
         OneSignalInit();
         threadAndTaskWait();
         assertEquals(1.0, ShadowOneSignalRestClient.lastPost.getDouble("lat"));
@@ -411,7 +412,7 @@ public class LocationIntegrationTests {
     }, sdk = 19)
     public void testLocationSchedule_Huawei() throws Exception {
         ShadowOSUtils.supportsHMS(true);
-        ShadowApplication.getInstance().grantPermissions("android.permission.ACCESS_FINE_LOCATION");
+        shadowOf(RuntimeEnvironment.application).grantPermissions("android.permission.ACCESS_FINE_LOCATION");
         ShadowHMSFusedLocationProviderClient.lat = 1.0d;
         ShadowHMSFusedLocationProviderClient.log = 2.0d;
         ShadowHMSFusedLocationProviderClient.accuracy = 3.0f;
@@ -475,7 +476,7 @@ public class LocationIntegrationTests {
     }, sdk = 19)
     public void testLocationFromSyncAlarm_Huawei() throws Exception {
         ShadowOSUtils.supportsHMS(true);
-        ShadowApplication.getInstance().grantPermissions("android.permission.ACCESS_COARSE_LOCATION");
+        shadowOf(RuntimeEnvironment.application).grantPermissions("android.permission.ACCESS_COARSE_LOCATION");
 
         ShadowHMSFusedLocationProviderClient.lat = 1.1d;
         ShadowHMSFusedLocationProviderClient.log = 2.1d;
@@ -520,7 +521,7 @@ public class LocationIntegrationTests {
     @Config(shadows = {ShadowHMSFusedLocationProviderClient.class})
     public void shouldSendLocationToEmailRecord_Huawei() throws Exception {
         ShadowOSUtils.supportsHMS(true);
-        ShadowApplication.getInstance().grantPermissions("android.permission.ACCESS_COARSE_LOCATION");
+        shadowOf(RuntimeEnvironment.application).grantPermissions("android.permission.ACCESS_COARSE_LOCATION");
 
         OneSignalInit();
         OneSignal.setEmail("josh@onesignal.com");
@@ -538,7 +539,7 @@ public class LocationIntegrationTests {
     @Config(shadows = {ShadowHMSFusedLocationProviderClient.class})
     public void shouldSendLocationToSMSRecord_Huawei() throws Exception {
         ShadowOSUtils.supportsHMS(true);
-        ShadowApplication.getInstance().grantPermissions("android.permission.ACCESS_COARSE_LOCATION");
+        shadowOf(RuntimeEnvironment.application).grantPermissions("android.permission.ACCESS_COARSE_LOCATION");
 
         OneSignalInit();
         OneSignal.setSMSNumber("123456789");
@@ -557,7 +558,7 @@ public class LocationIntegrationTests {
     public void shouldRegisterWhenPromptingAfterInit_Huawei() throws Exception {
         ShadowOSUtils.supportsHMS(true);
         ShadowHMSFusedLocationProviderClient.skipOnGetLocation = true;
-        ShadowApplication.getInstance().grantPermissions("android.permission.ACCESS_COARSE_LOCATION");
+        shadowOf(RuntimeEnvironment.application).grantPermissions("android.permission.ACCESS_COARSE_LOCATION");
 
         // Test promptLocation right after init race condition
         OneSignalInit();
@@ -578,7 +579,7 @@ public class LocationIntegrationTests {
         ShadowOSUtils.supportsHMS(true);
         ShadowHMSFusedLocationProviderClient.shadowTask = true;
         ShadowHuaweiTask.result = ShadowHMSFusedLocationProviderClient.getLocation();
-        ShadowApplication.getInstance().grantPermissions("android.permission.ACCESS_COARSE_LOCATION");
+        shadowOf(RuntimeEnvironment.application).grantPermissions("android.permission.ACCESS_COARSE_LOCATION");
 
         OneSignalInit();
         threadAndTaskWait();

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/LocationIntegrationTests.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/LocationIntegrationTests.java
@@ -52,6 +52,7 @@ import org.robolectric.RuntimeEnvironment;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 import org.robolectric.annotation.LooperMode;
+import org.robolectric.annotation.LooperMode;
 import org.robolectric.shadows.ShadowLog;
 
 import java.lang.reflect.Method;
@@ -82,6 +83,7 @@ import static org.robolectric.Shadows.shadowOf;
         sdk = 21
 )
 @RunWith(RobolectricTestRunner.class)
+@LooperMode(LooperMode.Mode.LEGACY)
 public class LocationIntegrationTests {
 
     private static final String ONESIGNAL_APP_ID = "b4f7f966-d8cc-11e4-bed1-df8f05be55ba";

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
@@ -109,6 +109,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.annotation.LooperMode;
 import org.robolectric.shadows.ShadowAlarmManager;
 import org.robolectric.shadows.ShadowConnectivityManager;
 import org.robolectric.shadows.ShadowLog;
@@ -188,6 +189,7 @@ import static org.robolectric.Shadows.shadowOf;
         sdk = 21
 )
 @RunWith(RobolectricTestRunner.class)
+@LooperMode(LooperMode.Mode.LEGACY)
 // Enable to ensure test order to consistency debug flaky test.
 // @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class MainOneSignalClassRunner {

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
@@ -106,10 +106,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowAlarmManager;
-import org.robolectric.shadows.ShadowApplication;
 import org.robolectric.shadows.ShadowConnectivityManager;
 import org.robolectric.shadows.ShadowLog;
 
@@ -2040,7 +2040,7 @@ public class MainOneSignalClassRunner {
    @Test
    @Config(shadows = {ShadowGoogleApiClientBuilder.class, ShadowGoogleApiClientCompatProxy.class, ShadowFusedLocationApiWrapper.class})
    public void testOneSignalMethodsBeforeInit() throws Exception {
-      ShadowApplication.getInstance().grantPermissions("android.permission.ACCESS_FINE_LOCATION");
+      shadowOf(RuntimeEnvironment.application).grantPermissions("android.permission.ACCESS_FINE_LOCATION");
       ShadowFusedLocationApiWrapper.lat = 1.0d;
       ShadowFusedLocationApiWrapper.log = 2.0d;
       ShadowFusedLocationApiWrapper.accuracy = 3.0f;
@@ -2134,7 +2134,7 @@ public class MainOneSignalClassRunner {
    @Test
    @Config(shadows = {ShadowGoogleApiClientBuilder.class, ShadowGoogleApiClientCompatProxy.class, ShadowFusedLocationApiWrapper.class})
    public void testOneSignalEmptyPendingTaskQueue() throws Exception {
-      ShadowApplication.getInstance().grantPermissions("android.permission.ACCESS_FINE_LOCATION");
+      shadowOf(RuntimeEnvironment.application).grantPermissions("android.permission.ACCESS_FINE_LOCATION");
       ShadowFusedLocationApiWrapper.lat = 1.0d;
       ShadowFusedLocationApiWrapper.log = 2.0d;
       ShadowFusedLocationApiWrapper.accuracy = 3.0f;
@@ -2405,7 +2405,7 @@ public class MainOneSignalClassRunner {
    @Config(sdk = 26, shadows = { ShadowGoogleApiClientCompatProxy.class, ShadowGMSLocationController.class })
    public void ensureSyncJobServiceRescheduleOnApiTimeout() throws Exception {
       ShadowGMSLocationController.apiFallbackTime = 0;
-      ShadowApplication.getInstance().grantPermissions("android.permission.ACCESS_FINE_LOCATION");
+      shadowOf(RuntimeEnvironment.application).grantPermissions("android.permission.ACCESS_FINE_LOCATION");
       ShadowGoogleApiClientCompatProxy.skipOnConnected = true;
 
       OneSignalInit();

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/NotificationLimitManagerRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/NotificationLimitManagerRunner.java
@@ -26,6 +26,7 @@ import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.annotation.LooperMode;
 import org.robolectric.shadows.ShadowLog;
 
 import static com.onesignal.OneSignalPackagePrivateHelper.NotificationBundleProcessor_ProcessFromFCMIntentService;
@@ -47,6 +48,7 @@ import static junit.framework.Assert.assertEquals;
         sdk = 26
 )
 @RunWith(RobolectricTestRunner.class)
+@LooperMode(LooperMode.Mode.LEGACY)
 public class NotificationLimitManagerRunner {
 
    private BlankActivity blankActivity;

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/NotificationOpenedActivityHMSIntegrationTestsRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/NotificationOpenedActivityHMSIntegrationTestsRunner.java
@@ -3,8 +3,8 @@ package com.test.onesignal;
 import android.app.Activity;
 import android.app.Application;
 import android.content.Intent;
-import android.support.annotation.NonNull;
 
+import androidx.annotation.NonNull;
 import androidx.test.core.app.ApplicationProvider;
 
 import com.onesignal.NotificationOpenedActivityHMS;

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/NotificationOpenedActivityHMSIntegrationTestsRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/NotificationOpenedActivityHMSIntegrationTestsRunner.java
@@ -31,6 +31,7 @@ import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.annotation.LooperMode;
 import org.robolectric.shadows.ShadowLog;
 
 import java.util.UUID;
@@ -63,6 +64,7 @@ import static org.robolectric.Shadows.shadowOf;
     sdk = 26
 )
 @RunWith(RobolectricTestRunner.class)
+@LooperMode(LooperMode.Mode.LEGACY)
 public class NotificationOpenedActivityHMSIntegrationTestsRunner {
 
     private static final String TEST_ACTION_ID = "myTestActionId";

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/OneSignalInitializationIntegrationTestsRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/OneSignalInitializationIntegrationTestsRunner.java
@@ -20,6 +20,7 @@ import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.annotation.LooperMode;
 import org.robolectric.shadows.ShadowLog;
 
 import static com.onesignal.OneSignalPackagePrivateHelper.MIN_ON_SESSION_TIME_MILLIS;
@@ -41,6 +42,7 @@ import static com.test.onesignal.TestHelpers.threadAndTaskWait;
 )
 
 @RunWith(RobolectricTestRunner.class)
+@LooperMode(LooperMode.Mode.LEGACY)
 public class OneSignalInitializationIntegrationTestsRunner {
     private ActivityController<BlankActivity> blankActivityController;
     private MockOSTimeImpl time;

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/OneSignalPrefsRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/OneSignalPrefsRunner.java
@@ -20,6 +20,7 @@ import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.annotation.LooperMode;
 import org.robolectric.shadows.ShadowLog;
 
 import static com.onesignal.ShadowOneSignalRestClient.setRemoteParamsGetHtmlResponse;
@@ -34,6 +35,7 @@ import static org.junit.Assert.assertEquals;
         sdk = 21
 )
 @RunWith(RobolectricTestRunner.class)
+@LooperMode(LooperMode.Mode.LEGACY)
 public class OneSignalPrefsRunner {
 
    private static final String ONESIGNAL_APP_ID = "b4f7f966-d8cc-11e4-bed1-df8f05be55ba";

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/OutcomeEventIntegrationTests.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/OutcomeEventIntegrationTests.java
@@ -47,6 +47,7 @@ import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.annotation.LooperMode;
 import org.robolectric.shadows.ShadowLog;
 import org.robolectric.shadows.ShadowPausedSystemClock;
 
@@ -95,6 +96,7 @@ import static junit.framework.Assert.assertTrue;
         },
         sdk = 26)
 @RunWith(RobolectricTestRunner.class)
+@LooperMode(LooperMode.Mode.LEGACY)
 public class OutcomeEventIntegrationTests {
 
     private static final String ONESIGNAL_APP_ID = "b2f7f966-d8cc-11e4-bed1-df8f05be55ba";

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/OutcomeEventUnitTests.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/OutcomeEventUnitTests.java
@@ -27,8 +27,7 @@
 
 package com.test.onesignal;
 
-import android.support.annotation.NonNull;
-
+import androidx.annotation.NonNull;
 import androidx.test.core.app.ApplicationProvider;
 
 import com.onesignal.MockOSLog;

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/OutcomeEventV2UnitTests.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/OutcomeEventV2UnitTests.java
@@ -27,8 +27,7 @@
 
 package com.test.onesignal;
 
-import android.support.annotation.NonNull;
-
+import androidx.annotation.NonNull;
 import androidx.test.core.app.ApplicationProvider;
 
 import com.onesignal.MockOSLog;

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/PushRegistratorHMSIntegrationTestsRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/PushRegistratorHMSIntegrationTestsRunner.java
@@ -25,6 +25,7 @@ import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.annotation.LooperMode;
 import org.robolectric.shadows.ShadowLog;
 
 import static com.onesignal.OneSignalPackagePrivateHelper.UserState.PUSH_STATUS_HMS_API_EXCEPTION_OTHER;
@@ -50,6 +51,7 @@ import static com.test.onesignal.TestHelpers.threadAndTaskWait;
     sdk = 26
 )
 @RunWith(RobolectricTestRunner.class)
+@LooperMode(LooperMode.Mode.LEGACY)
 public class PushRegistratorHMSIntegrationTestsRunner {
 
     @SuppressLint("StaticFieldLeak")

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/RemoteParamsTests.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/RemoteParamsTests.java
@@ -49,6 +49,7 @@ import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.annotation.LooperMode;
 
 import static com.onesignal.OneSignalPackagePrivateHelper.OneSignal_areNotificationsEnabledForSubscribedState;
 import static com.onesignal.OneSignalPackagePrivateHelper.OneSignal_getDisableGMSMissingPrompt;
@@ -68,6 +69,7 @@ import static junit.framework.Assert.assertTrue;
         sdk = 21
 )
 @RunWith(RobolectricTestRunner.class)
+@LooperMode(LooperMode.Mode.LEGACY)
 public class RemoteParamsTests {
 
     private static final String ONESIGNAL_APP_ID = "b2f7f966-d8cc-11e4-bed1-df8f05be55ba";

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/SessionManagerUnitTests.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/SessionManagerUnitTests.java
@@ -27,7 +27,7 @@
 
 package com.test.onesignal;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.onesignal.MockOSLog;
 import com.onesignal.MockOSSharedPreferences;

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/SynchronizerIntegrationTests.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/SynchronizerIntegrationTests.java
@@ -33,6 +33,7 @@ import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.annotation.LooperMode;
 import org.robolectric.shadows.ShadowLog;
 
 import java.lang.reflect.Field;
@@ -72,6 +73,7 @@ import static org.junit.Assert.assertNotEquals;
         sdk = 21
 )
 @RunWith(RobolectricTestRunner.class)
+@LooperMode(LooperMode.Mode.LEGACY)
 public class SynchronizerIntegrationTests {
     private static final String ONESIGNAL_APP_ID = "b4f7f966-d8cc-11e4-bed1-df8f05be55ba";
     private static final String ONESIGNAL_EMAIL_ADDRESS = "test@onesignal.com";

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/TestHelpers.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/TestHelpers.java
@@ -61,9 +61,9 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.robolectric.Robolectric;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.shadows.ShadowAlarmManager;
-import org.robolectric.shadows.ShadowApplication;
 import org.robolectric.util.Scheduler;
 
 import java.util.ArrayList;
@@ -207,7 +207,7 @@ public class TestHelpers {
 
    // Run any OneSignal background threads including any pending runnables
    public static void threadAndTaskWait() throws Exception {
-      ShadowApplication.getInstance().getForegroundThreadScheduler().runOneTask();
+      shadowOf(RuntimeEnvironment.application).getForegroundThreadScheduler().runOneTask();
       // Runs Runnables posted by calling View.post() which are run on the main thread.
       Robolectric.getForegroundThreadScheduler().runOneTask();
 


### PR DESCRIPTION
## Description
### One Line Summary
Upgraded to Roboelectric 4.4 which supports Android API 29.

### Details
* Updated to `compileSdkVersion 29`.
   - Required by Roboelectric 4.4
* Migrated off dropped `ShadowApplication.getInstance()` API.
* Forced `@LooperMode(LooperMode.Mode.LEGACY)` in all tests since most of our tests are not compatible with the new default PAUSE mode.
   - Details on the changes: http://robolectric.org/blog/2019/06/04/paused-looper/
   - This larger migration is something we can undertake in a follow up PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1338)
<!-- Reviewable:end -->
