### PR TITLE
Before casting a value to `Number`, check that it can

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/JSONUtils.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/JSONUtils.java
@@ -62,7 +62,7 @@ class JSONUtils {
                         Object curValue = cur.get(key);
                         if (!value.equals(curValue)) {
                             // Work around for JSON serializer turning doubles/floats into ints since it drops ending 0's
-                            if (curValue instanceof Integer && !"".equals(value)) {
+                            if (curValue instanceof Number && value instanceof Number) {
                                 if ( ((Number)curValue).doubleValue() != ((Number)value).doubleValue())
                                     output.put(key, value);
                             }


### PR DESCRIPTION
# Description
## One Line Summary
When generating the JSON diff, check that the new value is an instance of `Number` before we cast it to a `Number`.

## Details

### Motivation
PR made to fix https://github.com/OneSignal/OneSignal-Android-SDK/issues/1553, which raises a `ClassCastException` when trying to cast a String to a Number. While I can't think of any keys where this is possible for `deviceInfo` (from where this exception is raised), from crash reports it seems that we could have a situation where the new value is a string while the old value is an integer.

### Scope
If the above case happens, it will just put the new string value into the JSON object.

### Context
To decide whether or not to update each value, we check they are not equal with `!value.equals(curValue)`. The additional check for `((Number)curValue).doubleValue() != ((Number)value).doubleValue()` is for cases where the `curValue = 5` and the new `value = 5.0`. They would pass the first check but we don't need an update since the JSON serializer would turn `5.0` into `5` anyway, so `5.0` is not considered different from `5`.

Made a modification to check the current value is an instance of `Number` instead of `Integer` since it could be that it is a float or double.

# Testing
## Unit testing
- Existing unit tests pass
- This is a minor fix, so doesn't seem to warrant new unit tests.

## Manual testing
- app build with Android Studio 2020.3.1 with a fresh install of the OneSignal example app on a Pixel 5 with Android 11.
- hard coded some `deviceInfo` where the old value is an integer and the new value is a string for testing - got the same exception prior to fix

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1571)
<!-- Reviewable:end -->
