### PR TITLE
Fix Permission observer not being called

### DIFF
--- a/Examples/OneSignalDemo/app/src/main/AndroidManifest.xml
+++ b/Examples/OneSignalDemo/app/src/main/AndroidManifest.xml
@@ -84,6 +84,9 @@
 
         <activity android:name=".activity.MainActivity"/>
 
+        <activity
+          android:name=".activity.SecondaryActivity"
+          android:exported="false" />
     </application>
 
 </manifest>

--- a/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/activity/SecondaryActivity.java
+++ b/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/activity/SecondaryActivity.java
@@ -1,0 +1,16 @@
+package com.onesignal.sdktest.activity;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+import android.os.Bundle;
+
+import com.onesignal.sdktest.R;
+
+public class SecondaryActivity extends AppCompatActivity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_secondary);
+    }
+}

--- a/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/model/MainActivityViewModel.java
+++ b/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/model/MainActivityViewModel.java
@@ -9,6 +9,8 @@ import androidx.recyclerview.widget.GridLayoutManager;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 import androidx.appcompat.widget.Toolbar;
+
+import android.content.Intent;
 import android.util.Pair;
 import android.view.View;
 import android.view.ViewTreeObserver;
@@ -25,6 +27,7 @@ import com.onesignal.OSPermissionStateChanges;
 import com.onesignal.OSSubscriptionStateChanges;
 import com.onesignal.OneSignal;
 import com.onesignal.sdktest.R;
+import com.onesignal.sdktest.activity.SecondaryActivity;
 import com.onesignal.sdktest.adapter.InAppMessageRecyclerViewAdapter;
 import com.onesignal.sdktest.adapter.NotificationRecyclerViewAdapter;
 import com.onesignal.sdktest.adapter.PairRecyclerViewAdapter;
