### PR TITLE
Feat/notification accent color dark mode

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotification.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotification.java
@@ -926,17 +926,28 @@ class GenerateNotification {
    }
 
    // Android 5.0 accent color to use, only works when AndroidManifest.xml is targetSdkVersion >= 21
-   private static BigInteger getAccentColor(JSONObject fcmJson) {
+   static BigInteger getAccentColor(JSONObject fcmJson) {
       try {
          if (fcmJson.has("bgac"))
             return new BigInteger(fcmJson.optString("bgac", null), 16);
-      } catch (Throwable t) {} // Can throw a parse error parse error.
+      } catch (Throwable t) {} // Can throw a parse error.
 
+      // Try to get "onesignal_notification_accent_color" from resources
+      // This will get the correct color for day and dark modes
       try {
-         String defaultColor = OSUtils.getManifestMeta(currentContext, "com.onesignal.NotificationAccentColor.DEFAULT");
-         if (defaultColor != null)
+         String defaultColor = getResourceString(OneSignal.appContext, "onesignal_notification_accent_color", null);
+         if (defaultColor != null) {
             return new BigInteger(defaultColor, 16);
-      } catch (Throwable t) {} // Can throw a parse error parse error.
+         }
+      } catch (Throwable t) {} // Can throw a parse error.
+
+      // Get accent color from Manifest
+      try {
+         String defaultColor = OSUtils.getManifestMeta(OneSignal.appContext, "com.onesignal.NotificationAccentColor.DEFAULT");
+         if (defaultColor != null) {
+            return new BigInteger(defaultColor, 16);
+         }
+      } catch (Throwable t) {} // Can throw a parse error.
 
       return null;
    }

--- a/OneSignalSDK/unittest/src/main/res/values-night/strings.xml
+++ b/OneSignalSDK/unittest/src/main/res/values-night/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="onesignal_notification_accent_color">FFFF0000</string>
+</resources>

