### PR TITLE
Use consistent versions of dependencies; Fixes errors reported by strict-version-matcher-plugin

### DIFF
--- a/OneSignalSDK/onesignal/build.gradle
+++ b/OneSignalSDK/onesignal/build.gradle
@@ -47,27 +47,67 @@ dependencies {
 
     // play-services-location:16.0.0 is the last version before going to AndroidX
     // play-services-location:17.0.0 is the first version using AndroidX
-    compileOnly 'com.google.android.gms:play-services-location:[17.0.0, 18.0.99]'
+    compileOnly('com.google.android.gms:play-services-location:[17.0.0, 18.0.99]') {
+        version {
+            require '[17.0.0, 18.0.99]'
+            prefer '18.0.0'
+        }
+    }
 
     // play-services-base:16.1.0 is the last version before going to AndroidX
     // play-services-base:17.0.0 is the first version using AndroidX
     // Required for GoogleApiAvailability
-    implementation 'com.google.android.gms:play-services-base:[17.0.0, 17.6.99]'
+    implementation('com.google.android.gms:play-services-base') {
+        version {
+            require '[17.0.0, 17.6.99]'
+            prefer '17.6.0'
+        }
+    }
 
     // firebase-messaging:18.0.0 is the last version before going to AndroidX
     // firebase-messaging:19.0.0 is the first version using AndroidX
-    api 'com.google.firebase:firebase-messaging:[19.0.0, 22.0.99]'
+    api('com.google.firebase:firebase-messaging') {
+        version {
+            require '[19.0.0, 22.0.99]'
+            prefer '22.0.0'
+        }
+    }
 
     // Huawei PushKit
     // KEEP as "compileOnly", so OneSignal isn't a direct dependency in the POM file.
     compileOnly "com.huawei.hms:push:$huaweiHMSPushVersion"
     compileOnly "com.huawei.hms:location:$huaweiHMSLocationVersion"
 
-    api 'androidx.cardview:cardview:[1.0.0, 1.0.99]'
-    api 'androidx.legacy:legacy-support-v4:[1.0.0, 1.0.99]'
-    api 'androidx.browser:browser:[1.0.0, 1.3.99]'
-    api 'androidx.appcompat:appcompat:[1.0.0, 1.3.99]'
-    api 'androidx.work:work-runtime:[2.1.0, 2.7.99]'
+    api('androidx.cardview:cardview') {
+        version {
+            require '[1.0.0, 1.0.99]'
+            prefer '1.0.0'
+        }
+    }
+    api('androidx.legacy:legacy-support-v4') {
+        version {
+            require '[1.0.0, 1.0.99]'
+            prefer '1.0.0'
+        }
+    }
+    api('androidx.browser:browser') {
+        version {
+            require '[1.0.0, 1.3.99]'
+            prefer '1.3.0'
+        }
+    }
+    api('androidx.appcompat:appcompat') {
+        version {
+            require '[1.0.0, 1.3.99]'
+            prefer '1.3.1'
+        }
+    }
+    api('androidx.work:work-runtime') {
+        version {
+            require '[2.1.0, 2.7.99]'
+            prefer '2.7.1'
+        }
+    }
 }
 
 apply from: 'maven-push.gradle'


### PR DESCRIPTION
# Description
## One Line Summary
Use consistent versions of dependencies by using Gradle's rich versions, this solves build errors from `strict-version-matcher-plugin`.

## Details

### Motivation
Provides consistent versions of dependencies so apps get consistent builds. This also solves builds errors from the Google `strict-version-matcher-plugin` like the following:
```
* What went wrong:
Execution failed for task ':app:bundleGmsDebugResources'.
> In project 'app' a resolved Google Play services library dependency depends on another at an exact version (e.g. "[19.0.
  0, 22.0.99]", but isn't being resolved to that version. Behavior exhibited by the library will be unknown.
  
  Dependency failing: com.onesignal:OneSignal:4.6.3 -> com.google.firebase:firebase-messaging@[19.0.0, 22.0.99], but fireb
  ase-messaging version was 22.0.0.
  
  The following dependencies are project dependencies that are direct or have transitive dependencies that lead to the art
  ifact with the issue.
  -- Project 'app' depends onto com.onesignal:OneSignal@{strictly 4.6.3}
  -- Project 'app' depends onto com.google.firebase:firebase-messaging@{strictly 22.0.0}
  -- Project 'app' depends onto com.onesignal:OneSignal@4.6.3
```
`strict-version-matcher-plugin` is also used by `google-services` Gradle plugin and this means apps no longer need to set
`disableVersionCheck = true` or include the `onesignal-gradle-plugin` to disable it.

### Scope
This effects the version of Firebase messaging, Google Play services, and AndroidX libraries consumed by the app. This improves the version selected by Gradle to pick a more compatible version between all the projects dependencies.

### Related
* https://github.com/OneSignal/OneSignal-Flutter-SDK/issues/451
   - This was marked solved by the OP because they added the `onesignal-gradle-plugin`, however this PR solves the build error without requiring that.
* [ERROR: In project 'app' a resolved Google Play services library dependency depends on another at an exact version while iintegrating onesignal](https://stackoverflow.com/questions/59128152/error-in-project-app-a-resolved-google-play-services-library-dependency-depen?rq=1)
    - Again `onesignal-gradle-plugin` fixed this for them, but this PR means that the app project won't alway need to add the plugin, which means better project compatibility.
## Background
This utilizes the Gradle's rich version format, see [Gradle's Declaring Rich Versions documentation](https://docs.gradle.org/current/userguide/rich_versions.html) for more details on this format.

# Testing
## Manual testing
Tested changes by publishing to Maven Central's staging repo. In the example app I consumed it and tested with  `google-services` and without setting `disableVersionCheck` to ensure it no longer fails to build.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes
   - [X] Dependencies 

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1501)
<!-- Reviewable:end -->
