### PR TITLE
Fix Android 4.4 and older devices fail to register to onesignal.com

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalRestClient.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalRestClient.java
@@ -43,6 +43,8 @@ import java.util.Scanner;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import javax.net.ssl.HttpsURLConnection;
+
 class OneSignalRestClient {
    static abstract class ResponseHandler {
       void onSuccess(String response) {}
@@ -142,6 +144,13 @@ class OneSignalRestClient {
       try {
          OneSignal.Log(OneSignal.LOG_LEVEL.DEBUG, "OneSignalRestClient: Making request to: " + BASE_URL + url);
          con = newHttpURLConnection(url);
+
+         // https://github.com/OneSignal/OneSignal-Android-SDK/issues/1465
+         // Android 4.4 and older devices fail to register to onesignal.com to due it's TLS1.2+ requirement
+         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP_MR1 && con instanceof HttpsURLConnection) {
+            HttpsURLConnection conHttps = (HttpsURLConnection) con;
+            conHttps.setSSLSocketFactory(new TLS12SocketFactory(conHttps.getSSLSocketFactory()));
+         }
 
          con.setUseCaches(false);
          con.setConnectTimeout(timeout);

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/TLS12SocketFactory.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/TLS12SocketFactory.java
@@ -1,0 +1,64 @@
+package com.onesignal;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+
+public class TLS12SocketFactory extends SSLSocketFactory {
+    SSLSocketFactory sslSocketFactory;
+
+    public TLS12SocketFactory(SSLSocketFactory sslSocketFactory) {
+        super();
+        this.sslSocketFactory = sslSocketFactory;
+    }
+
+    @Override
+    public String[] getDefaultCipherSuites() {
+        return sslSocketFactory.getDefaultCipherSuites();
+    }
+
+    @Override
+    public String[] getSupportedCipherSuites() {
+        return sslSocketFactory.getSupportedCipherSuites();
+    }
+
+    @Override
+    public Socket createSocket() throws IOException {
+        return enableTLS(sslSocketFactory.createSocket());
+    }
+
+    @Override
+    public Socket createSocket(Socket s, String host, int port, boolean autoClose) throws IOException {
+        return enableTLS(sslSocketFactory.createSocket(s, host, port, autoClose));
+    }
+
+    @Override
+    public Socket createSocket(String host, int port) throws IOException {
+        return enableTLS(sslSocketFactory.createSocket(host, port));
+    }
+
+    @Override
+    public Socket createSocket(String host, int port, InetAddress localHost, int localPort) throws IOException {
+        return enableTLS(sslSocketFactory.createSocket(host, port, localHost, localPort));
+    }
+
+    @Override
+    public Socket createSocket(InetAddress host, int port) throws IOException {
+        return enableTLS(sslSocketFactory.createSocket(host, port));
+    }
+
+    @Override
+    public Socket createSocket(InetAddress address, int port, InetAddress localAddress, int localPort) throws IOException {
+        return enableTLS(sslSocketFactory.createSocket(address, port, localAddress, localPort));
+    }
+
+    private Socket enableTLS(Socket socket) {
+        if ((socket instanceof SSLSocket)) {
+            ((SSLSocket) socket).setEnabledProtocols(new String[]{"TLSv1.2"});
+        }
+        return socket;
+    }
+}


### PR DESCRIPTION
# Description
## One Line Summary
Fix issue #1465 Android 4.4 and older devices fail to register to onesignal.com to due it's TLS1.2+ requirement

## Details

### Motivation
TLS 1.2 is support by Android API 16+ (Android 4.1+) but is only enabled by default if the device is running Android API 20+ (devices with Android 5.0 or newer).
TLS 1.2 can be enabled on API 16+ (Android 4.1+) with code in the app.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [x] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1493)
<!-- Reviewable:end -->
