### PR TITLE
Fix notification background image layouts to render text RTL based on the device's language setting

### DIFF
--- a/OneSignalSDK/onesignal/src/main/res/layout/onesignal_bgimage_notif_layout.xml
+++ b/OneSignalSDK/onesignal/src/main/res/layout/onesignal_bgimage_notif_layout.xml
@@ -31,7 +31,7 @@
 
     <LinearLayout
         android:orientation="vertical"
-        android:layout_marginStart="@android:dimen/notification_large_icon_width"
+        android:layout_marginLeft="@android:dimen/notification_large_icon_width"
         android:layout_width="fill_parent"
         android:layout_height="64dp"
         android:textDirection="locale"
@@ -43,7 +43,7 @@
             android:textAppearance="@android:style/TextAppearance.StatusBar.EventContent.Title"
             android:text="Medium Text"
             android:paddingTop="8dp"
-            android:paddingLeft="4dp"
+            android:paddingStart="4dp"
             android:singleLine="true"
             android:ellipsize="marquee"/>
         <TextView
@@ -56,6 +56,6 @@
             android:singleLine="true"
             android:ellipsize="marquee"
             android:fadingEdge="horizontal"
-            android:paddingLeft="4dp"/>
+            android:paddingStart="4dp"/>
     </LinearLayout>
 </RelativeLayout>


### PR DESCRIPTION
# Description
## One Line Summary
Fix notification background image layouts to render RTL text based on the device's language setting.

## Details
### Motivation
Setting a [custom background image for notifications](https://documentation.onesignal.com/docs/android-customizations#background-images) is a supported feature only through the REST API, is limited in features, and [Android 12 has limited customizability](https://developer.android.com/about/versions/12/behavior-changes-12#custom-notifications). However OneSignal currently supports this feature and it should remind free of common/high impact bugs.

### Scope
Only affects the display of notifications when the following is true:
* Sent through the OneSignal REST API
* Includes `android_background_layout` in the payload.
* The `AndroidManifest.xml` has `android:supportsRtl="true"`
* The device has set a RTL language
    - Or Dev options > Drawing > "Force RTL layout direction" is enabled

This PR only affects the text rendering on background image notification layout.

#### Out of scope:
* Android 7-11, padding / styling. Known to not match other notifications on the device.
    - The background image layout assumes you are still conforming to the app icon / large icon being on the left which is Android 5-6 style layout. Not changing as this would be a breaking change since customers images are designed around that.
* Android 12 Rending - Android 12's layout changed dramatically, so omitting it from this scope.
* Android 4.1 (API 16), since `android:textDirection` was introduced in Android API level 17.
   * This might be ok, as this issue may not have existed on this version of android anyway.

### What was the bug?
When the notification background image is set and the RTL conditions are meet, the notification text renders on the left side instead of the right side. It also renders over the left safe area (where the app icon is).

**NOTE:** *Background image used in this example isn't the best example, an app icon should be backed into the background image, on left side.*

On LTR devices notifications looks like this :
![image](https://user-images.githubusercontent.com/645861/139180446-1606e063-320c-4848-bfac-69d7b6bff2d0.png)

On RTL devices notifications looks like this:
![image](https://user-images.githubusercontent.com/645861/139181412-2d56ec5d-b72c-48bf-8a6e-a2452782d207.png)

### Why the bug was happening?
The text elements on the notification layout had RTL disabled with `tools:ignore="RtlCompat"`, and didn't account for the different padding location.

### How the bug was fixed?
Added `android:textDirection="locale"` on the layout used for the both the title and body so it's influenced by the language direction. Also corrected title and body padding to support RTL.

# Testing
## Unit testing
N/A, only a visual layout change.

## Manual testing
Tested the Example app included in this repo (it has `android:supportsRtl="true"`) and set "Force RTL layout direction" on the device. Also tested w/o "Force RTL layout direction", to make sure it remained working.
Test on:
* Android 10 Emulator

### Screenshot after fix
Android 10 Emulator with English with "Force RTL layout direction" enabled:

![image](https://user-images.githubusercontent.com/645861/139189738-3c854385-30fc-41e9-ab93-8b25e1ee0f27.png)

* Odd resize of 2nd notification was indented, just tested different image sizes

# Affected code checklist
   - [X] Notifications
      - [X] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1473)
<!-- Reviewable:end -->
