### PR TITLE
Add onNewToken with Bundle HMS method support

### DIFF
--- a/Examples/OneSignalDemo/app/build.gradle
+++ b/Examples/OneSignalDemo/app/build.gradle
@@ -75,7 +75,7 @@ dependencies {
     // Test local OneSignal SDK
     gmsImplementation(project(':onesignal'))
 
-    huaweiImplementation 'com.huawei.hms:push:5.0.0.300'
+    huaweiImplementation 'com.huawei.hms:push:5.3.0.304'
     huaweiImplementation 'com.huawei.hms:location:4.0.0.300'
     // Omit Google / Firebase libraries for Huawei builds.
     huaweiImplementation(project(':onesignal')) {

--- a/Examples/OneSignalDemo/app/src/huawei/java/com/onesignal/sdktest/notification/HmsMessageServiceAppLevel.java
+++ b/Examples/OneSignalDemo/app/src/huawei/java/com/onesignal/sdktest/notification/HmsMessageServiceAppLevel.java
@@ -9,7 +9,6 @@ import com.onesignal.OneSignalHmsEventBridge;
 
 public class HmsMessageServiceAppLevel extends HmsMessageService {
 
-
     /**
      * When an app calls the getToken method to apply for a token from the server,
      * if the server does not return the token during current method calling, the server can return the token through this method later.

--- a/Examples/OneSignalDemo/app/src/huawei/java/com/onesignal/sdktest/notification/HmsMessageServiceAppLevel.java
+++ b/Examples/OneSignalDemo/app/src/huawei/java/com/onesignal/sdktest/notification/HmsMessageServiceAppLevel.java
@@ -1,5 +1,7 @@
 package com.onesignal.sdktest.notification;
 
+import android.os.Bundle;
+
 import com.huawei.hms.push.HmsMessageService;
 import com.huawei.hms.push.RemoteMessage;
 import com.onesignal.OneSignal;
@@ -7,19 +9,21 @@ import com.onesignal.OneSignalHmsEventBridge;
 
 public class HmsMessageServiceAppLevel extends HmsMessageService {
 
+
     /**
      * When an app calls the getToken method to apply for a token from the server,
      * if the server does not return the token during current method calling, the server can return the token through this method later.
      * This method callback must be completed in 10 seconds. Otherwise, you need to start a new Job for callback processing.
      *
      * @param token token
+     * @param bundle bundle
      */
     @Override
-    public void onNewToken(String token) {
-        OneSignal.onesignalLog(OneSignal.LOG_LEVEL.DEBUG, "HMS onNewToken refresh token:" + token);
+    public void onNewToken(String token, Bundle bundle) {
+        OneSignal.onesignalLog(OneSignal.LOG_LEVEL.DEBUG, "HMS onNewToken refresh token:" + token + " bundle: " + bundle);
 
         // Forward event on to OneSignal SDK
-        OneSignalHmsEventBridge.onNewToken(this, token);
+        OneSignalHmsEventBridge.onNewToken(this, token, bundle);
     }
 
     /**

--- a/Examples/OneSignalDemo/app/src/huawei/java/com/onesignal/sdktest/notification/HmsMessageServiceAppLevel.java
+++ b/Examples/OneSignalDemo/app/src/huawei/java/com/onesignal/sdktest/notification/HmsMessageServiceAppLevel.java
@@ -19,10 +19,19 @@ public class HmsMessageServiceAppLevel extends HmsMessageService {
      */
     @Override
     public void onNewToken(String token, Bundle bundle) {
-        OneSignal.onesignalLog(OneSignal.LOG_LEVEL.DEBUG, "HMS onNewToken refresh token:" + token + " bundle: " + bundle);
+        OneSignal.onesignalLog(OneSignal.LOG_LEVEL.DEBUG, "HmsMessageServiceAppLevel onNewToken refresh token:" + token + " bundle: " + bundle);
 
         // Forward event on to OneSignal SDK
         OneSignalHmsEventBridge.onNewToken(this, token, bundle);
+    }
+
+    @Deprecated
+    @Override
+    public void onNewToken(String token) {
+        OneSignal.onesignalLog(OneSignal.LOG_LEVEL.DEBUG, "HmsMessageServiceAppLevel onNewToken refresh token:" + token);
+
+        // Forward event on to OneSignal SDK
+        OneSignalHmsEventBridge.onNewToken(this, token);
     }
 
     /**

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/HmsMessageServiceOneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/HmsMessageServiceOneSignal.java
@@ -1,5 +1,7 @@
 package com.onesignal;
 
+import android.os.Bundle;
+
 import com.huawei.hms.push.HmsMessageService;
 import com.huawei.hms.push.RemoteMessage;
 
@@ -20,15 +22,18 @@ import com.huawei.hms.push.RemoteMessage;
  */
 public class HmsMessageServiceOneSignal extends HmsMessageService {
 
+
     /**
      * When an app calls the getToken method to apply for a token from the server,
      * if the server does not return the token during current method calling, the server can return the token through this method later.
      * This method callback must be completed in 10 seconds. Otherwise, you need to start a new Job for callback processing.
+     *
      * @param token token
+     * @param bundle bundle
      */
     @Override
-    public void onNewToken(String token) {
-        OneSignalHmsEventBridge.onNewToken(this, token);
+    public void onNewToken(String token, Bundle bundle) {
+        OneSignalHmsEventBridge.onNewToken(this, token, bundle);
     }
 
     /**

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/HmsMessageServiceOneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/HmsMessageServiceOneSignal.java
@@ -22,7 +22,6 @@ import com.huawei.hms.push.RemoteMessage;
  */
 public class HmsMessageServiceOneSignal extends HmsMessageService {
 
-
     /**
      * When an app calls the getToken method to apply for a token from the server,
      * if the server does not return the token during current method calling, the server can return the token through this method later.
@@ -33,7 +32,17 @@ public class HmsMessageServiceOneSignal extends HmsMessageService {
      */
     @Override
     public void onNewToken(String token, Bundle bundle) {
+        OneSignal.onesignalLog(OneSignal.LOG_LEVEL.DEBUG, "HmsMessageServiceOneSignal onNewToken refresh token:" + token);
+
         OneSignalHmsEventBridge.onNewToken(this, token, bundle);
+    }
+
+    @Deprecated
+    @Override
+    public void onNewToken(String token) {
+        OneSignal.onesignalLog(OneSignal.LOG_LEVEL.DEBUG, "HmsMessageServiceOneSignal onNewToken refresh token:" + token);
+
+        OneSignalHmsEventBridge.onNewToken(this, token);
     }
 
     /**

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalHmsEventBridge.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalHmsEventBridge.java
@@ -1,8 +1,10 @@
 package com.onesignal;
 
 import android.content.Context;
+import android.os.Bundle;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.huawei.hms.push.RemoteMessage;
 
@@ -16,9 +18,14 @@ import com.huawei.hms.push.RemoteMessage;
  */
 public class OneSignalHmsEventBridge {
 
-    public static void onNewToken(@NonNull Context context, @NonNull String token) {
-        OneSignal.Log(OneSignal.LOG_LEVEL.INFO, "HmsMessageServiceOneSignal.onNewToken - HMS token: " + token);
+    public static void onNewToken(@NonNull Context context, @NonNull String token, @Nullable Bundle bundle) {
+        OneSignal.Log(OneSignal.LOG_LEVEL.INFO, "HmsMessageServiceOneSignal.onNewToken - HMS token: " + token + " Bundle: " + bundle);
         PushRegistratorHMS.fireCallback(token);
+    }
+
+    @Deprecated
+    public static void onNewToken(@NonNull Context context, @NonNull String token) {
+        onNewToken(context, token, null);
     }
 
     public static void onMessageReceived(@NonNull Context context, @NonNull RemoteMessage message) {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalHmsEventBridge.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalHmsEventBridge.java
@@ -18,11 +18,18 @@ import com.huawei.hms.push.RemoteMessage;
  */
 public class OneSignalHmsEventBridge {
 
+    /**
+     * Method used by last HMS push version 5.3.0.304 and upper
+     */
     public static void onNewToken(@NonNull Context context, @NonNull String token, @Nullable Bundle bundle) {
         OneSignal.Log(OneSignal.LOG_LEVEL.INFO, "HmsMessageServiceOneSignal.onNewToken - HMS token: " + token + " Bundle: " + bundle);
         PushRegistratorHMS.fireCallback(token);
     }
 
+    /**
+     * This method is being deprecated
+     * @see OneSignalHmsEventBridge#onNewToken(Context, String, Bundle)
+     */
     @Deprecated
     public static void onNewToken(@NonNull Context context, @NonNull String token) {
         onNewToken(context, token, null);

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalHmsEventBridge.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalHmsEventBridge.java
@@ -8,6 +8,8 @@ import androidx.annotation.Nullable;
 
 import com.huawei.hms.push.RemoteMessage;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
 /**
  * If you have your own {@link com.huawei.hms.push.HmsMessageService} defined in your app please also
  * call {@link OneSignalHmsEventBridge#onNewToken} and {@link OneSignalHmsEventBridge#onMessageReceived}
@@ -18,12 +20,18 @@ import com.huawei.hms.push.RemoteMessage;
  */
 public class OneSignalHmsEventBridge {
 
+    private static final AtomicBoolean firstToken = new AtomicBoolean(true);
+
     /**
      * Method used by last HMS push version 5.3.0.304 and upper
      */
     public static void onNewToken(@NonNull Context context, @NonNull String token, @Nullable Bundle bundle) {
-        OneSignal.Log(OneSignal.LOG_LEVEL.INFO, "HmsMessageServiceOneSignal.onNewToken - HMS token: " + token + " Bundle: " + bundle);
-        PushRegistratorHMS.fireCallback(token);
+        if (firstToken.compareAndSet(true, false)) {
+            OneSignal.Log(OneSignal.LOG_LEVEL.INFO, "OneSignalHmsEventBridge onNewToken - HMS token: " + token + " Bundle: " + bundle);
+            PushRegistratorHMS.fireCallback(token);
+        } else {
+            OneSignal.Log(OneSignal.LOG_LEVEL.INFO, "OneSignalHmsEventBridge ignoring onNewToken - HMS token: " + token + " Bundle: " + bundle);
+        }
     }
 
     /**

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/PushRegistratorHMS.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/PushRegistratorHMS.java
@@ -68,9 +68,9 @@ class PushRegistratorHMS implements PushRegistrator {
         if (!TextUtils.isEmpty(pushToken)) {
             OneSignal.Log(LOG_LEVEL.INFO, "Device registered for HMS, push token = " + pushToken);
             callback.complete(pushToken, UserState.PUSH_STATUS_SUBSCRIBED);
-        }
-        else
+        } else {
             waitForOnNewPushTokenEvent(callback);
+        }
     }
 
     private static void doTimeOutWait() {
@@ -82,7 +82,7 @@ class PushRegistratorHMS implements PushRegistrator {
 
     // If EMUI 9.x or older getToken will always return null.
     // We must wait for HmsMessageService.onNewToken to fire instead.
-    void waitForOnNewPushTokenEvent(@NonNull RegisteredHandler callback) {
+    private void waitForOnNewPushTokenEvent(@NonNull RegisteredHandler callback) {
         doTimeOutWait();
         if (!callbackSuccessful) {
             OneSignal.Log(OneSignal.LOG_LEVEL.ERROR, "HmsMessageServiceOneSignal.onNewToken timed out.");

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowPushRegistratorHMS.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowPushRegistratorHMS.java
@@ -23,7 +23,7 @@ public class ShadowPushRegistratorHMS {
         if (backgroundSuccessful) {
             // prepare required since doTimeOutWait will be run from a new background thread.
             Looper.prepare();
-            new HmsMessageServiceOneSignal().onNewToken(ShadowHmsInstanceId.DEFAULT_MOCK_HMS_TOKEN_VALUE);
+            new HmsMessageServiceOneSignal().onNewToken(ShadowHmsInstanceId.DEFAULT_MOCK_HMS_TOKEN_VALUE, null);
         }
     }
 }


### PR DESCRIPTION
* Add onNewToken method support to HmsMessageServiceOneSignal, HmsMessageServiceAppLevel and OneSignalHmsEventBridge

Tested versions:

com.huawei.hms:push:5.0.0.300
com.huawei.hms:push:5.1.1.301
com.huawei.hms:push:5.3.0.304
com.huawei.hms:push:6.1.0.300

Flow tested:

Fresh app install
Check that onNewToken is called
Check that if both onNewToken methods are called, the registration only happens once

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1433)
<!-- Reviewable:end -->
