### PR TITLE
Remove kotlin extension plugin

### DIFF
--- a/OneSignalSDK/onesignal/build.gradle
+++ b/OneSignalSDK/onesignal/build.gradle
@@ -6,7 +6,6 @@ ext {
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion rootProject.buildVersions.compileSdkVersion


### PR DESCRIPTION
* Plugin has been deprecated, and is not needed for kotlin support from the SDK

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1383)
<!-- Reviewable:end -->
