### PR TITLE
No longer firing willShowInForegroundHandler for restoring notifications

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
@@ -146,7 +146,7 @@ class NotificationBundleProcessor {
 
         if (doDisplay) {
             androidNotificationId = notificationJob.getAndroidId();
-            if (fromBackgroundLogic && OneSignal.shouldFireForegroundHandlers()) {
+            if (fromBackgroundLogic && OneSignal.shouldFireForegroundHandlers(notificationJob)) {
                 notificationController.setFromBackgroundLogic(false);
                 OneSignal.fireForegroundHandlers(notificationController);
                 // Notification will be processed by foreground user complete or timer complete

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -2299,7 +2299,7 @@ public class OneSignal {
     * <br/><br/>
     * @see OSNotificationWillShowInForegroundHandler
     */
-   static boolean shouldFireForegroundHandlers() {
+   static boolean shouldFireForegroundHandlers(OSNotificationGenerationJob notificationJob) {
       if (!isInForeground()) {
          OneSignal.onesignalLog(LOG_LEVEL.INFO, "App is in background, show notification");
          return false;
@@ -2307,6 +2307,12 @@ public class OneSignal {
 
       if (notificationWillShowInForegroundHandler == null) {
          OneSignal.onesignalLog(LOG_LEVEL.INFO, "No NotificationWillShowInForegroundHandler setup, show notification");
+         return false;
+      }
+
+      // Notification is restored. Don't fire for restored notifications.
+      if (notificationJob.isRestoring()) {
+         OneSignal.onesignalLog(LOG_LEVEL.INFO, "Not firing notificationWillShowInForegroundHandler for restored notifications");
          return false;
       }
 


### PR DESCRIPTION
We will now check that a notification is not restoring before firing the willShowInForegroundHandler. This avoids a problem where the handler fires on reinstall if there were previously unread notifications.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1403)
<!-- Reviewable:end -->
