### PR TITLE
Android 12 Compatibility -add pending intent flag immutable

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotification.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotification.java
@@ -128,7 +128,7 @@ class GenerateNotification {
    }
 
    private static PendingIntent getNewDismissActionPendingIntent(int requestCode, Intent intent) {
-      return PendingIntent.getBroadcast(currentContext, requestCode, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+      return PendingIntent.getBroadcast(currentContext, requestCode, intent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
    }
 
    private static Intent getNewBaseDismissIntent(int notificationId) {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotificationOpenIntent.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotificationOpenIntent.kt
@@ -59,6 +59,7 @@ class GenerateNotificationOpenIntent(
         requestCode: Int,
         oneSignalIntent: Intent,
     ): PendingIntent? {
+        val flags =  PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         val launchIntent = getIntentVisible()
             ?:
             // Even though the default app open action is disabled we still need to attach OneSignal's
@@ -71,7 +72,7 @@ class GenerateNotificationOpenIntent(
                 context,
                 requestCode,
                 oneSignalIntent,
-                PendingIntent.FLAG_UPDATE_CURRENT
+                flags
             )
 
 
@@ -84,7 +85,7 @@ class GenerateNotificationOpenIntent(
             context,
             requestCode,
             arrayOf(launchIntent, oneSignalIntent),
-            PendingIntent.FLAG_UPDATE_CURRENT
+            flags
         )
     }
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSBackgroundSync.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSBackgroundSync.java
@@ -178,7 +178,7 @@ abstract class OSBackgroundSync {
                 context,
                 getSyncTaskId(),
                 new Intent(context, getSyncServicePendingIntentClass()),
-                PendingIntent.FLAG_UPDATE_CURRENT
+                PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE
         );
     }
 


### PR DESCRIPTION
## Details
Android 12 requires `PendingIntents` to set `FLAG_IMMUTABLE`
https://developer.android.com/about/versions/12/behavior-changes-12#pending-intent-mutability

This is based on PR #1400, thanks to @AndreasBoehm


##
`PendingIntent.FLAG_IMMUTABLE` was interduce in Android API 23 (android 6.0) but confirmed on Android 4.4 the flag is safely ignored.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1411)
<!-- Reviewable:end -->
