### PR TITLE
Fix Heads-Up Displaying Previous Notification When Grouped on some devices

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotification.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotification.java
@@ -385,7 +385,7 @@ class GenerateNotification {
       notifBuilder.setGroup(group);
 
       try {
-         notifBuilder.setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_SUMMARY);
+         notifBuilder.setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_CHILDREN);
       } catch (Throwable t) {
          //do nothing in this case...Android support lib 26 isn't in the project
       }
@@ -612,7 +612,7 @@ class GenerateNotification {
               .setGroupSummary(true);
 
          try {
-            summaryBuilder.setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_SUMMARY);
+            summaryBuilder.setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_CHILDREN);
          }
          catch (Throwable t) {
             //do nothing in this case...Android support lib 26 isn't in the project
@@ -674,7 +674,7 @@ class GenerateNotification {
                        .setGroupSummary(true);
 
          try {
-            summaryBuilder.setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_SUMMARY);
+            summaryBuilder.setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_CHILDREN);
          }
          catch (Throwable t) {
             //do nothing in this case...Android support lib 26 isn't in the project
@@ -730,7 +730,7 @@ class GenerateNotification {
             .setGroupSummary(true);
 
       try {
-        summaryBuilder.setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_SUMMARY);
+        summaryBuilder.setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_CHILDREN);
       }
       catch (Throwable t) {
         // Do nothing in this case... Android support lib 26 isn't in the project

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotification.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotification.java
@@ -82,10 +82,24 @@ class GenerateNotification {
    private static Resources contextResources = null;
    private static Context currentContext = null;
    private static String packageName = null;
+   private static Integer groupAlertBehavior = null;
 
    private static class OneSignalNotificationBuilder {
       NotificationCompat.Builder compatBuilder;
       boolean hasLargeIcon;
+   }
+
+   // NotificationCompat unfortunately doesn't correctly support some features
+   // such as sounds and heads-up notifications with GROUP_ALERT_CHILDREN on
+   // Android 6.0 and older.
+   // This includes:
+   //    Android 6.0 - No Sound or heads-up
+   //    Android 5.0 - Sound, but no heads-up
+   private static void initGroupAlertBehavior() {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N)
+         groupAlertBehavior = NotificationCompat.GROUP_ALERT_CHILDREN;
+     else
+         groupAlertBehavior = NotificationCompat.GROUP_ALERT_SUMMARY;
    }
 
    private static void setStatics(Context inContext) {
@@ -99,6 +113,8 @@ class GenerateNotification {
       setStatics(notificationJob.getContext());
 
       isRunningOnMainThreadCheck();
+
+      initGroupAlertBehavior();
 
       return showNotification(notificationJob);
    }
@@ -385,7 +401,7 @@ class GenerateNotification {
       notifBuilder.setGroup(group);
 
       try {
-         notifBuilder.setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_CHILDREN);
+         notifBuilder.setGroupAlertBehavior(groupAlertBehavior);
       } catch (Throwable t) {
          //do nothing in this case...Android support lib 26 isn't in the project
       }
@@ -612,7 +628,7 @@ class GenerateNotification {
               .setGroupSummary(true);
 
          try {
-            summaryBuilder.setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_CHILDREN);
+            summaryBuilder.setGroupAlertBehavior(groupAlertBehavior);
          }
          catch (Throwable t) {
             //do nothing in this case...Android support lib 26 isn't in the project
@@ -674,7 +690,7 @@ class GenerateNotification {
                        .setGroupSummary(true);
 
          try {
-            summaryBuilder.setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_CHILDREN);
+            summaryBuilder.setGroupAlertBehavior(groupAlertBehavior);
          }
          catch (Throwable t) {
             //do nothing in this case...Android support lib 26 isn't in the project
@@ -730,7 +746,7 @@ class GenerateNotification {
             .setGroupSummary(true);
 
       try {
-        summaryBuilder.setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_CHILDREN);
+        summaryBuilder.setGroupAlertBehavior(groupAlertBehavior);
       }
       catch (Throwable t) {
         // Do nothing in this case... Android support lib 26 isn't in the project


### PR DESCRIPTION
# Description
## One Line Summary
Some devices would display the previous notification as a heads-up notification when they become grouped which this PR addresses.

## Details

### Motivation
The main motivation is to fix the bug noted above. Secondary is this changes the heads-up notification from showing the group summary to showing the most recent notification. This makes it much easier to see what is new instead of it being mixed with older notifications. Video below will show this behavior difference.

### Scope
Only effects the display of grouped heads-up notifications for Android 7.0 and newer.

### Background details - Android features
Google's documentation on specific Android Notification features referenced in this PR:
* [Heads-up notification](https://developer.android.com/guide/topics/ui/notifiers/notifications#Heads-up)
* [Create a Group of Notifications](https://developer.android.com/training/notify-user/group)

### Details of the change
Using `GROUP_ALERT_CHILDREN` with `setGroupAlertBehavior` means the just receive notification will be used as the heads-up notification. Before `GROUP_ALERT_SUMMARY` would result in seeing a summary of all notifications in the group.

This also fixes a bug where the previous notification would be shown as the heads-up notification on some devices. Such as Samsung's OneUI 4 with the Brief style of notifications, as well as some other manufacturers.
Lastly the bug would sometimes happen on Android 7 and 8 AOSP since the summary and child notification are posted at the same time and these versions of Android would pick one at random. In this case it seemed to only be an issue when setting `android_group` and only on the 2nd notification display.

Fixes #1574

# Testing
## Unit testing
None, this is a visual change

## Manual testing
**Tested on Android Studio Emulators:**
* Android 5.0 
* Android 6.0
* Android 7.0
* Android 7.1
* Android 8.1
* Android 11
* Android 12

**Test on device:**
* Samsung S21 with Android 12 with One UI 4.1
   - With both Brief and Detailed pop-up styles.

### Videos
Android 12 Emulator
#### Before
https://user-images.githubusercontent.com/645861/166339104-0b9a8f10-052b-4dbd-8342-51e560742a98.mp4

#### After
https://user-images.githubusercontent.com/645861/166339113-b6f69fc5-d158-4ebd-ac61-78bd7c010465.mp4

# Affected code checklist
   - [X] Notifications
      - [X] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1578)
<!-- Reviewable:end -->
