### PR TITLE
Fix getManifestMetaBundle

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSUtils.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSUtils.java
@@ -403,8 +403,7 @@ class OSUtils {
    }
 
    static Bundle getManifestMetaBundle(Context context) {
-
-      ApplicationInfo ai = null;
+      ApplicationInfo ai;
       try {
          ai = context.getPackageManager().getApplicationInfo(context.getPackageName(), PackageManager.GET_META_DATA);
          return ai.metaData;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSUtils.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSUtils.java
@@ -407,6 +407,7 @@ class OSUtils {
       ApplicationInfo ai = null;
       try {
          ai = context.getPackageManager().getApplicationInfo(context.getPackageName(), PackageManager.GET_META_DATA);
+         return ai.metaData;
       } catch (PackageManager.NameNotFoundException e) {
          Log(OneSignal.LOG_LEVEL.ERROR, "Manifest application info not found", e);
       }


### PR DESCRIPTION
It seems this was removed by mistake in PR #1337
   - When this fixup was made
   https://github.com/OneSignal/OneSignal-Android-SDK/compare/25d936f5a83865f108475b8785055089f2cbda40..caa255b738b557a6f915a376fb920dcc91ffd004

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1341)
<!-- Reviewable:end -->
