### PR TITLE
Fix flakiness of notification display time test

### DIFF
--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
@@ -854,7 +854,9 @@ public class GenerateNotificationRunner {
       // Time stamp should be set and within a small range.
       long currentTime = System.currentTimeMillis() / 1000;
       cursor.moveToFirst();
-      assertTrue(cursor.getLong(0) > currentTime - 2 && cursor.getLong(0) <= currentTime);
+      long displayTime = cursor.getLong(0);
+      // Display time on notification record is within 1 second
+      assertTrue((displayTime + 1_000) > currentTime && displayTime <= currentTime);
       cursor.close();
 
       // Should get marked as opened.


### PR DESCRIPTION
* Changed test to allow within 1 second instead of 2ms to count
as passing the assert.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1368)
<!-- Reviewable:end -->
