### PR TITLE
Fixing material dependency error in dev app

### DIFF
--- a/Examples/OneSignalDemo/app/build.gradle
+++ b/Examples/OneSignalDemo/app/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
     implementation 'com.android.support:multidex:1.0.3'
-    implementation 'com.google.android.material:material:[1.0.0, 1.99.99]'
+    implementation 'com.google.android.material:material:[1.0.0, 1.4.99]'
 
     implementation 'androidx.cardview:cardview:[1.0.0, 1.99.99]'
     implementation 'androidx.appcompat:appcompat:[1.0.0, 1.99.99]'


### PR DESCRIPTION
The material design library updated to a version that requires a higher version than we support resulting in a build error in our dev app. This PR caps the version at 1.4.99

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1430)
<!-- Reviewable:end -->
