### PR TITLE
Remove extra addition of delayMs

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSBackgroundSync.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSBackgroundSync.java
@@ -154,7 +154,7 @@ abstract class OSBackgroundSync {
         PendingIntent pendingIntent = syncServicePendingIntent(context);
         AlarmManager alarm = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
         long triggerAtMs = OneSignal.getTime().getCurrentTimeMillis() + delayMs;
-        alarm.set(AlarmManager.RTC_WAKEUP, triggerAtMs + delayMs, pendingIntent);
+        alarm.set(AlarmManager.RTC_WAKEUP, triggerAtMs, pendingIntent);
     }
 
     protected void cancelBackgroundSyncTask(Context context) {


### PR DESCRIPTION
We accidentally added delayMs variable twice when it should be done once.
fixes #1339

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1361)
<!-- Reviewable:end -->
