### PR TITLE
Fix outside package target activities (Launch URL) not opening when notification is tapped on

### DIFF
--- a/OneSignalSDK/onesignal/src/main/AndroidManifest.xml
+++ b/OneSignalSDK/onesignal/src/main/AndroidManifest.xml
@@ -140,6 +140,12 @@
           android:theme="@android:style/Theme.Translucent.NoTitleBar"
           android:exported="true" />
 
+        <activity
+            android:name="com.onesignal.NotificationOpenedReceiverAndroid22AndOlder"
+            android:noHistory="true"
+            android:excludeFromRecents="true"
+            android:theme="@android:style/Theme.Translucent.NoTitleBar"
+            android:exported="true" />
     </application>
 
     <!-- NOTE: See release version for tags with placeholders -->

--- a/OneSignalSDK/onesignal/src/main/AndroidManifest.xml
+++ b/OneSignalSDK/onesignal/src/main/AndroidManifest.xml
@@ -136,6 +136,7 @@
           android:name="com.onesignal.NotificationOpenedReceiver"
           android:noHistory="true"
           android:excludeFromRecents="true"
+          android:taskAffinity=""
           android:theme="@android:style/Theme.Translucent.NoTitleBar"
           android:exported="true" />
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotificationOpenIntent.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotificationOpenIntent.kt
@@ -3,6 +3,7 @@ package com.onesignal
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import androidx.annotation.RequiresApi
 
 class GenerateNotificationOpenIntent(
     private val context: Context,
@@ -35,6 +36,7 @@ class GenerateNotificationOpenIntent(
         )
     }
 
