### PR TITLE
Release commit 3.16.0

### DIFF
--- a/OneSignalSDK/onesignal/maven-push.gradle
+++ b/OneSignalSDK/onesignal/maven-push.gradle
@@ -24,7 +24,7 @@ class Global {
     static def POM_NAME = 'OneSignal'
     static def POM_ARTIFACT_ID = 'OneSignal'
     static def POM_PACKAGING = 'aar'
-    static def VERSION_NAME = '3.15.7'
+    static def VERSION_NAME = '3.16.0'
 
     static def GROUP_ID = 'com.onesignal'
     static def POM_DESCRIPTION = 'OneSignal Android SDK'

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -450,7 +450,7 @@ public class OneSignal {
    private static TrackAmazonPurchase trackAmazonPurchase;
    private static TrackFirebaseAnalytics trackFirebaseAnalytics;
 
-   public static final String VERSION = "031507";
+   public static final String VERSION = "031600";
 
    private static OSSessionManager.SessionListener sessionListener = new OSSessionManager.SessionListener() {
          @Override


### PR DESCRIPTION
## Release Notes

* Added OneSignal.setLanguage to allow defining an app language used for Notifications, In-App Messages, and other channels such as SMS and Email. PR #1350
* Fix Compatibility with FCM (Firebase Messaging) 22.0.0. PR #1348
   - Fixes Failed resolution of: Lcom/google/firebase/iid/FirebaseInstanceId;. Issue #1346

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1354)
<!-- Reviewable:end -->
