### PR TITLE
SDK Development Environment - Automatically use local SDK source for example project

### DIFF
--- a/Examples/OneSignalDemo/app/build.gradle
+++ b/Examples/OneSignalDemo/app/build.gradle
@@ -1,4 +1,3 @@
-apply plugin: 'com.onesignal.androidsdk.onesignal-gradle-plugin'
 apply plugin: 'com.android.application'
 
 android {
@@ -46,6 +45,7 @@ android {
     task flavorSelection() {
         if (getGradle().getStartParameter().getTaskRequests().toString().contains("Gms")) {
             apply plugin: 'com.google.gms.google-services'
+            googleServices { disableVersionCheck = true }
         } else {
             apply plugin: 'com.huawei.agconnect'
         }

--- a/OneSignalSDK/settings.gradle
+++ b/OneSignalSDK/settings.gradle
@@ -1,2 +1,14 @@
 include ':app', ':onesignal', ':unittest'
 project(':app').projectDir = new File(settingsDir, '../examples/OneSignalDemo/app')
+
+// Allows running the :app project above with the local source for development of the SDK.
+// This means we can keep the example app as-is so it stays as a real world example.
+gradle.rootProject {
+    allprojects {
+        configurations.all {
+            resolutionStrategy.dependencySubstitution {
+                substitute(module('com.onesignal:OneSignal')).using(project(':onesignal'))
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Description
## One Line Summary
When the development project is used to build the example the OneSignal library will point the the local SDK source automatically.

## Details
### Motivation
We want to keep the public example app as real world as possible by pointing to the released OneSignal SDK, however for SDK development we want to use the local SDK source. Instead of requiring SDK developers to remember to change the example project locally this automatically points the OneSignal library to the local `onesignal` project when using the development root `build.gradle` in the `OneSignalSDK` folder.

# Testing
## Manual testing
Tested on Android Studio 2020.3,1 Patch 3 and ran the example app on Android 12 emulator. Ensured local SDK source was used in the manual test by changing a log message an observing the result in the logcat.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes
   - [X] Example App
   - [X] Development Environment

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1500)
<!-- Reviewable:end -->
