### PR TITLE
WIP - Move send saved outcomes to foreground

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSOutcomeEventsController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSOutcomeEventsController.java
@@ -32,6 +32,8 @@ class OSOutcomeEventsController {
     @NonNull
     private final OSSessionManager osSessionManager;
 
+    private boolean savedOutcomesSent = false;
+
     public OSOutcomeEventsController(@NonNull OSSessionManager osSessionManager, @NonNull OSOutcomeEventsFactory outcomeEventsFactory) {
         this.osSessionManager = osSessionManager;
         this.outcomeEventsFactory = outcomeEventsFactory;
@@ -79,6 +81,9 @@ class OSOutcomeEventsController {
      * Cached outcomes come from the failure callback of the network request
      */
     void sendSavedOutcomes() {
+        // Only try to send saved outcomes once per session
+        if (savedOutcomesSent)
+            return;
         new Thread(new Runnable() {
             @Override
             public void run() {
@@ -88,6 +93,7 @@ class OSOutcomeEventsController {
                 for (OSOutcomeEventParams event : outcomeEvents) {
                     sendSavedOutcomeEvent(event);
                 }
+                savedOutcomesSent = true;
             }
         }, OS_SEND_SAVED_OUTCOMES).start();
     }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -812,8 +812,6 @@ public class OneSignal {
       initDone = true;
       OneSignal.Log(LOG_LEVEL.VERBOSE, "OneSignal SDK initialization done.");
 
-      outcomeEventsController.sendSavedOutcomes();
-
       // Clean up any pending tasks that were queued up before initialization
       taskRemoteController.startPendingTasks();
    }
@@ -1367,6 +1365,10 @@ public class OneSignal {
          trackFirebaseAnalytics.trackInfluenceOpenEvent();
 
       OSSyncService.getInstance().cancelSyncTask(appContext);
+
+      // Avoid sending saved Outcomes when app in background, this will improve battery usage
+      if (outcomeEventsController != null)
+         outcomeEventsController.sendSavedOutcomes();
    }
 
    static void addNetType(JSONObject jsonObj) {


### PR DESCRIPTION
* Send saved outcomes when the app is in the foreground, avoid using battery when the app is in background
* Add check to send only once per active session

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1390)
<!-- Reviewable:end -->
