### PR TITLE
Fix HMS activity open

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationOpenedProcessor.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationOpenedProcessor.java
@@ -109,7 +109,7 @@ class NotificationOpenedProcessor {
          if (!(context instanceof Activity))
             OneSignal.onesignalLog(OneSignal.LOG_LEVEL.ERROR, "NotificationOpenedProcessor processIntent from an non Activity context: " + context);
          else OneSignal.handleNotificationOpen((Activity) context, intentExtras.getDataArray(),
-                 intent.getBooleanExtra("from_alert", false), OSNotificationFormatHelper.getOSNotificationIdFromJson(intentExtras.getJsonData()));
+                 false, OSNotificationFormatHelper.getOSNotificationIdFromJson(intentExtras.getJsonData()));
       }
    }
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationPayloadProcessorHMS.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationPayloadProcessorHMS.java
@@ -73,6 +73,10 @@ class NotificationPayloadProcessorHMS {
         );
     }
 
+    // HMS notification with Message Type being Message won't trigger Activity reverse trampolining logic
+    // for this case OneSignal rely on NotificationOpenedActivityHMS activity
+    // Last EMUI (12 to the date) is based on Android 10, so no
+    // Activity trampolining restriction exist for HMS devices
     public static void processDataMessageReceived(@NonNull final Context context, @Nullable String data) {
         OneSignal.initWithContext(context);
         if (data == null)

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationPayloadProcessorHMS.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationPayloadProcessorHMS.java
@@ -68,7 +68,7 @@ class NotificationPayloadProcessorHMS {
         OneSignal.handleNotificationOpen(
             activity,
             new JSONArray().put(jsonData),
-            false,
+            true,
             OSNotificationFormatHelper.getOSNotificationIdFromJson(jsonData)
         );
     }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -2336,7 +2336,7 @@ public class OneSignal {
    /**
     * Method called when opening a notification
     */
-   static void handleNotificationOpen(final Activity context, final JSONArray data, final boolean fromAlert, @Nullable final String notificationId) {
+   static void handleNotificationOpen(final Activity context, final JSONArray data, final boolean fromHMSMessage, @Nullable final String notificationId) {
       // Delay call until remote params are set
       if (taskRemoteController.shouldQueueTaskForInit(OSTaskRemoteController.HANDLE_NOTIFICATION_OPEN)) {
          logger.error("Waiting for remote params. " +
@@ -2346,7 +2346,7 @@ public class OneSignal {
             public void run() {
                if (appContext != null) {
                   logger.debug("Running " + OSTaskRemoteController.HANDLE_NOTIFICATION_OPEN + " operation from pending queue.");
-                  handleNotificationOpen(context, data, fromAlert, notificationId);
+                  handleNotificationOpen(context, data, fromHMSMessage, notificationId);
                }
             }
          });
@@ -2364,9 +2364,41 @@ public class OneSignal {
 
       if (shouldInitDirectSessionFromNotificationOpen(context, data)) {
          applicationOpenedByNotification(notificationId);
+
+         // HMS notification with Message Type being Message won't trigger Activity reverse trampolining logic
+         // for this case OneSignal rely on NotificationOpenedActivityHMS activity
+         // Last EMUI (12 to the date) is based on Android 10, so no
+         // Activity trampolining restriction exist for HMS devices
+         if (OSUtils.isHuaweiDeviceType() && fromHMSMessage) {
+            // Start activity with an activity trampolining
+            startOrResumeApp(context);
+         }
       }
 
       runNotificationOpenedCallback(data);
+   }
+
+   // This opens the app in the same way an Android home screen launcher does.
+   // This means we expect the following behavior:
+   //    1. Starts the Activity defined in the app's AndroidManifest.xml as "android.intent.action.MAIN"
+   //    2. If the app is already running, instead the last activity will be resumed
+   //    3. If the app is not running (due to being push out of memory), the last activity will be resumed
+   //    4. If the app is no longer in the recent apps list, it is not resumed, same as #1 above.
+   //        - App is removed from the recent app's list if it is swiped away or "clear all" is pressed.
+   static boolean startOrResumeApp(@NonNull Activity activity) {
+      Intent launchIntent = activity.getPackageManager().getLaunchIntentForPackage(activity.getPackageName());
+      logger.debug("startOrResumeApp from context: " + activity + " isRoot: " + activity.isTaskRoot() + " with launchIntent: " + launchIntent);
+
+      // Not all apps have a launcher intent, such as one that only provides a homescreen widget
+      if (launchIntent == null)
+         return false;
+      // Removing package from the intent, this treats the app as if it was started externally.
+      // This gives us the resume app behavior noted above.
+      // Android 11 no longer requires nulling this out to get this behavior.
+      launchIntent.setPackage(null);
+
+      activity.startActivity(launchIntent);
+      return true;
    }
 
    private static boolean shouldInitDirectSessionFromNotificationOpen(Activity context, final JSONArray data) {

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
@@ -129,8 +129,8 @@ public class OneSignalPackagePrivateHelper {
       return NotificationBundleProcessor.bundleAsJSONObject(bundle);
    }
 
-   public static void OneSignal_handleNotificationOpen(Activity context, final JSONArray data, final boolean fromAlert, final String notificationId) {
-      OneSignal.handleNotificationOpen(context, data, fromAlert, notificationId);
+   public static void OneSignal_handleNotificationOpen(Activity context, final JSONArray data, final boolean fromHMSMessage, final String notificationId) {
+      OneSignal.handleNotificationOpen(context, data, fromHMSMessage, notificationId);
    }
 
    public static BigInteger OneSignal_getAccentColor(JSONObject fcmJson) {


### PR DESCRIPTION
# Description
## One Line Summary
HMS notification with Message Type Message doesn't open the app.

## Details

### Motivation
HMS notification with Message Type Message, don't trigger OS logic. It doesn't enter on the activity reverse trampolining logic. Notification open depends on the start activity that was still implemented in the release 4.4.2. Also, the HMS notification trampolining point of entrance is NotificationOpenedActivityHMS configured by the backend.

Since the last EMUI is based on Android 10 and the coming HarmonyOS version doesn't specify activity trampolining requirements, the last logic was pulled back again.

### Scope
HMS notification with Message Type Message

## Manual testing
Test app opens by notification with data and message, message type, with application in the background and swiped away. On Huawei P20 Lite Android 9

# Affected code checklist
   - [x] Notifications
      - [ ] Display
      - [x] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1533)
<!-- Reviewable:end -->