@@ -244,6 +247,10 @@ public class MainActivityViewModel implements ActivityViewModel {
         pauseInAppMessagesSwitch = getActivity().findViewById(R.id.main_activity_settings_pause_in_app_messages_switch);
         revokeConsentButton = getActivity().findViewById(R.id.main_activity_settings_revoke_consent_button);
 
+        Button navigateNextActivity = getActivity().findViewById(R.id.main_activity_navigate_button);
+        navigateNextActivity.setOnClickListener(v -> {
+            getActivity().startActivity(new Intent(getActivity(), SecondaryActivity.class));
+        });
         tagSet = new HashMap<>();
         tagArrayList = new ArrayList<>();
 

--- a/Examples/OneSignalDemo/app/src/main/res/layout/activity_secondary.xml
+++ b/Examples/OneSignalDemo/app/src/main/res/layout/activity_secondary.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  tools:context=".activity.SecondaryActivity">
+
+</LinearLayout>

--- a/Examples/OneSignalDemo/app/src/main/res/layout/main_activity_layout.xml
+++ b/Examples/OneSignalDemo/app/src/main/res/layout/main_activity_layout.xml
@@ -1076,6 +1076,29 @@
 
             </LinearLayout>
 
+            <LinearLayout
+              android:layout_width="match_parent"
+              android:layout_height="56dp"
+              android:layout_gravity="center"
+              android:layout_marginStart="16dp"
+              android:layout_marginTop="4dp"
+              android:layout_marginEnd="16dp"
+              android:layout_marginBottom="16dp"
+              android:background="@color/colorPrimary"
+              android:gravity="center"
+              android:orientation="vertical">
+
+                <Button
+                  android:id="@+id/main_activity_navigate_button"
+                  android:layout_width="match_parent"
+                  android:layout_height="match_parent"
+                  android:text="@string/navigate_next_activity"
+                  android:textSize="19sp"
+                  android:textColor="@android:color/white"
+                  android:background="@drawable/ripple_selector_white_red"
+                  android:visibility="visible"/>
+
+            </LinearLayout>
         </LinearLayout>
 
     </androidx.core.widget.NestedScrollView>

--- a/Examples/OneSignalDemo/app/src/main/res/values/strings.xml
+++ b/Examples/OneSignalDemo/app/src/main/res/values/strings.xml
@@ -52,6 +52,8 @@
     <string name="allow">Allow</string>
     <string name="revoke_consent">Revoke Consent</string>
 
+    <string name="navigate_next_activity">Next activity</string>
+
     <string name="onesignal_app_id">0ba9731b-33bd-43f4-8b59-61172e27447d</string>
 
 </resources>

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/ActivityLifecycleHandler.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/ActivityLifecycleHandler.java
@@ -85,6 +85,7 @@ class ActivityLifecycleHandler implements OSSystemConditionController.OSSystemCo
     }
 
     void onActivityStarted(Activity activity) {
+        focusHandler.startOnStartFocusWork();
     }
 
     void onActivityResumed(Activity activity) {
@@ -106,6 +107,7 @@ class ActivityLifecycleHandler implements OSSystemConditionController.OSSystemCo
 
     void onActivityStopped(Activity activity) {
         OneSignal.Log(OneSignal.LOG_LEVEL.DEBUG, "onActivityStopped: " + activity);
+        focusHandler.startOnStopFocusWork();
 
         if (activity == curActivity) {
             curActivity = null;
@@ -184,8 +186,7 @@ class ActivityLifecycleHandler implements OSSystemConditionController.OSSystemCo
         if (focusHandler.hasBackgrounded() || nextResumeIsFirstActivity) {
             OneSignal.onesignalLog(OneSignal.LOG_LEVEL.DEBUG, "ActivityLifecycleHandler reset background state, call app focus");
             nextResumeIsFirstActivity = false;
-            focusHandler.resetBackgroundState();
-            OneSignal.onAppFocus();
+            focusHandler.startOnFocusWork();
         } else {
             OneSignal.onesignalLog(OneSignal.LOG_LEVEL.DEBUG, "ActivityLifecycleHandler cancel background lost focus worker");
             focusHandler.cancelOnLostFocusWorker(FOCUS_LOST_WORKER_TAG, OneSignal.appContext);

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/ActivityLifecycleHandler.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/ActivityLifecycleHandler.java
@@ -107,7 +107,6 @@ class ActivityLifecycleHandler implements OSSystemConditionController.OSSystemCo
 
     void onActivityStopped(Activity activity) {
         OneSignal.Log(OneSignal.LOG_LEVEL.DEBUG, "onActivityStopped: " + activity);
-        focusHandler.startOnStopFocusWork();
 
         if (activity == curActivity) {
             curActivity = null;
@@ -119,6 +118,9 @@ class ActivityLifecycleHandler implements OSSystemConditionController.OSSystemCo
         }
 
         logCurActivity();
+
+        if (curActivity == null)
+            focusHandler.startOnStopFocusWork();
     }
 
     void onActivityDestroyed(Activity activity) {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSFocusHandler.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSFocusHandler.kt
@@ -42,21 +42,34 @@ class OSFocusHandler {
 
     fun startOnFocusWork() {
         resetBackgroundState()
+        OneSignal.onesignalLog(
+            OneSignal.LOG_LEVEL.DEBUG,
+            "OSFocusHandler running onAppFocus"
+        )
         OneSignal.onAppFocus()
     }
 
     fun startOnStartFocusWork() {
         if (stopped) {
             stopped = false
-            OSTimeoutHandler.getTimeoutHandler().destroyTimeout(stopRunnable)
             stopRunnable = null
+            OneSignal.onesignalLog(
+                OneSignal.LOG_LEVEL.DEBUG,
+                "OSFocusHandler running onAppStartFocusLogic"
+            )
             OneSignal.onAppStartFocusLogic()
+        } else {
+            resetStopState()
         }
     }
 
     fun startOnStopFocusWork() {
         stopRunnable = Runnable {
             stopped = true
+            OneSignal.onesignalLog(
+                OneSignal.LOG_LEVEL.DEBUG,
+                "OSFocusHandler setting stop state: true"
+            )
         }.also {
             OSTimeoutHandler.getTimeoutHandler().startTimeout(stopDelay, it)
         }
@@ -81,7 +94,15 @@ class OSFocusHandler {
         WorkManager.getInstance(context).cancelAllWorkByTag(tag)
     }
 
+    private fun resetStopState() {
+        stopped = false
+        stopRunnable?.let {
+            OSTimeoutHandler.getTimeoutHandler().destroyTimeout(it)
+        }
+    }
+
     private fun resetBackgroundState() {
+        resetStopState()
         backgrounded = false
     }
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -1296,7 +1296,7 @@ public class OneSignal {
       Log(LOG_LEVEL.WARN, "HTTP code: " + statusCode + " " + errorString + jsonError, throwable);
    }
 
-   // Returns true if there is active time that is unsynced.
+   // Returns true if there is active time that is non synced.
    @WorkerThread
    static void onAppLostFocus() {
       Log(LOG_LEVEL.DEBUG, "Application lost focus initDone: " + initDone);
@@ -1373,6 +1373,10 @@ public class OneSignal {
       }
 
       onAppFocusLogic();
+   }
+
+   static void onAppStartFocusLogic() {
+      getCurrentPermissionState(appContext).refreshAsTo();
    }
 
    private static void onAppFocusLogic() {

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowFocusHandler.kt
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowFocusHandler.kt
@@ -35,11 +35,32 @@ import android.content.Context
 import com.onesignal.OSFocusHandler.Companion.onLostFocusDoWork
 import org.robolectric.annotation.Implementation
 import org.robolectric.annotation.Implements
+import org.robolectric.annotation.RealObject
 
 @Implements(OSFocusHandler::class)
 class ShadowFocusHandler {
+
+    @Implementation
+    fun startOnStartFocusWork() {
+        hasStopped = false
+        OneSignal.onAppStartFocusLogic()
+    }
+
+    @Implementation
+    fun startOnStopFocusWork() {
+        hasStopped = true
+    }
+
     @Implementation
     fun startOnLostFocusWorker(tag: String, delay: Long, context: Context) {
         onLostFocusDoWork()
+    }
+
+    companion object {
+        var hasStopped = false
+
+        fun resetStatics() {
+            hasStopped = false
+        }
     }
 }

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
@@ -161,6 +161,7 @@ import static com.test.onesignal.TestHelpers.getNextJob;
 import static com.test.onesignal.TestHelpers.pauseActivity;
 import static com.test.onesignal.TestHelpers.restartAppAndElapseTimeToNextSession;
 import static com.test.onesignal.TestHelpers.startRemoteNotificationReceivedHandlerService;
+import static com.test.onesignal.TestHelpers.stopActivity;
 import static com.test.onesignal.TestHelpers.threadAndTaskWait;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertFalse;
@@ -682,6 +683,20 @@ public class MainOneSignalClassRunner {
       pauseActivity(blankActivityController);
 
       assertRestCalls(4);
+   }
+
+   @Test
+   public void testAppStartFocus() throws Exception {
+      OneSignalInit();
+      threadAndTaskWait();
+
+      assertTrue(ShadowOneSignalRestClient.lastUrl.matches("players"));
+
+      stopActivity(blankActivityController);
+      assertTrue(ShadowFocusHandler.Companion.getHasStopped());
+
+      blankActivityController.resume();
+      assertFalse(ShadowFocusHandler.Companion.getHasStopped());
    }
 
    private void setOneSignalContextOpenAppThenBackgroundAndResume() throws Exception {
@@ -3194,22 +3209,18 @@ public class MainOneSignalClassRunner {
       OneSignalInit();
       threadAndTaskWait();
 
-      OSPermissionObserver permissionObserver = new OSPermissionObserver() {
-         @Override
-         public void onOSPermissionChanged(OSPermissionStateChanges stateChanges) {
-            lastPermissionStateChanges = stateChanges;
-            currentPermission = stateChanges.getTo().areNotificationsEnabled();
-         }
+      OSPermissionObserver permissionObserver = stateChanges -> {
+         lastPermissionStateChanges = stateChanges;
+         currentPermission = stateChanges.getTo().areNotificationsEnabled();
       };
       OneSignal.addPermissionObserver(permissionObserver);
       lastPermissionStateChanges = null;
       // Make sure garbage collection doesn't nuke any observers.
       Runtime.getRuntime().gc();
 
-      pauseActivity(blankActivityController);
+      stopActivity(blankActivityController);
       ShadowNotificationManagerCompat.enabled = false;
       blankActivityController.resume();
-      threadAndTaskWait();
 
       assertTrue(lastPermissionStateChanges.getFrom().areNotificationsEnabled());
       assertFalse(lastPermissionStateChanges.getTo().areNotificationsEnabled());

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/TestHelpers.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/TestHelpers.java
@@ -29,6 +29,7 @@ import com.onesignal.ShadowCustomTabsClient;
 import com.onesignal.ShadowDynamicTimer;
 import com.onesignal.ShadowFCMBroadcastReceiver;
 import com.onesignal.ShadowFirebaseAnalytics;
+import com.onesignal.ShadowFocusHandler;
 import com.onesignal.ShadowFusedLocationApiWrapper;
 import com.onesignal.ShadowGenerateNotification;
 import com.onesignal.ShadowGoogleApiClientCompatProxy;
@@ -129,6 +130,7 @@ public class TestHelpers {
       ShadowNotificationReceivedEvent.resetStatics();
       ShadowOneSignalNotificationManager.resetStatics();
       ShadowBadgeCountUpdater.resetStatics();
+      ShadowFocusHandler.Companion.resetStatics();
 
       lastException = null;
    }
@@ -585,6 +587,11 @@ public class TestHelpers {
 
    public static void pauseActivity(ActivityController activityController) throws Exception {
       activityController.pause();
+      threadAndTaskWait();
+   }
+
+   public static void stopActivity(ActivityController activityController) throws Exception {
+      activityController.stop();
       threadAndTaskWait();
    }
 


### PR DESCRIPTION
# Description
## One Line Summary
Permission observer was not being called when swapping fast between application and settings apps

## Details

### Motivation
PermissionObserver needs to be called for all scenarios when the user disables/enables the notification

### OPTIONAL - Other
* When the user swaps from the app to the setting and enables/disable notification fast enough no avoid onLostFocus runnable, the permission observer was not being fired
* Add new lifecycle event tracking, onStart, and onStop
* Check permission under on Start

## Manual testing
Followed steps given under https://github.com/OneSignal/OneSignal-Android-SDK/issues/1392

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [x] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1521)
<!-- Reviewable:end -->
