### PR TITLE
Fix flaky tests 2021-05-22

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -404,7 +404,7 @@ public class OneSignal {
    }
 
    private static OSLogger logger = new OSLogWrapper();
-   private static FocusTimeController focusTimeController = new FocusTimeController(new OSFocusTimeProcessorFactory(), logger);
+   private static FocusTimeController focusTimeController;
    private static OSSessionManager.SessionListener sessionListener = new OSSessionManager.SessionListener() {
          @Override
          public void onSessionEnding(@NonNull List<OSInfluence> lastInfluences) {
@@ -412,7 +412,7 @@ public class OneSignal {
                OneSignal.Log(LOG_LEVEL.WARN, "OneSignal onSessionEnding called before init!");
             if (outcomeEventsController != null)
                outcomeEventsController.cleanOutcomes();
-            focusTimeController.onSessionEnded(lastInfluences);
+            getFocusTimeController().onSessionEnded(lastInfluences);
          }
       };
 
@@ -891,7 +891,7 @@ public class OneSignal {
             activityLifecycleHandler.setNextResumeIsFirstActivity(true);
          }
          OSNotificationRestoreWorkManager.beginEnqueueingWork(context, false);
-         focusTimeController.appForegrounded();
+         getFocusTimeController().appForegrounded();
       } else if (activityLifecycleHandler != null) {
          activityLifecycleHandler.setNextResumeIsFirstActivity(true);
       }
@@ -1289,7 +1289,7 @@ public class OneSignal {
       if (trackAmazonPurchase != null)
          trackAmazonPurchase.checkListener();
 
-      focusTimeController.appBackgrounded();
+      getFocusTimeController().appBackgrounded();
 
       scheduleSyncService();
    }
