### PR TITLE
[Fix] Location update null pointer exception

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/GMSLocationController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/GMSLocationController.java
@@ -29,6 +29,7 @@ package com.onesignal;
 
 import android.location.Location;
 import android.os.Bundle;
+import android.os.Looper;
 
 import androidx.annotation.NonNull;
 
@@ -194,6 +195,8 @@ class GMSLocationController extends LocationController {
         static void requestLocationUpdates(GoogleApiClient googleApiClient, LocationRequest locationRequest, LocationListener locationListener) {
             try {
                 synchronized (GMSLocationController.syncLock) {
+                    if (Looper.myLooper() == null)
+                        Looper.prepare();
                     if (googleApiClient.isConnected())
                         LocationServices.FusedLocationApi.requestLocationUpdates(googleApiClient, locationRequest, locationListener);
                 }


### PR DESCRIPTION

# Description
## One Line Summary
Fix location update null pointer exception

## Details
### Motivation
The method `requestLocationUpdates` would occasionally run into a null pointer exception due to the Looper thread not being prepared. 
Fixes Flutter issue [372](https://github.com/OneSignal/OneSignal-Flutter-SDK/issues/372) and Xamarin issue [282](https://github.com/OneSignal/OneSignal-Xamarin-SDK/issues/282)

### Scope
* Add Looper null check in `requestLocationUpdates` of `GMSLocationController`
* Add `Looper.prepare()` on passing null check

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1565)
<!-- Reviewable:end -->
