### PR TITLE
Fix `onSuccess` callback invoking for setting email or SMS

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStatePushSynchronizer.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStatePushSynchronizer.java
@@ -229,19 +229,7 @@ class UserStatePushSynchronizer extends UserStateSynchronizer {
 
     @Override
     protected void onSuccessfulSync(JSONObject jsonFields) {
-        if (jsonFields.has(EMAIL_KEY))
-            OneSignal.fireEmailUpdateSuccess();
-
-        if (jsonFields.has(SMS_NUMBER_KEY)) {
-            JSONObject result = new JSONObject();
-            try {
-                result.put(SMS_NUMBER_KEY, jsonFields.get(SMS_NUMBER_KEY));
-                if (jsonFields.has(SMS_AUTH_HASH_KEY))
-                    result.put(SMS_AUTH_HASH_KEY, jsonFields.get(SMS_AUTH_HASH_KEY));
-            } catch (JSONException e) {
-                e.printStackTrace();
-            }
-            OneSignal.fireSMSUpdateSuccess(result);
-        }
+        // Previously, the onSuccess callbacks for setEmail and setSMSNumber were triggered here if applicable.
+        // However, this is too early, and the UserStateSecondaryChannelSynchronizer will fire the successful callback.
     }
 }


### PR DESCRIPTION
# Description
## One Line Summary
Don't call the `onSuccess` callback for setting email and SMS too early, which can be before those players have been successfully created and set their channels in the SDK.

## Details

### Motivation
These changes are investigated and made after a customer report needing to set external user ID after setting email and SMS, and wanting all the players to be updated with the EUID. Time has to pass after a call to `setEmail` or `setSMSNumber`, before `setExternalUserId` can successfully update all players. 

To work around this, the customer was recommended to make a call to `setExternalUserId` **within** the `onSuccess` callback of `setEmail` or `setSMSNumber`. However, this did not work as intended either since at the time the callback is invoked, the email or SMS player may not have been created or had the channel ID saved to the SDK, and setting external user ID only makes the request for the push channel, as a result.

### Implementation Details
Previously, `UserStatePushSynchronizer. onSuccessfulSync()` would fire the email and SMS successful callbacks if the request sent has "sms_number" or "email" in it, but this is too early to fire those since this is only for the push player sync. The /players endpoint is then called later for the SMS or email player. In the dashboard, the email or SMS player is created a few seconds after the push player.

Instead, let the `UserStateEmailSynchronizer` and `UserStateSMSSynchronizer` call these successful callbacks in their own `onSuccessfulSync`, which will happen after the requests for the email player or SMS player is successful.

Did not make any changes to the failure callback.

### Scope
This change affects the invoking of the successful callbacks and doesn't affect other OneSignal logic around setting email or SMS. 

# Testing
## Unit testing
Added two test handlers that call `setExternalUserId` in the callback:
- TestEmailUpdateHandler_onSuccess_callSetExternalUserId
- TestSMSUpdateHandler_onSuccess_callSetExternalUserId

Added two unit tests to reproduce the customer's reported behavior (these failed before the changes in this PR)
- shouldSetExternalUserId_inOnSuccessOfEmailUpdate
- shouldSetExternalUserId_inOnSuccessOfSMSUpdate

## Manual testing
App build with Android Studio 2020.3 using the OneSignal example app on a Pixel 5 API 30:

I made multiple calls to combinations of `setEmail` and `setSMS` with a callback set. This callback makes a call to `setExternalUserId` -> and then checked the callback is invoked correctly every time, and that all the players are updated with the EUID.
- in MainApplication onCreate
- returning to the app after a while away
- setting these within the app with a button tap
- setting email or SMS to the same value (meaning no change)
- calling logout, and setting again to same email/SMS
- calling logout, and then setting to different email/SMS

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
PR
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1555)
<!-- Reviewable:end -->
