### PR TITLE
Limit dependencies version ranges to only include stable versions

### DIFF
--- a/OneSignalSDK/onesignal/build.gradle
+++ b/OneSignalSDK/onesignal/build.gradle
@@ -3,8 +3,6 @@ ext {
             minSdkVersion: 16
     ]
 
-    androidXVersion = '[1.0.0, 1.99.99]'
-    androidWorkVersion = '[2.0.0, 2.99.99]'
     firebaseMessagingVersion = '[19.0.0, 22.99.99]'
     googleGMSVersion = '[17.0.0, 17.99.99]'
 }
@@ -37,6 +35,9 @@ android {
 // api || implementation = compile and runtime
 
 // KEEP: version ranges, these get used in the released POM file for maven central
+// NOTE: To prevent consumers from getting alpha or beta version of dependencies listed here
+//         make sure the latest minor value is a known stable version. Using a range for the
+//         patch version is ok, since this allows getting bug fix versions.
 dependencies {
     compileOnly fileTree(dir: 'libs', include: ['*.jar'])
 
@@ -60,11 +61,11 @@ dependencies {
     compileOnly "com.huawei.hms:push:$huaweiHMSPushVersion"
     compileOnly "com.huawei.hms:location:$huaweiHMSLocationVersion"
 
-    api "androidx.cardview:cardview:$androidXVersion"
-    api "androidx.legacy:legacy-support-v4:$androidXVersion"
-    api "androidx.browser:browser:$androidXVersion"
-    api "androidx.appcompat:appcompat:$androidXVersion"
-    api "androidx.work:work-runtime:$androidWorkVersion"
+    api 'androidx.cardview:cardview:[1.0.0, 1.0.99]'
+    api 'androidx.legacy:legacy-support-v4:[1.0.0, 1.0.99]'
+    api 'androidx.browser:browser:[1.0.0, 1.3.99]'
+    api 'androidx.appcompat:appcompat:[1.0.0, 1.3.99]'
+    api 'androidx.work:work-runtime:[2.0.0, 2.5.99]'
 }
 
 apply from: 'maven-push.gradle'

--- a/OneSignalSDK/onesignal/build.gradle
+++ b/OneSignalSDK/onesignal/build.gradle
@@ -2,9 +2,6 @@ ext {
     buildVersions = [
             minSdkVersion: 16
     ]
-
-    firebaseMessagingVersion = '[19.0.0, 22.99.99]'
-    googleGMSVersion = '[17.0.0, 17.99.99]'
 }
 
 apply plugin: 'com.android.library'
@@ -45,16 +42,16 @@ dependencies {
 
     // play-services-location:16.0.0 is the last version before going to AndroidX
     // play-services-location:17.0.0 is the first version using AndroidX
-    compileOnly "com.google.android.gms:play-services-location:$googleGMSVersion"
+    compileOnly 'com.google.android.gms:play-services-location:[17.0.0, 18.0.99]'
 
     // play-services-base:16.1.0 is the last version before going to AndroidX
     // play-services-base:17.0.0 is the first version using AndroidX
     // Required for GoogleApiAvailability
-    implementation "com.google.android.gms:play-services-base:$googleGMSVersion"
+    implementation 'com.google.android.gms:play-services-base:[17.0.0, 17.6.99]'
 
     // firebase-messaging:18.0.0 is the last version before going to AndroidX
     // firebase-messaging:19.0.0 is the first version using AndroidX
-    api "com.google.firebase:firebase-messaging:$firebaseMessagingVersion"
+    api 'com.google.firebase:firebase-messaging:[19.0.0, 22.0.99]'
 
     // Huawei PushKit
     // KEEP as "compileOnly", so OneSignal isn't a direct dependency in the POM file.


### PR DESCRIPTION
## Description
### One Line Summary
Limit OneSignal's dependencies to know stable versions to prevent alpha and beta version from being automatically used by app projects.

## Details
Set AndroidX, GMS, and FCM max version to know stable versions.
* This fixes an issue where projects can get the latest beta or alpha
versions of dependencies such as work-runtime unless they define their
own version.
* Example: work-runtime:[2.0.0, 2.99.99] would result in 2.7.0-alpha04
as the time of writing.
* Gradle unfortunately does not provide a version range syntax to omit
non-stable versions so the best strategy is to only include a known
stable minor version as the max version in the range.

## Related
* Fixes #1360

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1364)
<!-- Reviewable:end -->
