### PR TITLE
Fix default values when no TTL and sentTime is available

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSTime.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSTime.java
@@ -4,6 +4,4 @@ public interface OSTime {
     long getCurrentTimeMillis();
 
     long getElapsedRealtime();
-
-    long getCurrentThreadTimeMillis();
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSTimeImpl.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSTimeImpl.java
@@ -12,9 +12,4 @@ public class OSTimeImpl implements OSTime {
     public long getElapsedRealtime() {
         return SystemClock.elapsedRealtime();
     }
-
-    @Override
-    public long getCurrentThreadTimeMillis() {
-        return SystemClock.currentThreadTimeMillis();
-    }
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalHmsEventBridge.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalHmsEventBridge.java
@@ -53,8 +53,14 @@ public class OneSignalHmsEventBridge {
         String data = message.getData();
         try {
             JSONObject messageDataJSON = new JSONObject(message.getData());
-            messageDataJSON.put(HMS_TTL_KEY, message.getTtl());
-            messageDataJSON.put(HMS_SENT_TIME_KEY, message.getSentTime());
+            if (message.getTtl() == 0)
+                messageDataJSON.put(HMS_TTL_KEY, OSNotificationRestoreWorkManager.DEFAULT_TTL_IF_NOT_IN_PAYLOAD);
+            else
+                messageDataJSON.put(HMS_TTL_KEY, message.getTtl());
+            if (message.getSentTime() == 0)
+                messageDataJSON.put(HMS_SENT_TIME_KEY, OneSignal.getTime().getCurrentTimeMillis());
+            else
+                messageDataJSON.put(HMS_SENT_TIME_KEY, message.getSentTime());
             data = messageDataJSON.toString();
         } catch (JSONException e) {
             OneSignal.Log(OneSignal.LOG_LEVEL.ERROR, "OneSignalHmsEventBridge error when trying to create RemoteMessage data JSON");

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/MockOSTimeImpl.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/MockOSTimeImpl.java
@@ -4,12 +4,10 @@ public class MockOSTimeImpl extends OSTimeImpl {
 
     private Long mockedTime = null;
     private Long mockedElapsedTime = null;
-    private Long mockedCurrentThreadTimeMillis = null;
 
     public void reset() {
         mockedTime = null;
         mockedElapsedTime = null;
-        mockedCurrentThreadTimeMillis = null;
     }
 
     @Override
@@ -22,11 +20,6 @@ public class MockOSTimeImpl extends OSTimeImpl {
         return mockedElapsedTime != null ? mockedElapsedTime : super.getElapsedRealtime();
     }
 
-    @Override
-    public long getCurrentThreadTimeMillis() {
-        return mockedCurrentThreadTimeMillis != null ? mockedCurrentThreadTimeMillis : super.getCurrentThreadTimeMillis();
-    }
-
     public void setMockedTime(Long mockedTime) {
         this.mockedTime = mockedTime;
     }
@@ -35,18 +28,9 @@ public class MockOSTimeImpl extends OSTimeImpl {
         this.mockedElapsedTime = mockedForegroundTime;
     }
 
-    public void setMockedCurrentThreadTimeMillis(Long mockedCurrentThreadTimeMillis) {
-        this.mockedCurrentThreadTimeMillis = mockedCurrentThreadTimeMillis;
-    }
-
     public void advanceSystemTimeBy(long sec) {
         long ms = sec * 1_000L;
         setMockedTime(getCurrentTimeMillis() + ms);
-    }
-
-    public void advanceThreadTimeBy(long sec) {
-        long ms = sec * 1_000L;
-        setMockedCurrentThreadTimeMillis(getCurrentThreadTimeMillis() + ms);
     }
 
     public void advanceSystemAndElapsedTimeBy(long sec) {

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
@@ -225,6 +225,9 @@ public class OneSignalPackagePrivateHelper {
    }
 
    public static class OSNotificationRestoreWorkManager extends com.onesignal.OSNotificationRestoreWorkManager {
+      public static int getDEFAULT_TTL_IF_NOT_IN_PAYLOAD() {
+         return DEFAULT_TTL_IF_NOT_IN_PAYLOAD;
+      }
    }
 
    public static class OSNotificationGenerationJob extends com.onesignal.OSNotificationGenerationJob {

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowHmsNotificationPayloadProcessor.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowHmsNotificationPayloadProcessor.java
@@ -1,0 +1,30 @@
+package com.onesignal;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+
+@Implements(NotificationPayloadProcessorHMS.class)
+public class ShadowHmsNotificationPayloadProcessor {
+
+    private static @Nullable
+    String messageData;
+
+    public static void resetStatics() {
+        messageData = null;
+    }
+
+    @Implementation
+    public static void processDataMessageReceived(@NonNull final Context context, @Nullable String data) {
+        messageData = data;
+    }
+
+    @Nullable
+    public static String getMessageData() {
+        return messageData;
+    }
+}

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/HMSDataMessageReceivedIntegrationTestsRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/HMSDataMessageReceivedIntegrationTestsRunner.java
@@ -126,7 +126,7 @@ public class HMSDataMessageReceivedIntegrationTestsRunner {
         long sentTime = 1_635_971_895_940L;
         int ttl = 60;
 
-        time.setMockedCurrentThreadTimeMillis(sentTime * 1_000);
+        time.setMockedTime(sentTime * 1_000);
 
         ShadowHmsRemoteMessage.data = helperBasicOSPayload();
         ShadowHmsRemoteMessage.ttl = ttl;

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/TestHelpers.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/TestHelpers.java
@@ -35,6 +35,7 @@ import com.onesignal.ShadowGenerateNotification;
 import com.onesignal.ShadowGoogleApiClientCompatProxy;
 import com.onesignal.ShadowHMSFusedLocationProviderClient;
 import com.onesignal.ShadowHmsInstanceId;
+import com.onesignal.ShadowHmsNotificationPayloadProcessor;
 import com.onesignal.ShadowNotificationManagerCompat;
 import com.onesignal.ShadowNotificationReceivedEvent;
 import com.onesignal.ShadowOSUtils;
@@ -130,6 +131,7 @@ public class TestHelpers {
       ShadowNotificationReceivedEvent.resetStatics();
       ShadowOneSignalNotificationManager.resetStatics();
       ShadowBadgeCountUpdater.resetStatics();
+      ShadowHmsNotificationPayloadProcessor.resetStatics();
       ShadowFocusHandler.Companion.resetStatics();
 
       lastException = null;


### PR DESCRIPTION
# Description
## One Line Summary
Fix default values when no TTL and sentTime is available 

## Details

### Motivation
HMS Notification with Data Message type is not being displayed because TTL value and Sent Time is coming with 0. Due to TTL check notification is not displayed.
Not rely on getCurrentThreadTimeMillis since it depend on each Thread and is not the same between threads. N

### Scope
HMS Notifications

# Testing
## Unit testing
Add ttl_shouldDisplayNotificationWithNoTTLandSentTime test case

## Manual testing
Test notification display with data and message, message type notification, with application in background and swiped away. On Huawei P20 Lite Android 9

# Affected code checklist
   - [x] Notifications
      - [x] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1531)
<!-- Reviewable:end -->
