### PR TITLE
Fix Tests Stalling

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSTaskController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSTaskController.java
@@ -105,6 +105,12 @@ class OSTaskController {
         return taskQueueWaitingForInit;
     }
 
+    void shutdownNow() {
+        if (pendingTaskExecutor != null) {
+            pendingTaskExecutor.shutdownNow();
+        }
+    }
+
     private static class PendingTaskRunnable implements Runnable {
         private OSTaskController controller;
         private Runnable innerTask;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -3167,6 +3167,10 @@ public class OneSignal {
       return taskRemoteController;
    }
 
+   static OSTaskController getTaskController() {
+      return taskController;
+   }
+
    static FocusTimeController getFocusTimeController() {
       return focusTimeController;
    }

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
@@ -271,6 +271,11 @@ public class OneSignalPackagePrivateHelper {
       return OneSignal.getTaskRemoteController().getTaskQueueWaitingForInit();
    }
 
+   public static void OneSignal_OSTaskController_ShutdownNow() {
+      OneSignal.getTaskRemoteController().shutdownNow();
+      OneSignal.getTaskController().shutdownNow();
+   }
+
    public static boolean OneSignal_requiresUserPrivacyConsent() {
       return OneSignal.requiresUserPrivacyConsent();
    }

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/DeviceTypeTestsRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/DeviceTypeTestsRunner.java
@@ -6,6 +6,8 @@ import com.onesignal.OneSignal;
 import com.onesignal.ShadowOSUtils;
 import com.onesignal.StaticResetHelper;
 
+import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -41,6 +43,16 @@ public class DeviceTypeTestsRunner {
     public void beforeEachTest() throws Exception {
         TestHelpers.beforeTestInitAndCleanup();
         OneSignal.initWithContext(ApplicationProvider.getApplicationContext());
+    }
+
+    @AfterClass
+    public static void afterEverything() throws Exception {
+        TestHelpers.beforeTestInitAndCleanup();
+    }
+
+    @After
+    public void afterEachTest() throws Exception {
+        TestHelpers.afterTestCleanup();
     }
 
     @Test

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
@@ -86,6 +86,7 @@ import org.awaitility.Duration;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -216,7 +217,12 @@ public class GenerateNotificationRunner {
 
    @AfterClass
    public static void afterEverything() throws Exception {
-      StaticResetHelper.restSetStaticFields();
+      TestHelpers.beforeTestInitAndCleanup();
+   }
+
+   @After
+   public void afterEachTest() throws Exception {
+      TestHelpers.afterTestCleanup();
    }
    
    public static Bundle getBaseNotifBundle() {

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/HMSDataMessageReceivedIntegrationTestsRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/HMSDataMessageReceivedIntegrationTestsRunner.java
@@ -14,6 +14,8 @@ import com.onesignal.example.BlankActivity;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -63,6 +65,16 @@ public class HMSDataMessageReceivedIntegrationTestsRunner {
 
         blankActivityController = Robolectric.buildActivity(BlankActivity.class).create();
         blankActivity = blankActivityController.get();
+    }
+
+    @AfterClass
+    public static void afterEverything() throws Exception {
+        TestHelpers.beforeTestInitAndCleanup();
+    }
+
+    @After
+    public void afterEachTest() throws Exception {
+        TestHelpers.afterTestCleanup();
     }
 
     private static @NonNull String helperBasicOSPayload() throws JSONException {

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/NotificationOpenedActivityHMSIntegrationTestsRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/NotificationOpenedActivityHMSIntegrationTestsRunner.java
@@ -23,6 +23,8 @@ import com.onesignal.example.BlankActivity;
 
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -82,6 +84,16 @@ public class NotificationOpenedActivityHMSIntegrationTestsRunner {
         ShadowOSUtils.supportsHMS(true);
         // Set remote_params GET response
         setRemoteParamsGetHtmlResponse();
+    }
+
+    @AfterClass
+    public static void afterEverything() throws Exception {
+        TestHelpers.beforeTestInitAndCleanup();
+    }
+
+    @After
+    public void afterEachTest() throws Exception {
+        TestHelpers.afterTestCleanup();
     }
 
     private static @NonNull Intent helper_baseHMSOpenIntent() {

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/TestHelpers.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/TestHelpers.java
@@ -73,6 +73,7 @@ import java.util.List;
 import java.util.Set;
 
 import static com.onesignal.OneSignalPackagePrivateHelper.JSONUtils;
+import static com.onesignal.OneSignalPackagePrivateHelper.OneSignal_OSTaskController_ShutdownNow;
 import static junit.framework.Assert.assertEquals;
 import static org.robolectric.Shadows.shadowOf;
 
@@ -136,6 +137,7 @@ public class TestHelpers {
 
    public static void afterTestCleanup() throws Exception {
       try {
+         OneSignal_OSTaskController_ShutdownNow();
          stopAllOSThreads();
       } catch (Exception e) {
          e.printStackTrace();


### PR DESCRIPTION
## One Line Summary
Fixes tests stalling and never finishing. Tests still fail due to some flaky tests but it always completes now.

## Details
### Shutdown ExecutorService instances after each test
* Stalling would happen on stopAllOSThreads() where it would
continue to try to call interrupt() on a OS_PENDING_EXECUTOR_ thread
over and over. The thread can't be interrupted as an Android
ExecutorService will catch it.
* Added a shutdownNow() call to OSTaskController that tests can run to
correctly shutdown the pending tasks so it's thread can be stopped.


### Log of rerunning tests
* Run 1 - no stall
* Run 2 - stalled https://travis-ci.com/github/OneSignal/OneSignal-Android-SDK/builds/226617186
#### Added after test cleanup to HMSDataMessageReceivedIntegrationTestsRunner
* Run 1 - no stall https://travis-ci.com/github/OneSignal/OneSignal-Android-SDK/builds/226620653
* Run 2 - no stall
* Run 3 - no stall
* Run 4 - no stall
* Run 5 - no stall
* Run 6 - no stall
* Run 7 - no stall
* Run 8 - no stall

## Note


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1342)
<!-- Reviewable:end -->
