### PR TITLE
Fix notification background image not showing on when the device has a RTL set

### DIFF
--- a/OneSignalSDK/onesignal/src/main/res/layout/onesignal_bgimage_notif_layout.xml
+++ b/OneSignalSDK/onesignal/src/main/res/layout/onesignal_bgimage_notif_layout.xml
@@ -7,6 +7,7 @@
     <!--android:textAppearance="@android:style/TextAppearance.StatusBar.EventContent.Title"-->
 
     <RelativeLayout android:id="@+id/os_bgimage_notif_bgimage_align_layout"
+                    android:layoutDirection="ltr"
                     android:layout_width="wrap_content"
                     android:layout_height="64dp"
                     android:paddingLeft="0dp"


### PR DESCRIPTION
# Description
## One Line Summary
Fix notification background image not showing on when the device has a RTL language set and the app's `AndroidManifest.xml` has RTL support enabled.

## Details
### Motivation
Setting a [custom background image for notifications](https://documentation.onesignal.com/docs/android-customizations#background-images) is a supported feature only through the REST API, is limited in features, and [Android 12 has limited customizability](https://developer.android.com/about/versions/12/behavior-changes-12#custom-notifications). However OneSignal currently supports this feature and it should remind free of common/high impact bugs.

### Scope
Only affects the display of notifications when the following is true:
* Sent through the OneSignal REST API
* Includes `android_background_layout` in the payload.
* The `AndroidManifest.xml` has `android:supportsRtl="true"`
* The device has set a RTL language
    - Or Dev options > Drawing > "Force RTL layout direction" is enabled

This PR only affects the background image render. Changes / fixes to the title or body text is out of scope for this PR.
   * Keeping this PR as small as possible for a quicker turn around time as possible since it can result in a completely unreadable notification. A fix for rendering text in the in the correct direction for RTL is part of PR #1474.

Android 4.1 (API 16) is out of scope, since `android:layoutDirection` was introduced in Android API level 17.
   * This might be ok, as this issue may not have existed on this version of android anyway.

### What was the bug?
When the a notification background image is set and the RTL conditions are meet, notifications becoming a sold color (all known instances have been a white background). The text may or not be visible, but depends on the text color and that the resulting background.

On LTR devices notifications looks like this:
![image](https://user-images.githubusercontent.com/645861/139180446-1606e063-320c-4848-bfac-69d7b6bff2d0.png)

On RTL devices notifications looks like this:
![image](https://user-images.githubusercontent.com/645861/139180330-a8c3b089-08fd-42c7-9657-a77ef4e589c3.png)

### Why the bug was happening?
When RTL is set it moves all elements to the right, not just text elements.

### How the bug was fixed?
Set `android:layoutDirection="ltr"` on the layout used for the background image so it isn't influenced by the language direction.

# Testing
## Unit testing
N/A, only a visual layout change.

## Manual testing
Tested the Example app included in this repo (it has `android:supportsRtl="true"`) and set "Force RTL layout direction" on the device. Also tested w/o  "Force RTL layout direction", to make sure it remained working.
Test on:
* LG G7 with Android 9
* Android 10 Emulator
* Android 5.0 Emulator

### Screenshot after fix
Android 10 Emulator with English with "Force RTL layout direction" enabled:
![image](https://user-images.githubusercontent.com/645861/139181412-2d56ec5d-b72c-48bf-8a6e-a2452782d207.png)
* Odd resized image on the 2nd notification was indented, was done as a quick size test
* Text itself didn't change RTL, but not in this scope of this PR.

# Affected code checklist
   - [X] Notifications
      - [X] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1473)
<!-- Reviewable:end -->
