### PR TITLE
Fix FirebaseMessagingService migration comment

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/FCMBroadcastReceiver.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/FCMBroadcastReceiver.java
@@ -41,8 +41,10 @@ import androidx.legacy.content.WakefulBroadcastReceiver;
 
 import com.onesignal.NotificationBundleProcessor.ProcessedBundleResult;
 
-// This is the entry point when a FCM / GCM payload is received from the Google Play services app
-// TODO: 4.0.0 - Update to use <action android:name="com.google.firebase.MESSAGING_EVENT"/>
+// This is the entry point when a FCM payload is received from the Google Play services app
+// OneSignal does not use FirebaseMessagingService.onMessageReceived as it does not allow multiple
+//   to be setup in an app. See the following issue for context on why this this important:
+//    - https://github.com/OneSignal/OneSignal-Android-SDK/issues/1355
 public class FCMBroadcastReceiver extends WakefulBroadcastReceiver {
 
    private static final String FCM_RECEIVE_ACTION = "com.google.android.c2dm.intent.RECEIVE";


### PR DESCRIPTION
* Per the comment in this change we don't want to migrate to using
FirebaseMessagingService.onMessageReceived as it means the OneSignal
SDK would be less compatible with other SDKs and app code.
   - https://github.com/OneSignal/OneSignal-Android-SDK/issues/1355

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1359)
<!-- Reviewable:end -->
