### PR TITLE
Make UserStateSMSSynchronizer package-private

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStateSMSSynchronizer.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStateSMSSynchronizer.java
@@ -5,7 +5,7 @@ import org.json.JSONObject;
 import java.util.ArrayList;
 import java.util.List;
 
-public class UserStateSMSSynchronizer extends UserStateSecondaryChannelSynchronizer {
+class UserStateSMSSynchronizer extends UserStateSecondaryChannelSynchronizer {
 
     UserStateSMSSynchronizer() {
         super(OneSignalStateSynchronizer.UserStateSynchronizerType.SMS);


### PR DESCRIPTION
# Description
## One Line Summary
Change `UserStateSMSSynchronizer` access from `public` to `package-private`.
## Details

### Motivation
This class wasn't indented to be public and no public API exposes this class. Also Xamarin inspects this type with it's `class-parse` implementation which results in errors.

# Testing
## Manual testing
Tested with a Xamarin Android Binding project with the `class-parse` setting.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [X] In-App Messaging
   - [ ] REST API requests
   - [X] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1491)
<!-- Reviewable:end -->
