### PR TITLE
Check `NullPointerException` when `getDeviceType()`

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSReceiveReceiptController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSReceiveReceiptController.java
@@ -54,7 +54,7 @@ class OSReceiveReceiptController {
     void sendReceiveReceipt(final CallbackToFutureAdapter.Completer<ListenableWorker.Result> callbackCompleter, @NonNull final String notificationId) {
         final String appId = OneSignal.appId == null || OneSignal.appId.isEmpty() ? OneSignal.getSavedAppId() : OneSignal.appId;
         final String playerId = OneSignal.getUserId();
-        final int deviceType = new OSUtils().getDeviceType();
+        Integer deviceType = null;
 
         if (!remoteParamController.isReceiveReceiptEnabled()) {
             OneSignal.Log(OneSignal.LOG_LEVEL.DEBUG, "sendReceiveReceipt disable");
@@ -62,10 +62,19 @@ class OSReceiveReceiptController {
             return;
         }
 
+        try {
+            deviceType = new OSUtils().getDeviceType();
+        } catch (NullPointerException e) {
+            e.printStackTrace();
+        }
+
+        final Integer finalDeviceType = deviceType;
+        OneSignal.Log(OneSignal.LOG_LEVEL.DEBUG, "OSReceiveReceiptController: Device Type is: " + finalDeviceType);
+
         Runnable receiveReceiptRunnable = new Runnable() {
             @Override
             public void run() {
-                repository.sendReceiveReceipt(appId, playerId, deviceType, notificationId, new OneSignalRestClient.ResponseHandler() {
+                repository.sendReceiveReceipt(appId, playerId, finalDeviceType, notificationId, new OneSignalRestClient.ResponseHandler() {
                     @Override
                     void onSuccess(String response) {
                         OneSignal.Log(OneSignal.LOG_LEVEL.DEBUG, "Receive receipt sent for notificationID: " + notificationId);

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSReceiveReceiptRepository.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSReceiveReceiptRepository.java
@@ -28,6 +28,7 @@
 package com.onesignal;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -38,12 +39,15 @@ class OSReceiveReceiptRepository {
     private static final String PLAYER_ID = "player_id";
     private static final String DEVICE_TYPE = "device_type";
 
-    void sendReceiveReceipt(@NonNull String appId, @NonNull String playerId,  @NonNull int deviceType, @NonNull String notificationId, @NonNull OneSignalRestClient.ResponseHandler responseHandler) {
+    void sendReceiveReceipt(@NonNull String appId, @NonNull String playerId, @Nullable Integer deviceType, @NonNull String notificationId, @NonNull OneSignalRestClient.ResponseHandler responseHandler) {
         try {
             JSONObject jsonBody = new JSONObject()
                     .put(APP_ID, appId)
-                    .put(PLAYER_ID, playerId)
-                    .put(DEVICE_TYPE, deviceType);
+                    .put(PLAYER_ID, playerId);
+
+            if (deviceType != null) {
+                jsonBody.put(DEVICE_TYPE, deviceType);
+            }
 
             OneSignalRestClient.put("notifications/" + notificationId + "/report_received", jsonBody, responseHandler);
         } catch (JSONException e) {


### PR DESCRIPTION
- Calling getDeviceType() in OSUtils
- In packageInstalledAndEnabled(), the appContext can be null

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1416)
<!-- Reviewable:end -->
