### PR TITLE
Add Receive Receipt delay

### DIFF
--- a/OneSignalSDK/build.gradle
+++ b/OneSignalSDK/build.gradle
@@ -8,6 +8,7 @@ buildscript {
                 targetSdkVersion: 28
         ]
         androidGradlePluginVersion = '3.6.2'
+        androidConcurrentFutures = '1.1.0'
         googleServicesGradlePluginVersion = '4.3.2'
         huaweiAgconnectVersion = '1.2.1.301'
         huaweiHMSPushVersion = '4.0.2.300'

--- a/OneSignalSDK/onesignal/build.gradle
+++ b/OneSignalSDK/onesignal/build.gradle
@@ -49,6 +49,8 @@ dependencies {
     // Required for GoogleApiAvailability
     implementation 'com.google.android.gms:play-services-base:[17.0.0, 17.6.99]'
 
+    implementation("androidx.concurrent:concurrent-futures:$androidConcurrentFutures")
+
     // firebase-messaging:18.0.0 is the last version before going to AndroidX
     // firebase-messaging:19.0.0 is the first version using AndroidX
     api 'com.google.firebase:firebase-messaging:[19.0.0, 22.0.99]'

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
@@ -347,23 +347,23 @@ class NotificationBundleProcessor {
             return;
         String collapse_id = notificationJob.getJsonPayload().optString("collapse_key");
 
-      OneSignalDbHelper dbHelper = OneSignalDbHelper.getInstance(notificationJob.getContext());
-      Cursor cursor = dbHelper.query(
-              NotificationTable.TABLE_NAME,
-              new String[]{NotificationTable.COLUMN_NAME_ANDROID_NOTIFICATION_ID}, // retColumn
-              NotificationTable.COLUMN_NAME_COLLAPSE_ID + " = ? AND " +
-                      NotificationTable.COLUMN_NAME_DISMISSED + " = 0 AND " +
-                      NotificationTable.COLUMN_NAME_OPENED + " = 0 ",
-              new String[]{collapse_id},
-              null, null, null);
+        OneSignalDbHelper dbHelper = OneSignalDbHelper.getInstance(notificationJob.getContext());
+        Cursor cursor = dbHelper.query(
+                NotificationTable.TABLE_NAME,
+                new String[]{NotificationTable.COLUMN_NAME_ANDROID_NOTIFICATION_ID}, // retColumn
+                NotificationTable.COLUMN_NAME_COLLAPSE_ID + " = ? AND " +
+                        NotificationTable.COLUMN_NAME_DISMISSED + " = 0 AND " +
+                        NotificationTable.COLUMN_NAME_OPENED + " = 0 ",
+                new String[]{collapse_id},
+                null, null, null);
 
-      if (cursor.moveToFirst()) {
-         int androidNotificationId = cursor.getInt(cursor.getColumnIndex(NotificationTable.COLUMN_NAME_ANDROID_NOTIFICATION_ID));
-         notificationJob.setAndroidIdWithoutOverriding(androidNotificationId);
-      }
+        if (cursor.moveToFirst()) {
+            int androidNotificationId = cursor.getInt(cursor.getColumnIndex(NotificationTable.COLUMN_NAME_ANDROID_NOTIFICATION_ID));
+            notificationJob.setAndroidIdWithoutOverriding(androidNotificationId);
+        }
 
-      cursor.close();
-   }
+        cursor.close();
+    }
 
     /**
      * Process bundle passed from FCM / HMS / ADM broadcast receiver

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
@@ -165,6 +165,11 @@ class NotificationBundleProcessor {
             String osNotificationId = OSNotificationFormatHelper.getOSNotificationIdFromJson(notificationController.getNotificationJob().getJsonPayload());
             OSNotificationWorkManager.removeNotificationIdProcessed(osNotificationId);
             OneSignal.handleNotificationReceived(notificationJob);
+        } else {
+            CallbackToFutureAdapter.Completer<ListenableWorker.Result>  callbackCompleter = notificationJob.getCallbackCompleter();
+            OneSignal.Log(OneSignal.LOG_LEVEL.DEBUG, "Process notification restored or IAM with callback completer: " + callbackCompleter);
+            if (callbackCompleter != null)
+                callbackCompleter.set(ListenableWorker.Result.success());
         }
 
         return androidNotificationId;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationSummaryManager.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationSummaryManager.java
@@ -143,7 +143,7 @@ class NotificationSummaryManager {
              null
          );
 
-         OSNotificationRestoreWorkManager.showNotificationsFromCursor(context, cursor, 0);
+         OSNotificationRestoreWorkManager.showNotificationsFromCursor(context, cursor, 0, true);
       } catch (Throwable t) {
          OneSignal.Log(OneSignal.LOG_LEVEL.ERROR, "Error restoring notification records! ", t);
       } finally {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSDelayTaskController.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSDelayTaskController.kt
@@ -1,0 +1,40 @@
+package com.onesignal
+
+import java.util.concurrent.ScheduledThreadPoolExecutor
+import java.util.concurrent.ThreadFactory
+import java.util.concurrent.TimeUnit
+import kotlin.math.roundToInt
+
+open class OSDelayTaskController(private val logger: OSLogger) {
+    private val maxDelay = 25
+    private val minDelay = 0
+
+    private var scheduledThreadPoolExecutor: ScheduledThreadPoolExecutor
+
+    init {
+        scheduledThreadPoolExecutor = ScheduledThreadPoolExecutor(1, JobThreadFactory())
+    }
+
+    protected open fun getRandomNumber(): Int {
+        return (Math.random() * (maxDelay - minDelay + 1) + minDelay).roundToInt()
+    }
+
+    open fun delayTaskByRandom(runnable: Runnable) {
+        val randomNum = getRandomNumber()
+
+        logger.debug("OSDelayTaskController delaying task $randomNum second from thread: ${Thread.currentThread()}")
+        scheduledThreadPoolExecutor.schedule(runnable, randomNum.toLong(), TimeUnit.SECONDS)
+    }
+
+    fun shutdownNow() {
+        scheduledThreadPoolExecutor.shutdownNow()
+    }
+
+    private class JobThreadFactory : ThreadFactory {
+        private val delayThreadName = "ONE_SIGNAL_DELAY"
+
+        override fun newThread(runnable: Runnable): Thread {
+            return Thread(runnable, delayThreadName)
+        }
+    }
+}

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSDelayTaskController.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSDelayTaskController.kt
@@ -15,12 +15,12 @@ open class OSDelayTaskController(private val logger: OSLogger) {
         scheduledThreadPoolExecutor = ScheduledThreadPoolExecutor(1, JobThreadFactory())
     }
 
-    protected open fun getRandomNumber(): Int {
+    protected open fun getRandomDelay(): Int {
         return (Math.random() * (maxDelay - minDelay + 1) + minDelay).roundToInt()
     }
 
     open fun delayTaskByRandom(runnable: Runnable) {
-        val randomNum = getRandomNumber()
+        val randomNum = getRandomDelay()
 
         logger.debug("OSDelayTaskController delaying task $randomNum second from thread: ${Thread.currentThread()}")
         scheduledThreadPoolExecutor.schedule(runnable, randomNum.toLong(), TimeUnit.SECONDS)

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationController.java
@@ -30,6 +30,8 @@ package com.onesignal;
 import android.content.Context;
 
 import androidx.annotation.Nullable;
+import androidx.concurrent.futures.CallbackToFutureAdapter;
+import androidx.work.ListenableWorker;
 
 import org.json.JSONObject;
 
@@ -40,6 +42,7 @@ public class OSNotificationController {
    // The extension service app AndroidManifest.xml meta data tag key name
    private static final String EXTENSION_SERVICE_META_DATA_TAG_NAME = "com.onesignal.NotificationServiceExtension";
 
+   private final CallbackToFutureAdapter.Completer<ListenableWorker.Result> callbackCompleter;
    private final OSNotificationGenerationJob notificationJob;
    private boolean restoring;
    private boolean fromBackgroundLogic;
@@ -48,9 +51,12 @@ public class OSNotificationController {
       this.restoring = restoring;
       this.fromBackgroundLogic = fromBackgroundLogic;
       this.notificationJob = notificationJob;
+      this.callbackCompleter = notificationJob.getCallbackCompleter();
    }
 
-   OSNotificationController(Context context, JSONObject jsonPayload, boolean restoring, boolean fromBackgroundLogic, Long timestamp) {
+   OSNotificationController(CallbackToFutureAdapter.Completer<ListenableWorker.Result> callbackCompleter,
+                            Context context, JSONObject jsonPayload, boolean restoring, boolean fromBackgroundLogic, Long timestamp) {
+      this.callbackCompleter = callbackCompleter;
       this.restoring = restoring;
       this.fromBackgroundLogic = fromBackgroundLogic;
 
@@ -64,7 +70,7 @@ public class OSNotificationController {
     * @see OSNotificationGenerationJob
     */
    private OSNotificationGenerationJob createNotificationJobFromCurrent(Context context, JSONObject jsonPayload, Long timestamp) {
-      OSNotificationGenerationJob notificationJob = new OSNotificationGenerationJob(context);
+      OSNotificationGenerationJob notificationJob = new OSNotificationGenerationJob(callbackCompleter, context);
       notificationJob.setJsonPayload(jsonPayload);
       notificationJob.setShownTimeStamp(timestamp);
       notificationJob.setRestoring(restoring);

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationGenerationJob.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationGenerationJob.java
@@ -30,15 +30,17 @@ package com.onesignal;
 import android.content.Context;
 import android.net.Uri;
 
-import androidx.core.app.NotificationCompat;
+import androidx.annotation.Nullable;
+import androidx.concurrent.futures.CallbackToFutureAdapter;
+import androidx.work.ListenableWorker;
 
-import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.security.SecureRandom;
 
 public class OSNotificationGenerationJob {
 
+    private CallbackToFutureAdapter.Completer<ListenableWorker.Result> callbackCompleter;
     private OSNotification notification;
     private Context context;
     private JSONObject jsonPayload;
@@ -54,6 +56,11 @@ public class OSNotificationGenerationJob {
     private Uri orgSound;
 
     OSNotificationGenerationJob(Context context) {
+        this(null, context);
+    }
+
+    OSNotificationGenerationJob(CallbackToFutureAdapter.Completer<ListenableWorker.Result> callbackCompleter, Context context) {
+        this.callbackCompleter = callbackCompleter;
         this.context = context;
     }
 
@@ -65,6 +72,11 @@ public class OSNotificationGenerationJob {
         this.context = context;
         this.jsonPayload = jsonPayload;
         this.notification = notification;
+    }
+
+    @Nullable
+    public CallbackToFutureAdapter.Completer<ListenableWorker.Result> getCallbackCompleter() {
+        return callbackCompleter;
     }
 
     /**

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationRestoreWorkManager.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationRestoreWorkManager.java
@@ -77,7 +77,7 @@ class OSNotificationRestoreWorkManager {
             StringBuilder dbQuerySelection = OneSignalDbHelper.recentUninteractedWithNotificationsWhere();
             skipVisibleNotifications(context, dbQuerySelection);
 
-            queryAndRestoreNotificationsAndBadgeCount(context, dbHelper, dbQuerySelection, false);
+            queryAndRestoreNotificationsAndBadgeCount(context, dbHelper, dbQuerySelection);
 
             return Result.success();
         }
@@ -87,8 +87,7 @@ class OSNotificationRestoreWorkManager {
     private static void queryAndRestoreNotificationsAndBadgeCount(
             Context context,
             OneSignalDbHelper dbHelper,
-            StringBuilder dbQuerySelection,
-            boolean needsWorkerThread) {
+            StringBuilder dbQuerySelection) {
 
         OneSignal.Log(OneSignal.LOG_LEVEL.INFO,
                 "Querying DB for notifications to restore: " + dbQuerySelection.toString());
@@ -105,7 +104,7 @@ class OSNotificationRestoreWorkManager {
                     OneSignalDbContract.NotificationTable._ID + " DESC", // sort order, new to old
                     NotificationLimitManager.MAX_NUMBER_OF_NOTIFICATIONS_STR // limit
             );
-            showNotificationsFromCursor(context, cursor, DELAY_BETWEEN_NOTIFICATION_RESTORES_MS, needsWorkerThread);
+            showNotificationsFromCursor(context, cursor, DELAY_BETWEEN_NOTIFICATION_RESTORES_MS, false);
             BadgeCountUpdater.update(dbHelper, context);
         } catch (Throwable t) {
             OneSignal.Log(OneSignal.LOG_LEVEL.ERROR, "Error restoring notification records! ", t);

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationWorkManager.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationWorkManager.java
@@ -14,7 +14,6 @@ import androidx.work.WorkerParameters;
 
 import com.google.common.util.concurrent.ListenableFuture;
 
-import org.jetbrains.annotations.NotNull;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -107,7 +106,7 @@ class OSNotificationWorkManager {
             });
         }
 
-        private String doWork(@NotNull CallbackToFutureAdapter.Completer<Result> completer) {
+        private String doWork(@NonNull CallbackToFutureAdapter.Completer<Result> completer) {
             Data inputData = getInputData();
             try {
                 OneSignal.onesignalLog(OneSignal.LOG_LEVEL.DEBUG, "NotificationWorker running doWork with data: " + inputData);

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationWorkManager.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationWorkManager.java
@@ -3,13 +3,18 @@ package com.onesignal;
 import android.content.Context;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.concurrent.futures.CallbackToFutureAdapter;
 import androidx.work.Data;
 import androidx.work.ExistingWorkPolicy;
+import androidx.work.ListenableWorker;
 import androidx.work.OneTimeWorkRequest;
 import androidx.work.WorkManager;
-import androidx.work.Worker;
 import androidx.work.WorkerParameters;
 
+import com.google.common.util.concurrent.ListenableFuture;
+
+import org.jetbrains.annotations.NotNull;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -19,6 +24,7 @@ import static com.onesignal.OSUtils.isStringNotEmpty;
 
 class OSNotificationWorkManager {
 
+    private static final String OS_NOTIFICATION_ID = "os_bnotification_id";
     private static final String ANDROID_NOTIF_ID_WORKER_DATA_PARAM = "android_notif_id";
     private static final String JSON_PAYLOAD_WORKER_DATA_PARAM = "json_payload";
     private static final String TIMESTAMP_WORKER_DATA_PARAM = "timestamp";
@@ -48,10 +54,22 @@ class OSNotificationWorkManager {
         }
     }
 
-    static void beginEnqueueingWork(Context context, String osNotificationId, int androidNotificationId, String jsonPayload,
-                                    boolean isRestoring, long timestamp, boolean isHighPriority) {
+    static void beginEnqueueingWork(Context context, String osNotificationId, int androidNotificationId, String jsonPayload, long timestamp,
+                                    boolean isRestoring, boolean isHighPriority, boolean needsWorkerThread) {
+
+        if (!needsWorkerThread) {
+            try {
+                JSONObject jsonPayloadObject = new JSONObject(jsonPayload);
+                processNotificationData(context, androidNotificationId, jsonPayloadObject, isRestoring, timestamp);
+            } catch (JSONException e) {
+                OneSignal.onesignalLog(OneSignal.LOG_LEVEL.ERROR, "Error occurred parsing jsonPayload to JSONObject in beginEnqueueingWork e: " + e.getMessage());
+                e.printStackTrace();
+            }
+            return;
+        }
         // TODO: Need to figure out how to implement the isHighPriority param
         Data inputData = new Data.Builder()
+                .putString(OS_NOTIFICATION_ID, osNotificationId)
                 .putInt(ANDROID_NOTIF_ID_WORKER_DATA_PARAM, androidNotificationId)
                 .putString(JSON_PAYLOAD_WORKER_DATA_PARAM, jsonPayload)
                 .putLong(TIMESTAMP_WORKER_DATA_PARAM, timestamp)
@@ -67,7 +85,7 @@ class OSNotificationWorkManager {
                 .enqueueUniqueWork(osNotificationId, ExistingWorkPolicy.KEEP, workRequest);
     }
 
-    public static class NotificationWorker extends Worker {
+    public static class NotificationWorker extends ListenableWorker {
 
         public NotificationWorker(@NonNull Context context, @NonNull WorkerParameters workerParams) {
             super(context, workerParams);
@@ -75,7 +93,21 @@ class OSNotificationWorkManager {
 
         @NonNull
         @Override
-        public Result doWork() {
+        public ListenableFuture<Result> startWork() {
+            return CallbackToFutureAdapter.getFuture(new CallbackToFutureAdapter.Resolver<Result>() {
+                @Nullable
+                @Override
+                public Object attachCompleter(@NonNull CallbackToFutureAdapter.Completer<Result> completer) throws Exception {
+                    String notificationId = NotificationWorker.this.doWork(completer);
+
+                    // This value is used only for debug purposes: it will be used
+                    // in toString() of returned future or error cases.
+                    return "NotificationWorkerFutureCallback_" + notificationId;
+                }
+            });
+        }
+
+        private String doWork(@NotNull CallbackToFutureAdapter.Completer<Result> completer) {
             Data inputData = getInputData();
             try {
                 OneSignal.onesignalLog(OneSignal.LOG_LEVEL.DEBUG, "NotificationWorker running doWork with data: " + inputData);
@@ -86,38 +118,45 @@ class OSNotificationWorkManager {
                 boolean isRestoring = inputData.getBoolean(IS_RESTORING_WORKER_DATA_PARAM, false);
 
                 processNotificationData(
+                        completer,
                         getApplicationContext(),
                         androidNotificationId,
                         jsonPayload,
                         isRestoring,
                         timestamp);
-
             } catch (JSONException e) {
                 OneSignal.onesignalLog(OneSignal.LOG_LEVEL.ERROR, "Error occurred doing work for job with id: " + getId().toString());
                 e.printStackTrace();
-                return Result.failure();
+                completer.setException(e);
             }
-            return Result.success();
+            return inputData.getString(OS_NOTIFICATION_ID);
         }
+    }
 
-        private void processNotificationData(Context context, int androidNotificationId, JSONObject jsonPayload, boolean isRestoring, Long timestamp) {
-            OSNotification notification = new OSNotification(null, jsonPayload, androidNotificationId);
-            OSNotificationController controller = new OSNotificationController(context, jsonPayload, isRestoring, true, timestamp);
-            OSNotificationReceivedEvent notificationReceived = new OSNotificationReceivedEvent(controller, notification);
+    static void processNotificationData(Context context, int androidNotificationId, JSONObject jsonPayload,
+                                        boolean isRestoring, Long timestamp) {
+        processNotificationData(null, context, androidNotificationId, jsonPayload, isRestoring, timestamp);
+    }
 
-            if (OneSignal.remoteNotificationReceivedHandler != null)
-                try {
-                    OneSignal.remoteNotificationReceivedHandler.remoteNotificationReceived(context, notificationReceived);
-                } catch (Throwable t) {
-                    OneSignal.Log(OneSignal.LOG_LEVEL.ERROR, "remoteNotificationReceived throw an exception. Displaying normal OneSignal notification.", t);
-                    notificationReceived.complete(notification);
+    static void processNotificationData(CallbackToFutureAdapter.Completer<ListenableWorker.Result> completer,
+                                 Context context, int androidNotificationId, JSONObject jsonPayload,
+                                 boolean isRestoring, Long timestamp) {
+        OSNotification notification = new OSNotification(null, jsonPayload, androidNotificationId);
+        OSNotificationController controller = new OSNotificationController(completer, context, jsonPayload, isRestoring, true, timestamp);
+        OSNotificationReceivedEvent notificationReceived = new OSNotificationReceivedEvent(controller, notification);
 
-                    throw t;
-                }
-            else {
-                OneSignal.Log(OneSignal.LOG_LEVEL.WARN, "remoteNotificationReceivedHandler not setup, displaying normal OneSignal notification");
+        if (OneSignal.remoteNotificationReceivedHandler != null)
+            try {
+                OneSignal.remoteNotificationReceivedHandler.remoteNotificationReceived(context, notificationReceived);
+            } catch (Throwable t) {
+                OneSignal.Log(OneSignal.LOG_LEVEL.ERROR, "remoteNotificationReceived throw an exception. Displaying normal OneSignal notification.", t);
                 notificationReceived.complete(notification);
+
+                throw t;
             }
+        else {
+            OneSignal.Log(OneSignal.LOG_LEVEL.WARN, "remoteNotificationReceivedHandler not setup, displaying normal OneSignal notification");
+            notificationReceived.complete(notification);
         }
     }
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationWorkManager.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationWorkManager.java
@@ -55,7 +55,6 @@ class OSNotificationWorkManager {
 
     static void beginEnqueueingWork(Context context, String osNotificationId, int androidNotificationId, String jsonPayload, long timestamp,
                                     boolean isRestoring, boolean isHighPriority, boolean needsWorkerThread) {
-
         if (!needsWorkerThread) {
             try {
                 JSONObject jsonPayloadObject = new JSONObject(jsonPayload);

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSReceiveReceiptController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSReceiveReceiptController.java
@@ -28,51 +28,64 @@
 package com.onesignal;
 
 import androidx.annotation.NonNull;
+import androidx.concurrent.futures.CallbackToFutureAdapter;
+import androidx.work.ListenableWorker;
 
 class OSReceiveReceiptController {
 
+    private final OSDelayTaskController taskController;
     private final OSReceiveReceiptRepository repository;
+    private final OSRemoteParamController remoteParamController;
 
     private static OSReceiveReceiptController sInstance;
 
-    private OSReceiveReceiptController() {
+    private OSReceiveReceiptController(OSRemoteParamController remoteParamController, OSDelayTaskController taskController) {
+        this.remoteParamController = remoteParamController;
+        this.taskController = taskController;
         this.repository = new OSReceiveReceiptRepository();
     }
 
     synchronized public static OSReceiveReceiptController getInstance() {
         if (sInstance == null)
-            sInstance = new OSReceiveReceiptController();
+            sInstance = new OSReceiveReceiptController(OneSignal.getRemoteParamController(), OneSignal.getDelayTaskController());
         return sInstance;
     }
 
-    void sendReceiveReceipt(@NonNull final String notificationId) {
-        String appId = OneSignal.appId == null || OneSignal.appId.isEmpty() ? OneSignal.getSavedAppId() : OneSignal.appId;
-        String playerId = OneSignal.getUserId();
+    void sendReceiveReceipt(final CallbackToFutureAdapter.Completer<ListenableWorker.Result> callbackCompleter, @NonNull final String notificationId) {
+        final String appId = OneSignal.appId == null || OneSignal.appId.isEmpty() ? OneSignal.getSavedAppId() : OneSignal.appId;
+        final String playerId = OneSignal.getUserId();
 
-        if (!isReceiveReceiptEnabled()) {
+        if (!remoteParamController.isReceiveReceiptEnabled()) {
             OneSignal.Log(OneSignal.LOG_LEVEL.DEBUG, "sendReceiveReceipt disable");
+            endCallbackCompleterWithSuccess(callbackCompleter);
             return;
         }
 
-        OneSignal.Log(OneSignal.LOG_LEVEL.DEBUG, "sendReceiveReceipt appId: " + appId + " playerId: " + playerId + " notificationId: " + notificationId);
-        repository.sendReceiveReceipt(appId, playerId, notificationId, new OneSignalRestClient.ResponseHandler() {
+        Runnable receiveReceiptRunnable = new Runnable() {
             @Override
-            void onSuccess(String response) {
-                OneSignal.Log(OneSignal.LOG_LEVEL.DEBUG, "Receive receipt sent for notificationID: " + notificationId);
-            }
+            public void run() {
+                repository.sendReceiveReceipt(appId, playerId, notificationId, new OneSignalRestClient.ResponseHandler() {
+                    @Override
+                    void onSuccess(String response) {
+                        OneSignal.Log(OneSignal.LOG_LEVEL.DEBUG, "Receive receipt sent for notificationID: " + notificationId);
+                        endCallbackCompleterWithSuccess(callbackCompleter);
+                    }
 
-            @Override
-            void onFailure(int statusCode, String response, Throwable throwable) {
-                OneSignal.Log(OneSignal.LOG_LEVEL.ERROR, "Receive receipt failed with statusCode: " + statusCode + " response: " + response);
+                    @Override
+                    void onFailure(int statusCode, String response, Throwable throwable) {
+                        OneSignal.Log(OneSignal.LOG_LEVEL.ERROR, "Receive receipt failed with statusCode: " + statusCode + " response: " + response);
+                        endCallbackCompleterWithSuccess(callbackCompleter);
+                    }
+                });
             }
-        });
+        };
+
+        taskController.delayTaskByRandom(receiveReceiptRunnable);
     }
 
-    private boolean isReceiveReceiptEnabled() {
-        return OneSignalPrefs.getBool(
-           OneSignalPrefs.PREFS_ONESIGNAL,
-           OneSignalPrefs.PREFS_OS_RECEIVE_RECEIPTS_ENABLED,
-           false
-        );
+    private void endCallbackCompleterWithSuccess(CallbackToFutureAdapter.Completer<ListenableWorker.Result> callbackCompleter) {
+        OneSignal.Log(OneSignal.LOG_LEVEL.DEBUG, "Receive receipt ending with success callback completer: " + callbackCompleter);
+        if (callbackCompleter != null)
+            callbackCompleter.set(ListenableWorker.Result.success());
     }
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSRemoteParamController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSRemoteParamController.java
@@ -35,14 +35,11 @@ class OSRemoteParamController {
         );
         OneSignalPrefs.saveBool(
                 OneSignalPrefs.PREFS_ONESIGNAL,
-                OneSignalPrefs.PREFS_OS_RECEIVE_RECEIPTS_ENABLED,
-                remoteParams.receiveReceiptEnabled
-        );
-        OneSignalPrefs.saveBool(
-                OneSignalPrefs.PREFS_ONESIGNAL,
                 preferences.getOutcomesV2KeyName(),
                 remoteParams.influenceParams.outcomesV2ServiceEnabled
         );
+
+        saveReceiveReceiptEnabled(remoteParams.receiveReceiptEnabled);
 
         logger.debug("OneSignal saveInfluenceParams: " + remoteParams.influenceParams.toString());
         trackerFactory.saveInfluenceParams(remoteParams.influenceParams);
@@ -83,6 +80,22 @@ class OSRemoteParamController {
 
     void clearRemoteParams() {
         remoteParams = null;
+    }
+
+    private void saveReceiveReceiptEnabled(boolean receiveReceiptEnabled) {
+        OneSignalPrefs.saveBool(
+                OneSignalPrefs.PREFS_ONESIGNAL,
+                OneSignalPrefs.PREFS_OS_RECEIVE_RECEIPTS_ENABLED,
+                receiveReceiptEnabled
+        );
+    }
+
+    boolean isReceiveReceiptEnabled() {
+        return OneSignalPrefs.getBool(
+                OneSignalPrefs.PREFS_ONESIGNAL,
+                OneSignalPrefs.PREFS_OS_RECEIVE_RECEIPTS_ENABLED,
+                false
+        );
     }
 
     boolean getFirebaseAnalyticsEnabled() {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -426,6 +426,7 @@ public class OneSignal {
    }
    private static OSTime time = new OSTimeImpl();
    private static OSRemoteParamController remoteParamController = new OSRemoteParamController();
+   private static OSDelayTaskController delayTaskController = new OSDelayTaskController(logger);
    private static OSTaskController taskController = new OSTaskController(logger);
    private static OSTaskRemoteController taskRemoteController = new OSTaskRemoteController(remoteParamController, logger);
    private static OneSignalAPIClient apiClient = new OneSignalRestClientWrapper();
@@ -3190,6 +3191,7 @@ public class OneSignal {
    static OSTime getTime() {
       return time;
    }
+
    /*
     * Start Mock Injection module
     */
@@ -3207,6 +3209,10 @@ public class OneSignal {
 
    static void setSharedPreferences(OSSharedPreferences preferences) {
       OneSignal.preferences = preferences;
+   }
+
+   static void setDelayTaskController(OSDelayTaskController delayTaskController) {
+      OneSignal.delayTaskController = delayTaskController;
    }
 
    static OSSessionManager.SessionListener getSessionListener() {
@@ -3231,6 +3237,10 @@ public class OneSignal {
 
    static OSTaskController getTaskController() {
       return taskController;
+   }
+
+   static OSDelayTaskController getDelayTaskController() {
+      return delayTaskController;
    }
 
    static FocusTimeController getFocusTimeController() {

--- a/OneSignalSDK/unittest/build.gradle
+++ b/OneSignalSDK/unittest/build.gradle
@@ -16,7 +16,6 @@ ext {
 
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion rootProject.buildVersions.compileSdkVersion
@@ -75,6 +74,7 @@ dependencies {
 
     testImplementation "androidx.test:core:$androidTestCoreVersion"
     testImplementation "androidx.work:work-testing:$androidWorkTestVersion"
+    testImplementation("androidx.concurrent:concurrent-futures:$androidConcurrentFutures")
 
     testImplementation "org.robolectric:robolectric:$roboelectricVersion"
     testImplementation "org.awaitility:awaitility:$awaitilityVersion"

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/MockDelayTaskController.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/MockDelayTaskController.java
@@ -1,0 +1,32 @@
+package com.onesignal;
+
+import org.jetbrains.annotations.NotNull;
+
+public class MockDelayTaskController extends OSDelayTaskController {
+    private int mockedRandomValue = 0;
+    private boolean runOnSameThread = true;
+
+    public MockDelayTaskController(OSLogger logger) {
+        super(logger);
+    }
+
+    protected int getRandomNumber() {
+        return mockedRandomValue;
+    }
+
+    public void delayTaskByRandom(@NotNull Runnable runnable) {
+        if (runOnSameThread) {
+            runnable.run();
+        } else {
+            super.delayTaskByRandom(runnable);
+        }
+    }
+
+    public void setMockedRandomValue(int mockedRandomValue) {
+        this.mockedRandomValue = mockedRandomValue;
+    }
+
+    public void setRunOnSameThread(boolean runOnSameThread) {
+        this.runOnSameThread = runOnSameThread;
+    }
+}

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/MockDelayTaskController.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/MockDelayTaskController.java
@@ -1,6 +1,6 @@
 package com.onesignal;
 
-import org.jetbrains.annotations.NotNull;
+import androidx.annotation.NonNull;
 
 public class MockDelayTaskController extends OSDelayTaskController {
     private int mockedRandomValue = 0;
@@ -10,11 +10,11 @@ public class MockDelayTaskController extends OSDelayTaskController {
         super(logger);
     }
 
-    protected int getRandomNumber() {
+    protected int getRandomDelay() {
         return mockedRandomValue;
     }
 
-    public void delayTaskByRandom(@NotNull Runnable runnable) {
+    public void delayTaskByRandom(@NonNull Runnable runnable) {
         if (runOnSameThread) {
             runnable.run();
         } else {

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
@@ -120,6 +120,10 @@ public class OneSignalPackagePrivateHelper {
       OneSignal.setTrackerFactory(trackerFactory);
    }
 
+   public static void OneSignal_setDelayTaskController(OSDelayTaskController delayTaskController) {
+      OneSignal.setDelayTaskController(delayTaskController);
+   }
+
    public static JSONObject bundleAsJSONObject(Bundle bundle) {
       return NotificationBundleProcessor.bundleAsJSONObject(bundle);
    }
@@ -282,6 +286,7 @@ public class OneSignalPackagePrivateHelper {
    public static void OneSignal_OSTaskController_ShutdownNow() {
       OneSignal.getTaskRemoteController().shutdownNow();
       OneSignal.getTaskController().shutdownNow();
+      OneSignal.getDelayTaskController().shutdownNow();
    }
 
    public static boolean OneSignal_requiresUserPrivacyConsent() {

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/StaticResetHelper.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/StaticResetHelper.java
@@ -17,6 +17,7 @@ public class StaticResetHelper {
    private static Collection<ClassState> classes = new ArrayList<>();
 
    public static void load() {
+      OSLogger logger = new OSLogWrapper();
       classes.add(new ClassState(OneSignal.class, field -> {
          if (field.getName().equals("unprocessedOpenedNotifis")) {
             field.set(null, new ArrayList<JSONArray>());
@@ -25,12 +26,13 @@ public class StaticResetHelper {
             field.set(null, new OSRemoteParamController());
             return true;
          } else if (field.getName().equals("taskController")) {
-            OSLogger logger = new OSLogWrapper();
             field.set(null, new OSTaskController(logger));
             return true;
          } else if (field.getName().equals("taskRemoteController")) {
-            OSLogger logger = new OSLogWrapper();
             field.set(null, new OSTaskRemoteController(OneSignal.getRemoteParamController(), logger));
+            return true;
+         } else if (field.getName().equals("delayTaskController")) {
+            field.set(null, new MockDelayTaskController(logger));
             return true;
          } else if (field.getName().equals("inAppMessageControllerFactory")) {
             field.set(null, new OSInAppMessageControllerFactory());

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
@@ -121,6 +121,7 @@ import static com.onesignal.OneSignalPackagePrivateHelper.NotificationBundleProc
 import static com.onesignal.OneSignalPackagePrivateHelper.NotificationOpenedProcessor_processFromContext;
 import static com.onesignal.OneSignalPackagePrivateHelper.NotificationSummaryManager_updateSummaryNotificationAfterChildRemoved;
 import static com.onesignal.OneSignalPackagePrivateHelper.OneSignal_getAccentColor;
+import static com.onesignal.OneSignalPackagePrivateHelper.OneSignal_setDelayTaskController;
 import static com.onesignal.OneSignalPackagePrivateHelper.OneSignal_setTime;
 import static com.onesignal.OneSignalPackagePrivateHelper.OneSignal_setupNotificationServiceExtension;
 import static com.onesignal.OneSignalPackagePrivateHelper.createInternalPayloadBundle;
@@ -1253,8 +1254,11 @@ public class GenerateNotificationRunner {
    }
 
    @Test
-   @Config(shadows = { ShadowReceiveReceiptController.class, ShadowGenerateNotification.class })
+   @Config(shadows = { ShadowGenerateNotification.class })
    public void shouldSendReceivedReceiptWhenEnabled() throws Exception {
+
+      ShadowOneSignalRestClient.setRemoteParamsReceiveReceiptsEnable(true);
+
       String appId = "b2f7f966-d8cc-11e4-bed1-df8f05be55ba";
       OneSignal.setAppId(appId);
       OneSignal.initWithContext(blankActivity);

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
@@ -1256,7 +1256,6 @@ public class GenerateNotificationRunner {
    @Test
    @Config(shadows = { ShadowGenerateNotification.class })
    public void shouldSendReceivedReceiptWhenEnabled() throws Exception {
-
       ShadowOneSignalRestClient.setRemoteParamsReceiveReceiptsEnable(true);
 
       String appId = "b2f7f966-d8cc-11e4-bed1-df8f05be55ba";


### PR DESCRIPTION
* Add random delay from 0 to 25 seconds
* Add OSDelayTaskController for future delays
* Add MockDelayTaskController for test approaches
* Refactor Notification Work Manager to extends ListenableWorker. This adds future completion. Complete future after sending receive receipts
* Refactor Restoration Work Manager to not init another work manager, since Notification Work Manager nows expects a future when Restoration work is done, it will finish notification work manager that will end on a FutureGarbageCollectedException, avoid this exception by running everything on the same work thread

Note:

HMS and ADM handling always ends calling startNotificationProcessing which ends using OSNotificationWorkManager worker thread

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1356)
<!-- Reviewable:end -->
