### PR TITLE
Make OSInAppMessagePrompt public

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessagePrompt.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessagePrompt.java
@@ -1,6 +1,6 @@
 package com.onesignal;
 
-abstract class OSInAppMessagePrompt {
+public abstract class OSInAppMessagePrompt {
 
     private boolean prompted = false;
 


### PR DESCRIPTION
# Description
## One Line Summary
The public `OSInAppMessageAction.getPrompts` method which returns `List<OSInAppMessagePrompt>` so making `OSInAppMessagePrompt` public as well.

## Details

### Motivation
This change allows `OSInAppMessageAction.getPrompts` to be used by app developers. This change is also required to fix access errors from some tooling such as Xamarin Binding to this SDK's `.aar` file.

# Testing
## Manual testing
Tested with the OneSignal Xamarin Android Binding project (from the OneSignal/OneSignal-Xamarin-SDK 3.x.x) and run on an Android 12 emulator.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [X] In-App Messaging
   - [ ] REST API requests
   - [x] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1490)
<!-- Reviewable:end -->
