### PR TITLE
Remove a key from Shared Prefs if its value is `null`

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalPrefs.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalPrefs.java
@@ -204,6 +204,8 @@ class OneSignalPrefs {
                             editor.putLong(key, (Long)value);
                         else if (value instanceof Set)
                             editor.putStringSet(key, (Set<String>)value);
+                        else if (value == null)
+                            editor.remove(key);
                     }
                     prefHash.clear();
                 }


### PR DESCRIPTION
- This was a problem for `logoutEmail` and `logoutSMSNumber`
- The above methods end up calling `OneSignalPrefs.saveString` to save their channel IDs with the value of `null`
- However, when we `flushBufferToDisk`, the value of null falls through the "if-else if" checks and nothing happens, when it should be removed.