### PR TITLE
Notification background image RTL fixes for 3.x.x

### DIFF
--- a/OneSignalSDK/onesignal/src/main/res/layout/onesignal_bgimage_notif_layout.xml
+++ b/OneSignalSDK/onesignal/src/main/res/layout/onesignal_bgimage_notif_layout.xml
@@ -31,7 +31,7 @@
 
     <LinearLayout
         android:orientation="vertical"
-        android:layout_marginStart="@android:dimen/notification_large_icon_width"
+        android:layout_marginLeft="@android:dimen/notification_large_icon_width"
         android:layout_width="fill_parent"
         android:layout_height="64dp"
         android:textDirection="locale"
@@ -43,7 +43,7 @@
             android:textAppearance="@android:style/TextAppearance.StatusBar.EventContent.Title"
             android:text="Medium Text"
             android:paddingTop="8dp"
-            android:paddingLeft="4dp"
+            android:paddingStart="4dp"
             android:singleLine="true"
             android:ellipsize="marquee"/>
         <TextView
@@ -56,6 +56,6 @@
             android:singleLine="true"
             android:ellipsize="marquee"
             android:fadingEdge="horizontal"
-            android:paddingLeft="4dp"/>
+            android:paddingStart="4dp"/>
     </LinearLayout>
 </RelativeLayout>


### PR DESCRIPTION
# Description
## One Line Summary
This is a back port to 3.x.x for the following two fixes which have been pulled into this branch with `git cherry-pick`.
* https://github.com/OneSignal/OneSignal-Android-SDK/pull/1473
* https://github.com/OneSignal/OneSignal-Android-SDK/pull/1474

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1475)
<!-- Reviewable:end -->
