### PR TITLE
ClassCastException due to casting Application to Context

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/DelayedConsentInitializationParameters.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/DelayedConsentInitializationParameters.java
@@ -31,11 +31,19 @@ import android.content.Context;
 
 class DelayedConsentInitializationParameters {
 
-    Context context;
-    String appId;
+    private final Context context;
+    private final String appId;
 
     DelayedConsentInitializationParameters(Context delayContext, String delayAppId) {
         this.context = delayContext;
         this.appId = delayAppId;
+    }
+
+    Context getContext() {
+        return context;
+    }
+
+    String getAppId() {
+        return appId;
     }
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -698,10 +698,12 @@ public class OneSignal {
          return;
       }
 
-      boolean wasAppContextNull = (appContext == null);
-      appContext = context.getApplicationContext();
       if (context instanceof Activity)
          appActivity = new WeakReference<>((Activity) context);
+
+      boolean wasAppContextNull = (appContext == null);
+      appContext = context.getApplicationContext();
+
       setupContextListeners(wasAppContextNull);
       setupPrivacyConsent(appContext);
 
@@ -756,12 +758,12 @@ public class OneSignal {
             logger.verbose("OneSignal SDK initialization delayed, " +
                     "waiting for privacy consent to be set.");
 
-         delayedInitParams = new DelayedConsentInitializationParameters(context, appId);
+         delayedInitParams = new DelayedConsentInitializationParameters(appContext, appId);
          String lastAppId = appId;
          // Set app id null since OneSignal was not init fully
          appId = null;
          // Wrapper SDK's call init twice and pass null as the appId on the first call
-         //  the app ID is required to download parameters, so do not download params until the appID is provided
+         // the app ID is required to download parameters, so do not download params until the appID is provided
          if (lastAppId != null && context != null)
             makeAndroidParamsRequest(lastAppId, getUserId(), false);
          return;
@@ -889,11 +891,13 @@ public class OneSignal {
 
    private static void handleActivityLifecycleHandler(Context context) {
       ActivityLifecycleHandler activityLifecycleHandler = ActivityLifecycleListener.getActivityLifecycleHandler();
-      setInForeground(OneSignal.getCurrentActivity() != null || context instanceof Activity);
+      boolean isContextActivity = context instanceof Activity;
+      boolean isCurrentActivityNull = OneSignal.getCurrentActivity() == null;
+      setInForeground(!isCurrentActivityNull || isContextActivity);
       logger.debug("OneSignal handleActivityLifecycleHandler inForeground: " + inForeground);
 
       if (inForeground) {
-         if (OneSignal.getCurrentActivity() == null && activityLifecycleHandler != null) {
+         if (isCurrentActivityNull && isContextActivity && activityLifecycleHandler != null) {
             activityLifecycleHandler.setCurActivity((Activity) context);
             activityLifecycleHandler.setNextResumeIsFirstActivity(true);
          }
@@ -1086,8 +1090,8 @@ public class OneSignal {
          delayedContext = appContext;
          logger.error("Trying to continue OneSignal with null delayed params");
       } else {
-         delayedAppId = delayedInitParams.appId;
-         delayedContext = delayedInitParams.context;
+         delayedAppId = delayedInitParams.getAppId();
+         delayedContext = delayedInitParams.getContext();
       }
 
       logger.debug("reassignDelayedInitParams with appContext: " + appContext);


### PR DESCRIPTION
Inside handleActivityLifecycleHandler, a race condition might happen when current activity might change from available to null.

* Save boolean state inside variables to avoid state changes
* Check if the context is activity before casting
* Avoid saving activity context inside DelayedConsentInitializationParameters; only keep application context
* Improve encapsulation of DelayedConsentInitializationParameters

Fixes: https://github.com/OneSignal/OneSignal-Android-SDK/issues/1297

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1373)
<!-- Reviewable:end -->
