### PR TITLE
Proguard -assumenosideeffects Compatibility

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSUtils.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSUtils.java
@@ -138,36 +138,29 @@ class OSUtils {
       return subscribableStatus;
    }
 
-   // Interim method that prevents proguard from making a wrong assumption that NoClassDefFoundError
-   // catches are not needed when rules include "-assumenosideeffects" with getName().
-   // -assumenosideeffects public final class java.lang.Class {
-   //    public java.lang.String getName();
-   // }
-   // Using Class instead of String as class renames would result incorrectly not finding the class
-   // Using class.getName() as if no method is called then the try-catch would be removed.
-   // This @Keep annotation is also key so this method does not get inlined
+   // Interim method that works around Proguard's overly aggressive assumenosideeffects which
+   // ignores keep rules.
+   // This is specifically designed to address Proguard removing catches for NoClassDefFoundError
+   // when the config has "-assumenosideeffects" with
+   // java.lang.Class.getName() & java.lang.Object.getClass().
+   // This @Keep annotation is key so this method does not get removed / inlined.
+   // Addresses issue https://github.com/OneSignal/OneSignal-Android-SDK/issues/1423
    @Keep
-   private static boolean hasClass(Class<?> clazz) {
-      try {
-         clazz.getName();
-         return true;
-      } catch (NoClassDefFoundError e) {
-         return false;
-      }
+   private static boolean opaqueHasClass(Class<?> _class) {
+      return true;
    }
 
    static boolean hasFCMLibrary() {
       try {
-         return hasClass(com.google.firebase.messaging.FirebaseMessaging.class);
+         return opaqueHasClass(com.google.firebase.messaging.FirebaseMessaging.class);
       } catch (NoClassDefFoundError e) {
          return false;
       }
    }
 
-   @Keep
    static boolean hasGMSLocationLibrary() {
       try {
-         return hasClass(com.google.android.gms.location.LocationListener.class);
+         return opaqueHasClass(com.google.android.gms.location.LocationListener.class);
       } catch (NoClassDefFoundError e) {
          return false;
       }
@@ -175,7 +168,7 @@ class OSUtils {
 
    private static boolean hasHMSAvailabilityLibrary() {
       try {
-         return hasClass(com.huawei.hms.api.HuaweiApiAvailability.class);
+         return opaqueHasClass(com.huawei.hms.api.HuaweiApiAvailability.class);
       } catch (NoClassDefFoundError e) {
          return false;
       }
@@ -183,7 +176,7 @@ class OSUtils {
 
    private static boolean hasHMSPushKitLibrary() {
       try {
-         return hasClass(com.huawei.hms.aaid.HmsInstanceId.class);
+         return opaqueHasClass(com.huawei.hms.aaid.HmsInstanceId.class);
       } catch (NoClassDefFoundError e) {
          return false;
       }
@@ -191,7 +184,7 @@ class OSUtils {
 
    private static boolean hasHMSAGConnectLibrary() {
       try {
-         return hasClass(com.huawei.agconnect.config.AGConnectServicesConfig.class);
+         return opaqueHasClass(com.huawei.agconnect.config.AGConnectServicesConfig.class);
       } catch (NoClassDefFoundError e) {
          return false;
       }
@@ -199,7 +192,7 @@ class OSUtils {
 
    static boolean hasHMSLocationLibrary() {
       try {
-         return hasClass(com.huawei.hms.location.LocationCallback.class);
+         return opaqueHasClass(com.huawei.hms.location.LocationCallback.class);
       } catch (NoClassDefFoundError e) {
          return false;
       }


### PR DESCRIPTION
# Description
## One Line Summary
Fix compatibility issue with apps that use `-assumenosideeffects` with `java.lang.Class.getName()` with Proguard or Dexguard. _(No issue with R8.)_

## Details
### Motivation
To fix issue #1423 which cause a crash on some devices when aggressive minification setting `-assumenosideeffects` with `java.lang.Class.getName()` is used.

### Scope
This effects code paths that check if a Java class exists for feature detection. No logic was changed, just a proxy class was added to prevent Proguard from striping code.

## How this prevents the issue
Addressed this by adding a new private `opaqueHasClass` method and utilized it in all existing class exist helper methods.
This method has the "Keep" annotation on it so proguard will never change it's code and will not make a wrong assumptions about side effects.

### Before code change
Here in the smali output you can see the try-catch was removed by Proguard from `hasHMSAvailabilityLibrary`, even when the rule `-keep class com.onesignal.OSUtils** {*;}` or `@Keep` is added to try to prevent this modification.
```smali
.method private static n()Z
    .registers 1
    const-class v0, Lcom/huawei/hms/api/HuaweiApiAvailability;
    const/4 v0, 0x1
    return v0
.end method
```

### After code change
After you see `opaqueHasClass` is kept as-is. `hasHMSAvailabilityLibrary` is renamed which is ok, the important this is that the try-catch is kept which is required.
```smali
.method private static opaqueHasClass(Ljava/lang/Class;)Z
    .registers 1
    const/4 p0, 0x1
    return p0
.end method

// hasHMSAvailabilityLibrary
.method private static o()Z
    .registers 1

    :try_start_0
        const-class v0, Lcom/huawei/hms/api/HuaweiApiAvailability;
        invoke-static {v0}, Lcom/onesignal/OSUtils;->opaqueHasClass(Ljava/lang/Class;)Z
        move-result v0
    :try_end_6
        .catch Ljava/lang/NoClassDefFoundError; {:try_start_0 .. :try_end_6} :catch_7
        return v0
    :catch_7
        move-exception v0

    const/4 v0, 0x0
    return v0
.end method
```

# Testing
## Unit testing
No unit tests where added since this is a build issue and it has to run on a device to verify.

## Manual testing
Tested on a FireOS tablet and a Android 12 emulator without the FCM library.

Disabled R8 in `gradle.properties`, this forces the Android Gradle Plugin to use Proguard. 
````gradle.properties
android.enableR8 = false
android.enableR8.libraries = false
````

Tested with `classpath 'net.sf.proguard:proguard-gradle:6.1.1'` and with the following `proguard-rules.pro` file contents:
```proguard-rules.pro
-ignorewarnings
-optimizationpasses 1
-dontskipnonpubliclibraryclasses
-optimizations !field/*,!class/merging/*

-assumenosideeffects public class java.lang.Object {
    public final java.lang.Class getClass();
}
-assumenosideeffects public final class java.lang.Class {
    public java.lang.String getName();
}
```

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes
   - [X] Push Token Registration 

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1492)
<!-- Reviewable:end -->
