### PR TITLE
Fix removeObserver WeakReference Handling

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSObservable.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSObservable.java
@@ -55,6 +55,7 @@ class OSObservable<ObserverType, StateType> {
    void removeObserver(ObserverType observer) {
       for(int i = 0; i < observers.size(); i++) {
          Object anObserver = ((WeakReference)observers.get(i)).get();
+         if (anObserver == null) continue;
          if (anObserver.equals(observer)) {
             observers.remove(i);
             break;

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
@@ -824,4 +824,18 @@ public class OneSignalPackagePrivateHelper {
          }
       }
    }
+
+   public static class OSObservable<ObserverType, StateType> extends com.onesignal.OSObservable<ObserverType, StateType> {
+      public OSObservable(String methodName, boolean fireOnMainThread) {
+         super(methodName, fireOnMainThread);
+      }
+
+      public void addObserver(ObserverType observer) {
+         super.addObserver(observer);
+      }
+
+      public void removeObserver(ObserverType observer) {
+         super.removeObserver(observer);
+      }
+   }
 }

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
@@ -113,6 +113,7 @@ import org.robolectric.shadows.ShadowAlarmManager;
 import org.robolectric.shadows.ShadowConnectivityManager;
 import org.robolectric.shadows.ShadowLog;
 
+import java.lang.ref.WeakReference;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -136,6 +137,7 @@ import static com.onesignal.OneSignalPackagePrivateHelper.OneSignal_setSessionMa
 import static com.onesignal.OneSignalPackagePrivateHelper.OneSignal_setTime;
 import static com.onesignal.OneSignalPackagePrivateHelper.OneSignal_setTrackerFactory;
 import static com.onesignal.OneSignalPackagePrivateHelper.OneSignal_taskQueueWaitingForInit;
+import static com.onesignal.OneSignalPackagePrivateHelper.OSObservable;
 import static com.onesignal.ShadowOneSignalRestClient.EMAIL_USER_ID;
 import static com.onesignal.ShadowOneSignalRestClient.PUSH_USER_ID;
 import static com.onesignal.ShadowOneSignalRestClient.REST_METHOD;
@@ -3453,6 +3455,15 @@ public class MainOneSignalClassRunner {
       threadAndTaskWait();
 
       assertNull(lastSMSSubscriptionStateChanges);
+   }
+
+   @Test
+   public void shouldNotThrowWhenRemovingWeakReferenceObservableThatHasBeenGarbageCollected() {
+      OSObservable<Object, Object> observer = new OSObservable<>("", false);
+      WeakReference<Object> weakObject = new WeakReference<>(new Object());
+      observer.addObserver(weakObject.get());
+      Runtime.getRuntime().gc(); // Force cleaning up WeakReference above
+      observer.removeObserver(weakObject.get());
    }
 
    @Test


### PR DESCRIPTION
# Description
## One Line Summary
Fix NPE thrown by `OneSignal.remove*Observer` if any of its tracked observers where garbage collected.

## Details
### Motivation
This is a fundamental use case which needs to be correctly handled. The most prevalent report of this issue is https://github.com/OneSignal/OneSignal-Flutter-SDK/issues/494 due to the way the binding code was changed in PR [OneSignal-Flutter-SDK#445](https://github.com/OneSignal/OneSignal-Flutter-SDK/pull/445/files#diff-c909818a09ebc6f34d32e6d2088ffea1c449361f832300d960572c22c80222afR162-R168) which the main motivation to providing a quick an simple fix.

### Scope
Only effects apps that calls one of the `OneSignal.add*Observer` methods with a reference that is later garbage collected and then later calls one of the matching `OneSignal.remove*Observer` pair methods with any reference.

### Related
* Fixes https://github.com/OneSignal/OneSignal-Android-SDK/issues/1524
* Address https://github.com/OneSignal/OneSignal-Flutter-SDK/issues/494

# Testing
## Unit testing
New `shouldNotThrowWhenRemovingWeakReferenceObservableThatHasBeenGarbageCollected` has been added directly testing the internal `OSObservable` class.

## Manual testing
None, unit testing covers the code change.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes
   - [X] Observer methods

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1525)
<!-- Reviewable:end -->
