### PR TITLE
Fix possible NullPointerException under notValidOrDuplicated

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/ADMMessageHandler.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/ADMMessageHandler.java
@@ -93,7 +93,6 @@ public class ADMMessageHandler extends ADMMessageHandlerBase {
          }
       };
       NotificationBundleProcessor.processBundleFromReceiver(context, bundle, bundleReceiverCallback);
-
    }
 
    @Override

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/FCMIntentJobService.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/FCMIntentJobService.java
@@ -26,6 +26,7 @@ public class FCMIntentJobService extends JobIntentService {
         if (bundle == null)
             return;
 
+        OneSignal.initWithContext(this);
         processBundleFromReceiver(this, bundle, new NotificationBundleProcessor.ProcessBundleReceiverCallback() {
             @Override
             public void onBundleProcessed(@Nullable NotificationBundleProcessor.ProcessedBundleResult processedResult) {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/FCMIntentService.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/FCMIntentService.java
@@ -63,6 +63,7 @@ public class FCMIntentService extends IntentService {
       if (bundle == null)
          return;
 
+      OneSignal.initWithContext(this);
       NotificationBundleProcessor.ProcessBundleReceiverCallback bundleReceiverCallback = new NotificationBundleProcessor.ProcessBundleReceiverCallback() {
          @Override
          public void onBundleProcessed(@Nullable NotificationBundleProcessor.ProcessedBundleResult processedResult) {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
@@ -366,7 +366,9 @@ class NotificationBundleProcessor {
       cursor.close();
    }
 
-    //  Process bundle passed from fcm / adm broadcast receiver.
+    /**
+     * Process bundle passed from FCM / HMS / ADM broadcast receiver
+     * */
     static void processBundleFromReceiver(Context context, final Bundle bundle, final ProcessBundleReceiverCallback bundleReceiverCallback) {
         final ProcessedBundleResult bundleResult = new ProcessedBundleResult();
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
@@ -110,7 +110,7 @@ class NotificationBundleProcessor {
                 }
             };
 
-            OneSignal.notValidOrDuplicated(jsonPayload, callback);
+            OneSignal.notValidOrDuplicated(context, jsonPayload, callback);
         } catch (JSONException e) {
             e.printStackTrace();
         }
@@ -474,7 +474,7 @@ class NotificationBundleProcessor {
             }
         };
 
-        OneSignal.notValidOrDuplicated(jsonPayload, callback);
+        OneSignal.notValidOrDuplicated(context, jsonPayload, callback);
     }
 
     static @NonNull

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationDataController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationDataController.java
@@ -6,6 +6,9 @@ import android.content.Context;
 import android.database.Cursor;
 import android.os.Process;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import com.onesignal.OneSignalDbContract.NotificationTable;
 
 import org.json.JSONObject;
@@ -188,7 +191,7 @@ class OSNotificationDataController extends OSBackgroundManager {
         runRunnableOnThread(runCancelNotification, OS_NOTIFICATIONS_THREAD);
     }
 
-    void notValidOrDuplicated(JSONObject jsonPayload, final InvalidOrDuplicateNotificationCallback callback) {
+    void notValidOrDuplicated(@Nullable JSONObject jsonPayload, @NonNull final InvalidOrDuplicateNotificationCallback callback) {
         String id = OSNotificationFormatHelper.getOSNotificationIdFromJson(jsonPayload);
         if (id == null) {
             logger.debug("Notification notValidOrDuplicated with id null");
@@ -199,7 +202,7 @@ class OSNotificationDataController extends OSBackgroundManager {
         isDuplicateNotification(id, callback);
     }
 
-    private void isDuplicateNotification(final String id, final InvalidOrDuplicateNotificationCallback callback) {
+    private void isDuplicateNotification(final String id, @NonNull final InvalidOrDuplicateNotificationCallback callback) {
         if (id == null || "".equals(id)) {
             callback.onResult(false);
             return;


### PR DESCRIPTION
NullPointerException was happening when calling notValidOrDuplicated under an OSNotificationDataController not inited; this can occur if for some reason OSNotificationDataController got cleaned from memory, or the notification processing doesn't call initWithContext.

Task:
* Init notificationDataController if controller is null
* Add description to notValidOrDuplicated method

Fixes https://github.com/OneSignal/OneSignal-Android-SDK/issues/1357

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1372)
<!-- Reviewable:end -->
