### PR TITLE
make PendingIntents compatible with Android 12

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotification.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotification.java
@@ -133,11 +133,29 @@ class GenerateNotification {
     * on weird UI interaction
     */
    private static PendingIntent getNewActionPendingIntent(int requestCode, Intent intent) {
-      return PendingIntent.getActivity(currentContext, requestCode, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+      final int flags;
+
+      if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
+         flags = PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE;
+
+      } else {
+         flags = PendingIntent.FLAG_UPDATE_CURRENT;
+      }
+
+      return PendingIntent.getActivity(currentContext, requestCode, intent, flags);
    }
 
    private static PendingIntent getNewDismissActionPendingIntent(int requestCode, Intent intent) {
-      return PendingIntent.getBroadcast(currentContext, requestCode, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+      final int flags;
+
+      if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
+         flags = PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE;
+
+      } else {
+         flags = PendingIntent.FLAG_UPDATE_CURRENT;
+      }
+
+      return PendingIntent.getBroadcast(currentContext, requestCode, intent, flags);
    }
 
    private static Intent getNewBaseIntent(int notificationId) {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSBackgroundSync.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSBackgroundSync.java
@@ -174,11 +174,21 @@ abstract class OSBackgroundSync {
         // KEEP - PendingIntent.FLAG_UPDATE_CURRENT
         //          Some Samsung devices will throw the below exception otherwise.
         //          "java.lang.SecurityException: !@Too many alarms (500) registered"
+
+        final int flags;
+
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
+            flags = PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE;
+
+        } else {
+            flags = PendingIntent.FLAG_UPDATE_CURRENT;
+        }
+
         return PendingIntent.getService(
                 context,
                 getSyncTaskId(),
                 new Intent(context, getSyncServicePendingIntentClass()),
-                PendingIntent.FLAG_UPDATE_CURRENT
+                flags
         );
     }
 


### PR DESCRIPTION
Because Android 12 forces mutability to be specified when creating a PendingIntent I got a couple of errors in logcat when starting my app targeting Android SDK 31 (Android 12).
https://developer.android.com/about/versions/12/behavior-changes-12#pending-intent-mutability

This PR fixes those issues on OneSignal side. (https://github.com/OneSignal/OneSignal-Android-SDK/issues/1408)
The be fully compatible we would need to upgrade workmanager to at least `2.7.0-alpha05` but I think that we should wait with that until `2.7.0` is stable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1400)
<!-- Reviewable:end -->
