### PR TITLE
Speculative fix for null layout params.

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/InAppMessageView.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/InAppMessageView.java
@@ -153,6 +153,13 @@ class InAppMessageView {
                 }
 
                 ViewGroup.LayoutParams layoutParams = webView.getLayoutParams();
+                if (layoutParams == null) {
+                    OneSignal.onesignalLog(
+                        OneSignal.LOG_LEVEL.WARN,
+                        "WebView height update skipped because of null layoutParams, new height will be used once it is displayed.");
+                    return;
+                }
+
                 layoutParams.height = pageHeight;
                 // We only need to update the WebView size since it's parent layouts are set to
                 //   WRAP_CONTENT to always match the height of the WebView. (Expect for fullscreen)


### PR DESCRIPTION
# Description
## One Line Summary
Checks for null layoutParams when setting IAM height.

## Details

### Motivation
Prevent crashes. Crash reports received of NPE on InAppMessageView.java:156.

### Scope
Don't change the height if the layoutParams are null. Wait for the height to be changed when the IAM is displayed.

### OPTIONAL - Other
N/A

# Testing
## Unit testing
None added.

## Manual testing
Unable to reliably reproduce the failure case, so the fix could not be verified, but a manual test fo receiv

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ x ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

