### PR TITLE
Fix  Crash when tapping on Notification action button in Android 12

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationOpenedProcessor.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationOpenedProcessor.java
@@ -75,10 +75,9 @@ class NotificationOpenedProcessor {
       if (intent.getBooleanExtra("action_button", false)) {
          NotificationManagerCompat.from(context).cancel(intent.getIntExtra(BUNDLE_KEY_ANDROID_NOTIFICATION_ID, 0));
 
-         //Close notification drawer user override targetSdkVersion to  be lower than Android 11
+         // Only close the notifications shade on Android versions where it is allowed, Android 11 and lower.
          // See https://developer.android.com/about/versions/12/behavior-changes-all#close-system-dialogs
-         int targetSdkVersion = context.getApplicationContext().getApplicationInfo().targetSdkVersion;
-         if (targetSdkVersion < Build.VERSION_CODES.S ) {
+         if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.S)  {
             context.sendBroadcast(new Intent(Intent.ACTION_CLOSE_SYSTEM_DIALOGS));
          }
       }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationOpenedProcessor.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationOpenedProcessor.java
@@ -74,7 +74,13 @@ class NotificationOpenedProcessor {
       // Pressed an action button, need to clear the notification and close the notification area manually.
       if (intent.getBooleanExtra("action_button", false)) {
          NotificationManagerCompat.from(context).cancel(intent.getIntExtra(BUNDLE_KEY_ANDROID_NOTIFICATION_ID, 0));
-         context.sendBroadcast(new Intent(Intent.ACTION_CLOSE_SYSTEM_DIALOGS));
+
+         //Close notification drawer user override targetSdkVersion to  be lower than Android 11
+         // See https://developer.android.com/about/versions/12/behavior-changes-all#close-system-dialogs
+         int targetSdkVersion = context.getApplicationContext().getApplicationInfo().targetSdkVersion;
+         if (targetSdkVersion < Build.VERSION_CODES.S ) {
+            context.sendBroadcast(new Intent(Intent.ACTION_CLOSE_SYSTEM_DIALOGS));
+         }
       }
    }
 


### PR DESCRIPTION
# Description
## One Line Summary
Fixes a crash in Android 12 when interacting with action button due to [notification drawer behavior changes](https://developer.android.com/about/versions/12/behavior-changes-all#close-system-dialogs)

## Details

### Motivation
This PR addresses the issue #1543 and fixes the crash.

### Scope
This will impact the functionality of dismiss on action press. By default, it will remove this close drawer feature completely since it's no longer supported starting from Android 12+.  However, if the consumer of the lib uses `overrideLibrary` flag to change the lib's target sdk, the behavior will still works up to Android 11. But on Android 12, it will does a silent no-op and log the error.

# Testing
## Unit testing
Not sure if I need to update unit test for this, let me know if it need changes.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [x] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1548)
<!-- Reviewable:end -->
