### PR TITLE
Checking shouldLogUserPrivacyConsentErrorMessage for Outcomes

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -3304,6 +3304,10 @@ public class OneSignal {
          return;
       }
 
+      if (shouldLogUserPrivacyConsentErrorMessageForMethodName("sendOutcome()")) {
+         return;
+      }
+
       outcomeEventsController.sendOutcomeEvent(name, callback);
    }
 
@@ -3326,6 +3330,10 @@ public class OneSignal {
                sendUniqueOutcome(name, callback);
             }
          });
+         return;
+      }
+
+      if (shouldLogUserPrivacyConsentErrorMessageForMethodName("sendUniqueOutcome()")) {
          return;
       }
 


### PR DESCRIPTION
Currently OneSignal crashes if an App sends outcomes or unique outcomes when requires privacy consent is true.
Now we will log an error message and return instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1409)
<!-- Reviewable:end -->
