### PR TITLE
Match and fix any external id that has escaped forward slashes

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalRestClient.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalRestClient.java
@@ -40,6 +40,8 @@ import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.Scanner;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 class OneSignalRestClient {
    static abstract class ResponseHandler {
@@ -158,6 +160,18 @@ class OneSignalRestClient {
 
          if (jsonBody != null) {
             String strJsonBody = jsonBody.toString();
+
+            Pattern eidPattern = Pattern.compile("(?<=\"external_user_id\":\").*\\\\/.*?(?=\",|\"\\})");
+            Matcher eidMatcher = eidPattern.matcher(strJsonBody);
+
+            if (eidMatcher.find()) {
+               String matched = eidMatcher.group(0);
+               if (matched != null) {
+                  String unescapedEID = matched.replace("\\/", "/");
+                  strJsonBody = eidMatcher.replaceAll(unescapedEID);
+               }
+            }
+
             OneSignal.Log(OneSignal.LOG_LEVEL.DEBUG, "OneSignalRestClient: " + method + " SEND JSON: " + strJsonBody);
 
             byte[] sendBytes = strJsonBody.getBytes("UTF-8");


### PR DESCRIPTION
Fix for https://app.asana.com/0/1193807006058450/1201230887422941/f which explicitly only checks outbound external user ids. 

This will NOT prevent the client from saving the EID with escaped slashes. This is why there is no `if (matched != currentEID)` check. We cannot rely on the current EID on the client to be unescaped.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1478)
<!-- Reviewable:end -->
