### PR TITLE
Fix Firebase Messaging 22.0.0 Compatibility for 3.x.x branch

### DIFF
--- a/OneSignalSDK/onesignal/consumer-proguard-rules.pro
+++ b/OneSignalSDK/onesignal/consumer-proguard-rules.pro
@@ -6,6 +6,10 @@
     void disconnect();
 }
 
+# Need to keep as getToken as it is called with reflection from com.onesignal.PushRegistratorFCM
+-keep class com.google.firebase.messaging.FirebaseMessaging {
+    com.google.android.gms.tasks.Task getToken();
+}
 
 -keep class com.onesignal.ActivityLifecycleListenerCompat** {*;}
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/PushRegistratorFCM.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/PushRegistratorFCM.java
@@ -91,6 +91,10 @@ class PushRegistratorFCM extends PushRegistratorAbstractGoogle {
    @Override
    String getToken(String senderId) throws Throwable {
       initFirebaseApp(senderId);
+      return getTokenWithClassFirebaseInstanceId(senderId);
+   }
+
+   private String getTokenWithClassFirebaseInstanceId(String senderId) throws IOException {
       FirebaseInstanceId instanceId = FirebaseInstanceId.getInstance(firebaseApp);
       return instanceId.getToken(senderId, FirebaseMessaging.INSTANCE_ID_SCOPE);
    }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/PushRegistratorFCM.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/PushRegistratorFCM.java
@@ -125,13 +125,17 @@ class PushRegistratorFCM extends PushRegistratorAbstractGoogle {
       // We use firebaseApp.get(FirebaseMessaging.class) instead of FirebaseMessaging.getInstance()
       //   as the latter uses the default Firebase app. We need to use a custom Firebase app as
       //   the senderId is provided at runtime.
-      FirebaseMessaging fcmInstance = firebaseApp.get(FirebaseMessaging.class);
+      FirebaseMessaging firebaseMessagingInstance = firebaseApp.get(FirebaseMessaging.class);
+
+      if (firebaseMessagingInstance == null) {
+         throw new Error("firebaseMessagingInstance is null");
+      }
 
       Exception exception;
       // FirebaseMessaging.getToken API was introduced in firebase-messaging:21.0.0
       try {
-         Method getTokenMethod = fcmInstance.getClass().getMethod("getToken");
-         Object tokenTask = getTokenMethod.invoke(fcmInstance);
+         Method getTokenMethod = firebaseMessagingInstance.getClass().getMethod("getToken");
+         Object tokenTask = getTokenMethod.invoke(firebaseMessagingInstance);
          return Tasks.await((Task<String>)tokenTask);
       } catch (NoSuchMethodException e) {
          exception = e;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/PushRegistratorFCM.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/PushRegistratorFCM.java
@@ -91,12 +91,35 @@ class PushRegistratorFCM extends PushRegistratorAbstractGoogle {
    @Override
    String getToken(String senderId) throws Throwable {
       initFirebaseApp(senderId);
+
+      try {
+         return getTokenWithClassFirebaseMessaging();
+      } catch (NoClassDefFoundError | NoSuchMethodError e) {
+         // Class or method wil be missing at runtime if firebase-message older than 21.0.0 is used.
+         OneSignal.Log(
+            OneSignal.LOG_LEVEL.INFO,
+            "FirebaseMessaging.getToken not found, attempting to use FirebaseInstanceId.getToken"
+         );
+      }
+
+      // Fallback for firebase-message versions older than 21.0.0
       return getTokenWithClassFirebaseInstanceId(senderId);
    }
 
    private String getTokenWithClassFirebaseInstanceId(String senderId) throws IOException {
       FirebaseInstanceId instanceId = FirebaseInstanceId.getInstance(firebaseApp);
       return instanceId.getToken(senderId, FirebaseMessaging.INSTANCE_ID_SCOPE);
+   }
+
+   @WorkerThread
+   private String getTokenWithClassFirebaseMessaging() throws ExecutionException, InterruptedException {
+      // We use firebaseApp.get(FirebaseMessaging.class) instead of FirebaseMessaging.getInstance()
+      //   as the latter uses the default Firebase app. We need to use a custom Firebase app as
+      //   the senderId is provided at runtime.
+      FirebaseMessaging fcmInstance = firebaseApp.get(FirebaseMessaging.class);
+      // FirebaseMessaging.getToken API was introduced in firebase-messaging:21.0.0
+      Task<String> tokenTask = fcmInstance.getToken();
+      return Tasks.await(tokenTask);
    }
 
    private void initFirebaseApp(String senderId) {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/PushRegistratorFCM.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/PushRegistratorFCM.java
@@ -33,17 +33,22 @@ import android.content.pm.PackageManager;
 import android.util.Base64;
 
 import android.support.annotation.NonNull;
+import android.support.annotation.WorkerThread;
 
+import com.google.android.gms.tasks.Task;
+import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import com.google.firebase.iid.FirebaseInstanceId;
 import com.google.firebase.iid.FirebaseInstanceIdService;
 import com.google.firebase.messaging.FirebaseMessaging;
 
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+
 // TODO: 4.0.0 - Switch to using <action android:name="com.google.firebase.INSTANCE_ID_EVENT"/>
 // Note: Starting with Firebase Messaging 17.1.0 onNewToken in FirebaseMessagingService should be
 //   used instead.
-
 class PushRegistratorFCM extends PushRegistratorAbstractGoogle {
 
    // project_info.project_id
@@ -88,8 +93,9 @@ class PushRegistratorFCM extends PushRegistratorAbstractGoogle {
       return "FCM";
    }
 
+   @WorkerThread
    @Override
-   String getToken(String senderId) throws Throwable {
+   String getToken(String senderId) throws ExecutionException, InterruptedException, IOException {
       initFirebaseApp(senderId);
 
       try {
@@ -106,6 +112,7 @@ class PushRegistratorFCM extends PushRegistratorAbstractGoogle {
       return getTokenWithClassFirebaseInstanceId(senderId);
    }
 
+   @WorkerThread
    private String getTokenWithClassFirebaseInstanceId(String senderId) throws IOException {
       FirebaseInstanceId instanceId = FirebaseInstanceId.getInstance(firebaseApp);
       return instanceId.getToken(senderId, FirebaseMessaging.INSTANCE_ID_SCOPE);


### PR DESCRIPTION
## Description
### One Line Summary
Same as PR #1340 expect for this 3.x.x branch to back port.

### Details
First 3 commits were cherry picked from the master branch version of this PR. However instead of using reflection on the old firebase-messaging API we had to write new code to use reflection on the new API. This is due to the fact we can't upgrade firebase-messaging on this 3.x.x patch branch as it would introduce a dependency on AndroidX.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1348)
<!-- Reviewable:end -->
