### PR TITLE
Fix `ttl` and related current time logic

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
@@ -236,7 +236,7 @@ class NotificationBundleProcessor {
             values.put(NotificationTable.COLUMN_NAME_MESSAGE, notificationJob.getBody().toString());
 
          // Set expire_time
-         long sentTime = jsonPayload.optLong(OSNotificationController.GOOGLE_SENT_TIME_KEY, OneSignal.getTime().getCurrentThreadTimeMillis()) / 1_000L;
+         long sentTime = jsonPayload.optLong(OSNotificationController.GOOGLE_SENT_TIME_KEY, OneSignal.getTime().getCurrentTimeMillis()) / 1_000L;
          int ttl = jsonPayload.optInt(OSNotificationController.GOOGLE_TTL_KEY, OSNotificationRestoreWorkManager.DEFAULT_TTL_IF_NOT_IN_PAYLOAD);
          long expireTime = sentTime + ttl;
          values.put(NotificationTable.COLUMN_NAME_EXPIRE_TIME, expireTime);

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotification.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotification.java
@@ -146,7 +146,7 @@ public class OSNotification {
          return;
       }
 
-      long currentTime = OneSignal.getTime().getCurrentThreadTimeMillis();
+      long currentTime = OneSignal.getTime().getCurrentTimeMillis();
       if (currentJsonPayload.has(GOOGLE_TTL_KEY)) {
          sentTime = currentJsonPayload.optLong(GOOGLE_SENT_TIME_KEY, currentTime) / 1_000;
          ttl = currentJsonPayload.optInt(GOOGLE_TTL_KEY, OSNotificationRestoreWorkManager.DEFAULT_TTL_IF_NOT_IN_PAYLOAD);

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotification.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotification.java
@@ -117,6 +117,7 @@ public class OSNotification {
       this.title = notification.title;
       this.body = notification.body;
       this.additionalData = notification.additionalData;
+      this.smallIcon = notification.smallIcon;
       this.largeIcon = notification.largeIcon;
       this.bigPicture = notification.bigPicture;
       this.smallIconAccentColor = notification.smallIconAccentColor;
@@ -132,6 +133,8 @@ public class OSNotification {
       this.collapseId = notification.collapseId;
       this.priority = notification.priority;
       this.rawPayload = notification.rawPayload;
+      this.sentTime = notification.sentTime;
+      this.ttl = notification.ttl;
    }
 
    private void initPayloadData(JSONObject currentJsonPayload) {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationController.java
@@ -125,7 +125,7 @@ public class OSNotificationController {
       if (!useTtl)
          return true;
 
-      long currentTimeInSeconds = OneSignal.getTime().getCurrentThreadTimeMillis() / 1_000;
+      long currentTimeInSeconds = OneSignal.getTime().getCurrentTimeMillis() / 1_000;
       long sentTime = notificationJob.getNotification().getSentTime();
       // If available TTL times comes in seconds, by default is 3 days in seconds
       int ttl = notificationJob.getNotification().getTtl();

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
@@ -1252,7 +1252,7 @@ public class GenerateNotificationRunner {
    @Test
    @Config (sdk = 23, shadows = { ShadowGenerateNotification.class })
    public void notShowNotificationPastTTL() throws Exception {
-      long sentTime = time.getCurrentThreadTimeMillis();
+      long sentTime = time.getCurrentTimeMillis();
       long ttl = 60L;
 
       Bundle bundle = getBaseNotifBundle();
@@ -1260,7 +1260,7 @@ public class GenerateNotificationRunner {
       bundle.putLong(OneSignalPackagePrivateHelper.GOOGLE_TTL_KEY, ttl);
 
       // Go forward just past the TTL of the notification
-      time.advanceThreadTimeBy(ttl + 1);
+      time.advanceSystemTimeBy(ttl + 1);
 
       NotificationBundleProcessor_ProcessFromFCMIntentService(blankActivity, bundle);
       threadAndTaskWait();
@@ -1275,7 +1275,7 @@ public class GenerateNotificationRunner {
       threadAndTaskWait();
 
       long expireTime = (Long)TestHelpers.getAllNotificationRecords(dbHelper).get(0).get(NotificationTable.COLUMN_NAME_EXPIRE_TIME);
-      assertEquals((SystemClock.currentThreadTimeMillis() / 1_000L) + 259_200, expireTime);
+      assertEquals((System.currentTimeMillis() / 1_000L) + 259_200, expireTime);
    }
 
    // TODO: Once we figure out the correct way to process notifications with high priority using the WorkManager


### PR DESCRIPTION
# Description
## One Line Summary
Add `ttl` and `sentTime` (and `smallIcon`) to an OSNotification constructor and change usages of `currentThreadTimeMillis` (time thread has been active) to `currentTimeMillis` (epoch time) instead.

## Details

### Motivation
This PR is related to some features of https://github.com/OneSignal/OneSignal-Android-SDK/pull/1479.

The `protected OSNotification(OSNotification notification)` constructor was missing `ttl` and `sentTime` so that when the NSE is used along with the foreground handler, and the NSE passes on a `mutableCopy()`, the notification that is processed by the foreground handler next has `ttl` and `sentTime` missing, and thus defaulted to `0`, which ends up not displaying due to `isNotificationWithinTTL()` check returning `false` erroneously.

Unrelated, but `smallIcon` was also missing so I added it as well.

While making the above changes, I noticed that the `currentTimeInSeconds` for `isNotificationWithinTTL()` would be close to zero. When we check `isNotificationWithinTTL()` to determine if we should display it, we should use `currentTimeMillis` (milliseconds since epoch) instead of `currentThreadTimeMillis` (the time a thread has been active)  to determine the current time that will be used in the logic. Note that the `google.sent_time` is also in milliseconds since epoch.

While working on this, I looked at other places that used thread time inaccurately and changed to using `currentTimeMillis` instead.

### Scope
I think using `currentThreadTimeMillis` was not a problem in the past because it was only the backup value when `google.sent_time` was not in the payload. 

# Testing
## Unit testing
Added test `testNotificationProcessingAndForegroundHandler_callCompleteWithMutableNotification_displays()` and handler `RemoteNotificationReceivedHandler_notificationReceivedCallCompleteWithMutableNotification`. The test NSE calls `complete()` with a `mutableCopy()` of the notification that is used by the foreground handler later. We test that the notification will display.

The two tests `notShowNotificationPastTTL` and `shouldSetExpireTimeCorrectlyWhenMissingFromPayload` are now failing because they were using thread time. I modified these to use current non-thread time and they now pass.

- [x] All unit tests pass

## Manual testing
Tested using Android emulator Pixel 5 on API 30 with the demo app in the SDK. Sent notification to the device in the foreground and it didn't display before. Now it displays. Also regularly checked values of `sentTime`, `ttl` and `currentTimeInSeconds` throughout testing.

# Affected code checklist
   - [X] Notifications
      - [X] Display
      - [ ] Open
      - [x] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1528)
<!-- Reviewable:end -->