@@ -1337,7 +1337,7 @@ public class OneSignal {
       if (shouldLogUserPrivacyConsentErrorMessageForMethodName("onAppFocus"))
          return;
 
-      focusTimeController.appForegrounded();
+      getFocusTimeController().appForegrounded();
 
       doSessionInit();
 
@@ -3172,6 +3172,10 @@ public class OneSignal {
    }
 
    static FocusTimeController getFocusTimeController() {
+      if (focusTimeController == null) {
+         focusTimeController = new FocusTimeController(new OSFocusTimeProcessorFactory(), logger);
+      }
+
       return focusTimeController;
    }
    /*

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
@@ -30,6 +30,8 @@ public class OneSignalPackagePrivateHelper {
 
    public static final long MIN_ON_SESSION_TIME_MILLIS = com.onesignal.OneSignal.MIN_ON_SESSION_TIME_MILLIS;
 
+   private static final String LOGCAT_TAG = "OS_PACKAGE_HELPER";
+
    private static abstract class RunnableArg<T> {
       abstract void run(T object) throws Exception;
    }
@@ -515,9 +517,8 @@ public class OneSignalPackagePrivateHelper {
       com.onesignal.OSInAppMessage message = OneSignal.getInAppMessageController().getCurrentDisplayedInAppMessage();
       if (message != null) {
          OneSignal.getInAppMessageController().messageWasDismissed(message);
-      }
-      else {
-         System.out.println("No currently displaying IAM to dismiss!");
+      } else {
+         Log.e(LOGCAT_TAG, "No currently displaying IAM to dismiss!");
       }
    }
 

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
@@ -513,8 +513,12 @@ public class OneSignalPackagePrivateHelper {
 
    public static void dismissCurrentMessage() {
       com.onesignal.OSInAppMessage message = OneSignal.getInAppMessageController().getCurrentDisplayedInAppMessage();
-      if (message != null)
+      if (message != null) {
          OneSignal.getInAppMessageController().messageWasDismissed(message);
+      }
+      else {
+         System.out.println("No currently displaying IAM to dismiss!");
+      }
    }
 
    public static boolean isInAppMessageShowing() {

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
+import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowOneSignalRestClient.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowOneSignalRestClient.java
@@ -311,7 +311,7 @@ public class ShadowOneSignalRestClient {
 
       String retJson;
 
-      if (nextSuccessfulRegistrationResponse != null) {
+      if (nextSuccessfulRegistrationResponse != null && url.contains("players")) {
          retJson = nextSuccessfulRegistrationResponse;
          nextSuccessfulRegistrationResponse = null;
       }

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/StaticResetHelper.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/StaticResetHelper.java
@@ -59,7 +59,6 @@ public class StaticResetHelper {
          }
          return false;
       }));
-      classes.add(new ClassState(FocusTimeController.class, null));
       classes.add(new ClassState(OSSessionManager.class, null));
       classes.add(new ClassState(MockSessionManager.class, null));
       classes.add(new ClassState(OSNotificationWorkManager.class,  field -> {

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
@@ -719,9 +719,10 @@ public class GenerateNotificationRunner {
    
    @Test
    @Config(shadows = { ShadowGenerateNotification.class })
-   public void shouldUpdateBadgesWhenDismissingNotification() {
+   public void shouldUpdateBadgesWhenDismissingNotification() throws Exception {
       Bundle bundle = getBaseNotifBundle();
       NotificationBundleProcessor_ProcessFromFCMIntentService(blankActivity, bundle);
+      threadAndTaskWait();
       assertEquals(notifMessage, ShadowRoboNotificationManager.getLastShadowNotif().getContentText());
       assertEquals(1, ShadowBadgeCountUpdater.lastCount);
    

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/InAppMessageIntegrationTests.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/InAppMessageIntegrationTests.java
@@ -440,7 +440,12 @@ public class InAppMessageIntegrationTests {
                 .pollInterval(new Duration(100, TimeUnit.MILLISECONDS))
                 .untilAsserted(() -> {
                     assertEquals(1, OneSignalPackagePrivateHelper.getInAppMessageDisplayQueue().size());
-                    assertEquals(message2.messageId, OneSignalPackagePrivateHelper.getShowingInAppMessageId());
+                    try {
+                        assertEquals(message2.messageId, OneSignalPackagePrivateHelper.getShowingInAppMessageId());
+                    } catch (NullPointerException e) {
+                        // Awaitility won't retry if something is thrown, but will if an assert fails.
+                        fail("Should not throw");
+                    }
                 });
 
 

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/InAppMessageIntegrationTests.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/InAppMessageIntegrationTests.java
@@ -420,7 +420,12 @@ public class InAppMessageIntegrationTests {
                 .pollInterval(new Duration(10, TimeUnit.MILLISECONDS))
                 .untilAsserted(() -> {
                     assertEquals(1, OneSignalPackagePrivateHelper.getInAppMessageDisplayQueue().size());
-                    assertEquals(message1.messageId, OneSignalPackagePrivateHelper.getShowingInAppMessageId());
+                    try {
+                        assertEquals(message1.messageId, OneSignalPackagePrivateHelper.getShowingInAppMessageId());
+                    } catch (NullPointerException e) {
+                        // Awaitility won't retry if something is thrown, but will if an assert fails.
+                        fail("Should not throw");
+                    }
                 });
 
         OneSignalPackagePrivateHelper.dismissCurrentMessage();

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/InAppMessageIntegrationTests.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/InAppMessageIntegrationTests.java
@@ -366,6 +366,17 @@ public class InAppMessageIntegrationTests {
                 .pollInterval(new Duration(10, TimeUnit.MILLISECONDS))
                 .until(() -> OneSignalPackagePrivateHelper.getInAppMessageDisplayQueue().size() == 1);
 
+        // After IAM is added to display queue we now need to wait until it is shown
+        Awaitility.await()
+                .atMost(new Duration(1_000, TimeUnit.MILLISECONDS))
+                .pollInterval(new Duration(10, TimeUnit.MILLISECONDS))
+                .untilAsserted(new ThrowingRunnable() {
+                    @Override
+                    public void run() {
+                        assertTrue(OneSignalPackagePrivateHelper.isInAppMessageShowing());
+                    }
+                });
+
         OneSignalPackagePrivateHelper.dismissCurrentMessage();
 
         // Check that the IAM is not displayed again
@@ -1330,6 +1341,17 @@ public class InAppMessageIntegrationTests {
 
         // No schedule should happen, IAM should evaluate to true
         assertEquals(1, OneSignalPackagePrivateHelper.getInAppMessageDisplayQueue().size());
+
+        // After IAM is added to display queue we now need to wait until it is shown
+        Awaitility.await()
+            .atMost(new Duration(1_000, TimeUnit.MILLISECONDS))
+            .pollInterval(new Duration(10, TimeUnit.MILLISECONDS))
+            .untilAsserted(new ThrowingRunnable() {
+                @Override
+                public void run() throws Exception {
+                    assertTrue(OneSignalPackagePrivateHelper.isInAppMessageShowing());
+                }
+            });
 
         // Dismiss IAM will make display quantity increase and last display time to change
         OneSignalPackagePrivateHelper.dismissCurrentMessage();

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/InAppMessageIntegrationTests.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/InAppMessageIntegrationTests.java
@@ -75,6 +75,7 @@ import static com.test.onesignal.TestHelpers.threadAndTaskWait;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 @Config(packageName = "com.onesignal.example",
         shadows = {
@@ -362,7 +363,7 @@ public class InAppMessageIntegrationTests {
         // for the correct amount of time, so all we are doing here is checking to
         // make sure the message actually gets displayed once the timer fires
         Awaitility.await()
-                .atMost(new Duration(150, TimeUnit.MILLISECONDS))
+                .atMost(new Duration(1_000, TimeUnit.MILLISECONDS))
                 .pollInterval(new Duration(10, TimeUnit.MILLISECONDS))
                 .until(() -> OneSignalPackagePrivateHelper.getInAppMessageDisplayQueue().size() == 1);
 
@@ -380,7 +381,10 @@ public class InAppMessageIntegrationTests {
         OneSignalPackagePrivateHelper.dismissCurrentMessage();
 
         // Check that the IAM is not displayed again
-        assertEquals(0, OneSignalPackagePrivateHelper.getInAppMessageDisplayQueue().size());
+        Awaitility.await()
+                .atMost(new Duration(1_000, TimeUnit.MILLISECONDS))
+                .pollInterval(new Duration(10, TimeUnit.MILLISECONDS))
+                .until(() -> OneSignalPackagePrivateHelper.getInAppMessageDisplayQueue().size() == 0);
     }
 
     @Test

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/InAppMessageIntegrationTests.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/InAppMessageIntegrationTests.java
@@ -1340,7 +1340,15 @@ public class InAppMessageIntegrationTests {
         threadAndTaskWait();
 
         // No schedule should happen, IAM should evaluate to true
-        assertEquals(1, OneSignalPackagePrivateHelper.getInAppMessageDisplayQueue().size());
+        Awaitility.await()
+            .atMost(new Duration(1_000, TimeUnit.MILLISECONDS))
+            .pollInterval(new Duration(10, TimeUnit.MILLISECONDS))
+            .untilAsserted(new ThrowingRunnable() {
+                @Override
+                public void run() throws Exception {
+                    assertEquals(1, OneSignalPackagePrivateHelper.getInAppMessageDisplayQueue().size());
+                }
+            });
 
         // After IAM is added to display queue we now need to wait until it is shown
         Awaitility.await()
@@ -1378,7 +1386,7 @@ public class InAppMessageIntegrationTests {
         // No schedule should happen since session time period is very small, should evaluate to true on first run
         // Wait for redisplay logic
         Awaitility.await()
-                .atMost(new Duration(150, TimeUnit.MILLISECONDS))
+                .atMost(new Duration(1_000, TimeUnit.MILLISECONDS))
                 .pollInterval(new Duration(10, TimeUnit.MILLISECONDS))
                 .untilAsserted(new ThrowingRunnable() {
                     @Override

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/InAppMessageIntegrationTests.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/InAppMessageIntegrationTests.java
@@ -149,9 +149,8 @@ public class InAppMessageIntegrationTests {
         ShadowDynamicTimer.shouldScheduleTimers = true;
         ShadowDynamicTimer.hasScheduledTimer = false;
         OneSignal.setInAppMessageClickHandler(null);
-        TestHelpers.afterTestCleanup();
-
         InAppMessagingHelpers.clearTestState();
+        TestHelpers.afterTestCleanup();
     }
 
     @Test

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/LocationIntegrationTests.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/LocationIntegrationTests.java
@@ -233,7 +233,6 @@ public class LocationIntegrationTests {
         assertEquals(3.3f, ShadowOneSignalRestClient.lastPost.opt("loc_acc"));
 
         assertEquals(false, ShadowOneSignalRestClient.lastPost.opt("loc_bg"));
-        assertEquals("11111111-2222-3333-4444-555555555555", ShadowOneSignalRestClient.lastPost.opt("ad_id"));
 
         // Testing loc_bg
         blankActivityController.pause();
@@ -249,7 +248,6 @@ public class LocationIntegrationTests {
         assertEquals(3.3f, ShadowOneSignalRestClient.lastPost.opt("loc_acc"));
         assertEquals(true, ShadowOneSignalRestClient.lastPost.opt("loc_bg"));
         assertEquals(1, ShadowOneSignalRestClient.lastPost.optInt("loc_type"));
-        assertEquals("11111111-2222-3333-4444-555555555555", ShadowOneSignalRestClient.lastPost.opt("ad_id"));
     }
 
     @Test
@@ -449,8 +447,6 @@ public class LocationIntegrationTests {
         assertEquals(3.3f, ShadowOneSignalRestClient.lastPost.opt("loc_acc"));
 
         assertEquals(false, ShadowOneSignalRestClient.lastPost.opt("loc_bg"));
-        // Currently not getting ad_id for HMS devices
-        assertNull(ShadowOneSignalRestClient.lastPost.opt("ad_id"));
 
         // Testing loc_bg
         blankActivityController.pause();
@@ -467,8 +463,6 @@ public class LocationIntegrationTests {
         assertEquals(3.3f, ShadowOneSignalRestClient.lastPost.opt("loc_acc"));
         assertEquals(true, ShadowOneSignalRestClient.lastPost.opt("loc_bg"));
         assertEquals(1, ShadowOneSignalRestClient.lastPost.optInt("loc_type"));
-        // Currently not getting ad_id for HMS devices
-        assertNull(ShadowOneSignalRestClient.lastPost.opt("ad_id"));
     }
 
     @Test


### PR DESCRIPTION
## Description
### One Line Summary
Fix both some individual flaky tests as well as some general test carry over issues.

### Details
* Fix some ad_id field asserts in some testss that didn't get removed.
* Fix focusTimeController carry over from test to test issue.
* Fix test util method `nextSuccessfulRegistrationResponse` not correctly filtering to just player requests.
* Fix InAppMessageIntegrationTests afterEach test not force stopping some threads which sometimes created test carry over.
* A number of flaky tests in InAppMessageIntegrationTests fixed on the individual level, see commit-by-commit for each one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1345)
<!-- Reviewable:end -->