--- a/OneSignalSDK/unittest/src/main/res/values/strings.xml
+++ b/OneSignalSDK/unittest/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="onesignal_notification_accent_color">FF00FF00</string>
+</resources>

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
@@ -17,6 +17,7 @@ import org.json.JSONObject;
 import org.robolectric.util.Scheduler;
 
 import java.lang.reflect.Field;
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -125,6 +126,10 @@ public class OneSignalPackagePrivateHelper {
 
    public static void OneSignal_handleNotificationOpen(Activity context, final JSONArray data, final boolean fromAlert, final String notificationId) {
       OneSignal.handleNotificationOpen(context, data, fromAlert, notificationId);
+   }
+
+   public static BigInteger OneSignal_getAccentColor(JSONObject fcmJson) {
+      return GenerateNotification.getAccentColor(fcmJson);
    }
 
    public static BundleCompat createInternalPayloadBundle(Bundle bundle) {

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowResources.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowResources.java
@@ -1,0 +1,14 @@
+package com.onesignal;
+
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+
+@Implements(value = android.content.res.Resources.class)
+public class ShadowResources {
+
+    // Returns 0 to mimic no resources found
+    @Implementation
+    public int getIdentifier(String name, String defType, String defPackage) {
+        return 0;
+    }
+}

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
@@ -75,6 +75,7 @@ import com.onesignal.ShadowOSWebView;
 import com.onesignal.ShadowOneSignal;
 import com.onesignal.ShadowOneSignalRestClient;
 import com.onesignal.ShadowReceiveReceiptController;
+import com.onesignal.ShadowResources;
 import com.onesignal.ShadowRoboNotificationManager;
 import com.onesignal.ShadowRoboNotificationManager.PostedNotification;
 import com.onesignal.ShadowTimeoutHandler;
@@ -119,6 +120,7 @@ import static com.onesignal.OneSignalPackagePrivateHelper.NotificationBundleProc
 import static com.onesignal.OneSignalPackagePrivateHelper.NotificationBundleProcessor_ProcessFromFCMIntentService_NoWrap;
 import static com.onesignal.OneSignalPackagePrivateHelper.NotificationOpenedProcessor_processFromContext;
 import static com.onesignal.OneSignalPackagePrivateHelper.NotificationSummaryManager_updateSummaryNotificationAfterChildRemoved;
+import static com.onesignal.OneSignalPackagePrivateHelper.OneSignal_getAccentColor;
 import static com.onesignal.OneSignalPackagePrivateHelper.OneSignal_setTime;
 import static com.onesignal.OneSignalPackagePrivateHelper.OneSignal_setupNotificationServiceExtension;
 import static com.onesignal.OneSignalPackagePrivateHelper.createInternalPayloadBundle;
@@ -246,7 +248,7 @@ public class GenerateNotificationRunner {
    private Intent createOpenIntent(Bundle bundle) {
       return createOpenIntent(ShadowRoboNotificationManager.lastNotifId, bundle);
    }
-   
+
    @Test
    @Config (sdk = 22, shadows = { ShadowGenerateNotification.class })
    public void shouldSetTitleCorrectly() throws Exception {
@@ -1411,7 +1413,6 @@ public class GenerateNotificationRunner {
       // 2. Add app context and setup the established notification extension service
       OneSignal.initWithContext(ApplicationProvider.getApplicationContext());
       OneSignal_setupNotificationServiceExtension();
-
       final boolean[] callbackEnded = {false};
       OneSignalPackagePrivateHelper.ProcessBundleReceiverCallback processBundleReceiverCallback = new OneSignalPackagePrivateHelper.ProcessBundleReceiverCallback() {
          public void onBundleProcessed(OneSignalPackagePrivateHelper.ProcessedBundleResult processedResult) {
@@ -2301,6 +2302,59 @@ public class GenerateNotificationRunner {
 
       // 5. Make sure 1 notification exists in DB
       assertNotificationDbRecords(1);
+   }
+
+   /**
+    * Small icon accent color uses string.xml value in values-night when device in dark mode
+    */
+   @Test
+   @Config(qualifiers = "night")
+   public void shouldUseDarkIconAccentColorInDarkMode_hasMetaData() throws Exception {
+      OneSignal.initWithContext(blankActivity);
+      // Add the 'com.onesignal.NotificationAccentColor.DEFAULT' as 'FF0000AA' meta-data tag
+      OneSignalShadowPackageManager.addManifestMetaData("com.onesignal.NotificationAccentColor.DEFAULT", "FF0000AA");
+
+      BigInteger defaultColor = OneSignal_getAccentColor(new JSONObject());
+      assertEquals("FFFF0000", defaultColor.toString(16).toUpperCase());
+   }
+
+   /**
+    * Small icon accent color uses string.xml value in values when device in day (non-dark) mode
+    */
+   @Test
+   public void shouldUseDayIconAccentColorInDayMode() throws Exception {
+      OneSignal.initWithContext(blankActivity);
+      BigInteger defaultColor = OneSignal_getAccentColor(new JSONObject());
+      assertEquals("FF00FF00", defaultColor.toString(16).toUpperCase());
+   }
+
+   /**
+    * Small icon accent color uses value from Manifest if there are no resource strings provided
+    */
+   @Test
+   @Config(shadows = { ShadowResources.class })
+   public void shouldUseManifestIconAccentColor() throws Exception {
+      OneSignal.initWithContext(blankActivity);
+
+      // Add the 'com.onesignal.NotificationAccentColor.DEFAULT' as 'FF0000AA' meta-data tag
+      OneSignalShadowPackageManager.addManifestMetaData("com.onesignal.NotificationAccentColor.DEFAULT", "FF0000AA");
+
+      BigInteger defaultColor = OneSignal_getAccentColor(new JSONObject());
+      assertEquals("FF0000AA", defaultColor.toString(16).toUpperCase());
+   }
+
+   /**
+    * Small icon accent color uses value of 'bgac' if available
+    */
+   @Test
+   public void shouldUseBgacAccentColor_hasMetaData() throws Exception {
+      OneSignal.initWithContext(blankActivity);
+      // Add the 'com.onesignal.NotificationAccentColor.DEFAULT' as 'FF0000AA' meta-data tag
+      OneSignalShadowPackageManager.addManifestMetaData("com.onesignal.NotificationAccentColor.DEFAULT", "FF0000AA");
+      JSONObject fcmJson = new JSONObject();
+      fcmJson.put("bgac", "FF0F0F0F");
+      BigInteger defaultColor = OneSignal_getAccentColor(fcmJson);
+      assertEquals("FF0F0F0F", defaultColor.toString(16).toUpperCase());
    }
 
    /* Helpers */


### PR DESCRIPTION
## Issue
Notification accent color set in `strings.xml` in `values-night` folder were not being used when a device is in dark mode. The color was set in the manifest metadata `com.onesignal.NotificationAccentColor.DEFAULT` and did not seem to grab the night values.

## Solution
Get the resource string directly in `GenerateNotification.getAccentColor()`. Users will need to put `<string name="onesignal_notification_accent_color">` in their resources instead of in the manifest. Documentation will need to be updated as well.

## Tests
The following tests were written in `GenerateNotificationRunner.java`:

- shouldUseDarkIconAccentColorInDarkMode_hasMetaData
- shouldUseDayIconAccentColorInDayMode
- shouldUseManifestIconAccentColor
- shouldUseBgacAccentColor_hasMetaData

In order to test, I removed the `private` keyword from getAccentColor().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1370)
<!-- Reviewable:end -->