+    @RequiresApi(android.os.Build.VERSION_CODES.M)
     private fun getNewBaseIntentAndroidAPI23Plus(): Intent {
         return Intent(
             context,
@@ -43,6 +45,7 @@ class GenerateNotificationOpenIntent(
     }
 
     // See NotificationOpenedReceiverAndroid22AndOlder.java for details
+    @Deprecated("Use getNewBaseIntentAndroidAPI23Plus instead for Android 6+")
     private fun getNewBaseIntentAndroidAPI22AndOlder(): Intent {
         val intent = Intent(
             context,

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotificationOpenIntent.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotificationOpenIntent.kt
@@ -44,7 +44,7 @@ class GenerateNotificationOpenIntent(
         )
     }
 
-    // See NotificationOpenedReceiverAndroid22AndOlder.java for details
+    // See NotificationOpenedReceiverAndroid22AndOlder.kt for details
     @Deprecated("Use getNewBaseIntentAndroidAPI23Plus instead for Android 6+")
     private fun getNewBaseIntentAndroidAPI22AndOlder(): Intent {
         val intent = Intent(

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotificationOpenIntent.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotificationOpenIntent.kt
@@ -17,19 +17,9 @@ class GenerateNotificationOpenIntent(
     ): Intent {
         // We use SINGLE_TOP and CLEAR_TOP as we don't want more than one OneSignal invisible click
         //   tracking Activity instance around.
-        var intentFlags =
+        val intentFlags =
             Intent.FLAG_ACTIVITY_SINGLE_TOP or
             Intent.FLAG_ACTIVITY_CLEAR_TOP
-        if (!startApp) {
-            // If we don't want the app to launch we put OneSignal's invisible click tracking Activity on it's own task
-            //   so it doesn't resume an existing one once it closes.
-            intentFlags =
-                intentFlags or (
-                    Intent.FLAG_ACTIVITY_NEW_TASK or
-                    Intent.FLAG_ACTIVITY_MULTIPLE_TASK or
-                    Intent.FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET
-                )
-        }
 
         return Intent(
             context,

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationOpenedReceiver.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationOpenedReceiver.kt
@@ -1,7 +1,7 @@
 /**
  * Modified MIT License
  *
- * Copyright 2021 OneSignal
+ * Copyright 2017 OneSignal
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,37 +24,22 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+package com.onesignal
 
-package com.onesignal;
+import android.app.Activity
+import android.content.Intent
+import android.os.Bundle
 
-import android.app.Activity;
-import android.content.Intent;
-import android.os.Bundle;
-
-/**
- * This is the same as NotificationOpenedReceiver expect it doesn't contain
- * android:taskAffinity="" in it's AndroidManifest.xml entry. This is to
- * account for the resume behavior not working on Android API 22 and older.
- *
- * In Android 5.x and older, android:taskAffinity="" starts a new task as
- * expected, however the allowTaskReparenting behavior does not happen which
- * results in the app not resuming, when using reverse Activity trampoline.
- * Oddly enough cold starts of the app were not a problem.
- */
-public class NotificationOpenedReceiverAndroid22AndOlder extends Activity {
-
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        NotificationOpenedProcessor.processFromContext(this, getIntent());
-        finish();
+class NotificationOpenedReceiver : Activity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        NotificationOpenedProcessor.processFromContext(this, intent)
+        finish()
     }
 
-    @Override
-    protected void onNewIntent(Intent intent) {
-        super.onNewIntent(intent);
-        NotificationOpenedProcessor.processFromContext(this, getIntent());
-        finish();
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        NotificationOpenedProcessor.processFromContext(this, getIntent())
+        finish()
     }
-
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationOpenedReceiver.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationOpenedReceiver.kt
@@ -1,7 +1,7 @@
 /**
  * Modified MIT License
  *
- * Copyright 2017 OneSignal
+ * Copyright 2021 OneSignal
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -26,20 +26,4 @@
  */
 package com.onesignal
 
-import android.app.Activity
-import android.content.Intent
-import android.os.Bundle
-
-class NotificationOpenedReceiver : Activity() {
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        NotificationOpenedProcessor.processFromContext(this, intent)
-        finish()
-    }
-
-    override fun onNewIntent(intent: Intent) {
-        super.onNewIntent(intent)
-        NotificationOpenedProcessor.processFromContext(this, getIntent())
-        finish()
-    }
-}
+class NotificationOpenedReceiver : NotificationOpenedReceiverBase()

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationOpenedReceiverAndroid22AndOlder.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationOpenedReceiverAndroid22AndOlder.java
@@ -1,0 +1,60 @@
+/**
+ * Modified MIT License
+ *
+ * Copyright 2021 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.onesignal;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Bundle;
+
+/**
+ * This is the same as NotificationOpenedReceiver expect it doesn't contain
+ * android:taskAffinity="" in it's AndroidManifest.xml entry. This is to
+ * account for the resume behavior not working on Android API 22 and older.
+ *
+ * In Android 5.x and older, android:taskAffinity="" starts a new task as
+ * expected, however the allowTaskReparenting behavior does not happen which
+ * results in the app not resuming, when using reverse Activity trampoline.
+ * Oddly enough cold starts of the app were not a problem.
+ */
+public class NotificationOpenedReceiverAndroid22AndOlder extends Activity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        NotificationOpenedProcessor.processFromContext(this, getIntent());
+        finish();
+    }
+
+    @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        NotificationOpenedProcessor.processFromContext(this, getIntent());
+        finish();
+    }
+
+}

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationOpenedReceiverAndroid22AndOlder.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationOpenedReceiverAndroid22AndOlder.kt
@@ -1,7 +1,7 @@
 /**
  * Modified MIT License
  *
- * Copyright 2017 OneSignal
+ * Copyright 2021 OneSignal
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,27 +24,32 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+package com.onesignal
 
-package com.onesignal;
+import android.app.Activity
+import android.content.Intent
+import android.os.Bundle
 
-import android.app.Activity;
-import android.content.Intent;
-import android.os.Bundle;
+/**
+ * This is the same as NotificationOpenedReceiver expect it doesn't contain
+ * android:taskAffinity="" in it's AndroidManifest.xml entry. This is to
+ * account for the resume behavior not working on Android API 22 and older.
+ *
+ * In Android 5.x and older, android:taskAffinity="" starts a new task as
+ * expected, however the allowTaskReparenting behavior does not happen which
+ * results in the app not resuming, when using reverse Activity trampoline.
+ * Oddly enough cold starts of the app were not a problem.
+ */
+class NotificationOpenedReceiverAndroid22AndOlder : Activity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        NotificationOpenedProcessor.processFromContext(this, intent)
+        finish()
+    }
 
-public class NotificationOpenedReceiver extends Activity {
-
-   @Override
-   protected void onCreate(Bundle savedInstanceState) {
-      super.onCreate(savedInstanceState);
-      NotificationOpenedProcessor.processFromContext(this, getIntent());
-      finish();
-   }
-
-   @Override
-   protected void onNewIntent(Intent intent) {
-      super.onNewIntent(intent);
-      NotificationOpenedProcessor.processFromContext(this, getIntent());
-      finish();
-   }
-
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        NotificationOpenedProcessor.processFromContext(this, getIntent())
+        finish()
+    }
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationOpenedReceiverBase.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationOpenedReceiverBase.kt
@@ -26,14 +26,20 @@
  */
 package com.onesignal
 
-/**
- * This is the same as NotificationOpenedReceiver expect it doesn't contain
- * android:taskAffinity="" in it's AndroidManifest.xml entry. This is to
- * account for the resume behavior not working on Android API 22 and older.
- *
- * In Android 5.x and older, android:taskAffinity="" starts a new task as
- * expected, however the allowTaskReparenting behavior does not happen which
- * results in the app not resuming, when using reverse Activity trampoline.
- * Oddly enough cold starts of the app were not a problem.
- */
-class NotificationOpenedReceiverAndroid22AndOlder : NotificationOpenedReceiverBase()
+import android.app.Activity
+import android.content.Intent
+import android.os.Bundle
+
+abstract class NotificationOpenedReceiverBase : Activity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        NotificationOpenedProcessor.processFromContext(this, intent)
+        finish()
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        NotificationOpenedProcessor.processFromContext(this, getIntent())
+        finish()
+    }
+}

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
@@ -1131,6 +1131,21 @@ public class GenerateNotificationRunner {
    }
 
    @Test
