### PR TITLE
Feature set language callbacks

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -1490,7 +1490,7 @@ public class OneSignal {
       deviceInfo.put("carrier", osUtils.getCarrierName());
       deviceInfo.put("rooted", RootToolsInternalMethods.isRooted());
 
-      OneSignalStateSynchronizer.updateDeviceInfo(deviceInfo);
+      OneSignalStateSynchronizer.updateDeviceInfo(deviceInfo, null);
 
       JSONObject pushState = new JSONObject();
       pushState.put("identifier", lastRegistrationId);
@@ -1716,6 +1716,10 @@ public class OneSignal {
    }
 
    public static void setLanguage(@NonNull final String language) {
+      setLanguage(language, null);
+   }
+
+   public static void setLanguage(@NonNull final String language, @Nullable final OSDeviceInfoCompletionHandler completionCallback) {
       if (taskRemoteController.shouldQueueTaskForInit(OSTaskRemoteController.SET_LANGUAGE)) {
          logger.error("Waiting for remote params. " +
                  "Moving " + OSTaskRemoteController.SET_LANGUAGE + " operation to a pending task queue.");
@@ -1723,7 +1727,7 @@ public class OneSignal {
             @Override
             public void run() {
                logger.debug("Running " + OSTaskRemoteController.SET_LANGUAGE + " operation from pending task queue.");
-               setLanguage(language);
+               setLanguage(language, completionCallback);
             }
          });
          return;
@@ -1739,7 +1743,7 @@ public class OneSignal {
       try {
          JSONObject deviceInfo = new JSONObject();
          deviceInfo.put("language", languageContext.getLanguage());
-         OneSignalStateSynchronizer.updateDeviceInfo(deviceInfo);
+         OneSignalStateSynchronizer.updateDeviceInfo(deviceInfo, completionCallback);
       } catch (JSONException exception) {
          exception.printStackTrace();
       }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -49,6 +49,8 @@ import com.onesignal.influence.data.OSTrackerFactory;
 import com.onesignal.influence.domain.OSInfluence;
 import com.onesignal.language.LanguageContext;
 import com.onesignal.language.LanguageProviderAppDefined;
+import com.onesignal.OneSignalStateSynchronizer.OSDeviceInfoError;
+import com.onesignal.OneSignalStateSynchronizer.OSDeviceInfoCompletionHandler;
 import com.onesignal.outcomes.data.OSOutcomeEventsFactory;
 
 import org.json.JSONArray;
@@ -227,25 +229,6 @@ public class OneSignal {
 
       public int getCode() { return code; }
       public String getMessage() { return message; }
-   }
-
-   static class OSDeviceInfoError {
-      private int errorCode;
-      private String message;
-
-      OSDeviceInfoError(int errorCode, String message) {
-         this.errorCode = errorCode;
-         this.message = message;
-      }
-
-      public int getCode() { return errorCode; }
-
-      public String getMessage() { return message; }
-   }
-
-   interface OSDeviceInfoCompletionHandler {
-      void onSuccess(String results);
-      void onFailure(OSDeviceInfoError error);
    }
 
    public static class OSLanguageError {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -229,6 +229,25 @@ public class OneSignal {
       public String getMessage() { return message; }
    }
 
+   public static class OSDeviceInfoError {
+      private int errorCode;
+      private String message;
+
+      OSDeviceInfoError(int errorCode, String message) {
+         this.errorCode = errorCode;
+         this.message = message;
+      }
+
+      public int getCode() { return errorCode; }
+
+      public String getMessage() { return message; }
+   }
+
+   public interface OSDeviceInfoCompletionHandler {
+      void onSuccess(String results);
+      void onFailure(OSDeviceInfoError error);
+   }
+
    public enum ExternalIdErrorType {
       REQUIRES_EXTERNAL_ID_AUTH, INVALID_OPERATION, NETWORK
    }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalStateSynchronizer.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalStateSynchronizer.java
@@ -60,6 +60,25 @@ class OneSignalStateSynchronizer {
       }
    }
 
+   static class OSDeviceInfoError {
+      public int errorCode;
+      public String message;
+
+      OSDeviceInfoError(int errorCode, String message) {
+         this.errorCode = errorCode;
+         this.message = message;
+      }
+
+      public int getCode() { return errorCode; }
+
+      public String getMessage() { return message; }
+   }
+
+   interface OSDeviceInfoCompletionHandler {
+      void onSuccess(String results);
+      void onFailure(OSDeviceInfoError error);
+   }
+
    // Each class abstracts from UserStateSynchronizer and this will allow us to handle different channels for specific method calls and requests
    // Each time we create a new UserStateSynchronizer we should add it to the userStateSynchronizers HashMap
    // Currently we have 2 channels:
@@ -222,7 +241,7 @@ class OneSignalStateSynchronizer {
       OneSignal.setLastSessionTime(-60 * 61);
    }
 
-   static void updateDeviceInfo(JSONObject deviceInfo, OneSignal.OSDeviceInfoCompletionHandler handler) {
+   static void updateDeviceInfo(JSONObject deviceInfo, OSDeviceInfoCompletionHandler handler) {
       getPushStateSynchronizer().updateDeviceInfo(deviceInfo, handler);
       getEmailStateSynchronizer().updateDeviceInfo(deviceInfo, handler);
       getSMSStateSynchronizer().updateDeviceInfo(deviceInfo, handler);

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalStateSynchronizer.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalStateSynchronizer.java
@@ -222,10 +222,10 @@ class OneSignalStateSynchronizer {
       OneSignal.setLastSessionTime(-60 * 61);
    }
 
-   static void updateDeviceInfo(JSONObject deviceInfo) {
-      getPushStateSynchronizer().updateDeviceInfo(deviceInfo);
-      getEmailStateSynchronizer().updateDeviceInfo(deviceInfo);
-      getSMSStateSynchronizer().updateDeviceInfo(deviceInfo);
+   static void updateDeviceInfo(JSONObject deviceInfo, OneSignal.OSDeviceInfoCompletionHandler handler) {
+      getPushStateSynchronizer().updateDeviceInfo(deviceInfo, handler);
+      getEmailStateSynchronizer().updateDeviceInfo(deviceInfo, handler);
+      getSMSStateSynchronizer().updateDeviceInfo(deviceInfo, handler);
    }
 
    static void updatePushState(JSONObject pushState) {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalStateSynchronizer.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalStateSynchronizer.java
@@ -183,6 +183,10 @@ class OneSignalStateSynchronizer {
    static boolean getUserSubscribePreference() {
       return getPushStateSynchronizer().getUserSubscribePreference();
    }
+
+   static String getLanguage() {
+      return getPushStateSynchronizer().getLanguage();
+   }
    
    static void setPermission(boolean enable) {
       getPushStateSynchronizer().setPermission(enable);

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStatePushSynchronizer.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStatePushSynchronizer.java
@@ -158,6 +158,10 @@ class UserStatePushSynchronizer extends UserStateSynchronizer {
         return getToSyncUserState().getDependValues().optBoolean(USER_SUBSCRIBE_PREF, true);
     }
 
+    public String getLanguage() {
+        return  getToSyncUserState().getDependValues().optString(LANGUAGE, null);
+    }
+
     @Override
     public void setPermission(boolean enable) {
         try {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStateSynchronizer.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStateSynchronizer.java
@@ -8,8 +8,8 @@ import androidx.annotation.Nullable;
 import com.onesignal.OneSignal.ChangeTagsUpdateHandler;
 import com.onesignal.OneSignal.SendTagsError;
 import com.onesignal.OneSignalStateSynchronizer.UserStateSynchronizerType;
-import com.onesignal.OneSignal.OSDeviceInfoCompletionHandler;
-import com.onesignal.OneSignal.OSDeviceInfoError;
+import com.onesignal.OneSignalStateSynchronizer.OSDeviceInfoCompletionHandler;
+import com.onesignal.OneSignalStateSynchronizer.OSDeviceInfoError;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -95,7 +95,7 @@ abstract class UserStateSynchronizer {
     //    sendTags() multiple times it will call each callback
     final private Queue<ChangeTagsUpdateHandler> sendTagsHandlers = new ConcurrentLinkedQueue<>();
     final private Queue<OneSignal.OSInternalExternalUserIdUpdateCompletionHandler> externalUserIdUpdateHandlers = new ConcurrentLinkedQueue<>();
-    final private Queue<OneSignal.OSDeviceInfoCompletionHandler> deviceInfoCompletionHandler = new ConcurrentLinkedQueue<>();
+    final private Queue<OSDeviceInfoCompletionHandler> deviceInfoCompletionHandler = new ConcurrentLinkedQueue<>();
 
     boolean hasQueuedHandlers() {
         return externalUserIdUpdateHandlers.size() > 0;
@@ -626,14 +626,14 @@ abstract class UserStateSynchronizer {
 
     private void deviceInfoHandlersPerformOnSuccess() {
         String language = OneSignalStateSynchronizer.getLanguage();
-        OneSignal.OSDeviceInfoCompletionHandler handler;
+        OSDeviceInfoCompletionHandler handler;
         while ((handler = deviceInfoCompletionHandler.poll()) != null) {
             handler.onSuccess(language);
         }
     }
 
     private void deviceInfoHandlersPerformOnFailure(OSDeviceInfoError error) {
-        OneSignal.OSDeviceInfoCompletionHandler handler;
+        OSDeviceInfoCompletionHandler handler;
         while((handler = deviceInfoCompletionHandler.poll()) != null) {
             handler.onFailure(error);
         }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStateSynchronizer.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStateSynchronizer.java
@@ -8,6 +8,8 @@ import androidx.annotation.Nullable;
 import com.onesignal.OneSignal.ChangeTagsUpdateHandler;
 import com.onesignal.OneSignal.SendTagsError;
 import com.onesignal.OneSignalStateSynchronizer.UserStateSynchronizerType;
+import com.onesignal.OneSignal.OSDeviceInfoCompletionHandler;
+import com.onesignal.OneSignal.OSDeviceInfoError;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -37,6 +39,7 @@ abstract class UserStateSynchronizer {
     protected static final String ANDROID_PERMISSION = "androidPermission";
     protected static final String SUBSCRIBABLE_STATUS = "subscribableStatus";
     protected static final String TAGS = "tags";
+    protected static final String LANGUAGE = "language";
     protected static final String EXTERNAL_USER_ID = "external_user_id";
     protected static final String EMAIL_KEY = "email";
     protected static final String LOGOUT_EMAIL = "logoutEmail";
@@ -92,6 +95,7 @@ abstract class UserStateSynchronizer {
     //    sendTags() multiple times it will call each callback
     final private Queue<ChangeTagsUpdateHandler> sendTagsHandlers = new ConcurrentLinkedQueue<>();
     final private Queue<OneSignal.OSInternalExternalUserIdUpdateCompletionHandler> externalUserIdUpdateHandlers = new ConcurrentLinkedQueue<>();
+    final private Queue<OneSignal.OSDeviceInfoCompletionHandler> deviceInfoCompletionHandler = new ConcurrentLinkedQueue<>();
 
     boolean hasQueuedHandlers() {
         return externalUserIdUpdateHandlers.size() > 0;
@@ -367,6 +371,9 @@ abstract class UserStateSynchronizer {
                     OneSignal.onesignalLog(OneSignal.LOG_LEVEL.ERROR, "Error setting external user id for push with status code: "  + statusCode + " and message: " + response);
                     externalUserIdUpdateHandlersPerformOnFailure();
                 }
+
+                if (jsonBody.has(LANGUAGE))
+                    deviceInfoHandlersPerformOnFailure(new OSDeviceInfoError(statusCode, response));
             }
 
             @Override
@@ -381,6 +388,9 @@ abstract class UserStateSynchronizer {
 
                 if (jsonBody.has(EXTERNAL_USER_ID))
                     externalUserIdUpdateHandlersPerformOnSuccess();
+
+                if (jsonBody.has(LANGUAGE))
+                    deviceInfoHandlersPerformOnSuccess();
             }
         });
     }
@@ -505,7 +515,9 @@ abstract class UserStateSynchronizer {
 
     abstract protected void scheduleSyncToServer();
 
-    void updateDeviceInfo(JSONObject deviceInfo) {
+    void updateDeviceInfo(JSONObject deviceInfo, @Nullable OSDeviceInfoCompletionHandler handler) {
+        if (handler != null)
+            this.deviceInfoCompletionHandler.add(handler);
         getUserStateForModification().generateJsonDiffFromIntoSyncValued(deviceInfo, null);
     }
 
@@ -612,4 +624,18 @@ abstract class UserStateSynchronizer {
         }
     }
 
+    private void deviceInfoHandlersPerformOnSuccess() {
+        String language = OneSignalStateSynchronizer.getLanguage();
+        OneSignal.OSDeviceInfoCompletionHandler handler;
+        while ((handler = deviceInfoCompletionHandler.poll()) != null) {
+            handler.onSuccess(language);
+        }
+    }
+
+    private void deviceInfoHandlersPerformOnFailure(OSDeviceInfoError error) {
+        OneSignal.OSDeviceInfoCompletionHandler handler;
+        while((handler = deviceInfoCompletionHandler.poll()) != null) {
+            handler.onFailure(error);
+        }
+    }
 }

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
@@ -2807,7 +2807,7 @@ public class MainOneSignalClassRunner {
       assertTrue(handler.getSucceeded());
 
       // now test to make sure the handler still fires for a call to
-      // setLanguage() that doesn't modify existing language (no JSON delta)
+      // setLanguage() that modifies existing language
 
       handler = new TestSetLanguageHandler();
 


### PR DESCRIPTION
# Description
## Line Summary
Add set language callback

## Details

### Motivation
The feature allows the user to use the onSuccess and onFailure callbacks for setLanguage method

### Public API Changes
The documentation will need to be updated for Android to provide these new methods
* Add `OSDeviceInfoCompletionHandler`
* Add `setLanguage(String, OSDeviceInfoCompletionHandler)`

## Testing
### Unit Tests
Add `TestSetLanguageHandler` to set up callbacks for setLanguage
Add following Unit test cases
* Add `shouldSetLanguageWithResponse` to test for success callback
* Add `shouldFailToSetLanguageWithResponse` to test for failure callback

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1536)
<!-- Reviewable:end -->
