### PR TITLE
IAM Lifecycle Events

### DIFF
--- a/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/application/MainApplication.java
+++ b/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/application/MainApplication.java
@@ -5,6 +5,8 @@ import android.util.Log;
 import androidx.multidex.MultiDexApplication;
 
 import com.onesignal.OSNotification;
+import com.onesignal.OSNotificationOpenedResult;
+import com.onesignal.OSIAMLifecycleHandler;
 import com.onesignal.OneSignal;
 import com.onesignal.sdktest.R;
 import com.onesignal.sdktest.constant.Tag;
@@ -18,6 +20,27 @@ public class MainApplication extends MultiDexApplication {
     @Override
     public void onCreate() {
         super.onCreate();
+
+        OSIAMLifecycleHandler handler = new OSIAMLifecycleHandler() {
+            @Override
+            public void onWillDisplayInAppMessage(String message) {
+                return;
+            }
+            @Override
+            public void onDidDisplayInAppMessage(String message) {
+                return;
+            }
+            @Override
+            public void onWillDismissInAppMessage(String message) {
+                return;
+            }
+            @Override
+            public void onDidDismissInAppMessage(String message) {
+                return;
+            }
+        };
+
+        OneSignal.setIAMLifecycleHandler(handler);
 
         OneSignal.setLogLevel(OneSignal.LOG_LEVEL.VERBOSE, OneSignal.LOG_LEVEL.NONE);
 

--- a/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/application/MainApplication.java
+++ b/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/application/MainApplication.java
@@ -25,19 +25,19 @@ public class MainApplication extends MultiDexApplication {
         OSIAMLifecycleHandler handler = new OSIAMLifecycleHandler() {
             @Override
             public void onWillDisplayInAppMessage(OSInAppMessage message) {
-                return;
+                OneSignal.onesignalLog(OneSignal.LOG_LEVEL.VERBOSE, "MainApplication onWillDisplayInAppMessage");
             }
             @Override
             public void onDidDisplayInAppMessage(OSInAppMessage message) {
-                return;
+                OneSignal.onesignalLog(OneSignal.LOG_LEVEL.VERBOSE, "MainApplication onDidDisplayInAppMessage");
             }
             @Override
             public void onWillDismissInAppMessage(OSInAppMessage message) {
-                return;
+                OneSignal.onesignalLog(OneSignal.LOG_LEVEL.VERBOSE, "MainApplication onWillDismissInAppMessage");
             }
             @Override
             public void onDidDismissInAppMessage(OSInAppMessage message) {
-                return;
+                OneSignal.onesignalLog(OneSignal.LOG_LEVEL.VERBOSE, "MainApplication onDidDismissInAppMessage");
             }
         };
 

--- a/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/application/MainApplication.java
+++ b/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/application/MainApplication.java
@@ -4,6 +4,7 @@ import android.util.Log;
 
 import androidx.multidex.MultiDexApplication;
 
+import com.onesignal.OSInAppMessage;
 import com.onesignal.OSNotification;
 import com.onesignal.OSNotificationOpenedResult;
 import com.onesignal.OSIAMLifecycleHandler;
@@ -23,19 +24,19 @@ public class MainApplication extends MultiDexApplication {
 
         OSIAMLifecycleHandler handler = new OSIAMLifecycleHandler() {
             @Override
-            public void onWillDisplayInAppMessage(String message) {
+            public void onWillDisplayInAppMessage(OSInAppMessage message) {
                 return;
             }
             @Override
-            public void onDidDisplayInAppMessage(String message) {
+            public void onDidDisplayInAppMessage(OSInAppMessage message) {
                 return;
             }
             @Override
-            public void onWillDismissInAppMessage(String message) {
+            public void onWillDismissInAppMessage(OSInAppMessage message) {
                 return;
             }
             @Override
-            public void onDidDismissInAppMessage(String message) {
+            public void onDidDismissInAppMessage(OSInAppMessage message) {
                 return;
             }
         };

--- a/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/application/MainApplication.java
+++ b/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/application/MainApplication.java
@@ -6,8 +6,7 @@ import androidx.multidex.MultiDexApplication;
 
 import com.onesignal.OSInAppMessage;
 import com.onesignal.OSNotification;
-import com.onesignal.OSNotificationOpenedResult;
-import com.onesignal.OSIAMLifecycleHandler;
+import com.onesignal.OSInAppMessageLifecycleHandler;
 import com.onesignal.OneSignal;
 import com.onesignal.sdktest.R;
 import com.onesignal.sdktest.constant.Tag;
@@ -22,7 +21,7 @@ public class MainApplication extends MultiDexApplication {
     public void onCreate() {
         super.onCreate();
 
-        OSIAMLifecycleHandler handler = new OSIAMLifecycleHandler() {
+        OSInAppMessageLifecycleHandler handler = new OSInAppMessageLifecycleHandler() {
             @Override
             public void onWillDisplayInAppMessage(OSInAppMessage message) {
                 OneSignal.onesignalLog(OneSignal.LOG_LEVEL.VERBOSE, "MainApplication onWillDisplayInAppMessage");
@@ -41,7 +40,7 @@ public class MainApplication extends MultiDexApplication {
             }
         };
 
-        OneSignal.setIAMLifecycleHandler(handler);
+        OneSignal.setInAppMessageLifecycleHandler(handler);
 
         OneSignal.setLogLevel(OneSignal.LOG_LEVEL.VERBOSE, OneSignal.LOG_LEVEL.NONE);
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/InAppMessageView.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/InAppMessageView.java
@@ -391,6 +391,9 @@ class InAppMessageView {
 
         scheduleDismissRunnable = new Runnable() {
             public void run() {
+                if (messageController != null) {
+                    messageController.onMessageWillDismiss();
+                }
                 if (currentActivity != null) {
                     dismissAndAwaitNextMessage(null);
                     scheduleDismissRunnable = null;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/InAppMessageView.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/InAppMessageView.java
@@ -61,6 +61,7 @@ class InAppMessageView {
 
     interface InAppMessageViewListener {
         void onMessageWasShown();
+        void onMessageWillDismiss();
         void onMessageWasDismissed();
     }
 
@@ -243,7 +244,6 @@ class InAppMessageView {
 
                 if (messageController != null) {
                     animateInAppMessage(displayLocation, draggableRelativeLayout, parentRelativeLayout);
-                    messageController.onMessageWasShown();
                 }
 
                 startDismissTimerIfNeeded();
@@ -310,6 +310,9 @@ class InAppMessageView {
         draggableRelativeLayout.setListener(new DraggableRelativeLayout.DraggableListener() {
             @Override
             public void onDismiss() {
+                if (messageController != null) {
+                    messageController.onMessageWillDismiss();
+                }
                 finishAfterDelay(null);
             }
 
@@ -489,9 +492,7 @@ class InAppMessageView {
     private void animateInAppMessage(WebViewManager.Position displayLocation, View messageView, View backgroundView) {
         final CardView messageViewCardView = messageView.findViewWithTag(IN_APP_MESSAGE_CARD_VIEW_TAG);
 
-        Animation.AnimationListener cardViewAnimCallback = null;
-        if (Build.VERSION.SDK_INT == Build.VERSION_CODES.M)
-            cardViewAnimCallback = createAnimationListenerForAndroidApi23Elevation(messageViewCardView);
+        Animation.AnimationListener cardViewAnimCallback = createAnimationListener(messageViewCardView);
 
         // Based on the location of the in app message apply and animation to match
         switch (displayLocation) {
@@ -508,7 +509,7 @@ class InAppMessageView {
         }
     }
 
-    private Animation.AnimationListener createAnimationListenerForAndroidApi23Elevation(final CardView messageViewCardView) {
+    private Animation.AnimationListener createAnimationListener(final CardView messageViewCardView) {
         return new Animation.AnimationListener() {
             @Override
             public void onAnimationStart(Animation animation) {
@@ -518,7 +519,12 @@ class InAppMessageView {
             @Override
             public void onAnimationEnd(Animation animation) {
                 // For Android 6 API 23 devices, waits until end of animation to set elevation of CardView class
-                messageViewCardView.setCardElevation(dpToPx(5));
+                if (Build.VERSION.SDK_INT == Build.VERSION_CODES.M) {
+                    messageViewCardView.setCardElevation(dpToPx(5));
+                }
+                if (messageController != null) {
+                    messageController.onMessageWasShown();
+                }
             }
 
             @Override

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSIAMLifecycleHandler.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSIAMLifecycleHandler.java
@@ -1,0 +1,43 @@
+/**
+ * Modified MIT License
+ *
+ * Copyright 2021 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.onesignal;
+
+public abstract class OSIAMLifecycleHandler {
+    public void onWillDisplayInAppMessage(OSInAppMessage message) {
+        OneSignal.Log(OneSignal.LOG_LEVEL.VERBOSE, "OSIAMLifecycleHandler: IAM Will Display: " + message.getMessageId());
+    }
+    public void onDidDisplayInAppMessage(OSInAppMessage message) {
+        OneSignal.Log(OneSignal.LOG_LEVEL.VERBOSE, "OSIAMLifecycleHandler: IAM Did Display: " + message.getMessageId());
+    }
+    public void onWillDismissInAppMessage(OSInAppMessage message) {
+        OneSignal.Log(OneSignal.LOG_LEVEL.VERBOSE, "OSIAMLifecycleHandler: IAM Will Dismiss: " + message.getMessageId());
+    }
+    public void onDidDismissInAppMessage(OSInAppMessage message) {
+        OneSignal.Log(OneSignal.LOG_LEVEL.VERBOSE, "OSIAMLifecycleHandler: IAM Did Dismiss: " + message.getMessageId());
+    }
+}

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessage.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessage.java
@@ -35,9 +35,15 @@ public class OSInAppMessage {
      * The unique identifier for this in-app message
      */
     @NonNull
-    public String messageId;
+    protected String messageId;
 
-    OSInAppMessage(String messageId) {
+    OSInAppMessage(@NonNull String messageId) {
         this.messageId = messageId;
     }
+
+    @NonNull
+    public String getMessageId() {
+        return messageId;
+    }
+
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessage.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessage.java
@@ -1,0 +1,43 @@
+/**
+ * Modified MIT License
+ *
+ * Copyright 2021 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.onesignal;
+
+import androidx.annotation.NonNull;
+
+public class OSInAppMessage {
+
+    /**
+     * The unique identifier for this in-app message
+     */
+    @NonNull
+    public String messageId;
+
+    OSInAppMessage(String messageId) {
+        this.messageId = messageId;
+    }
+}

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageController.java
@@ -45,6 +45,7 @@ class OSInAppMessageController extends OSBackgroundManager implements OSDynamicT
 
     private OSSystemConditionController systemConditionController;
     private OSInAppMessageRepository inAppMessageRepository;
+    private OSInAppMessageLifecycleHandler inAppMessageLifecycleHandler;
 
     OSTriggerController triggerController;
 
@@ -349,38 +350,42 @@ class OSInAppMessageController extends OSBackgroundManager implements OSDynamicT
 
     /**
      * IAM Lifecycle methods
-     * The following methods call the public inAppMessageLifecycleHandler callbacks
+     * The following methods call the public OSInAppMessageLifecycleHandler callbacks
      */
+    void setInAppMessageLifecycleHandler(@Nullable OSInAppMessageLifecycleHandler handler) {
+        inAppMessageLifecycleHandler = handler;
+    }
+
     void onMessageWillDisplay(@NonNull final OSInAppMessageInternal message) {
-        if (OneSignal.inAppMessageLifecycleHandler == null) {
+        if (inAppMessageLifecycleHandler == null) {
             logger.verbose("OSInAppMessageController onMessageWillDisplay: inAppMessageLifecycleHandler is null");
             return;
         }
-        OneSignal.inAppMessageLifecycleHandler.onWillDisplayInAppMessage(message);
+        inAppMessageLifecycleHandler.onWillDisplayInAppMessage(message);
     }
 
     void onMessageDidDisplay(@NonNull final OSInAppMessageInternal message) {
-        if (OneSignal.inAppMessageLifecycleHandler == null) {
+        if (inAppMessageLifecycleHandler == null) {
             logger.verbose("OSInAppMessageController onMessageDidDisplay: inAppMessageLifecycleHandler is null");
             return;
         }
-        OneSignal.inAppMessageLifecycleHandler.onDidDisplayInAppMessage(message);
+        inAppMessageLifecycleHandler.onDidDisplayInAppMessage(message);
     }
 
     void onMessageWillDismiss(@NonNull final OSInAppMessageInternal message) {
-        if (OneSignal.inAppMessageLifecycleHandler == null) {
+        if (inAppMessageLifecycleHandler == null) {
             logger.verbose("OSInAppMessageController onMessageWillDismiss: inAppMessageLifecycleHandler is null");
             return;
         }
-        OneSignal.inAppMessageLifecycleHandler.onWillDismissInAppMessage(message);
+        inAppMessageLifecycleHandler.onWillDismissInAppMessage(message);
     }
 
     void onMessageDidDismiss(@NonNull final OSInAppMessageInternal message) {
-        if (OneSignal.inAppMessageLifecycleHandler == null) {
+        if (inAppMessageLifecycleHandler == null) {
             logger.verbose("OSInAppMessageController onMessageDidDismiss: inAppMessageLifecycleHandler is null");
             return;
         }
-        OneSignal.inAppMessageLifecycleHandler.onDidDismissInAppMessage(message);
+        inAppMessageLifecycleHandler.onDidDismissInAppMessage(message);
     }
 
     /* End IAM Lifecycle methods */

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageController.java
@@ -284,6 +284,9 @@ class OSInAppMessageController extends OSBackgroundManager implements OSDynamicT
     }
 
     void onMessageWasShown(@NonNull final OSInAppMessageInternal message) {
+
+        onMessageDidDisplay(message);
+
         if (message.isPreview)
             return;
 
@@ -344,10 +347,13 @@ class OSInAppMessageController extends OSBackgroundManager implements OSDynamicT
         logInAppMessagePreviewActions(action);
     }
 
-    /* IAM Lifecycle */
+    /**
+     * IAM Lifecycle methods
+     * The following methods call the public inAppMessageLifecycleHandler callbacks
+     */
     void onMessageWillDisplay(@NonNull final OSInAppMessageInternal message) {
         if (OneSignal.inAppMessageLifecycleHandler == null) {
-            OneSignal.onesignalLog(OneSignal.LOG_LEVEL.VERBOSE, "OSInAppMessageController onMessageWillDisplay: inAppMessageLifecycleHandler is null");
+            logger.verbose("OSInAppMessageController onMessageWillDisplay: inAppMessageLifecycleHandler is null");
             return;
         }
         OneSignal.inAppMessageLifecycleHandler.onWillDisplayInAppMessage(message);
@@ -355,7 +361,7 @@ class OSInAppMessageController extends OSBackgroundManager implements OSDynamicT
 
     void onMessageDidDisplay(@NonNull final OSInAppMessageInternal message) {
         if (OneSignal.inAppMessageLifecycleHandler == null) {
-            OneSignal.onesignalLog(OneSignal.LOG_LEVEL.VERBOSE, "OSInAppMessageController onMessageDidDisplay: inAppMessageLifecycleHandler is null");
+            logger.verbose("OSInAppMessageController onMessageDidDisplay: inAppMessageLifecycleHandler is null");
             return;
         }
         OneSignal.inAppMessageLifecycleHandler.onDidDisplayInAppMessage(message);
@@ -363,7 +369,7 @@ class OSInAppMessageController extends OSBackgroundManager implements OSDynamicT
 
     void onMessageWillDismiss(@NonNull final OSInAppMessageInternal message) {
         if (OneSignal.inAppMessageLifecycleHandler == null) {
-            OneSignal.onesignalLog(OneSignal.LOG_LEVEL.VERBOSE, "OSInAppMessageController onMessageWillDismiss: inAppMessageLifecycleHandler is null");
+            logger.verbose("OSInAppMessageController onMessageWillDismiss: inAppMessageLifecycleHandler is null");
             return;
         }
         OneSignal.inAppMessageLifecycleHandler.onWillDismissInAppMessage(message);
@@ -371,11 +377,13 @@ class OSInAppMessageController extends OSBackgroundManager implements OSDynamicT
 
     void onMessageDidDismiss(@NonNull final OSInAppMessageInternal message) {
         if (OneSignal.inAppMessageLifecycleHandler == null) {
-            OneSignal.onesignalLog(OneSignal.LOG_LEVEL.VERBOSE, "OSInAppMessageController onMessageDidDismiss: inAppMessageLifecycleHandler is null");
+            logger.verbose("OSInAppMessageController onMessageDidDismiss: inAppMessageLifecycleHandler is null");
             return;
         }
         OneSignal.inAppMessageLifecycleHandler.onDidDismissInAppMessage(message);
     }
+
+    /* End IAM Lifecycle methods */
 
     private void logInAppMessagePreviewActions(final OSInAppMessageAction action) {
         if (action.getTags() != null)
@@ -654,6 +662,9 @@ class OSInAppMessageController extends OSBackgroundManager implements OSDynamicT
     }
 
     void messageWasDismissed(@NonNull OSInAppMessageInternal message, boolean failed) {
+        if (!failed)
+            onMessageDidDismiss(message);
+
         if (!message.isPreview) {
             dismissedMessages.add(message.messageId);
             // If failed we will retry on next session
@@ -791,6 +802,7 @@ class OSInAppMessageController extends OSBackgroundManager implements OSDynamicT
                                 return;
                             }
                             OneSignal.getSessionManager().onInAppMessageReceived(message.messageId);
+                            onMessageWillDisplay(message);
                             WebViewManager.showHTMLString(message, taggedHTMLString(htmlStr));
                         } catch (JSONException e) {
                             e.printStackTrace();

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageController.java
@@ -346,15 +346,35 @@ class OSInAppMessageController extends OSBackgroundManager implements OSDynamicT
 
     /* IAM Lifecycle */
     void onMessageWillDisplay(@NonNull final OSInAppMessageInternal message) {
+        if (OneSignal.inAppMessageLifecycleHandler == null) {
+            OneSignal.onesignalLog(OneSignal.LOG_LEVEL.VERBOSE, "OSInAppMessageController onMessageWillDisplay: inAppMessageLifecycleHandler is null");
+            return;
+        }
+        OneSignal.inAppMessageLifecycleHandler.onWillDisplayInAppMessage(message);
     }
 
     void onMessageDidDisplay(@NonNull final OSInAppMessageInternal message) {
+        if (OneSignal.inAppMessageLifecycleHandler == null) {
+            OneSignal.onesignalLog(OneSignal.LOG_LEVEL.VERBOSE, "OSInAppMessageController onMessageDidDisplay: inAppMessageLifecycleHandler is null");
+            return;
+        }
+        OneSignal.inAppMessageLifecycleHandler.onDidDisplayInAppMessage(message);
     }
 
     void onMessageWillDismiss(@NonNull final OSInAppMessageInternal message) {
+        if (OneSignal.inAppMessageLifecycleHandler == null) {
+            OneSignal.onesignalLog(OneSignal.LOG_LEVEL.VERBOSE, "OSInAppMessageController onMessageWillDismiss: inAppMessageLifecycleHandler is null");
+            return;
+        }
+        OneSignal.inAppMessageLifecycleHandler.onWillDismissInAppMessage(message);
     }
 
     void onMessageDidDismiss(@NonNull final OSInAppMessageInternal message) {
+        if (OneSignal.inAppMessageLifecycleHandler == null) {
+            OneSignal.onesignalLog(OneSignal.LOG_LEVEL.VERBOSE, "OSInAppMessageController onMessageDidDismiss: inAppMessageLifecycleHandler is null");
+            return;
+        }
+        OneSignal.inAppMessageLifecycleHandler.onDidDismissInAppMessage(message);
     }
 
     private void logInAppMessagePreviewActions(final OSInAppMessageAction action) {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageController.java
@@ -662,8 +662,6 @@ class OSInAppMessageController extends OSBackgroundManager implements OSDynamicT
     }
 
     void messageWasDismissed(@NonNull OSInAppMessageInternal message, boolean failed) {
-        if (!failed)
-            onMessageDidDismiss(message);
 
         if (!message.isPreview) {
             dismissedMessages.add(message.messageId);
@@ -679,6 +677,9 @@ class OSInAppMessageController extends OSBackgroundManager implements OSDynamicT
             logger.debug("OSInAppMessageController messageWasDismissed dismissedMessages: " + dismissedMessages.toString());
         }
 
+        if (!shouldWaitForPromptsBeforeDismiss())
+            onMessageDidDismiss(message);
+
         dismissCurrentMessage(message);
     }
 
@@ -686,6 +687,10 @@ class OSInAppMessageController extends OSBackgroundManager implements OSDynamicT
         logger.debug("In app message OSInAppMessageController messageWasDismissed by back press: " + message.toString());
         // IAM was not dismissed by user, will be redisplay again until user dismiss it
         dismissCurrentMessage(message);
+    }
+
+    private boolean shouldWaitForPromptsBeforeDismiss() {
+        return currentPrompt != null;
     }
 
     /**
@@ -697,7 +702,7 @@ class OSInAppMessageController extends OSBackgroundManager implements OSDynamicT
         // Remove DIRECT influence due to ClickHandler of ClickAction outcomes
         OneSignal.getSessionManager().onDirectInfluenceFromIAMClickFinished();
 
-        if (currentPrompt != null) {
+        if (shouldWaitForPromptsBeforeDismiss()) {
             logger.debug("Stop evaluateMessageDisplayQueue because prompt is currently displayed");
             return;
         }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageController.java
@@ -856,6 +856,7 @@ class OSInAppMessageController extends OSBackgroundManager implements OSDynamicT
                         pendingHTMLContent = htmlStr;
                         return;
                     }
+                    onMessageWillDisplay(message);
                     WebViewManager.showHTMLString(message, taggedHTMLString(htmlStr));
                 } catch (JSONException e) {
                     e.printStackTrace();

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageController.java
@@ -344,6 +344,19 @@ class OSInAppMessageController extends OSBackgroundManager implements OSDynamicT
         logInAppMessagePreviewActions(action);
     }
 
+    /* IAM Lifecycle */
+    void onMessageWillDisplay(@NonNull final OSInAppMessageInternal message) {
+    }
+
+    void onMessageDidDisplay(@NonNull final OSInAppMessageInternal message) {
+    }
+
+    void onMessageWillDismiss(@NonNull final OSInAppMessageInternal message) {
+    }
+
+    void onMessageDidDismiss(@NonNull final OSInAppMessageInternal message) {
+    }
+
     private void logInAppMessagePreviewActions(final OSInAppMessageAction action) {
         if (action.getTags() != null)
             logger.debug("Tags detected inside of the action click payload, ignoring because action came from IAM preview:: " + action.getTags().toString());

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageDummyController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageDummyController.java
@@ -35,20 +35,20 @@ class OSInAppMessageDummyController extends OSInAppMessageController {
     void receivedInAppMessageJson(@NonNull JSONArray json) throws JSONException { }
 
     @Override
-    void onMessageActionOccurredOnMessage(@NonNull OSInAppMessage message, @NonNull JSONObject actionJson) { }
+    void onMessageActionOccurredOnMessage(@NonNull OSInAppMessageInternal message, @NonNull JSONObject actionJson) { }
 
     @Override
-    void onMessageActionOccurredOnPreview(@NonNull OSInAppMessage message, @NonNull JSONObject actionJson) { }
+    void onMessageActionOccurredOnPreview(@NonNull OSInAppMessageInternal message, @NonNull JSONObject actionJson) { }
 
     @Override
     boolean isInAppMessageShowing() { return false; }
 
     @Nullable
     @Override
-    OSInAppMessage getCurrentDisplayedInAppMessage() { return null; }
+    OSInAppMessageInternal getCurrentDisplayedInAppMessage() { return null; }
 
     @Override
-    public void messageWasDismissed(@NonNull OSInAppMessage message) { }
+    public void messageWasDismissed(@NonNull OSInAppMessageInternal message) { }
 
     @Override
     void displayPreviewMessage(@NonNull String previewUUID) { }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageInternal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageInternal.java
@@ -15,7 +15,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 
-class OSInAppMessageInternal {
+class OSInAppMessageInternal extends OSInAppMessage {
 
     private static final String IAM_ID = "id";
     private static final String IAM_VARIANTS = "variants";
@@ -24,12 +24,6 @@ class OSInAppMessageInternal {
     private static final String DISPLAY_DURATION = "displayDuration";
     private static final String END_TIME = "end_time";
     private static final String HAS_LIQUID = "has_liquid";
-
-    /**
-     * The unique identifier for this in-app message
-     */
-    @NonNull
-    public String messageId;
 
     /**
      * Allows in-app messages to use multiple language variants, or to have variations between
@@ -67,11 +61,12 @@ class OSInAppMessageInternal {
     private boolean hasLiquid;
 
     OSInAppMessageInternal(boolean isPreview) {
+        super("");
         this.isPreview = isPreview;
     }
 
     OSInAppMessageInternal(@NonNull String messageId, @NonNull Set<String> clickIds, boolean displayedInSession, OSInAppMessageRedisplayStats redisplayStats) {
-        this.messageId = messageId;
+        super(messageId);
         this.clickedClickIds = clickIds;
         this.displayedInSession = displayedInSession;
         this.redisplayStats = redisplayStats;
@@ -79,7 +74,7 @@ class OSInAppMessageInternal {
 
     OSInAppMessageInternal(JSONObject json) throws JSONException {
         // initialize simple root properties
-        this.messageId = json.getString(IAM_ID);
+        super(json.getString(IAM_ID));
         this.variants = parseVariants(json.getJSONObject(IAM_VARIANTS));
         this.triggers = parseTriggerJson(json.getJSONArray(IAM_TRIGGERS));
         this.clickedClickIds = new HashSet<>();

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageInternal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageInternal.java
@@ -13,10 +13,9 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.Locale;
 import java.util.Set;
 
-class OSInAppMessage {
+class OSInAppMessageInternal {
 
     private static final String IAM_ID = "id";
     private static final String IAM_VARIANTS = "variants";
@@ -67,18 +66,18 @@ class OSInAppMessage {
     boolean isPreview;
     private boolean hasLiquid;
 
-    OSInAppMessage(boolean isPreview) {
+    OSInAppMessageInternal(boolean isPreview) {
         this.isPreview = isPreview;
     }
 
-    OSInAppMessage(@NonNull String messageId, @NonNull Set<String> clickIds, boolean displayedInSession, OSInAppMessageRedisplayStats redisplayStats) {
+    OSInAppMessageInternal(@NonNull String messageId, @NonNull Set<String> clickIds, boolean displayedInSession, OSInAppMessageRedisplayStats redisplayStats) {
         this.messageId = messageId;
         this.clickedClickIds = clickIds;
         this.displayedInSession = displayedInSession;
         this.redisplayStats = redisplayStats;
     }
 
-    OSInAppMessage(JSONObject json) throws JSONException {
+    OSInAppMessageInternal(JSONObject json) throws JSONException {
         // initialize simple root properties
         this.messageId = json.getString(IAM_ID);
         this.variants = parseVariants(json.getJSONObject(IAM_VARIANTS));
@@ -292,7 +291,7 @@ class OSInAppMessage {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        OSInAppMessage that = (OSInAppMessage) o;
+        OSInAppMessageInternal that = (OSInAppMessageInternal) o;
         return messageId.equals(that.messageId);
     }
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageLifecycleHandler.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageLifecycleHandler.java
@@ -27,17 +27,17 @@
 
 package com.onesignal;
 
-public abstract class OSIAMLifecycleHandler {
+public abstract class OSInAppMessageLifecycleHandler {
     public void onWillDisplayInAppMessage(OSInAppMessage message) {
-        OneSignal.Log(OneSignal.LOG_LEVEL.VERBOSE, "OSIAMLifecycleHandler: IAM Will Display: " + message.getMessageId());
+        OneSignal.Log(OneSignal.LOG_LEVEL.VERBOSE, "OSInAppMessageLifecycleHandler: IAM Will Display: " + message.getMessageId());
     }
     public void onDidDisplayInAppMessage(OSInAppMessage message) {
-        OneSignal.Log(OneSignal.LOG_LEVEL.VERBOSE, "OSIAMLifecycleHandler: IAM Did Display: " + message.getMessageId());
+        OneSignal.Log(OneSignal.LOG_LEVEL.VERBOSE, "OSInAppMessageLifecycleHandler: IAM Did Display: " + message.getMessageId());
     }
     public void onWillDismissInAppMessage(OSInAppMessage message) {
-        OneSignal.Log(OneSignal.LOG_LEVEL.VERBOSE, "OSIAMLifecycleHandler: IAM Will Dismiss: " + message.getMessageId());
+        OneSignal.Log(OneSignal.LOG_LEVEL.VERBOSE, "OSInAppMessageLifecycleHandler: IAM Will Dismiss: " + message.getMessageId());
     }
     public void onDidDismissInAppMessage(OSInAppMessage message) {
-        OneSignal.Log(OneSignal.LOG_LEVEL.VERBOSE, "OSIAMLifecycleHandler: IAM Did Dismiss: " + message.getMessageId());
+        OneSignal.Log(OneSignal.LOG_LEVEL.VERBOSE, "OSInAppMessageLifecycleHandler: IAM Did Dismiss: " + message.getMessageId());
     }
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageRepository.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageRepository.java
@@ -179,7 +179,7 @@ class OSInAppMessageRepository {
     }
 
     @WorkerThread
-    synchronized void saveInAppMessage(OSInAppMessage inAppMessage) {
+    synchronized void saveInAppMessage(OSInAppMessageInternal inAppMessage) {
         ContentValues values = new ContentValues();
         values.put(OneSignalDbContract.InAppMessageTable.COLUMN_NAME_MESSAGE_ID, inAppMessage.messageId);
         values.put(OneSignalDbContract.InAppMessageTable.COLUMN_NAME_DISPLAY_QUANTITY, inAppMessage.getRedisplayStats().getDisplayQuantity());
@@ -194,8 +194,8 @@ class OSInAppMessageRepository {
     }
 
     @WorkerThread
-    synchronized List<OSInAppMessage> getCachedInAppMessages() {
-        List<OSInAppMessage> inAppMessages = new ArrayList<>();
+    synchronized List<OSInAppMessageInternal> getCachedInAppMessages() {
+        List<OSInAppMessageInternal> inAppMessages = new ArrayList<>();
         Cursor cursor = null;
 
         try {
@@ -219,7 +219,7 @@ class OSInAppMessageRepository {
 
                     Set<String> clickIdsSet = OSUtils.newStringSetFromJSONArray(new JSONArray(clickIds));
 
-                    OSInAppMessage inAppMessage = new OSInAppMessage(messageId, clickIdsSet, displayed, new OSInAppMessageRedisplayStats(displayQuantity, lastDisplay));
+                    OSInAppMessageInternal inAppMessage = new OSInAppMessageInternal(messageId, clickIdsSet, displayed, new OSInAppMessageRedisplayStats(displayQuantity, lastDisplay));
                     inAppMessages.add(inAppMessage);
                 } while (cursor.moveToNext());
             }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSTaskRemoteController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSTaskRemoteController.java
@@ -28,6 +28,7 @@ class OSTaskRemoteController extends OSTaskController {
     static final String REMOVE_GROUPED_NOTIFICATIONS = "removeGroupedNotifications()";
     static final String REMOVE_NOTIFICATION = "removeNotification()";
     static final String PAUSE_IN_APP_MESSAGES = "pauseInAppMessages()";
+    static final String SET_IN_APP_MESSAGE_LIFECYCLE_HANDLER = "setInAppMessageLifecycleHandler()";
     static final String APP_LOST_FOCUS = "onAppLostFocus()";
     static final String SEND_OUTCOME = "sendOutcome()";
     static final String SEND_UNIQUE_OUTCOME = "sendUniqueOutcome()";

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSTriggerController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSTriggerController.java
@@ -30,7 +30,7 @@ class OSTriggerController {
      * AND conditions. If all of the triggers in an inner array evaluate to true, it means the
      * message should be shown and the function returns true.
      */
-    boolean evaluateMessageTriggers(@NonNull OSInAppMessage message) {
+    boolean evaluateMessageTriggers(@NonNull OSInAppMessageInternal message) {
         // If there are no triggers then we display the In-App when a new session is triggered
         if (message.triggers.size() == 0)
             return true;
@@ -180,7 +180,7 @@ class OSTriggerController {
      *
      * If trigger key is part of message triggers, then return true, otherwise false
      * */
-    boolean isTriggerOnMessage(OSInAppMessage message, Collection<String> newTriggersKeys) {
+    boolean isTriggerOnMessage(OSInAppMessageInternal message, Collection<String> newTriggersKeys) {
         if (message.triggers == null)
             return false;
 
@@ -205,7 +205,7 @@ class OSTriggerController {
      *
      * If message has only dynamic trigger return true, otherwise false
      * */
-    boolean messageHasOnlyDynamicTriggers(OSInAppMessage message) {
+    boolean messageHasOnlyDynamicTriggers(OSInAppMessageInternal message) {
         if (message.triggers == null || message.triggers.isEmpty())
             return false;
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -376,7 +376,6 @@ public class OneSignal {
    static OSNotificationWillShowInForegroundHandler notificationWillShowInForegroundHandler;
    static OSNotificationOpenedHandler notificationOpenedHandler;
    static OSInAppMessageClickHandler inAppMessageClickHandler;
-   static OSInAppMessageLifecycleHandler inAppMessageLifecycleHandler;
 
    // Is the init() of OneSignal SDK finished yet
    private static boolean initDone;
@@ -741,8 +740,20 @@ public class OneSignal {
       notificationWillShowInForegroundHandler = callback;
    }
 
-   public static void setInAppMessageLifecycleHandler(@Nullable OSInAppMessageLifecycleHandler handler) {
-      inAppMessageLifecycleHandler = handler;
+   public static void setInAppMessageLifecycleHandler(@Nullable final OSInAppMessageLifecycleHandler handler) {
+      if (appContext == null) {
+         logger.error("Waiting initWithContext. " +
+                 "Moving " + OSTaskRemoteController.SET_IN_APP_MESSAGE_LIFECYCLE_HANDLER + " operation to a pending task queue.");
+         taskRemoteController.addTaskToQueue(new Runnable() {
+            @Override
+            public void run() {
+               logger.debug("Running " + OSTaskRemoteController.SET_IN_APP_MESSAGE_LIFECYCLE_HANDLER + " operation from pending queue.");
+               setInAppMessageLifecycleHandler(handler);
+            }
+         });
+         return;
+      }
+      getInAppMessageController().setInAppMessageLifecycleHandler(handler);
    }
 
    public static void setNotificationOpenedHandler(@Nullable OSNotificationOpenedHandler callback) {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -740,6 +740,10 @@ public class OneSignal {
       notificationWillShowInForegroundHandler = callback;
    }
 
+   public static void setIAMLifecycleHandler(@Nullable OSIAMLifecycleHandler handler) {
+
+   }
+
    public static void setNotificationOpenedHandler(@Nullable OSNotificationOpenedHandler callback) {
       notificationOpenedHandler = callback;
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -376,6 +376,7 @@ public class OneSignal {
    static OSNotificationWillShowInForegroundHandler notificationWillShowInForegroundHandler;
    static OSNotificationOpenedHandler notificationOpenedHandler;
    static OSInAppMessageClickHandler inAppMessageClickHandler;
+   static OSIAMLifecycleHandler inAppMessageLifecycleHandler;
 
    // Is the init() of OneSignal SDK finished yet
    private static boolean initDone;
@@ -741,7 +742,7 @@ public class OneSignal {
    }
 
    public static void setIAMLifecycleHandler(@Nullable OSIAMLifecycleHandler handler) {
-
+      inAppMessageLifecycleHandler = handler;
    }
 
    public static void setNotificationOpenedHandler(@Nullable OSNotificationOpenedHandler callback) {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -376,7 +376,7 @@ public class OneSignal {
    static OSNotificationWillShowInForegroundHandler notificationWillShowInForegroundHandler;
    static OSNotificationOpenedHandler notificationOpenedHandler;
    static OSInAppMessageClickHandler inAppMessageClickHandler;
-   static OSIAMLifecycleHandler inAppMessageLifecycleHandler;
+   static OSInAppMessageLifecycleHandler inAppMessageLifecycleHandler;
 
    // Is the init() of OneSignal SDK finished yet
    private static boolean initDone;
@@ -741,7 +741,7 @@ public class OneSignal {
       notificationWillShowInForegroundHandler = callback;
    }
 
-   public static void setIAMLifecycleHandler(@Nullable OSIAMLifecycleHandler handler) {
+   public static void setInAppMessageLifecycleHandler(@Nullable OSInAppMessageLifecycleHandler handler) {
       inAppMessageLifecycleHandler = handler;
    }
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/WebViewManager.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/WebViewManager.java
@@ -62,7 +62,7 @@ class WebViewManager extends ActivityLifecycleHandler.ActivityAvailableListener 
     @Nullable protected static WebViewManager lastInstance = null;
 
     @NonNull private Activity activity;
-    @NonNull private OSInAppMessage message;
+    @NonNull private OSInAppMessageInternal message;
 
     @Nullable private String currentActivityName = null;
     private Integer lastPageHeight = null;
@@ -71,7 +71,7 @@ class WebViewManager extends ActivityLifecycleHandler.ActivityAvailableListener 
         void onComplete();
     }
 
-    protected WebViewManager(@NonNull OSInAppMessage message, @NonNull Activity activity) {
+    protected WebViewManager(@NonNull OSInAppMessageInternal message, @NonNull Activity activity) {
         this.message = message;
         this.activity = activity;
     }
@@ -83,7 +83,7 @@ class WebViewManager extends ActivityLifecycleHandler.ActivityAvailableListener 
      * @param message the message to show
      * @param htmlStr the html to display on the WebView
      */
-    static void showHTMLString(@NonNull final OSInAppMessage message, @NonNull final String htmlStr) {
+    static void showHTMLString(@NonNull final OSInAppMessageInternal message, @NonNull final String htmlStr) {
         final Activity currentActivity = OneSignal.getCurrentActivity();
         OneSignal.onesignalLog(OneSignal.LOG_LEVEL.DEBUG, "in app message showHTMLString on currentActivity: " + currentActivity);
         /* IMPORTANT
@@ -124,7 +124,7 @@ class WebViewManager extends ActivityLifecycleHandler.ActivityAvailableListener 
         }
     }
 
-    private static void initInAppMessage(@NonNull final Activity currentActivity, @NonNull OSInAppMessage message, @NonNull String htmlStr) {
+    private static void initInAppMessage(@NonNull final Activity currentActivity, @NonNull OSInAppMessageInternal message, @NonNull String htmlStr) {
         try {
             final String base64Str = Base64.encodeToString(
                     htmlStr.getBytes("UTF-8"),

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/WebViewManager.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/WebViewManager.java
@@ -234,8 +234,12 @@ class WebViewManager extends ActivityLifecycleHandler.ActivityAvailableListener 
             }
 
             boolean close = body.getBoolean("close");
-            if (close)
+            if (close) {
+                if (message != null) {
+                    OneSignal.getInAppMessageController().onMessageWillDismiss(message);
+                }
                 dismissAndAwaitNextMessage(null);
+            }
         }
 
         private void handlePageChange(JSONObject jsonObject) throws JSONException {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/WebViewManager.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/WebViewManager.java
@@ -67,6 +67,8 @@ class WebViewManager extends ActivityLifecycleHandler.ActivityAvailableListener 
     @Nullable private String currentActivityName = null;
     private Integer lastPageHeight = null;
 
+    private boolean dismissing = false;
+
     interface OneSignalGenericCallback {
         void onComplete();
     }
@@ -448,7 +450,7 @@ class WebViewManager extends ActivityLifecycleHandler.ActivityAvailableListener 
      * Trigger the {@link #messageView} dismiss animation flow
      */
     protected void dismissAndAwaitNextMessage(@Nullable final OneSignalGenericCallback callback) {
-        if (messageView == null) {
+        if (messageView == null || dismissing) {
             if (callback != null)
                 callback.onComplete();
             return;
@@ -459,10 +461,12 @@ class WebViewManager extends ActivityLifecycleHandler.ActivityAvailableListener 
         messageView.dismissAndAwaitNextMessage(new OneSignalGenericCallback() {
             @Override
             public void onComplete() {
+                dismissing = false;
                 messageView = null;
                 if (callback != null)
                     callback.onComplete();
             }
         });
+        dismissing = true;
     }
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/WebViewManager.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/WebViewManager.java
@@ -235,9 +235,6 @@ class WebViewManager extends ActivityLifecycleHandler.ActivityAvailableListener 
 
             boolean close = body.getBoolean("close");
             if (close) {
-                if (message != null) {
-                    OneSignal.getInAppMessageController().onMessageWillDismiss(message);
-                }
                 dismissAndAwaitNextMessage(null);
             }
         }
@@ -409,6 +406,11 @@ class WebViewManager extends ActivityLifecycleHandler.ActivityAvailableListener 
             }
 
             @Override
+            public void onMessageWillDismiss() {
+                OneSignal.getInAppMessageController().onMessageWillDismiss(message);
+            }
+
+            @Override
             public void onMessageWasDismissed() {
                 OneSignal.getInAppMessageController().messageWasDismissed(message);
                 removeActivityListener();
@@ -451,7 +453,9 @@ class WebViewManager extends ActivityLifecycleHandler.ActivityAvailableListener 
                 callback.onComplete();
             return;
         }
-
+        if (message != null && messageView != null) {
+            OneSignal.getInAppMessageController().onMessageWillDismiss(message);
+        }
         messageView.dismissAndAwaitNextMessage(new OneSignalGenericCallback() {
             @Override
             public void onComplete() {

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/InAppMessagingHelpers.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/InAppMessagingHelpers.java
@@ -5,10 +5,9 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.UUID;
 
-import static com.onesignal.OneSignalPackagePrivateHelper.OSTestInAppMessage;
+import static com.onesignal.OneSignalPackagePrivateHelper.OSTestInAppMessageInternal;
 import static com.onesignal.OneSignalPackagePrivateHelper.OSTestTrigger;
 import static com.onesignal.OneSignalPackagePrivateHelper.OSTestTrigger.OSTriggerKind;
 
@@ -20,7 +19,7 @@ public class InAppMessagingHelpers {
     public static final String IAM_PAGE_ID = "12345678-1234-ABCD-1234-123456789012";
     public static final String IAM_HAS_LIQUID = "has_liquid";
 
-    public static boolean evaluateMessage(OSInAppMessage message) {
+    public static boolean evaluateMessage(OSInAppMessageInternal message) {
         return OneSignal.getInAppMessageController().triggerController.evaluateMessageTriggers(message);
     }
 
@@ -54,20 +53,20 @@ public class InAppMessagingHelpers {
         return wrap(wrap(triggerJson));
     }
 
-    public static OSTestInAppMessage buildTestMessageWitRedisplay(final int limit, final long delay) throws JSONException {
+    public static OSTestInAppMessageInternal buildTestMessageWitRedisplay(final int limit, final long delay) throws JSONException {
         return buildTestMessageWithMultipleDisplays(null, limit, delay);
     }
 
     // Most tests build a test message using only one trigger.
     // This convenience method makes it easy to build such a message
-    public static OSTestInAppMessage buildTestMessageWithSingleTrigger(final OSTriggerKind kind, final String key, final String operator, final Object value) throws JSONException {
+    public static OSTestInAppMessageInternal buildTestMessageWithSingleTrigger(final OSTriggerKind kind, final String key, final String operator, final Object value) throws JSONException {
         JSONArray triggersJson = basicTrigger(kind, key, operator, value);
 
         return buildTestMessage(triggersJson);
     }
 
-    public static OSTestInAppMessage buildTestMessageWithSingleTriggerAndRedisplay(final OSTriggerKind kind, final String key, final String operator,
-                                                                                   final Object value, int limit, long delay) throws JSONException {
+    public static OSTestInAppMessageInternal buildTestMessageWithSingleTriggerAndRedisplay(final OSTriggerKind kind, final String key, final String operator,
+                                                                                           final Object value, int limit, long delay) throws JSONException {
         JSONArray triggersJson = basicTrigger(kind, key, operator, value);
 
         return buildTestMessageWithMultipleDisplays(triggersJson, limit, delay);
@@ -96,32 +95,32 @@ public class InAppMessagingHelpers {
         return json;
     }
 
-    public static OSTestInAppMessage buildTestMessageWithLiquid(final JSONArray triggerJson) throws JSONException {
+    public static OSTestInAppMessageInternal buildTestMessageWithLiquid(final JSONArray triggerJson) throws JSONException {
         JSONObject json = basicIAMJSONObject(triggerJson);
         json.put(IAM_HAS_LIQUID, true);
-        return new OSTestInAppMessage(json);
+        return new OSTestInAppMessageInternal(json);
     }
 
-    public static OSTestInAppMessage buildTestMessageWithSingleTriggerAndLiquid(final OSTriggerKind kind, final String key, final String operator, final Object value) throws JSONException {
+    public static OSTestInAppMessageInternal buildTestMessageWithSingleTriggerAndLiquid(final OSTriggerKind kind, final String key, final String operator, final Object value) throws JSONException {
         JSONArray triggersJson = basicTrigger(kind, key, operator, value);
         return buildTestMessageWithLiquid(triggersJson);
     }
 
-    private static OSTestInAppMessage buildTestMessageWithMultipleDisplays(final JSONArray triggerJson, final int limit, final long delay) throws JSONException {
+    private static OSTestInAppMessageInternal buildTestMessageWithMultipleDisplays(final JSONArray triggerJson, final int limit, final long delay) throws JSONException {
         JSONObject json = basicIAMJSONObject(triggerJson);
         json.put("redisplay",  new JSONObject() {{
             put("limit", limit);
             put("delay", delay);//in seconds
         }});
 
-        return new OSTestInAppMessage(json);
+        return new OSTestInAppMessageInternal(json);
     }
 
-    public static OSTestInAppMessage buildTestMessage(final JSONArray triggerJson) throws JSONException {
-        return new OSTestInAppMessage(basicIAMJSONObject(triggerJson));
+    public static OSTestInAppMessageInternal buildTestMessage(final JSONArray triggerJson) throws JSONException {
+        return new OSTestInAppMessageInternal(basicIAMJSONObject(triggerJson));
     }
 
-    public static OSTestInAppMessage buildTestMessageWithEndTime(final OSTriggerKind kind, final String key, final String operator, final Object value, final boolean pastEndTime) throws JSONException {
+    public static OSTestInAppMessageInternal buildTestMessageWithEndTime(final OSTriggerKind kind, final String key, final String operator, final Object value, final boolean pastEndTime) throws JSONException {
         JSONArray triggerJson = basicTrigger(kind, key, operator, value);
         JSONObject json = basicIAMJSONObject(triggerJson);
         if (pastEndTime) {
@@ -129,15 +128,15 @@ public class InAppMessagingHelpers {
         } else {
             json.put("end_time", "2200-01-01T00:00:00.000Z");
         }
-        return new OSTestInAppMessage(json);
+        return new OSTestInAppMessageInternal(json);
     }
 
-    public static OSTestInAppMessage buildTestMessageWithMultipleTriggers(ArrayList<ArrayList<OSTestTrigger>> triggers) throws JSONException {
+    public static OSTestInAppMessageInternal buildTestMessageWithMultipleTriggers(ArrayList<ArrayList<OSTestTrigger>> triggers) throws JSONException {
         JSONArray ors = buildTriggers(triggers);
         return buildTestMessage(ors);
     }
 
-    public static OSTestInAppMessage buildTestMessageWithMultipleTriggersAndRedisplay(ArrayList<ArrayList<OSTestTrigger>> triggers, int limit, long delay) throws JSONException {
+    public static OSTestInAppMessageInternal buildTestMessageWithMultipleTriggersAndRedisplay(ArrayList<ArrayList<OSTestTrigger>> triggers, int limit, long delay) throws JSONException {
         JSONArray ors = buildTriggers(triggers);
         return buildTestMessageWithMultipleDisplays(ors, limit, delay);
     }

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
@@ -348,17 +348,17 @@ public class OneSignalPackagePrivateHelper {
 
    /** In-App Messaging Helpers */
 
-   public static class OSTestInAppMessage extends com.onesignal.OSInAppMessage {
+   public static class OSTestInAppMessageInternal extends OSInAppMessageInternal {
 
-      public OSTestInAppMessage(@NonNull String messageId, int displaysQuantity, long lastDisplayTime, boolean displayed, Set<String> clickIds) {
+      public OSTestInAppMessageInternal(@NonNull String messageId, int displaysQuantity, long lastDisplayTime, boolean displayed, Set<String> clickIds) {
          super(messageId, clickIds, displayed, new OSInAppMessageRedisplayStats(displaysQuantity, lastDisplayTime));
       }
 
-      OSTestInAppMessage(JSONObject json) throws JSONException {
+      OSTestInAppMessageInternal(JSONObject json) throws JSONException {
          super(json);
       }
 
-      OSTestInAppMessage(com.onesignal.OSInAppMessage inAppMessage) throws JSONException {
+      OSTestInAppMessageInternal(OSInAppMessageInternal inAppMessage) throws JSONException {
          super(inAppMessage.toJSONObject());
       }
 
@@ -525,7 +525,7 @@ public class OneSignalPackagePrivateHelper {
    }
 
    public static void dismissCurrentMessage() {
-      com.onesignal.OSInAppMessage message = OneSignal.getInAppMessageController().getCurrentDisplayedInAppMessage();
+      OSInAppMessageInternal message = OneSignal.getInAppMessageController().getCurrentDisplayedInAppMessage();
       if (message != null) {
          OneSignal.getInAppMessageController().messageWasDismissed(message);
       } else {
@@ -541,29 +541,29 @@ public class OneSignalPackagePrivateHelper {
       return OneSignal.getInAppMessageController().getCurrentDisplayedInAppMessage().messageId;
    }
 
-   public static ArrayList<com.onesignal.OSInAppMessage> getInAppMessageDisplayQueue() {
+   public static ArrayList<OSInAppMessageInternal> getInAppMessageDisplayQueue() {
       return OneSignal.getInAppMessageController().getInAppMessageDisplayQueue();
    }
 
-   public static void onMessageActionOccurredOnMessage(@NonNull final com.onesignal.OSInAppMessage message, @NonNull final JSONObject actionJson) throws JSONException {
+   public static void onMessageActionOccurredOnMessage(@NonNull final OSInAppMessageInternal message, @NonNull final JSONObject actionJson) throws JSONException {
       OneSignal.getInAppMessageController().onMessageActionOccurredOnMessage(message, actionJson);
    }
 
-   public static void onMessageWasShown(@NonNull com.onesignal.OSInAppMessage message) {
+   public static void onMessageWasShown(@NonNull OSInAppMessageInternal message) {
       OneSignal.getInAppMessageController().onMessageWasShown(message);
    }
 
-   public static void onPageChanged(@NonNull com.onesignal.OSInAppMessage message, @NonNull final JSONObject eventJson) {
+   public static void onPageChanged(@NonNull OSInAppMessageInternal message, @NonNull final JSONObject eventJson) {
       OneSignal.getInAppMessageController().onPageChanged(message, eventJson);
    }
 
-   public static List<OSTestInAppMessage> getRedisplayInAppMessages() {
-      List<OSInAppMessage> messages = OneSignal.getInAppMessageController().getRedisplayedInAppMessages();
-      List<OSTestInAppMessage> testMessages = new ArrayList<>();
+   public static List<OSTestInAppMessageInternal> getRedisplayInAppMessages() {
+      List<OSInAppMessageInternal> messages = OneSignal.getInAppMessageController().getRedisplayedInAppMessages();
+      List<OSTestInAppMessageInternal> testMessages = new ArrayList<>();
 
-      for (OSInAppMessage message : messages) {
+      for (OSInAppMessageInternal message : messages) {
          try {
-            OSTestInAppMessage testInAppMessage = new OSTestInAppMessage(message);
+            OSTestInAppMessageInternal testInAppMessage = new OSTestInAppMessageInternal(message);
             testInAppMessage.getRedisplayStats().setDisplayStats(message.getRedisplayStats());
             testMessages.add(testInAppMessage);
 
@@ -598,7 +598,7 @@ public class OneSignalPackagePrivateHelper {
          super.dismissAndAwaitNextMessage(callback);
       }
 
-      protected WebViewManager(@NonNull com.onesignal.OSInAppMessage message, @NonNull Activity activity) {
+      protected WebViewManager(@NonNull OSInAppMessageInternal message, @NonNull Activity activity) {
          super(message, activity);
       }
    }

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
@@ -557,6 +557,25 @@ public class OneSignalPackagePrivateHelper {
       OneSignal.getInAppMessageController().onPageChanged(message, eventJson);
    }
 
+   /** IAM Lifecycle */
+   public static void onMessageWillDisplay(@NonNull final OSInAppMessageInternal message) {
+      OneSignal.getInAppMessageController().onMessageWillDisplay(message);
+   }
+
+   public static void onMessageDidDisplay(@NonNull final OSInAppMessageInternal message) {
+      OneSignal.getInAppMessageController().onMessageDidDisplay(message);
+   }
+
+   public static void onMessageWillDismiss(@NonNull final OSInAppMessageInternal message) {
+      OneSignal.getInAppMessageController().onMessageWillDismiss(message);
+   }
+
+   public static void onMessageDidDismiss(@NonNull final OSInAppMessageInternal message) {
+      OneSignal.getInAppMessageController().onMessageDidDismiss(message);
+   }
+   
+   // End IAM Lifecycle
+
    public static List<OSTestInAppMessageInternal> getRedisplayInAppMessages() {
       List<OSInAppMessageInternal> messages = OneSignal.getInAppMessageController().getRedisplayedInAppMessages();
       List<OSTestInAppMessageInternal> testMessages = new ArrayList<>();

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
@@ -362,6 +362,10 @@ public class OneSignalPackagePrivateHelper {
          super(inAppMessage.toJSONObject());
       }
 
+      public void setMessageId(String messageId) {
+         this.messageId = messageId;
+      }
+
       @Override
       protected ArrayList<ArrayList<OSTrigger>> parseTriggerJson(JSONArray triggersJson) throws JSONException {
          ArrayList<ArrayList<OSTrigger>> parsedTriggers = new ArrayList<>();

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/DatabaseRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/DatabaseRunner.java
@@ -11,7 +11,7 @@ import com.onesignal.MockOneSignalDBHelper;
 import com.onesignal.OneSignalPackagePrivateHelper;
 import com.onesignal.OneSignalPackagePrivateHelper.InAppMessageTable;
 import com.onesignal.OneSignalPackagePrivateHelper.NotificationTable;
-import com.onesignal.OneSignalPackagePrivateHelper.OSTestInAppMessage;
+import com.onesignal.OneSignalPackagePrivateHelper.OSTestInAppMessageInternal;
 import com.onesignal.OSOutcomeEvent;
 import com.onesignal.ShadowOneSignalDbHelper;
 import com.onesignal.StaticResetHelper;
@@ -308,7 +308,7 @@ public class DatabaseRunner {
         writableDatabase.close();
 
         // Create an IAM
-        final OSTestInAppMessage inAppMessage = InAppMessagingHelpers.buildTestMessageWithSingleTrigger(
+        final OSTestInAppMessageInternal inAppMessage = InAppMessagingHelpers.buildTestMessageWithSingleTrigger(
                 OSTriggerKind.SESSION_TIME,
                 null,
                 OneSignalPackagePrivateHelper.OSTestTrigger.OSTriggerOperator.NOT_EXISTS.toString(),
@@ -327,7 +327,7 @@ public class DatabaseRunner {
         ShadowOneSignalDbHelper.restSetStaticFields();
 
         // 4. Opening the DB will auto trigger the update.
-        List<OSTestInAppMessage> savedInAppMessages = TestHelpers.getAllInAppMessages(dbHelper);
+        List<OSTestInAppMessageInternal> savedInAppMessages = TestHelpers.getAllInAppMessages(dbHelper);
         assertEquals(savedInAppMessages.size(), 0);
 
         writableDatabase = dbHelper.getSQLiteDatabaseWithRetries();
@@ -335,10 +335,10 @@ public class DatabaseRunner {
         writableDatabase.insert(InAppMessageTable.TABLE_NAME, null, values);
         writableDatabase.close();
 
-        List<OSTestInAppMessage> savedInAppMessagesAfterCreation = TestHelpers.getAllInAppMessages(dbHelper);
+        List<OSTestInAppMessageInternal> savedInAppMessagesAfterCreation = TestHelpers.getAllInAppMessages(dbHelper);
 
         assertEquals(savedInAppMessagesAfterCreation.size(), 1);
-        OSTestInAppMessage savedInAppMessage = savedInAppMessagesAfterCreation.get(0);
+        OSTestInAppMessageInternal savedInAppMessage = savedInAppMessagesAfterCreation.get(0);
         assertEquals(savedInAppMessage.getRedisplayStats().getDisplayQuantity(), inAppMessage.getRedisplayStats().getDisplayQuantity());
         assertEquals(savedInAppMessage.getRedisplayStats().getLastDisplayTime(), inAppMessage.getRedisplayStats().getLastDisplayTime());
         assertEquals(savedInAppMessage.getClickedClickIds().toString(), inAppMessage.getClickedClickIds().toString());

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/DatabaseRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/DatabaseRunner.java
@@ -317,7 +317,7 @@ public class DatabaseRunner {
         inAppMessage.setDisplayedInSession(true);
 
         ContentValues values = new ContentValues();
-        values.put(InAppMessageTable.COLUMN_NAME_MESSAGE_ID, inAppMessage.messageId);
+        values.put(InAppMessageTable.COLUMN_NAME_MESSAGE_ID, inAppMessage.getMessageId());
         values.put(InAppMessageTable.COLUMN_NAME_DISPLAY_QUANTITY, inAppMessage.getRedisplayStats().getDisplayQuantity());
         values.put(InAppMessageTable.COLUMN_NAME_LAST_DISPLAY, inAppMessage.getRedisplayStats().getLastDisplayTime());
         values.put(InAppMessageTable.COLUMN_CLICK_IDS, inAppMessage.getClickedClickIds().toString());

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/InAppMessageIntegrationTests.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/InAppMessageIntegrationTests.java
@@ -14,7 +14,7 @@ import com.onesignal.MockSessionManager;
 import com.onesignal.OSInAppMessageAction;
 import com.onesignal.OneSignal;
 import com.onesignal.OneSignalPackagePrivateHelper;
-import com.onesignal.OneSignalPackagePrivateHelper.OSTestInAppMessage;
+import com.onesignal.OneSignalPackagePrivateHelper.OSTestInAppMessageInternal;
 import com.onesignal.OneSignalPackagePrivateHelper.OSTestTrigger;
 import com.onesignal.OneSignalPackagePrivateHelper.TestOneSignalPrefs;
 import com.onesignal.ShadowCustomTabsClient;
@@ -156,9 +156,9 @@ public class InAppMessageIntegrationTests {
 
     @Test
     public void testDisableInAppMessagingPreventsMessageDisplay() throws Exception {
-        final OSTestInAppMessage testMessage = InAppMessagingHelpers.buildTestMessageWithSingleTrigger(OSTriggerKind.CUSTOM, "test_key", OSTestTrigger.OSTriggerOperator.EQUAL_TO.toString(), 3);
+        final OSTestInAppMessageInternal testMessage = InAppMessagingHelpers.buildTestMessageWithSingleTrigger(OSTriggerKind.CUSTOM, "test_key", OSTestTrigger.OSTriggerOperator.EQUAL_TO.toString(), 3);
 
-        setMockRegistrationResponseWithMessages(new ArrayList<OSTestInAppMessage>() {{
+        setMockRegistrationResponseWithMessages(new ArrayList<OSTestInAppMessageInternal>() {{
             add(testMessage);
         }});
 
@@ -191,8 +191,8 @@ public class InAppMessageIntegrationTests {
 
     @Test
     public void testMessagesDoNotDisplayPastEndTime() throws Exception {
-        final OSTestInAppMessage message = InAppMessagingHelpers.buildTestMessageWithEndTime(OSTriggerKind.CUSTOM, "test_key", OSTestTrigger.OSTriggerOperator.EQUAL_TO.toString(), 3, true);
-        setMockRegistrationResponseWithMessages(new ArrayList<OSTestInAppMessage>() {{
+        final OSTestInAppMessageInternal message = InAppMessagingHelpers.buildTestMessageWithEndTime(OSTriggerKind.CUSTOM, "test_key", OSTestTrigger.OSTriggerOperator.EQUAL_TO.toString(), 3, true);
+        setMockRegistrationResponseWithMessages(new ArrayList<OSTestInAppMessageInternal>() {{
             add(message);
         }});
 
@@ -211,8 +211,8 @@ public class InAppMessageIntegrationTests {
 
     @Test
     public void testMessagesDoDisplayBeforeEndTime() throws Exception {
-        final OSTestInAppMessage message = InAppMessagingHelpers.buildTestMessageWithEndTime(OSTriggerKind.CUSTOM, "test_key", OSTestTrigger.OSTriggerOperator.EQUAL_TO.toString(), 3, false);
-        setMockRegistrationResponseWithMessages(new ArrayList<OSTestInAppMessage>() {{
+        final OSTestInAppMessageInternal message = InAppMessagingHelpers.buildTestMessageWithEndTime(OSTriggerKind.CUSTOM, "test_key", OSTestTrigger.OSTriggerOperator.EQUAL_TO.toString(), 3, false);
+        setMockRegistrationResponseWithMessages(new ArrayList<OSTestInAppMessageInternal>() {{
             add(message);
         }});
 
@@ -322,10 +322,10 @@ public class InAppMessageIntegrationTests {
 
 
     private void nextResponseMultiplePendingMessages() throws JSONException {
-        final OSTestInAppMessage testFirstMessage = InAppMessagingHelpers.buildTestMessageWithSingleTrigger(OSTriggerKind.CUSTOM, "test_1", OSTestTrigger.OSTriggerOperator.EQUAL_TO.toString(), 3);
-        final OSTestInAppMessage testSecondMessage = InAppMessagingHelpers.buildTestMessageWithSingleTrigger(OSTriggerKind.CUSTOM, "test_2", OSTestTrigger.OSTriggerOperator.EQUAL_TO.toString(), 2);
+        final OSTestInAppMessageInternal testFirstMessage = InAppMessagingHelpers.buildTestMessageWithSingleTrigger(OSTriggerKind.CUSTOM, "test_1", OSTestTrigger.OSTriggerOperator.EQUAL_TO.toString(), 3);
+        final OSTestInAppMessageInternal testSecondMessage = InAppMessagingHelpers.buildTestMessageWithSingleTrigger(OSTriggerKind.CUSTOM, "test_2", OSTestTrigger.OSTriggerOperator.EQUAL_TO.toString(), 2);
 
-        setMockRegistrationResponseWithMessages(new ArrayList<OSTestInAppMessage>() {{
+        setMockRegistrationResponseWithMessages(new ArrayList<OSTestInAppMessageInternal>() {{
             add(testFirstMessage);
             add(testSecondMessage);
         }});
@@ -341,7 +341,7 @@ public class InAppMessageIntegrationTests {
 
     @Test
     public void testTimedMessageIsDisplayedOncePerSession() throws Exception {
-        final OSTestInAppMessage message = InAppMessagingHelpers.buildTestMessageWithSingleTriggerAndRedisplay(
+        final OSTestInAppMessageInternal message = InAppMessagingHelpers.buildTestMessageWithSingleTriggerAndRedisplay(
                 OSTriggerKind.SESSION_TIME,
                 null,
                 OSTestTrigger.OSTriggerOperator.GREATER_THAN.toString(),
@@ -349,7 +349,7 @@ public class InAppMessageIntegrationTests {
                 10,
                 0);
 
-        setMockRegistrationResponseWithMessages(new ArrayList<OSTestInAppMessage>() {{
+        setMockRegistrationResponseWithMessages(new ArrayList<OSTestInAppMessageInternal>() {{
             add(message);
         }});
 
@@ -389,7 +389,7 @@ public class InAppMessageIntegrationTests {
 
     @Test
     public void testAfterLastInAppTimeIsDisplayedOncePerSession() throws Exception {
-        final OSTestInAppMessage message1 = InAppMessagingHelpers.buildTestMessageWithSingleTriggerAndRedisplay(
+        final OSTestInAppMessageInternal message1 = InAppMessagingHelpers.buildTestMessageWithSingleTriggerAndRedisplay(
                 OSTriggerKind.SESSION_TIME,
                 null,
                 OSTestTrigger.OSTriggerOperator.GREATER_THAN.toString(),
@@ -403,9 +403,9 @@ public class InAppMessageIntegrationTests {
                 add(InAppMessagingHelpers.buildTrigger(OSTriggerKind.TIME_SINCE_LAST_IN_APP, null, OSTestTrigger.OSTriggerOperator.GREATER_THAN.toString(), 0.05));
             }});
         }};
-        final OSTestInAppMessage message2 = InAppMessagingHelpers.buildTestMessageWithMultipleTriggersAndRedisplay(triggers2, 10, 0);
+        final OSTestInAppMessageInternal message2 = InAppMessagingHelpers.buildTestMessageWithMultipleTriggersAndRedisplay(triggers2, 10, 0);
 
-        setMockRegistrationResponseWithMessages(new ArrayList<OSTestInAppMessage>() {{
+        setMockRegistrationResponseWithMessages(new ArrayList<OSTestInAppMessageInternal>() {{
             add(message1);
             add(message2);
         }});
@@ -472,9 +472,9 @@ public class InAppMessageIntegrationTests {
             }});
         }};
 
-        final OSTestInAppMessage message = InAppMessagingHelpers.buildTestMessageWithMultipleTriggers(triggers);
+        final OSTestInAppMessageInternal message = InAppMessagingHelpers.buildTestMessageWithMultipleTriggers(triggers);
 
-        setMockRegistrationResponseWithMessages(new ArrayList<OSTestInAppMessage>() {{
+        setMockRegistrationResponseWithMessages(new ArrayList<OSTestInAppMessageInternal>() {{
             add(message);
         }});
 
@@ -503,10 +503,10 @@ public class InAppMessageIntegrationTests {
     @Test
     public void testMessageDisplayedAfterAddTriggerEqualWithStringVsNumber() throws Exception {
         // Set IAM with EQUAL trigger with number value as string
-        final OSTestInAppMessage message =
+        final OSTestInAppMessageInternal message =
                 InAppMessagingHelpers.buildTestMessageWithSingleTrigger(OSTriggerKind.CUSTOM, "test", OSTestTrigger.OSTriggerOperator.EQUAL_TO.toString(), "5");
 
-        setMockRegistrationResponseWithMessages(new ArrayList<OSTestInAppMessage>() {{
+        setMockRegistrationResponseWithMessages(new ArrayList<OSTestInAppMessageInternal>() {{
             add(message);
         }});
 
@@ -528,10 +528,10 @@ public class InAppMessageIntegrationTests {
     @Test
     public void testMessageDisplayedAfterAddTriggerEqualWithStringVsNumberFloat() throws Exception {
         // Set IAM with EQUAL trigger with number value as string
-        final OSTestInAppMessage message =
+        final OSTestInAppMessageInternal message =
                 InAppMessagingHelpers.buildTestMessageWithSingleTrigger(OSTriggerKind.CUSTOM, "test", OSTestTrigger.OSTriggerOperator.EQUAL_TO.toString(), "5.5");
 
-        setMockRegistrationResponseWithMessages(new ArrayList<OSTestInAppMessage>() {{
+        setMockRegistrationResponseWithMessages(new ArrayList<OSTestInAppMessageInternal>() {{
             add(message);
         }});
 
@@ -648,7 +648,7 @@ public class InAppMessageIntegrationTests {
         threadAndTaskWait();
 
         // 2. Create an IAM
-        final OSTestInAppMessage message = InAppMessagingHelpers.buildTestMessageWithSingleTrigger(
+        final OSTestInAppMessageInternal message = InAppMessagingHelpers.buildTestMessageWithSingleTrigger(
                 OSTriggerKind.SESSION_TIME,
                 null,
                 OSTestTrigger.OSTriggerOperator.NOT_EXISTS.toString(),
@@ -689,7 +689,7 @@ public class InAppMessageIntegrationTests {
         trackerFactory.saveInfluenceParams(new OneSignalPackagePrivateHelper.RemoteOutcomeParams());
 
         // 2. Create an IAM
-        final OSTestInAppMessage message = InAppMessagingHelpers.buildTestMessageWithSingleTrigger(
+        final OSTestInAppMessageInternal message = InAppMessagingHelpers.buildTestMessageWithSingleTrigger(
                 OSTriggerKind.SESSION_TIME,
                 null,
                 OSTestTrigger.OSTriggerOperator.NOT_EXISTS.toString(),
@@ -739,7 +739,7 @@ public class InAppMessageIntegrationTests {
         trackerFactory.saveInfluenceParams(new OneSignalPackagePrivateHelper.RemoteOutcomeParams());
 
         // 2. Create an IAM
-        final OSTestInAppMessage message = InAppMessagingHelpers.buildTestMessageWithSingleTrigger(
+        final OSTestInAppMessageInternal message = InAppMessagingHelpers.buildTestMessageWithSingleTrigger(
                 OSTriggerKind.SESSION_TIME,
                 null,
                 OSTestTrigger.OSTriggerOperator.NOT_EXISTS.toString(),
@@ -771,7 +771,7 @@ public class InAppMessageIntegrationTests {
         trackerFactory.saveInfluenceParams(new OneSignalPackagePrivateHelper.RemoteOutcomeParams());
 
         // 2. Create an IAM
-        final OSTestInAppMessage message = InAppMessagingHelpers.buildTestMessageWithSingleTrigger(
+        final OSTestInAppMessageInternal message = InAppMessagingHelpers.buildTestMessageWithSingleTrigger(
                 OSTriggerKind.SESSION_TIME,
                 null,
                 OSTestTrigger.OSTriggerOperator.NOT_EXISTS.toString(),
@@ -814,10 +814,10 @@ public class InAppMessageIntegrationTests {
         OneSignal_setTrackerFactory(trackerFactory);
         OneSignal_setSessionManager(sessionManager);
 
-        final OSTestInAppMessage message = InAppMessagingHelpers.buildTestMessageWithSingleTrigger(
+        final OSTestInAppMessageInternal message = InAppMessagingHelpers.buildTestMessageWithSingleTrigger(
                 OSTriggerKind.CUSTOM, "test_1", OSTestTrigger.OSTriggerOperator.EQUAL_TO.toString(), 2);
 
-        setMockRegistrationResponseWithMessages(new ArrayList<OSTestInAppMessage>() {{
+        setMockRegistrationResponseWithMessages(new ArrayList<OSTestInAppMessageInternal>() {{
             add(message);
         }});
 
@@ -875,10 +875,10 @@ public class InAppMessageIntegrationTests {
         OneSignal_setTrackerFactory(trackerFactory);
         OneSignal_setSessionManager(sessionManager);
 
-        final OSTestInAppMessage message = InAppMessagingHelpers.buildTestMessageWithSingleTrigger(
+        final OSTestInAppMessageInternal message = InAppMessagingHelpers.buildTestMessageWithSingleTrigger(
                 OSTriggerKind.CUSTOM, "test_1", OSTestTrigger.OSTriggerOperator.EQUAL_TO.toString(), 2);
 
-        setMockRegistrationResponseWithMessages(new ArrayList<OSTestInAppMessage>() {{
+        setMockRegistrationResponseWithMessages(new ArrayList<OSTestInAppMessageInternal>() {{
             add(message);
         }});
 
@@ -936,7 +936,7 @@ public class InAppMessageIntegrationTests {
         trackerFactory.saveInfluenceParams(new OneSignalPackagePrivateHelper.RemoteOutcomeParams());
 
         // 2. Create an IAM
-        final OSTestInAppMessage message = InAppMessagingHelpers.buildTestMessageWithSingleTrigger(
+        final OSTestInAppMessageInternal message = InAppMessagingHelpers.buildTestMessageWithSingleTrigger(
                 OSTriggerKind.SESSION_TIME,
                 null,
                 OSTestTrigger.OSTriggerOperator.NOT_EXISTS.toString(),
@@ -986,7 +986,7 @@ public class InAppMessageIntegrationTests {
         trackerFactory.saveInfluenceParams(new OneSignalPackagePrivateHelper.RemoteOutcomeParams(false, false, false));
 
         // 2. Create an IAM
-        final OSTestInAppMessage message = InAppMessagingHelpers.buildTestMessageWithSingleTrigger(
+        final OSTestInAppMessageInternal message = InAppMessagingHelpers.buildTestMessageWithSingleTrigger(
                 OSTriggerKind.SESSION_TIME,
                 null,
                 OSTestTrigger.OSTriggerOperator.NOT_EXISTS.toString(),
@@ -1020,7 +1020,7 @@ public class InAppMessageIntegrationTests {
         trackerFactory.saveInfluenceParams(new OneSignalPackagePrivateHelper.RemoteOutcomeParams());
 
         // 2. Create an IAM
-        final OSTestInAppMessage message = InAppMessagingHelpers.buildTestMessageWithSingleTrigger(
+        final OSTestInAppMessageInternal message = InAppMessagingHelpers.buildTestMessageWithSingleTrigger(
                 OSTriggerKind.SESSION_TIME,
                 null,
                 OSTestTrigger.OSTriggerOperator.NOT_EXISTS.toString(),
@@ -1062,7 +1062,7 @@ public class InAppMessageIntegrationTests {
         threadAndTaskWait();
 
         // 2. Create an IAM
-        final OSTestInAppMessage message = InAppMessagingHelpers.buildTestMessageWithSingleTrigger(
+        final OSTestInAppMessageInternal message = InAppMessagingHelpers.buildTestMessageWithSingleTrigger(
                 OSTriggerKind.SESSION_TIME,
                 null,
                 OSTestTrigger.OSTriggerOperator.NOT_EXISTS.toString(),
@@ -1098,7 +1098,7 @@ public class InAppMessageIntegrationTests {
         threadAndTaskWait();
 
         // 2. Create an IAM
-        final OSTestInAppMessage message = InAppMessagingHelpers.buildTestMessageWithSingleTrigger(
+        final OSTestInAppMessageInternal message = InAppMessagingHelpers.buildTestMessageWithSingleTrigger(
                 OSTriggerKind.SESSION_TIME,
                 null,
                 OSTestTrigger.OSTriggerOperator.NOT_EXISTS.toString(),
@@ -1136,7 +1136,7 @@ public class InAppMessageIntegrationTests {
         threadAndTaskWait();
 
         // 2. Create an IAM
-        final OSTestInAppMessage message = InAppMessagingHelpers.buildTestMessageWithSingleTrigger(
+        final OSTestInAppMessageInternal message = InAppMessagingHelpers.buildTestMessageWithSingleTrigger(
                 OSTriggerKind.SESSION_TIME,
                 null,
                 OSTestTrigger.OSTriggerOperator.NOT_EXISTS.toString(),
@@ -1194,7 +1194,7 @@ public class InAppMessageIntegrationTests {
         threadAndTaskWait();
 
         // 2. Create an IAM
-        final OSTestInAppMessage message = InAppMessagingHelpers.buildTestMessageWithSingleTrigger(
+        final OSTestInAppMessageInternal message = InAppMessagingHelpers.buildTestMessageWithSingleTrigger(
                 OSTriggerKind.SESSION_TIME,
                 null,
                 OSTestTrigger.OSTriggerOperator.NOT_EXISTS.toString(),
@@ -1231,7 +1231,7 @@ public class InAppMessageIntegrationTests {
         threadAndTaskWait();
 
         // Create an IAM
-        final OSTestInAppMessage message = InAppMessagingHelpers.buildTestMessageWithSingleTrigger(
+        final OSTestInAppMessageInternal message = InAppMessagingHelpers.buildTestMessageWithSingleTrigger(
                 OSTriggerKind.SESSION_TIME,
                 null,
                 OSTestTrigger.OSTriggerOperator.NOT_EXISTS.toString(),
@@ -1264,7 +1264,7 @@ public class InAppMessageIntegrationTests {
         threadAndTaskWait();
 
         // Create an IAM
-        final OSTestInAppMessage message = InAppMessagingHelpers.buildTestMessageWithSingleTrigger(
+        final OSTestInAppMessageInternal message = InAppMessagingHelpers.buildTestMessageWithSingleTrigger(
                 OSTriggerKind.SESSION_TIME,
                 null,
                 OSTestTrigger.OSTriggerOperator.NOT_EXISTS.toString(),
@@ -1292,10 +1292,10 @@ public class InAppMessageIntegrationTests {
 
     @Test
     public void testInAppMessageDisplayMultipleTimes() throws Exception {
-        final OSTestInAppMessage message = InAppMessagingHelpers.buildTestMessageWithSingleTriggerAndRedisplay(
+        final OSTestInAppMessageInternal message = InAppMessagingHelpers.buildTestMessageWithSingleTriggerAndRedisplay(
                 OSTriggerKind.CUSTOM, "test_1", OSTestTrigger.OSTriggerOperator.EQUAL_TO.toString(), 2, LIMIT, DELAY);
 
-        setMockRegistrationResponseWithMessages(new ArrayList<OSTestInAppMessage>() {{
+        setMockRegistrationResponseWithMessages(new ArrayList<OSTestInAppMessageInternal>() {{
             add(message);
         }});
 
@@ -1342,10 +1342,10 @@ public class InAppMessageIntegrationTests {
 
     @Test
     public void testInAppMessageDisplayMultipleTimes_sessionDurationTrigger() throws Exception {
-        final OSTestInAppMessage message = InAppMessagingHelpers.buildTestMessageWithSingleTriggerAndRedisplay(OSTriggerKind.SESSION_TIME, "",
+        final OSTestInAppMessageInternal message = InAppMessagingHelpers.buildTestMessageWithSingleTriggerAndRedisplay(OSTriggerKind.SESSION_TIME, "",
                 OSTestTrigger.OSTriggerOperator.GREATER_THAN.toString(), 0.05, LIMIT, DELAY);
 
-        setMockRegistrationResponseWithMessages(new ArrayList<OSTestInAppMessage>() {{
+        setMockRegistrationResponseWithMessages(new ArrayList<OSTestInAppMessageInternal>() {{
             add(message);
         }});
 
@@ -1389,7 +1389,7 @@ public class InAppMessageIntegrationTests {
         time.advanceSystemTimeBy(DELAY);
         fastColdRestartApp();
 
-        setMockRegistrationResponseWithMessages(new ArrayList<OSTestInAppMessage>() {{
+        setMockRegistrationResponseWithMessages(new ArrayList<OSTestInAppMessageInternal>() {{
             add(message);
         }});
 
@@ -1423,7 +1423,7 @@ public class InAppMessageIntegrationTests {
         final long currentTimeInSeconds = System.currentTimeMillis() / 1000;
 
         // Create an IAM
-        final OSTestInAppMessage message = InAppMessagingHelpers.buildTestMessageWitRedisplay(LIMIT, DELAY);
+        final OSTestInAppMessageInternal message = InAppMessagingHelpers.buildTestMessageWitRedisplay(LIMIT, DELAY);
         message.getRedisplayStats().setLastDisplayTime(currentTimeInSeconds);
         message.getRedisplayStats().setDisplayQuantity(1);
         message.setDisplayedInSession(true);
@@ -1437,11 +1437,11 @@ public class InAppMessageIntegrationTests {
         );
 
         // Check IAM was saved correctly
-        List<OSTestInAppMessage> savedInAppMessages = TestHelpers.getAllInAppMessages(dbHelper);
+        List<OSTestInAppMessageInternal> savedInAppMessages = TestHelpers.getAllInAppMessages(dbHelper);
         assertEquals(savedInAppMessages.size(), 1);
         assertTrue(savedInAppMessages.get(0).isDisplayedInSession());
 
-        setMockRegistrationResponseWithMessages(new ArrayList<OSTestInAppMessage>() {{
+        setMockRegistrationResponseWithMessages(new ArrayList<OSTestInAppMessageInternal>() {{
             add(message);
         }});
         // Change time for delay to be covered
@@ -1459,7 +1459,7 @@ public class InAppMessageIntegrationTests {
         assertEquals(0, OneSignalPackagePrivateHelper.getInAppMessageDisplayQueue().size());
         // Restart OneSignal
         fastColdRestartApp();
-        setMockRegistrationResponseWithMessages(new ArrayList<OSTestInAppMessage>() {{
+        setMockRegistrationResponseWithMessages(new ArrayList<OSTestInAppMessageInternal>() {{
             add(message);
         }});
         OneSignalInit();
@@ -1475,10 +1475,10 @@ public class InAppMessageIntegrationTests {
 
     @Test
     public void testInAppMessageDisplayMultipleTimes_RemoveTrigger() throws Exception {
-        final OSTestInAppMessage message = InAppMessagingHelpers.buildTestMessageWithSingleTriggerAndRedisplay(
+        final OSTestInAppMessageInternal message = InAppMessagingHelpers.buildTestMessageWithSingleTriggerAndRedisplay(
                 OSTriggerKind.CUSTOM, "test_1", OSTestTrigger.OSTriggerOperator.NOT_EXISTS.toString(), 2, LIMIT, DELAY);
 
-        setMockRegistrationResponseWithMessages(new ArrayList<OSTestInAppMessage>() {{
+        setMockRegistrationResponseWithMessages(new ArrayList<OSTestInAppMessageInternal>() {{
             add(message);
         }});
         // Init OneSignal with IAM with redisplay
@@ -1510,10 +1510,10 @@ public class InAppMessageIntegrationTests {
 
     @Test
     public void testInAppMessageNoDisplayMultipleTimes_Delay() throws Exception {
-        final OSTestInAppMessage message = InAppMessagingHelpers.buildTestMessageWithSingleTriggerAndRedisplay(
+        final OSTestInAppMessageInternal message = InAppMessagingHelpers.buildTestMessageWithSingleTriggerAndRedisplay(
                 OSTriggerKind.CUSTOM, "test_1", OSTestTrigger.OSTriggerOperator.EQUAL_TO.toString(), 2, LIMIT, DELAY);
 
-        setMockRegistrationResponseWithMessages(new ArrayList<OSTestInAppMessage>() {{
+        setMockRegistrationResponseWithMessages(new ArrayList<OSTestInAppMessageInternal>() {{
             add(message);
         }});
 
@@ -1544,10 +1544,10 @@ public class InAppMessageIntegrationTests {
 
     @Test
     public void testInAppMessageNoDisplayMultipleTimes_Limit() throws Exception {
-        final OSTestInAppMessage message = InAppMessagingHelpers.buildTestMessageWithSingleTriggerAndRedisplay(
+        final OSTestInAppMessageInternal message = InAppMessagingHelpers.buildTestMessageWithSingleTriggerAndRedisplay(
                 OSTriggerKind.CUSTOM, "test_1", OSTestTrigger.OSTriggerOperator.EQUAL_TO.toString(), 2, 1, DELAY);
 
-        setMockRegistrationResponseWithMessages(new ArrayList<OSTestInAppMessage>() {{
+        setMockRegistrationResponseWithMessages(new ArrayList<OSTestInAppMessageInternal>() {{
             add(message);
         }});
 
@@ -1582,10 +1582,10 @@ public class InAppMessageIntegrationTests {
 
     @Test
     public void testInAppMessageDisplayMultipleTimes_onColdRestart() throws Exception {
-        final OSTestInAppMessage message = InAppMessagingHelpers.buildTestMessageWithSingleTriggerAndRedisplay(
+        final OSTestInAppMessageInternal message = InAppMessagingHelpers.buildTestMessageWithSingleTriggerAndRedisplay(
                 OSTriggerKind.CUSTOM, "test_1", OSTestTrigger.OSTriggerOperator.EQUAL_TO.toString(), 2, LIMIT, DELAY);
 
-        setMockRegistrationResponseWithMessages(new ArrayList<OSTestInAppMessage>() {{
+        setMockRegistrationResponseWithMessages(new ArrayList<OSTestInAppMessageInternal>() {{
             add(message);
         }});
 
@@ -1618,7 +1618,7 @@ public class InAppMessageIntegrationTests {
         // Swipe away app
         fastColdRestartApp();
         // Cold Start app
-        setMockRegistrationResponseWithMessages(new ArrayList<OSTestInAppMessage>() {{
+        setMockRegistrationResponseWithMessages(new ArrayList<OSTestInAppMessageInternal>() {{
             add(message);
         }});
 
@@ -1650,7 +1650,7 @@ public class InAppMessageIntegrationTests {
         threadAndTaskWait();
 
         // Create an IAM
-        final OSTestInAppMessage message = InAppMessagingHelpers.buildTestMessageWithSingleTriggerAndRedisplay(
+        final OSTestInAppMessageInternal message = InAppMessagingHelpers.buildTestMessageWithSingleTriggerAndRedisplay(
                 OSTriggerKind.CUSTOM, "test_1", OSTestTrigger.OSTriggerOperator.EQUAL_TO.toString(), 2, LIMIT, DELAY);
 
         assertTrue(message.getClickedClickIds().isEmpty());
@@ -1717,14 +1717,14 @@ public class InAppMessageIntegrationTests {
 
         // 1. Setup IAMs
         // Create an IAM younger than 6 months
-        final OSTestInAppMessage iam1 = InAppMessagingHelpers.buildTestMessage(null);
+        final OSTestInAppMessageInternal iam1 = InAppMessagingHelpers.buildTestMessage(null);
         iam1.setRedisplayStats(1, currentTimeInSeconds - SIX_MONTHS_TIME_SECONDS + 10);
         String clickId1 = "iam1_click_id_1";
         iam1.addClickId(clickId1);
         TestHelpers.saveIAM(iam1, dbHelper);
 
         // Create an IAM older than 6 months
-        final OSTestInAppMessage iam2 = InAppMessagingHelpers.buildTestMessage(null);
+        final OSTestInAppMessageInternal iam2 = InAppMessagingHelpers.buildTestMessage(null);
         iam2.setRedisplayStats(1, currentTimeInSeconds - SIX_MONTHS_TIME_SECONDS - 10);
         String clickId2 = "iam2_click_id_1";
         iam2.addClickId(clickId2);
@@ -1781,7 +1781,7 @@ public class InAppMessageIntegrationTests {
         assertTrue(testClickedClickIds.contains(clickId1));
 
         // 5. Make sure only IAM left is the IAM younger than 6 months
-        List<OSTestInAppMessage> savedInAppMessagesAfterInit = TestHelpers.getAllInAppMessages(dbHelper);
+        List<OSTestInAppMessageInternal> savedInAppMessagesAfterInit = TestHelpers.getAllInAppMessages(dbHelper);
         assertEquals(1, savedInAppMessagesAfterInit.size());
         assertEquals(iam1.messageId, savedInAppMessagesAfterInit.get(0).messageId);
     }
@@ -1790,7 +1790,7 @@ public class InAppMessageIntegrationTests {
     public void testInAppMessageRedisplayCacheCleaning() throws Exception {
         final long currentTimeInSeconds = System.currentTimeMillis() / 1000;
 
-        final OSTestInAppMessage inAppMessage = InAppMessagingHelpers.buildTestMessageWithSingleTriggerAndRedisplay(
+        final OSTestInAppMessageInternal inAppMessage = InAppMessagingHelpers.buildTestMessageWithSingleTriggerAndRedisplay(
                 OSTriggerKind.CUSTOM, "test_saved", OneSignalPackagePrivateHelper.OSTestTrigger.OSTriggerOperator.EQUAL_TO.toString(), 2, LIMIT, DELAY);
 
         String firstID = inAppMessage.messageId + "_test";
@@ -1802,16 +1802,16 @@ public class InAppMessageIntegrationTests {
         inAppMessage.messageId += "1";
         TestHelpers.saveIAM(inAppMessage, dbHelper);
 
-        List<OSTestInAppMessage> savedInAppMessages = TestHelpers.getAllInAppMessages(dbHelper);
+        List<OSTestInAppMessageInternal> savedInAppMessages = TestHelpers.getAllInAppMessages(dbHelper);
 
         assertEquals(2, savedInAppMessages.size());
 
-        final OSTestInAppMessage message1 = InAppMessagingHelpers.buildTestMessageWithSingleTriggerAndRedisplay(
+        final OSTestInAppMessageInternal message1 = InAppMessagingHelpers.buildTestMessageWithSingleTriggerAndRedisplay(
                 OSTriggerKind.CUSTOM, "test_1", OSTestTrigger.OSTriggerOperator.EQUAL_TO.toString(), 2, LIMIT, DELAY);
-        final OSTestInAppMessage message2 = InAppMessagingHelpers.buildTestMessageWithSingleTriggerAndRedisplay(
+        final OSTestInAppMessageInternal message2 = InAppMessagingHelpers.buildTestMessageWithSingleTriggerAndRedisplay(
                 OSTriggerKind.CUSTOM, "test_2", OSTestTrigger.OSTriggerOperator.EQUAL_TO.toString(), 2, LIMIT, DELAY);
 
-        setMockRegistrationResponseWithMessages(new ArrayList<OSTestInAppMessage>() {{
+        setMockRegistrationResponseWithMessages(new ArrayList<OSTestInAppMessageInternal>() {{
             add(message1);
             add(message2);
         }});
@@ -1820,7 +1820,7 @@ public class InAppMessageIntegrationTests {
         OneSignalInit();
         threadAndTaskWait();
 
-        List<OSTestInAppMessage> savedInAppMessagesAfterInit = TestHelpers.getAllInAppMessages(dbHelper);
+        List<OSTestInAppMessageInternal> savedInAppMessagesAfterInit = TestHelpers.getAllInAppMessages(dbHelper);
         // Message with old display time should be removed
         assertEquals(1, savedInAppMessagesAfterInit.size());
         assertEquals(firstID, savedInAppMessagesAfterInit.get(0).messageId);
@@ -1843,10 +1843,10 @@ public class InAppMessageIntegrationTests {
 
     @Test
     public void testInAppMessageIdTracked() throws Exception {
-        final OSTestInAppMessage message = InAppMessagingHelpers.buildTestMessageWithSingleTriggerAndRedisplay(
+        final OSTestInAppMessageInternal message = InAppMessagingHelpers.buildTestMessageWithSingleTriggerAndRedisplay(
                 OSTriggerKind.CUSTOM, "test_1", OSTestTrigger.OSTriggerOperator.EQUAL_TO.toString(), 2, LIMIT, DELAY);
 
-        setMockRegistrationResponseWithMessages(new ArrayList<OSTestInAppMessage>() {{
+        setMockRegistrationResponseWithMessages(new ArrayList<OSTestInAppMessageInternal>() {{
             add(message);
         }});
 
@@ -1872,10 +1872,10 @@ public class InAppMessageIntegrationTests {
 
     @Test
     public void testLiquidIAMDisplayWaitsForGetTags() throws Exception {
-        final OSTestInAppMessage message = InAppMessagingHelpers.buildTestMessageWithSingleTriggerAndLiquid(
+        final OSTestInAppMessageInternal message = InAppMessagingHelpers.buildTestMessageWithSingleTriggerAndLiquid(
                 OSTriggerKind.CUSTOM, "test_1", OSTestTrigger.OSTriggerOperator.EQUAL_TO.toString(), 2);
 
-        setMockRegistrationResponseWithMessages(new ArrayList<OSTestInAppMessage>() {{
+        setMockRegistrationResponseWithMessages(new ArrayList<OSTestInAppMessageInternal>() {{
             add(message);
         }});
 
@@ -1904,10 +1904,10 @@ public class InAppMessageIntegrationTests {
         assertEquals("in_app_messages/" + message.messageId + "/impression", iamImpressionRequest.url);
     }
 
-    private void setMockRegistrationResponseWithMessages(ArrayList<OSTestInAppMessage> messages) throws JSONException {
+    private void setMockRegistrationResponseWithMessages(ArrayList<OSTestInAppMessageInternal> messages) throws JSONException {
         final JSONArray jsonMessages = new JSONArray();
 
-        for (OSTestInAppMessage message : messages)
+        for (OSTestInAppMessageInternal message : messages)
             jsonMessages.put(message.toJSONObject());
 
         ShadowOneSignalRestClient.setNextSuccessfulRegistrationResponse(new JSONObject() {{

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/InAppMessageIntegrationTests.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/InAppMessageIntegrationTests.java
@@ -1898,10 +1898,13 @@ public class InAppMessageIntegrationTests {
         threadAndTaskWait();
         // Runnable for webView is run from background thread to main thread
         threadAndTaskWait();
-        // Check impression request
-        requestSize = ShadowOneSignalRestClient.requests.size();
-        ShadowOneSignalRestClient.Request iamImpressionRequest = ShadowOneSignalRestClient.requests.get(requestSize - 1);
-        assertEquals("in_app_messages/" + message.messageId + "/impression", iamImpressionRequest.url);
+        ShadowOneSignalRestClient.Request lastRequest = ShadowOneSignalRestClient.requests.get(ShadowOneSignalRestClient.requests.size() - 1);
+        while (!lastRequest.url.equals("in_app_messages/" + message.messageId + "/impression")) {
+            // Check impression request by waiting until animationEnd
+            threadAndTaskWait();
+            lastRequest = ShadowOneSignalRestClient.requests.get(ShadowOneSignalRestClient.requests.size() - 1);
+        }
+        assertEquals("in_app_messages/" + message.messageId + "/impression", lastRequest.url);
     }
 
     private void setMockRegistrationResponseWithMessages(ArrayList<OSTestInAppMessageInternal> messages) throws JSONException {

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/InAppMessageIntegrationTests.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/InAppMessageIntegrationTests.java
@@ -425,7 +425,7 @@ public class InAppMessageIntegrationTests {
                 .untilAsserted(() -> {
                     assertEquals(1, OneSignalPackagePrivateHelper.getInAppMessageDisplayQueue().size());
                     try {
-                        assertEquals(message1.messageId, OneSignalPackagePrivateHelper.getShowingInAppMessageId());
+                        assertEquals(message1.getMessageId(), OneSignalPackagePrivateHelper.getShowingInAppMessageId());
                     } catch (NullPointerException e) {
                         // Awaitility won't retry if something is thrown, but will if an assert fails.
                         fail("Should not throw");
@@ -441,7 +441,7 @@ public class InAppMessageIntegrationTests {
                 .untilAsserted(() -> {
                     assertEquals(1, OneSignalPackagePrivateHelper.getInAppMessageDisplayQueue().size());
                     try {
-                        assertEquals(message2.messageId, OneSignalPackagePrivateHelper.getShowingInAppMessageId());
+                        assertEquals(message2.getMessageId(), OneSignalPackagePrivateHelper.getShowingInAppMessageId());
                     } catch (NullPointerException e) {
                         // Awaitility won't retry if something is thrown, but will if an assert fails.
                         fail("Should not throw");
@@ -663,7 +663,7 @@ public class InAppMessageIntegrationTests {
 
         // 3. Ensure click is sent
         ShadowOneSignalRestClient.Request iamImpressionRequest = ShadowOneSignalRestClient.requests.get(2);
-        assertEquals("in_app_messages/" + message.messageId + "/click", iamImpressionRequest.url);
+        assertEquals("in_app_messages/" + message.getMessageId() + "/click", iamImpressionRequest.url);
         assertEquals(3, ShadowOneSignalRestClient.requests.size());
 
         // 4. Call IAM clicked again, ensure a 2nd network call is not made.
@@ -758,7 +758,7 @@ public class InAppMessageIntegrationTests {
         OneSignalPackagePrivateHelper.onMessageActionOccurredOnMessage(message, action);
 
         // 3. Ensure outcome is sent
-        assertMeasureOnV2AtIndex(3, "outcome_name", new JSONArray().put(message.messageId), new JSONArray(), null, null);
+        assertMeasureOnV2AtIndex(3, "outcome_name", new JSONArray().put(message.getMessageId()), new JSONArray(), null, null);
     }
 
     @Test
@@ -840,7 +840,7 @@ public class InAppMessageIntegrationTests {
                 OneSignal.sendOutcome("test");
                 try {
                     // Ensure outcome is sent
-                    assertMeasureOnV2AtIndex(4, "test", new JSONArray().put(message.messageId), new JSONArray(), null, null);
+                    assertMeasureOnV2AtIndex(4, "test", new JSONArray().put(message.getMessageId()), new JSONArray(), null, null);
                 } catch (JSONException e) {
                     e.printStackTrace();
                 }
@@ -920,7 +920,7 @@ public class InAppMessageIntegrationTests {
         OneSignal.sendOutcome("test1");
         try {
             // Ensure outcome is sent but with INDIRECT influence from IAM
-            assertMeasureOnV2AtIndex(5, "test1", null, null, new JSONArray().put(message.messageId), new JSONArray());
+            assertMeasureOnV2AtIndex(5, "test1", null, null, new JSONArray().put(message.getMessageId()), new JSONArray());
         } catch (JSONException e) {
             e.printStackTrace();
         }
@@ -1007,7 +1007,7 @@ public class InAppMessageIntegrationTests {
         OneSignalPackagePrivateHelper.onMessageActionOccurredOnMessage(message, action);
         // Requests: Param request + Players Request + Click request
         assertEquals(3, ShadowOneSignalRestClient.requests.size());
-        assertEquals("in_app_messages/" + message.messageId + "/click", ShadowOneSignalRestClient.requests.get(2).url);
+        assertEquals("in_app_messages/" + message.getMessageId() + "/click", ShadowOneSignalRestClient.requests.get(2).url);
     }
 
     @Test
@@ -1220,7 +1220,7 @@ public class InAppMessageIntegrationTests {
         assertEquals(4, ShadowOneSignalRestClient.requests.size());
 
         // Now verify the most recent request was not a click request
-        boolean isIamClickUrl = mostRecentRequest.url.equals("in_app_messages/" + message.messageId + "/click");
+        boolean isIamClickUrl = mostRecentRequest.url.equals("in_app_messages/" + message.getMessageId() + "/click");
         assertFalse(isIamClickUrl);
     }
 
@@ -1241,7 +1241,7 @@ public class InAppMessageIntegrationTests {
         OneSignalPackagePrivateHelper.onMessageWasShown(message);
 
         ShadowOneSignalRestClient.Request iamImpressionRequest = ShadowOneSignalRestClient.requests.get(2);
-        assertEquals("in_app_messages/" + message.messageId + "/impression", iamImpressionRequest.url);
+        assertEquals("in_app_messages/" + message.getMessageId() + "/impression", iamImpressionRequest.url);
         assertEquals(3, ShadowOneSignalRestClient.requests.size());
 
         // Call message shown again and make sure no other requests were made, so the impression tracking exists locally
@@ -1286,7 +1286,7 @@ public class InAppMessageIntegrationTests {
         assertEquals(4, ShadowOneSignalRestClient.requests.size());
 
         // Now verify the most recent request was not a impression request
-        boolean isImpressionUrl = mostRecentRequest.url.equals("in_app_messages/" + message.messageId + "/impression");
+        boolean isImpressionUrl = mostRecentRequest.url.equals("in_app_messages/" + message.getMessageId() + "/impression");
         assertFalse(isImpressionUrl);
     }
 
@@ -1309,7 +1309,7 @@ public class InAppMessageIntegrationTests {
         // Check impression request
         int requestSize = ShadowOneSignalRestClient.requests.size();
         ShadowOneSignalRestClient.Request iamImpressionRequest = ShadowOneSignalRestClient.requests.get(requestSize - 1);
-        assertEquals("in_app_messages/" + message.messageId + "/impression", iamImpressionRequest.url);
+        assertEquals("in_app_messages/" + message.getMessageId() + "/impression", iamImpressionRequest.url);
 
         // Dismiss IAM will make display quantity increase and last display time to change
         OneSignalPackagePrivateHelper.dismissCurrentMessage();
@@ -1329,7 +1329,7 @@ public class InAppMessageIntegrationTests {
         // Check impression request is sent again
         int requestSizeAfterRedisplay = ShadowOneSignalRestClient.requests.size();
         ShadowOneSignalRestClient.Request iamImpressionRequestAfterRedisplay = ShadowOneSignalRestClient.requests.get(requestSizeAfterRedisplay - 1);
-        assertEquals("in_app_messages/" + message.messageId + "/impression", iamImpressionRequestAfterRedisplay.url);
+        assertEquals("in_app_messages/" + message.getMessageId() + "/impression", iamImpressionRequestAfterRedisplay.url);
 
         OneSignalPackagePrivateHelper.dismissCurrentMessage();
         // Check IAMs was removed from queue
@@ -1433,7 +1433,7 @@ public class InAppMessageIntegrationTests {
         TestOneSignalPrefs.saveStringSet(
                 TestOneSignalPrefs.PREFS_ONESIGNAL,
                 TestOneSignalPrefs.PREFS_OS_DISMISSED_IAMS,
-                new HashSet<>(Collections.singletonList(message.messageId))
+                new HashSet<>(Collections.singletonList(message.getMessageId()))
         );
 
         // Check IAM was saved correctly
@@ -1600,7 +1600,7 @@ public class InAppMessageIntegrationTests {
         // Check impression request
         int requestSize = ShadowOneSignalRestClient.requests.size();
         ShadowOneSignalRestClient.Request iamImpressionRequest = ShadowOneSignalRestClient.requests.get(requestSize - 1);
-        assertEquals("in_app_messages/" + message.messageId + "/impression", iamImpressionRequest.url);
+        assertEquals("in_app_messages/" + message.getMessageId() + "/impression", iamImpressionRequest.url);
 
         // Dismiss IAM will make display quantity increase and last display time to change
         OneSignalPackagePrivateHelper.dismissCurrentMessage();
@@ -1634,7 +1634,7 @@ public class InAppMessageIntegrationTests {
         // Check impression request is sent again
         int requestSizeAfterRedisplay = ShadowOneSignalRestClient.requests.size();
         ShadowOneSignalRestClient.Request iamImpressionRequestAfterRedisplay = ShadowOneSignalRestClient.requests.get(requestSizeAfterRedisplay - 1);
-        assertEquals("in_app_messages/" + message.messageId + "/impression", iamImpressionRequestAfterRedisplay.url);
+        assertEquals("in_app_messages/" + message.getMessageId() + "/impression", iamImpressionRequestAfterRedisplay.url);
 
         OneSignalPackagePrivateHelper.dismissCurrentMessage();
         // Check if data after dismiss is set correctly
@@ -1662,7 +1662,7 @@ public class InAppMessageIntegrationTests {
 
         // Ensure click is sent
         ShadowOneSignalRestClient.Request firstIAMClickRequest = ShadowOneSignalRestClient.requests.get(2);
-        assertEquals("in_app_messages/" + message.messageId + "/click", firstIAMClickRequest.url);
+        assertEquals("in_app_messages/" + message.getMessageId() + "/click", firstIAMClickRequest.url);
         assertEquals(3, ShadowOneSignalRestClient.requests.size());
 
         // Call IAM clicked again, ensure a 2nd network call isn't made.
@@ -1688,7 +1688,7 @@ public class InAppMessageIntegrationTests {
 
         // Call IAM clicked again, ensure a 2nd network call is made.
         ShadowOneSignalRestClient.Request secondIAMClickRequest = ShadowOneSignalRestClient.requests.get(3);
-        assertEquals("in_app_messages/" + message.messageId + "/click", secondIAMClickRequest.url);
+        assertEquals("in_app_messages/" + message.getMessageId() + "/click", secondIAMClickRequest.url);
         assertEquals(4, ShadowOneSignalRestClient.requests.size());
 
         // Verify clickId was persisted locally
@@ -1707,7 +1707,7 @@ public class InAppMessageIntegrationTests {
         OneSignalPackagePrivateHelper.onMessageActionOccurredOnMessage(message, action);
 
         // Call IAM clicked again, ensure a 3nd network call isn't made.
-        assertEquals("in_app_messages/" + message.messageId + "/click", secondIAMClickRequest.url);
+        assertEquals("in_app_messages/" + message.getMessageId() + "/click", secondIAMClickRequest.url);
         assertEquals(4, ShadowOneSignalRestClient.requests.size());
     }
 
@@ -1732,8 +1732,8 @@ public class InAppMessageIntegrationTests {
 
         // 2. Cache IAMs as dismissed, impressioned, and clicked
         Set<String> messageIds = new HashSet<String>() {{
-            add(iam1.messageId);
-            add(iam2.messageId);
+            add(iam1.getMessageId());
+            add(iam2.getMessageId());
         }};
         TestOneSignalPrefs.saveStringSet(
                 TestOneSignalPrefs.PREFS_ONESIGNAL,
@@ -1764,14 +1764,14 @@ public class InAppMessageIntegrationTests {
                 TestOneSignalPrefs.PREFS_OS_DISMISSED_IAMS,
                 null);
         assertEquals(1, testDismissedMessages.size());
-        assertTrue(testDismissedMessages.contains(iam1.messageId));
+        assertTrue(testDismissedMessages.contains(iam1.getMessageId()));
 
         Set<String> testImpressionedMessages = TestOneSignalPrefs.getStringSet(
                 TestOneSignalPrefs.PREFS_ONESIGNAL,
                 TestOneSignalPrefs.PREFS_OS_IMPRESSIONED_IAMS,
                 null);
         assertEquals(1, testImpressionedMessages.size());
-        assertTrue(testImpressionedMessages.contains(iam1.messageId));
+        assertTrue(testImpressionedMessages.contains(iam1.getMessageId()));
 
         Set<String> testClickedClickIds = TestOneSignalPrefs.getStringSet(
                 TestOneSignalPrefs.PREFS_ONESIGNAL,
@@ -1783,7 +1783,7 @@ public class InAppMessageIntegrationTests {
         // 5. Make sure only IAM left is the IAM younger than 6 months
         List<OSTestInAppMessageInternal> savedInAppMessagesAfterInit = TestHelpers.getAllInAppMessages(dbHelper);
         assertEquals(1, savedInAppMessagesAfterInit.size());
-        assertEquals(iam1.messageId, savedInAppMessagesAfterInit.get(0).messageId);
+        assertEquals(iam1.getMessageId(), savedInAppMessagesAfterInit.get(0).getMessageId());
     }
 
     @Test
@@ -1793,13 +1793,13 @@ public class InAppMessageIntegrationTests {
         final OSTestInAppMessageInternal inAppMessage = InAppMessagingHelpers.buildTestMessageWithSingleTriggerAndRedisplay(
                 OSTriggerKind.CUSTOM, "test_saved", OneSignalPackagePrivateHelper.OSTestTrigger.OSTriggerOperator.EQUAL_TO.toString(), 2, LIMIT, DELAY);
 
-        String firstID = inAppMessage.messageId + "_test";
-        inAppMessage.messageId = firstID;
+        String firstID = inAppMessage.getMessageId() + "_test";
+        inAppMessage.setMessageId(firstID);
         inAppMessage.getRedisplayStats().setLastDisplayTime(currentTimeInSeconds - SIX_MONTHS_TIME_SECONDS + 1);
         TestHelpers.saveIAM(inAppMessage, dbHelper);
 
         inAppMessage.getRedisplayStats().setLastDisplayTime(currentTimeInSeconds - SIX_MONTHS_TIME_SECONDS - 1);
-        inAppMessage.messageId += "1";
+        inAppMessage.setMessageId(inAppMessage.getMessageId() + "1");
         TestHelpers.saveIAM(inAppMessage, dbHelper);
 
         List<OSTestInAppMessageInternal> savedInAppMessages = TestHelpers.getAllInAppMessages(dbHelper);
@@ -1823,7 +1823,7 @@ public class InAppMessageIntegrationTests {
         List<OSTestInAppMessageInternal> savedInAppMessagesAfterInit = TestHelpers.getAllInAppMessages(dbHelper);
         // Message with old display time should be removed
         assertEquals(1, savedInAppMessagesAfterInit.size());
-        assertEquals(firstID, savedInAppMessagesAfterInit.get(0).messageId);
+        assertEquals(firstID, savedInAppMessagesAfterInit.get(0).getMessageId());
     }
 
     @Test
@@ -1899,12 +1899,12 @@ public class InAppMessageIntegrationTests {
         // Runnable for webView is run from background thread to main thread
         threadAndTaskWait();
         ShadowOneSignalRestClient.Request lastRequest = ShadowOneSignalRestClient.requests.get(ShadowOneSignalRestClient.requests.size() - 1);
-        while (!lastRequest.url.equals("in_app_messages/" + message.messageId + "/impression")) {
+        while (!lastRequest.url.equals("in_app_messages/" + message.getMessageId() + "/impression")) {
             // Check impression request by waiting until animationEnd
             threadAndTaskWait();
             lastRequest = ShadowOneSignalRestClient.requests.get(ShadowOneSignalRestClient.requests.size() - 1);
         }
-        assertEquals("in_app_messages/" + message.messageId + "/impression", lastRequest.url);
+        assertEquals("in_app_messages/" + message.getMessageId() + "/impression", lastRequest.url);
     }
 
     private void setMockRegistrationResponseWithMessages(ArrayList<OSTestInAppMessageInternal> messages) throws JSONException {

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/InAppMessagingUnitTests.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/InAppMessagingUnitTests.java
@@ -10,7 +10,7 @@ import com.onesignal.MockOSTimeImpl;
 import com.onesignal.OSInAppMessageAction;
 import com.onesignal.OneSignal;
 import com.onesignal.OneSignalPackagePrivateHelper;
-import com.onesignal.OneSignalPackagePrivateHelper.OSTestInAppMessage;
+import com.onesignal.OneSignalPackagePrivateHelper.OSTestInAppMessageInternal;
 import com.onesignal.OneSignalPackagePrivateHelper.OSTestInAppMessageAction;
 import com.onesignal.OneSignalPackagePrivateHelper.OSTestTrigger;
 import com.onesignal.ShadowCustomTabsClient;
@@ -79,7 +79,7 @@ public class InAppMessagingUnitTests {
     private static final int LIMIT = 5;
     private static final long DELAY = 60;
 
-    private static OSTestInAppMessage message;
+    private static OSTestInAppMessageInternal message;
 
     @SuppressLint("StaticFieldLeak")
     private static Activity blankActivity;
@@ -142,7 +142,7 @@ public class InAppMessagingUnitTests {
      */
     private static boolean comparativeOperatorTest(OSTriggerOperator operator, Object triggerValue, Object localValue) throws JSONException {
         setLocalTriggerValue("test_property", localValue);
-        OSTestInAppMessage testMessage = InAppMessagingHelpers.buildTestMessageWithSingleTrigger(OSTriggerKind.CUSTOM, "test_property", operator.toString(), triggerValue);
+        OSTestInAppMessageInternal testMessage = InAppMessagingHelpers.buildTestMessageWithSingleTrigger(OSTriggerKind.CUSTOM, "test_property", operator.toString(), triggerValue);
         return InAppMessagingHelpers.evaluateMessage(testMessage);
     }
 
@@ -160,7 +160,7 @@ public class InAppMessagingUnitTests {
 
     @Test
     public void testBuiltMessageReDisplay() throws JSONException {
-        OSTestInAppMessage message = InAppMessagingHelpers.buildTestMessageWitRedisplay(
+        OSTestInAppMessageInternal message = InAppMessagingHelpers.buildTestMessageWitRedisplay(
                 LIMIT,
                 DELAY
         );
@@ -170,7 +170,7 @@ public class InAppMessagingUnitTests {
         assertEquals(-1, message.getRedisplayStats().getLastDisplayTime());
         assertEquals(0, message.getRedisplayStats().getDisplayQuantity());
 
-        OSTestInAppMessage messageWithoutDisplay = InAppMessagingHelpers.buildTestMessageWithSingleTrigger(
+        OSTestInAppMessageInternal messageWithoutDisplay = InAppMessagingHelpers.buildTestMessageWithSingleTrigger(
                 OSTriggerKind.SESSION_TIME,
                 null,
                 OSTriggerOperator.GREATER_THAN_OR_EQUAL_TO.toString(),
@@ -185,7 +185,7 @@ public class InAppMessagingUnitTests {
 
     @Test
     public void testBuiltMessageRedisplayLimit() throws JSONException {
-        OSTestInAppMessage message = InAppMessagingHelpers.buildTestMessageWitRedisplay(
+        OSTestInAppMessageInternal message = InAppMessagingHelpers.buildTestMessageWitRedisplay(
                 LIMIT,
                 DELAY
         );
@@ -203,7 +203,7 @@ public class InAppMessagingUnitTests {
     public void testBuiltMessageRedisplayDelay() throws JSONException {
         MockOSTimeImpl time = new MockOSTimeImpl();
         OneSignal_setTime(time);
-        OSTestInAppMessage message = InAppMessagingHelpers.buildTestMessageWitRedisplay(
+        OSTestInAppMessageInternal message = InAppMessagingHelpers.buildTestMessageWitRedisplay(
                 LIMIT,
                 DELAY
         );
@@ -221,7 +221,7 @@ public class InAppMessagingUnitTests {
 
     @Test
     public void testBuiltMessageRedisplayCLickId() throws JSONException {
-        OSTestInAppMessage message = InAppMessagingHelpers.buildTestMessageWitRedisplay(
+        OSTestInAppMessageInternal message = InAppMessagingHelpers.buildTestMessageWitRedisplay(
                 LIMIT,
                 DELAY
         );
@@ -240,7 +240,7 @@ public class InAppMessagingUnitTests {
 
         assertFalse(message.isClickAvailable(IAM_CLICK_ID));
 
-        OSTestInAppMessage messageWithoutDisplay = InAppMessagingHelpers.buildTestMessageWithSingleTrigger(
+        OSTestInAppMessageInternal messageWithoutDisplay = InAppMessagingHelpers.buildTestMessageWithSingleTrigger(
                 OSTriggerKind.SESSION_TIME,
                 null,
                 OSTriggerOperator.GREATER_THAN_OR_EQUAL_TO.toString(),
@@ -529,7 +529,7 @@ public class InAppMessagingUnitTests {
             }});
         }};
 
-        OSTestInAppMessage testMessage = InAppMessagingHelpers.buildTestMessageWithMultipleTriggers(triggers);
+        OSTestInAppMessageInternal testMessage = InAppMessagingHelpers.buildTestMessageWithMultipleTriggers(triggers);
         assertFalse(InAppMessagingHelpers.evaluateMessage(testMessage));
         assertTrue(ShadowDynamicTimer.hasScheduledTimer);
         assertTrue(roughlyEqualTimerValues(5.0, ShadowDynamicTimer.mostRecentTimerDelaySeconds()));
@@ -551,7 +551,7 @@ public class InAppMessagingUnitTests {
             }});
         }};
 
-        OSTestInAppMessage testMessage = InAppMessagingHelpers.buildTestMessageWithMultipleTriggers(triggers);
+        OSTestInAppMessageInternal testMessage = InAppMessagingHelpers.buildTestMessageWithMultipleTriggers(triggers);
         assertTrue(InAppMessagingHelpers.evaluateMessage(testMessage));
     }
 

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/InAppMessagingUnitTests.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/InAppMessagingUnitTests.java
@@ -152,7 +152,7 @@ public class InAppMessagingUnitTests {
 
     @Test
     public void testBuiltMessage() {
-        UUID.fromString(message.messageId); // Throws if invalid
+        UUID.fromString(message.getMessageId()); // Throws if invalid
         assertNotNull(message.variants);
     }
 
@@ -594,7 +594,7 @@ public class InAppMessagingUnitTests {
 
         // Ensure we make REST call to OneSignal to report click.
         ShadowOneSignalRestClient.Request iamClickRequest = ShadowOneSignalRestClient.requests.get(2);
-        assertEquals("in_app_messages/" + message.messageId + "/click", iamClickRequest.url);
+        assertEquals("in_app_messages/" + message.getMessageId() + "/click", iamClickRequest.url);
         assertEquals(InAppMessagingHelpers.ONESIGNAL_APP_ID, iamClickRequest.payload.get("app_id"));
         assertEquals(1, iamClickRequest.payload.get("device_type"));
         assertEquals(message.variants.get("android").get("en"), iamClickRequest.payload.get("variant_id"));
@@ -614,7 +614,7 @@ public class InAppMessagingUnitTests {
 
         ShadowOneSignalRestClient.Request iamImpressionRequest = ShadowOneSignalRestClient.requests.get(2);
 
-        assertEquals("in_app_messages/" + message.messageId + "/impression", iamImpressionRequest.url);
+        assertEquals("in_app_messages/" + message.getMessageId() + "/impression", iamImpressionRequest.url);
         assertEquals(InAppMessagingHelpers.ONESIGNAL_APP_ID, iamImpressionRequest.payload.get("app_id"));
         assertEquals(ShadowOneSignalRestClient.pushUserId, iamImpressionRequest.payload.get("player_id"));
         assertEquals(1, iamImpressionRequest.payload.get("device_type"));
@@ -629,7 +629,7 @@ public class InAppMessagingUnitTests {
 
         ShadowOneSignalRestClient.Request iamPageImpressionRequest = ShadowOneSignalRestClient.requests.get(2);
 
-        assertEquals("in_app_messages/" + message.messageId + "/pageImpression", iamPageImpressionRequest.url);
+        assertEquals("in_app_messages/" + message.getMessageId() + "/pageImpression", iamPageImpressionRequest.url);
         assertEquals(InAppMessagingHelpers.ONESIGNAL_APP_ID, iamPageImpressionRequest.payload.get("app_id"));
         assertEquals(ShadowOneSignalRestClient.pushUserId, iamPageImpressionRequest.payload.get("player_id"));
         assertEquals(1, iamPageImpressionRequest.payload.get("device_type"));
@@ -684,6 +684,6 @@ public class InAppMessagingUnitTests {
         assertEquals(4,iamLifecycleCounter);
 
         assertNotNull(lastMessage);
-        assertEquals(lastMessage.messageId, message.messageId);
+        assertEquals(lastMessage.getMessageId(), message.getMessageId());
     }
 }

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/InAppMessagingUnitTests.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/InAppMessagingUnitTests.java
@@ -7,7 +7,7 @@ import androidx.annotation.Nullable;
 
 import com.onesignal.InAppMessagingHelpers;
 import com.onesignal.MockOSTimeImpl;
-import com.onesignal.OSIAMLifecycleHandler;
+import com.onesignal.OSInAppMessageLifecycleHandler;
 import com.onesignal.OSInAppMessage;
 import com.onesignal.OSInAppMessageAction;
 import com.onesignal.OneSignal;
@@ -642,7 +642,7 @@ public class InAppMessagingUnitTests {
     private static int iamLifecycleCounter;
     @Test
     public void testIAMLifecycleEventsFlow() throws Exception {
-        OneSignal.setIAMLifecycleHandler(new OSIAMLifecycleHandler() {
+        OneSignal.setInAppMessageLifecycleHandler(new OSInAppMessageLifecycleHandler() {
             @Override
             public void onWillDisplayInAppMessage(OSInAppMessage message) {
                 lastMessage = message;

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/TestHelpers.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/TestHelpers.java
@@ -19,10 +19,9 @@ import androidx.work.testing.WorkManagerTestInitHelper;
 
 import com.onesignal.FocusDelaySyncJobService;
 import com.onesignal.MockOSTimeImpl;
-import com.onesignal.OneSignal;
 import com.onesignal.OneSignalDb;
 import com.onesignal.OneSignalPackagePrivateHelper;
-import com.onesignal.OneSignalPackagePrivateHelper.OSTestInAppMessage;
+import com.onesignal.OneSignalPackagePrivateHelper.OSTestInAppMessageInternal;
 import com.onesignal.OneSignalPackagePrivateHelper.TestOneSignalPrefs;
 import com.onesignal.OneSignalShadowPackageManager;
 import com.onesignal.OSOutcomeEvent;
@@ -59,7 +58,6 @@ import junit.framework.Assert;
 
 import org.json.JSONArray;
 import org.json.JSONException;
-import org.json.JSONObject;
 import org.robolectric.Robolectric;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.android.controller.ActivityController;
@@ -72,7 +70,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import static com.onesignal.OneSignalPackagePrivateHelper.JSONUtils;
 import static com.onesignal.OneSignalPackagePrivateHelper.OneSignal_OSTaskController_ShutdownNow;
 import static junit.framework.Assert.assertEquals;
 import static org.robolectric.Shadows.shadowOf;
@@ -439,7 +436,7 @@ public class TestHelpers {
       return cachedUniqueOutcomes;
    }
 
-   synchronized static void saveIAM(OSTestInAppMessage inAppMessage, OneSignalDb db) {
+   synchronized static void saveIAM(OSTestInAppMessageInternal inAppMessage, OneSignalDb db) {
       ContentValues values = new ContentValues();
       values.put(OneSignalPackagePrivateHelper.InAppMessageTable.COLUMN_NAME_MESSAGE_ID, inAppMessage.messageId);
       values.put(OneSignalPackagePrivateHelper.InAppMessageTable.COLUMN_NAME_DISPLAY_QUANTITY, inAppMessage.getRedisplayStats().getDisplayQuantity());
@@ -450,7 +447,7 @@ public class TestHelpers {
       db.insert(OneSignalPackagePrivateHelper.InAppMessageTable.TABLE_NAME, null, values);
    }
 
-   synchronized static List<OSTestInAppMessage> getAllInAppMessages(OneSignalDb db) throws JSONException {
+   synchronized static List<OSTestInAppMessageInternal> getAllInAppMessages(OneSignalDb db) throws JSONException {
       Cursor cursor = db.query(
               OneSignalPackagePrivateHelper.InAppMessageTable.TABLE_NAME,
               null,
@@ -461,7 +458,7 @@ public class TestHelpers {
               null
       );
 
-      List<OSTestInAppMessage> iams = new ArrayList<>();
+      List<OSTestInAppMessageInternal> iams = new ArrayList<>();
       if (cursor.moveToFirst())
          do {
             String messageId = cursor.getString(cursor.getColumnIndex(OneSignalPackagePrivateHelper.InAppMessageTable.COLUMN_NAME_MESSAGE_ID));
@@ -477,7 +474,7 @@ public class TestHelpers {
                clickIdsSet.add(clickIdsArray.getString(i));
             }
 
-            OSTestInAppMessage inAppMessage = new OSTestInAppMessage(messageId, displayQuantity, lastDisplay, displayed, clickIdsSet);
+            OSTestInAppMessageInternal inAppMessage = new OSTestInAppMessageInternal(messageId, displayQuantity, lastDisplay, displayed, clickIdsSet);
             iams.add(inAppMessage);
          } while (cursor.moveToNext());
 

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/TestHelpers.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/TestHelpers.java
@@ -438,7 +438,7 @@ public class TestHelpers {
 
    synchronized static void saveIAM(OSTestInAppMessageInternal inAppMessage, OneSignalDb db) {
       ContentValues values = new ContentValues();
-      values.put(OneSignalPackagePrivateHelper.InAppMessageTable.COLUMN_NAME_MESSAGE_ID, inAppMessage.messageId);
+      values.put(OneSignalPackagePrivateHelper.InAppMessageTable.COLUMN_NAME_MESSAGE_ID, inAppMessage.getMessageId());
       values.put(OneSignalPackagePrivateHelper.InAppMessageTable.COLUMN_NAME_DISPLAY_QUANTITY, inAppMessage.getRedisplayStats().getDisplayQuantity());
       values.put(OneSignalPackagePrivateHelper.InAppMessageTable.COLUMN_NAME_LAST_DISPLAY, inAppMessage.getRedisplayStats().getLastDisplayTime());
       values.put(OneSignalPackagePrivateHelper.InAppMessageTable.COLUMN_CLICK_IDS, inAppMessage.getClickedClickIds().toString());


### PR DESCRIPTION
Provide these events to users through `setIAMLifecycleHandler(OSIAMLifecycleHandler handler)`
- onWillDisplayInAppMessage (OSInAppMessage message)
- onDidDisplayInAppMessage (OSInAppMessage message)
- onWillDismissInAppMessage (OSInAppMessage message)
- onDidDismissInAppMessage (OSInAppMessage message)

Callouts:
- changed when impressions are sent (from start of animation to end of animation instead)
- known issue with launch URLs with `Dismiss on click` **unchecked**, causing IAM to to be dismissed without firing the lifecycle events for dismissing
- renamed OSInAppMessage to OSInAppMessageInternal
- OSInAppMessageInternal now inherits from OSInAppMessage (which contains only messageId)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1405)
<!-- Reviewable:end -->
