### PR TITLE
Fix greater than IAM trigger firing on same MS

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSDynamicTriggerController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSDynamicTriggerController.java
@@ -95,7 +95,8 @@ class OSDynamicTriggerController {
             case LESS_THAN_OR_EQUAL_TO:
                 return currentTimeInterval <= timeInterval || roughlyEqual(timeInterval, currentTimeInterval);
             case GREATER_THAN:
-                return currentTimeInterval > timeInterval;
+                // Counting equal as greater. This way we don't need to schedule a Runnable for 1ms in the future.
+                return currentTimeInterval >= timeInterval;
             case GREATER_THAN_OR_EQUAL_TO:
                 return currentTimeInterval >= timeInterval || roughlyEqual(timeInterval, currentTimeInterval);
             case EQUAL_TO:


### PR DESCRIPTION
* This was discovered as testAfterLastInAppTimeIsDisplayedOncePerSession
was a flaky test.
* We never schedule a Runnable if the condition is meet so this change
isn't going a double fire issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1363)
<!-- Reviewable:end -->
