### PR TITLE
Fix Amazon IAP crash ClassCastException

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/TrackAmazonPurchase.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/TrackAmazonPurchase.java
@@ -85,6 +85,8 @@ class TrackAmazonPurchase {
          logAmazonIAPListenerError(e);
       } catch (NoSuchFieldException e) {
          logAmazonIAPListenerError(e);
+      } catch (ClassCastException e) {
+         logAmazonIAPListenerError(e);
       }
    }
 


### PR DESCRIPTION
## Description
### One Line Summary
Fixes crash when an Amazon In-App purchase is made when some version newer than 2.0.1 of Amazon's IAP library is used.

### Details 
* This crash is due some newer version of Amazon's IAP library than
2.0.1 where a class name was changed.
* This PR simplify fixes the crash issue but does not correctly
address IAPs not longer being tracked for Amazon purchases made with an
app that uses some unknown version newer than 2.0.1 of the IAP library.
* Due to work required to continue automatically track IAPs for newer versions of the library, the fragileness of the reflection that is most likely still required, and demand for continued support the crash is only addressed in this PR.

### Related
* Fixes #1344

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1365)
<!-- Reviewable:end -->
