### PR TITLE
Don't set backgroundImageLayout if device is Android 12 or higher

### DIFF
--- a/Examples/OneSignalDemo/app/build.gradle
+++ b/Examples/OneSignalDemo/app/build.gradle
@@ -2,10 +2,10 @@ apply plugin: 'com.onesignal.androidsdk.onesignal-gradle-plugin'
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 30
+        targetSdkVersion 31
         versionCode 1
         versionName "1.0"
         multiDexEnabled true

--- a/OneSignalSDK/build.gradle
+++ b/OneSignalSDK/build.gradle
@@ -4,8 +4,8 @@ buildscript {
 
     ext {
         buildVersions = [
-                compileSdkVersion: 30,
-                targetSdkVersion: 30
+                compileSdkVersion: 31,
+                targetSdkVersion: 31
         ]
         androidGradlePluginVersion = '3.6.2'
         googleServicesGradlePluginVersion = '4.3.2'

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotification.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotification.java
@@ -767,9 +767,13 @@ class GenerateNotification {
    // Keep 'throws Throwable' as 'onesignal_bgimage_notif_layout' may not be available
    //    This maybe the case if a jar is used instead of an aar.
    private static void addBackgroundImage(JSONObject fcmJson, NotificationCompat.Builder notifBuilder) throws Throwable {
-      // Required to right align image
-      if (android.os.Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN)
+      // Not adding Background Images to API Versions < 16 or >= 31
+      if (android.os.Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN ||
+          android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+         OneSignal.Log(OneSignal.LOG_LEVEL.VERBOSE,
+              "Cannot use background images in notifications for device on version: " + android.os.Build.VERSION.SDK_INT);
          return;
+      }
 
       Bitmap bg_image = null;
       JSONObject jsonBgImage = null;


### PR DESCRIPTION
# Description
## One Line Summary
Don't set backgroundImageLayout if device is Android 12 or higher

## Details
[Documentation for Android Background Images](https://documentation.onesignal.com/docs/android-customizations#background-images)
We currently add the backgroundImageLayout in the addBackgroundImage method of `GenerateNotification.java`

We are now checking for the device SDK version being less than 31 (s) and returning early if >= 31.

### Motivation
Android 12+ changed the "Customizable Area" within notifications. So background images will look different and we recommend creating your own custom layout to handle this. Therefore we have decided to disable background image layouts for devices on Android 12+.


### Scope
Notification appearance for Android 12+ devices only.

# Testing
## Unit testing
**OPTIONAL -**  Explain unit tests added, if not clear in the code.

## Manual testing
**RECOMMEND - OPTIONAL -** Explain what scenarios were tested and the environment.
Example: Tested opening a notification while the app was foregrounded, app build with Android Studio 2020.3 with a fresh install of the OneSignal example app on a Pixel 6 with Android 12.

# Affected code checklist
   - [x] Notifications
      - [x] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [ ] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [ ] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [ ] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1495)
<!-- Reviewable:end -->
