### PR TITLE
Remove Runtime.getRuntime().exec from OPPO Badge implementation

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/shortcutbadger/impl/OPPOHomeBader.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/shortcutbadger/impl/OPPOHomeBader.java
@@ -1,35 +1,25 @@
-// Subpackaged to prevent conflicts with other plugins
 package com.onesignal.shortcutbadger.impl;
 
 import android.annotation.TargetApi;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.ProviderInfo;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
+import java.util.Collections;
+import java.util.List;
 
 import com.onesignal.shortcutbadger.Badger;
 import com.onesignal.shortcutbadger.ShortcutBadgeException;
 import com.onesignal.shortcutbadger.util.BroadcastHelper;
-import com.onesignal.shortcutbadger.util.CloseHelper;
-
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.Collections;
-import java.util.List;
 
 /**
  * Created by NingSo on 2016/10/14.上午10:09
  *
  * @author: NingSo
  * Email: ningso.ping@gmail.com
- * <p>
- * OPPO R9 not supported
- * Version number 6 applies only to chat-type apps
  */
 
 public class OPPOHomeBader implements Badger {
@@ -40,31 +30,18 @@ public class OPPOHomeBader implements Badger {
     private static final String INTENT_EXTRA_BADGE_COUNT = "number";
     private static final String INTENT_EXTRA_BADGE_UPGRADENUMBER = "upgradeNumber";
     private static final String INTENT_EXTRA_BADGEUPGRADE_COUNT = "app_badge_count";
-    private static int ROMVERSION = -1;
+    private int mCurrentTotalCount = -1;
 
-    @TargetApi(Build.VERSION_CODES.HONEYCOMB)
     @Override
     public void executeBadge(Context context, ComponentName componentName, int badgeCount) throws ShortcutBadgeException {
-        if (badgeCount == 0) {
-            badgeCount = -1;
+        if (mCurrentTotalCount == badgeCount) {
+            return;
         }
-        Intent intent = new Intent(INTENT_ACTION);
-        intent.putExtra(INTENT_EXTRA_PACKAGENAME, componentName.getPackageName());
-        intent.putExtra(INTENT_EXTRA_BADGE_COUNT, badgeCount);
-        intent.putExtra(INTENT_EXTRA_BADGE_UPGRADENUMBER, badgeCount);
-        if (BroadcastHelper.canResolveBroadcast(context, intent)) {
-            context.sendBroadcast(intent);
+        mCurrentTotalCount = badgeCount;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB){
+            executeBadgeByContentProvider(context, badgeCount);
         } else {
-            int version = getSupportVersion();
-            if (version == 6) {
-                try {
-                    Bundle extras = new Bundle();
-                    extras.putInt(INTENT_EXTRA_BADGEUPGRADE_COUNT, badgeCount);
-                    context.getContentResolver().call(Uri.parse(PROVIDER_CONTENT_URI), "setAppBadgeCount", null, extras);
-                } catch (Throwable th) {
-                    throw new ShortcutBadgeException("unable to resolve intent: " + intent.toString());
-                }
-            }
+            executeBadgeByBroadcast(context, componentName, badgeCount);
         }
     }
 
@@ -73,101 +50,33 @@ public class OPPOHomeBader implements Badger {
         return Collections.singletonList("com.oppo.launcher");
     }
 
-    private int getSupportVersion() {
-        int i = ROMVERSION;
-        if (i >= 0) {
-            return ROMVERSION;
+    private void executeBadgeByBroadcast(Context context, ComponentName componentName,
+                                         int badgeCount) throws ShortcutBadgeException {
+        if (badgeCount == 0) {
+            badgeCount = -1;
         }
+        Intent intent = new Intent(INTENT_ACTION);
+        intent.putExtra(INTENT_EXTRA_PACKAGENAME, componentName.getPackageName());
+        intent.putExtra(INTENT_EXTRA_BADGE_COUNT, badgeCount);
+        intent.putExtra(INTENT_EXTRA_BADGE_UPGRADENUMBER, badgeCount);
+
+        BroadcastHelper.sendIntentExplicitly(context, intent);
+    }
+
+    /**
+     * Send request to OPPO badge content provider to set badge in OPPO home launcher.
+     *
+     * @param context       the context to use
+     * @param badgeCount    the badge count
+     */
+    @TargetApi(Build.VERSION_CODES.HONEYCOMB)
+    private void executeBadgeByContentProvider(Context context, int badgeCount) throws ShortcutBadgeException {
         try {
-            i = ((Integer) executeClassLoad(getClass("com.color.os.ColorBuild"), "getColorOSVERSION", null, null)).intValue();
-        } catch (Exception e) {
-            i = 0;
+            Bundle extras = new Bundle();
+            extras.putInt(INTENT_EXTRA_BADGEUPGRADE_COUNT, badgeCount);
+            context.getContentResolver().call(Uri.parse(PROVIDER_CONTENT_URI), "setAppBadgeCount", null, extras);
+        } catch (Throwable ignored) {
+            throw new ShortcutBadgeException("Unable to execute Badge By Content Provider");
         }
-        if (i == 0) {
-            try {
-                String str = getSystemProperty("ro.build.version.opporom");
-                if (str.startsWith("V1.4")) {
-                    return 3;
-                }
-                if (str.startsWith("V2.0")) {
-                    return 4;
-                }
-                if (str.startsWith("V2.1")) {
-                    return 5;
-                }
-            } catch (Exception ignored) {
-
-            }
-        }
-        ROMVERSION = i;
-        return ROMVERSION;
-    }
-
-
-    private Object executeClassLoad(Class cls, String str, Class[] clsArr, Object[] objArr) {
-        Object obj = null;
-        if (!(cls == null || checkObjExists(str))) {
-            Method method = getMethod(cls, str, clsArr);
-            if (method != null) {
-                method.setAccessible(true);
-                try {
-                    obj = method.invoke(null, objArr);
-                } catch (IllegalAccessException e) {
-                    e.printStackTrace();
-                } catch (InvocationTargetException e) {
-                    e.printStackTrace();
-                }
-            }
-        }
-        return obj;
-    }
-
-    private Method getMethod(Class cls, String str, Class[] clsArr) {
-        Method method = null;
-        if (cls == null || checkObjExists(str)) {
-            return method;
-        }
-        try {
-            cls.getMethods();
-            cls.getDeclaredMethods();
-            return cls.getDeclaredMethod(str, clsArr);
-        } catch (Exception e) {
-            try {
-                return cls.getMethod(str, clsArr);
-            } catch (Exception e2) {
-                return cls.getSuperclass() != null ? getMethod(cls.getSuperclass(), str, clsArr) : method;
-            }
-        }
-    }
-
-    private Class getClass(String str) {
-        Class cls = null;
-        try {
-            cls = Class.forName(str);
-        } catch (ClassNotFoundException ignored) {
-        }
-        return cls;
-    }
-
-
-    private boolean checkObjExists(Object obj) {
-        return obj == null || obj.toString().equals("") || obj.toString().trim().equals("null");
-    }
-
-
-    private String getSystemProperty(String propName) {
-        String line;
-        BufferedReader input = null;
-        try {
-            Process p = Runtime.getRuntime().exec("getprop " + propName);
-            input = new BufferedReader(new InputStreamReader(p.getInputStream()), 1024);
-            line = input.readLine();
-            input.close();
-        } catch (IOException ex) {
-            return null;
-        } finally {
-            CloseHelper.closeQuietly(input);
-        }
-        return line;
     }
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/shortcutbadger/util/BroadcastHelper.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/shortcutbadger/util/BroadcastHelper.java
@@ -5,6 +5,9 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 
+import com.onesignal.shortcutbadger.ShortcutBadgeException;
+
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -15,5 +18,29 @@ public class BroadcastHelper {
 		PackageManager packageManager = context.getPackageManager();
 		List<ResolveInfo> receivers = packageManager.queryBroadcastReceivers(intent, 0);
 		return receivers != null && receivers.size() > 0;
+	}
+
+	public static List<ResolveInfo> resolveBroadcast(Context context, Intent intent) {
+		PackageManager packageManager = context.getPackageManager();
+		List<ResolveInfo> receivers = packageManager.queryBroadcastReceivers(intent, 0);
+
+		return receivers != null ? receivers : Collections.<ResolveInfo>emptyList();
+	}
+
+	public static void sendIntentExplicitly(Context context, Intent intent) throws ShortcutBadgeException {
+		List<ResolveInfo> resolveInfos = resolveBroadcast(context, intent);
+
+		if (resolveInfos.size() == 0) {
+			throw new ShortcutBadgeException("unable to resolve intent: " + intent.toString());
+		}
+
+		for (ResolveInfo info : resolveInfos) {
+			Intent actualIntent = new Intent(intent);
+
+			if (info != null) {
+				actualIntent.setPackage(info.resolvePackageName);
+				context.sendBroadcast(actualIntent);
+			}
+		}
 	}
 }


### PR DESCRIPTION
# Description
## One Line Summary
Pulled in latest upstream source for OPPO badge setting code to remove usage of `Runtime.getRuntime().exec`, which is flagged as an insecure API by static analysis tools.

## Details

### Motivation
While it was found the current instances of `Runtime.getRuntime().exec` are safely some static analysis tools do flag this which eats up developer's time to investigate and have to suppress.

### Scope
Only effects badge count updates on OPPO devices, most likely those limited to Android 7 or older.

### Code Source
This SDK has the https://github.com/leolin310148/ShortcutBadger imbedded in it, the code changes in this PR are sourced from the latest source from there. See commit for more details.

# Testing
No test was done, don't have an OPPO device and this code is already vetted by the ShortcutBadger library.

# Affected code checklist
   - [X] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
      - [X] Badges (OPPO only)
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1557)
<!-- Reviewable:end -->
