### PR TITLE
Fix NPE for `outcomeEventsController` during initialization

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -370,7 +370,8 @@ public class OneSignal {
    private static String smsId = null;
    private static int subscribableStatus = Integer.MAX_VALUE;
 
-   private static LanguageContext languageContext = null;
+   // changed from private to package-private for unit test access
+   static LanguageContext languageContext = null;
 
    static OSRemoteNotificationReceivedHandler remoteNotificationReceivedHandler;
    static OSNotificationWillShowInForegroundHandler notificationWillShowInForegroundHandler;

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowOneSignalWithMockSetupContextListeners.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/ShadowOneSignalWithMockSetupContextListeners.java
@@ -1,0 +1,27 @@
+package com.onesignal;
+
+import com.onesignal.language.LanguageContext;
+
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+
+/**
+ * This shadow is added for the test initWithContext_setupContextListenersNotCompleted_doesNotProduceNPE
+ * Changes the behavior of one method without affecting other unit tests using ShadowOneSignal
+ */
+@Implements(OneSignal.class)
+public class ShadowOneSignalWithMockSetupContextListeners {
+
+   /**
+    * Simulates setupContextListeners() in initWithContext() not completing.
+    * However, languageContext initialization is needed for later, so that is the only code kept
+    */
+   @Implementation
+   public static void setupContextListeners(boolean wasAppContextNull) {
+
+      // Do work here that should only happen once or at the start of a new lifecycle
+      if (wasAppContextNull) {
+         OneSignal.languageContext = new LanguageContext(OneSignal.getSharedPreferences());
+      }
+   }
+}

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/OneSignalInitializationIntegrationTestsRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/OneSignalInitializationIntegrationTestsRunner.java
@@ -7,6 +7,7 @@ import com.onesignal.OneSignal;
 import com.onesignal.ShadowCustomTabsClient;
 import com.onesignal.ShadowCustomTabsSession;
 import com.onesignal.ShadowOSUtils;
+import com.onesignal.ShadowOneSignalWithMockSetupContextListeners;
 import com.onesignal.ShadowOneSignalRestClient;
 import com.onesignal.ShadowPushRegistratorFCM;
 import com.onesignal.StaticResetHelper;
@@ -86,6 +87,19 @@ public class OneSignalInitializationIntegrationTestsRunner {
         threadAndTaskWait();
 
         RestClientAsserts.assertRemoteParamsWasTheOnlyNetworkCall();
+    }
+
+    // This test reproduces https://github.com/OneSignal/OneSignal-Android-SDK/issues/1514
+    @Test
+    @Config(shadows = { ShadowOneSignalWithMockSetupContextListeners.class })
+    public void initWithContext_setupContextListenersNotCompleted_doesNotProduceNPE() throws Exception {
+        OneSignal.setAppId(APP_ID);
+
+        // call initWithContext() but don't complete setupContextListeners() via the Shadow class
+        // this prevents the initialization of outcomeEventsController in setupContextListeners()
+        helper_OneSignal_initWithAppContext();
+        threadAndTaskWait();
+        // we implicitly test that no exception is thrown
     }
 
     @Test


### PR DESCRIPTION
# Description
## One Line Summary
Lazily initialize and access the `OneSignal.outcomeEventsController`, adding a null check when invoking its methods that wasn't checked before, as it may not have been initialized yet in the critical initialization step of `setupContextListeners()`.

## Details

### Motivation
This is a speculative fix for a non-reproducible `NullPointerException` of `outcomeEventsController.sendSavedOutcomes()` during initialization, as reported by users in production [here](https://github.com/OneSignal/OneSignal-Android-SDK/issues/1374) and [here](https://github.com/OneSignal/OneSignal-Android-SDK/issues/1514).

### Context
During initialization, `initWithContext()` and `setAppId()` run. The first method also initializes the `outcomeEventsController` in the method `setupContextListeners()` [see code](https://github.com/OneSignal/OneSignal-Android-SDK/blob/10867586a325eaf9e69292e5d3e288083768ce8a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java#L874).

After the appContext and appId are set by the above methods, the `init()` method runs, which calls `OSOutcomeEventsController.sendSavedOutcomes()` [towards the method's end](https://github.com/OneSignal/OneSignal-Android-SDK/blob/10867586a325eaf9e69292e5d3e288083768ce8a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java#L837). 

It **may** be that in some cases, the `init()` method is called before `initWithContext()` is fully complete, resulting in a null `outcomeEventsController` instance that `init()` relies on.

One GitHub reporter speculated it is due to adding `setLanguage` functionality in `4.4.0`, and there are now more calls to `initWithContext` added in `4.4.1` for more FCM entry points. 

It is possible that multiple threads are initializing and one hangs after setting the `appContext` but hasn't finished `setupContextListeners`.

This is ultimately speculative and it may be some other reason that `outcomeEventsController` is `null`.

### Implementation Details
When we want to access `OneSignal.outcomeEventsController`, use lazy initialization and singleton pattern to access and create it via `getOutcomeEventsController()`. Use synchronization when creating the object.

There are some methods where `outcomeEventsController` is called such as in `sendUniqueOutcome()` where there is already a `null` check and the method returns if `outcomeEventsController == null`. In these methods I didn’t make any changes as it already had its own null check logic.

### Scope
This affects OneSignal initialization.

### Potential Problems
If the root issue is in fact that `setupContextListeners()` isn't completed before `init()` runs, it may be possible that `languageContext` isn't initialized either. In this case, while we move past the NPE for `outcomeEventsController`, we may encounter a NPE for `languageContext` next, such as in `registerUserTask()` or when it is passed as an argument to `getInAppMessageController()`.

However, that may be far enough down the line that it won't pose a problem.

# Testing
## Unit testing
Added unit test to simulate `setupContextListeners()` not completing:

- Add unit test `initWithContext_setupContextListenersNotCompleted_doesNotProduceNPE` to reproduce the NPE of `outcomeEventsController` in `init()`.

- Shadow the `OneSignal.setupContextListeners()` method to simulate it not completing (thus not initializing the `outcomeEventsController`).

- However, the `languageContext` initialization is needed or else it leads to a subsequent NPE for this property in `registerUserTask()`.

- Change access of `languageContext` in OneSignal.java from private to package-private so it can be accessed in unit tests.

- All other unit tests pass

## Manual testing
App built with Android Studio 2020.3.1 with the OneSignal example app on a Pixel 5 with API 30.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, but is insufficient as this error is not reproducible.

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1539)
<!-- Reviewable:end -->
