### PR TITLE
Remove setRequiresUserConesnt call when there is no value in the manifest

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -883,7 +883,8 @@ public class OneSignal {
 
          // Read the current privacy consent setting from AndroidManifest.xml
          String requireSetting = bundle.getString("com.onesignal.PrivacyConsent");
-         setRequiresUserPrivacyConsent("ENABLE".equalsIgnoreCase(requireSetting));
+         if (requireSetting!=null)
+            setRequiresUserPrivacyConsent("ENABLE".equalsIgnoreCase(requireSetting));
       } catch (Throwable t) {
          t.printStackTrace();
       }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -883,7 +883,7 @@ public class OneSignal {
 
          // Read the current privacy consent setting from AndroidManifest.xml
          String requireSetting = bundle.getString("com.onesignal.PrivacyConsent");
-         if (requireSetting!=null)
+         if (requireSetting != null)
             setRequiresUserPrivacyConsent("ENABLE".equalsIgnoreCase(requireSetting));
       } catch (Throwable t) {
          t.printStackTrace();


### PR DESCRIPTION
# Description
## One Line Summary
Remove call to `setRequiresUserConesnt` when there is no value for `PrivacyConsent` in the AndroidManifest.

## Details

### Motivation
Removes error log reported in [OneSignal/OneSignal-Android-SDK#1520](https://github.com/OneSignal/OneSignal-Android-SDK/issues/1520).

### Scope
Effects apps that initialize OneSignal with `setRequiresUserConesnt(True)` and have no value for `PrivacyConsent` in the AndroidManifest. 

# Testing
## Manual testing
Tested by opening the app, app built with Android Studio 2021.1 with a fresh install of the OneSignal example app on a Pixel 6 with Android 12.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1527)
<!-- Reviewable:end -->