+   @Config(sdk = 23, shadows = { ShadowGenerateNotification.class })
+   public void shouldUseCorrectActivityForAndroid23Plus() throws Exception {
+      NotificationBundleProcessor_ProcessFromFCMIntentService(blankActivity, getBaseNotifBundle());
+      threadAndTaskWait();
+
+      Intent[] intents = lastNotificationIntents();
+      assertEquals("android.intent.action.MAIN", intents[0].getAction());
+      assertEquals(
+         com.onesignal.NotificationOpenedReceiver.class.getName(),
+         intents[1].getComponent().getClassName()
+      );
+      assertEquals(2, intents.length);
+   }
+
+   @Test
    @Config(shadows = { ShadowGenerateNotification.class })
    public void shouldSetContentIntentForLaunchURL() throws Exception {
       generateNotificationWithLaunchURL();

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
@@ -1180,7 +1180,7 @@ public class GenerateNotificationRunner {
    }
 
    private void assertNotificationOpenedReceiver(@NonNull Intent intent) {
-      assertEquals("com.onesignal.NotificationOpenedReceiver", intent.getComponent().getClassName());
+      assertEquals(com.onesignal.NotificationOpenedReceiverAndroid22AndOlder.class.getName(), intent.getComponent().getClassName());
    }
 
    private void assertOpenMainActivityIntent(@NonNull Intent intent) {


### PR DESCRIPTION
# Description
## One Line Summary
Fix notification open with Launch URL not showing any Activities, this was a regression bug introduced in PR #1377.

## Details
### Motivation
Notification Launch URL is an active supported feature used by OneSignal customers so ensuring it works correctly is high priority.

### Scope
The main goal is to fix Launch URL not working but the code change in this PR effects all notification opens. The "opens" noted here is scoped to how `Activities` are shown to the user. This includes the `Activity` flags used to start `Activities` and the backstace it generates.
No changes to how OneSignal consumes or generates `Intent` data.

### Why the bug was happening?
The issue was due to an Activity backstack not being built correctly. Both `NotificationOpenedReceiver` and the target `Activity` were launched with `FLAG_ACTIVITY_NEW_TASK` however this means when `NotificationOpenedReceiver` is finished it does not bring up the target since it is on a different task. The Android flag `allowTaskReparenting` allows this to happen, however this can effect the backstack of the main task which we don't want to do.

### How the bug was fixed?
Setting `android:taskAffinity` sets `FLAG_ACTIVITY_NEW_TASK` and `allowTaskReparenting` for us. By setting the value to "" (empty string) it prevents any side effects on existing tasks as it means it has no affinity to associate it with. This allowed us to clean up some runtime logic to add `FLAG_ACTIVITY_NEW_TASK` and others we no longer need now.

A caveat is that on Android 5.1 and older `android:taskAffinity=""` doesn't give us the `allowTaskReparenting` behavior, nor does setting it explicitly work. To account for this an `Activity` named `NotificationOpenedReceiverAndroid22AndOlder` was created without the `android:taskAffinity` parameter.

### Related additional information

#### Tasks and the back stack
Basic understand of this topic is recommend
* https://developer.android.com/guide/components/activities/tasks-and-back-stack

#### What `android:taskAffinity=""` does
> By default, all activities in an application have the same affinity. You can set this attribute to group them differently, and even place activities defined in different applications within the same task. To specify that the activity does not have an affinity for any task, set it to an empty string.

*Source: https://developer.android.com/guide/topics/manifest/activity-element#aff*

#### Notification Trampolines
Background on what "Notification Trampolines" are and how a "Reverse Activity Trampoline" works.
* https://onesignal.com/blog/android-12-notification-open-changes/
* [Reverse Activity Trampolining Implementation PR #1377](https://github.com/OneSignal/OneSignal-Android-SDK/pull/1377)

# Testing
## Unit testing
Added test to ensure correct Activity is used for newer vs older versions of Android.
No existing exist unit tests to ensure correct Activity is infocus or the backstack is built correctly. Robolectric doesn't have fakes / mocking to simulate to this level.

## Manual testing
Each scenario was tested with the following devices:
   - ⚠️Can't test older Android versions, due to [know TLS1.2 issue](https://github.com/OneSignal/OneSignal-Android-SDK/issues/1465)
   - ✅Android 5.0 Emulator
   - ✅Android 5.1 Emulator
   - ✅Android 6.0 Emulator
   - ✅Android 7.1 Emulator
   - ✅Android 8.1 Emulator
   - ✅Android 9 LG G7
   - ✅Android 9 Amazon Fire 7 (KFMUWI)
   - ✅Android 10 Emulator
   - ✅Android 11 Emulator
   - ✅Android 12 Emulator

### Default notification
* [X] App Foreground
* [X] App Background - by pressing back button
* [X] App Background - by pressing home button
* [X] App not running - Task still in recent list, resumes app's task correctly
* [X] App not running - Recent list cleared, app cold starts new task

### HTTPS URL notification
* [X] App Foreground
* [X] App Background - by pressing home button
* [X] App not running - Recent list cleared, app cold starts new task
 
### com.onesignal.NotificationOpened.DEFAULT set to DISABLE
* [X] App Foreground
* [X]  App Background - by pressing home button
* [X] App not running - swiped away app

### Data URL scheme - appname://test
Tested by adding the following `<intent-filter>` entries for the following Activities in the example app's `AndroidManifest.xml`.
```xml
<activity
    android:name=".activity.SplashActivity"
    android:exported="true">
  <intent-filter>
      <action android:name="android.intent.action.MAIN" />
      <category android:name="android.intent.category.LAUNCHER" />
  </intent-filter>
  <intent-filter>
      <action android:name="android.intent.action.VIEW"/>
      <category android:name="android.intent.category.DEFAULT"/>
      <category android:name="android.intent.category.BROWSABLE"/>
      <data android:scheme="osexamplesplash"/>
  </intent-filter>
</activity>

<activity
    android:name=".activity.MainActivity"
    android:exported="true">
    <intent-filter>
        <action android:name="android.intent.action.VIEW"/>
        <category android:name="android.intent.category.DEFAULT"/>
        <category android:name="android.intent.category.BROWSABLE"/>
        <data android:scheme="osexample"/>
    </intent-filter>
</activity>
```

Each scenario below includes testing twice, once with `osexamplesplash:// ` another with `osexample://`.

* [X] App Foreground
* [X] App Background - by pressing home button
* [X] App Background - App swiped away
* [X] App not running - Recent list cleared, app cold starts new task


# Affected code checklist
   - [X] Notifications
      - [ ] Display
      - [X] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all REPLACE sections above
   - [X] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [X] Public API changes are intended and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1469)
<!-- Reviewable:end -->
