### PR TITLE
Add `toJSONObject` method to `OSInAppMessage`

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessage.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessage.java
@@ -29,7 +29,12 @@ package com.onesignal;
 
 import androidx.annotation.NonNull;
 
+import org.json.JSONException;
+import org.json.JSONObject;
+
 public class OSInAppMessage {
+
+    public static final String IAM_ID = "messageId";
 
     /**
      * The unique identifier for this in-app message
@@ -44,6 +49,18 @@ public class OSInAppMessage {
     @NonNull
     public String getMessageId() {
         return messageId;
+    }
+
+    public JSONObject toJSONObject() {
+        JSONObject mainObj = new JSONObject();
+        try {
+            mainObj.put(IAM_ID, messageId);
+        }
+        catch(JSONException e) {
+            e.printStackTrace();
+        }
+
+        return mainObj;
     }
 
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageInternal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageInternal.java
@@ -145,7 +145,8 @@ class OSInAppMessageInternal extends OSInAppMessage {
         return parsedTriggers;
     }
 
-    JSONObject toJSONObject() {
+    @Override
+    public JSONObject toJSONObject() {
         JSONObject json = new JSONObject();
 
         try {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageInternal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageInternal.java
@@ -17,7 +17,9 @@ import java.util.Set;
 
 class OSInAppMessageInternal extends OSInAppMessage {
 
-    private static final String IAM_ID = "id";
+    // "id" is expected instead of "messageId" when parsing JSON from the backend
+    private static final String ID = "id";
+    private static final String IAM_ID = "messageId";
     private static final String IAM_VARIANTS = "variants";
     private static final String IAM_TRIGGERS = "triggers";
     private static final String IAM_REDISPLAY_STATS = "redisplay";
@@ -74,7 +76,8 @@ class OSInAppMessageInternal extends OSInAppMessage {
 
     OSInAppMessageInternal(JSONObject json) throws JSONException {
         // initialize simple root properties
-        super(json.getString(IAM_ID));
+        // "id" is expected instead of "messageId" when parsing JSON from the backend
+        super(json.getString(ID));
         this.variants = parseVariants(json.getJSONObject(IAM_VARIANTS));
         this.triggers = parseTriggerJson(json.getJSONArray(IAM_TRIGGERS));
         this.clickedClickIds = new HashSet<>();

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/InAppMessagingHelpers.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/InAppMessagingHelpers.java
@@ -19,6 +19,20 @@ public class InAppMessagingHelpers {
     public static final String IAM_PAGE_ID = "12345678-1234-ABCD-1234-123456789012";
     public static final String IAM_HAS_LIQUID = "has_liquid";
 
+    // unit tests will create an IAM based off JSON of another IAM
+    // toJSONObject uses key of "messageId" so we need to replace that with "id" for creating IAM
+    public static JSONObject convertIAMtoJSONObject(OSInAppMessageInternal inAppMessage) {
+        JSONObject json = inAppMessage.toJSONObject();
+        try {
+            json.put("id", json.get("messageId"));
+            json.remove("messageId");
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
+
+        return json;
+    }
+
     public static boolean evaluateMessage(OSInAppMessageInternal message) {
         return OneSignal.getInAppMessageController().triggerController.evaluateMessageTriggers(message);
     }

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
@@ -358,10 +358,6 @@ public class OneSignalPackagePrivateHelper {
          super(json);
       }
 
-      OSTestInAppMessageInternal(OSInAppMessageInternal inAppMessage) throws JSONException {
-         super(inAppMessage.toJSONObject());
-      }
-
       public void setMessageId(String messageId) {
          this.messageId = messageId;
       }
@@ -586,7 +582,8 @@ public class OneSignalPackagePrivateHelper {
 
       for (OSInAppMessageInternal message : messages) {
          try {
-            OSTestInAppMessageInternal testInAppMessage = new OSTestInAppMessageInternal(message);
+            JSONObject json = InAppMessagingHelpers.convertIAMtoJSONObject(message);
+            OSTestInAppMessageInternal testInAppMessage = new OSTestInAppMessageInternal(json);
             testInAppMessage.getRedisplayStats().setDisplayStats(message.getRedisplayStats());
             testMessages.add(testInAppMessage);
 

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/InAppMessageIntegrationTests.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/InAppMessageIntegrationTests.java
@@ -1907,6 +1907,27 @@ public class InAppMessageIntegrationTests {
         assertEquals("in_app_messages/" + message.getMessageId() + "/impression", lastRequest.url);
     }
 
+    // Test toJSONObject() method currently only checks JSON for "messageId"
+    @Test
+    public void testInAppMessageInternalToJSONObject_messageId() throws Exception {
+        // 1. Create a basic test IAM
+        OSTestInAppMessageInternal iam = InAppMessagingHelpers.buildTestMessage(null);
+
+        // 2. Set a message ID for the IAM
+        String messageId = new String(new char[64]).replace('\0', '0');
+        iam.setMessageId(messageId);
+
+        // 3. Init
+        OneSignalInit();
+        threadAndTaskWait();
+
+        // 4. call toJSONObject() on IAM
+        JSONObject testJsonObj = iam.toJSONObject();
+
+        // 5. Check "messageId" in JSON Object
+        assertEquals(messageId, testJsonObj.optString("messageId"));
+    }
+
     private void setMockRegistrationResponseWithMessages(ArrayList<OSTestInAppMessageInternal> messages) throws JSONException {
         final JSONArray jsonMessages = new JSONArray();
 

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/InAppMessageIntegrationTests.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/InAppMessageIntegrationTests.java
@@ -1911,7 +1911,7 @@ public class InAppMessageIntegrationTests {
         final JSONArray jsonMessages = new JSONArray();
 
         for (OSTestInAppMessageInternal message : messages)
-            jsonMessages.put(message.toJSONObject());
+            jsonMessages.put(InAppMessagingHelpers.convertIAMtoJSONObject(message));
 
         ShadowOneSignalRestClient.setNextSuccessfulRegistrationResponse(new JSONObject() {{
             put("id", "df8f05be55ba-b2f7f966-d8cc-11e4-bed1");


### PR DESCRIPTION
# Description
## One Line Summary
Add JSON stringifier to the public `OSInAppMessage` class and refactor JSON stringifier for internal `OSInAppMessageInternal` class to return JSON key of `"messageId"` instead of `"id"`.

## Details
### Motivation
We want the public `OSInAppMessage` to have a `toJSONObject` method for the wrappers to use. This JSON Object only has one item of `"messageId"`. Since IAMs have the property `messageId` and our documentation refer to `messageId`, this key was chosen over `"id"`.

The need for this method first arose when adding the InAppMessage Lifecycle Handler to React Native.
We also modified the `OSInAppMessageInternal` class's `toJSONObject` to return a JSON key of `"messageId"` instead of `"id"` for clarity and consistency to the public class.

### Background Context
Previously, the current `OSInAppMessageInternal` class was named `OSInAppMessage` before being refactored into an internal InAppMessage class and a public InAppMessage class. 

> OSInOSInAppMessageInternal extends OSInAppMessage  

Worth noting, `"id"` is expected instead of `"messageId"` when parsing JSON from the backend, so it is used in the constructor.

### Scope
We didn't use any InAppMessage `toJSONObject` in SDK code, except in unit tests (see below) and those are removed now. The existing `OSInAppMessageInternal` `toJSONObject` method was _package-private_ (made _public_ in this PR) so users _couldn't_ have used this method prior to this PR. This means changing the JSON key from `"id"` to `"messageId"` has no public API _changes_ (but introduces a new method to the public).

Currently, all of the `OSInAppMessage` objects are actually `OSInAppMessageInternal` objects. We don't create any superclass OSInAppMessage objects in the existing codebase. This means when a user calls  `OSInAppMessage.toJSONObject()`, they will receive the results of `OSInAppMessageInternal.toJSONObject()`.

# Testing
## Unit testing
Some unit tests were creating an IAM based off the JSON of another IAM by calling its `toJSONObject()`. 
With the above changes, some tests in `InAppMessageIntegrationTests` broke  because IAM constructors expect `"id"` instead of `"messageId"` when parsing the JSON, so  we need to replace that with `"id"` for creating an IAM.

#### Added method: 
`convertIAMtoJSONObject(OSInAppMessageInternal inAppMessage)`
- just replaces key `"messageId"` with `"id"`
- refactored unit test code to use this method instead of `toJSONObject()`

#### Removed a constructor: 
`OSTestInAppMessageInternal(OSInAppMessageInternal inAppMessage)`
- this constructor passed the JSON from `inAppMessage.toJSONObject()`
- instead, use `convertIAMtoJSONObject` and pass this JSON into constructor

#### Added test: 
`testInAppMessageInternalToJSONObject_messageId`
- tests `OSInAppMessageInternal` (not `OSInAppMessage`)
- only tests for `"messageId"`, the primary focus

## Manual testing
✅  Tested by calling `OSInAppMessage.toJSONObject()` in demo app:
- [X] Android 11 Emulator
- [X] Android 12 Emulator

### Example of the JSON
``` json
{
  "messageId": "abe479ed-dc54-4446-898a-a82b67cfd5aa",
  "variants": {"all":{"default":"2a8934de-d3c1-4734-8b7c-796cd691456b"}},
  "displayDuration": 0,
  "redisplay": {"limit":1,"delay":0},"triggers":[],
  "has_liquid": false
}
```

✅  Tested in **react-native-onesignal** via the InAppMessageLifecycleHandler by logging the `message` and `message.messageId`
- When a user logs the `message` object, they receive the entire JSON object above, not just the `messageId`

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [X] In-App Messaging
   - [ ] REST API requests
   - [X] Public API changes -  exposes a new method (will update documentation)

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1461)
<!-- Reviewable:end -->
