### PR TITLE
[Change] Notification Activity Trampoline forward instead of reverse

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotification.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotification.java
@@ -275,9 +275,8 @@ class GenerateNotification {
       JSONObject fcmJson = notificationJob.getJsonPayload();
       String group = fcmJson.optString("grp", null);
 
-      GenerateNotificationOpenIntent intentGenerator = GenerateNotificationOpenIntentFromPushPayload.INSTANCE.create(
-          currentContext,
-          fcmJson
+      IntentGeneratorForAttachingToNotifications intentGenerator = new IntentGeneratorForAttachingToNotifications(
+          currentContext
       );
 
       ArrayList<StatusBarNotification> grouplessNotifs = new ArrayList<>();
@@ -368,7 +367,7 @@ class GenerateNotification {
 
    private static Notification createGenericPendingIntentsForNotif(
        NotificationCompat.Builder notifBuilder,
-       GenerateNotificationOpenIntent intentGenerator,
+       IntentGeneratorForAttachingToNotifications intentGenerator,
        JSONObject gcmBundle,
        int notificationId
    ) {
@@ -385,7 +384,7 @@ class GenerateNotification {
 
    private static void createGenericPendingIntentsForGroup(
        NotificationCompat.Builder notifBuilder,
-       GenerateNotificationOpenIntent intentGenerator,
+       IntentGeneratorForAttachingToNotifications intentGenerator,
        JSONObject gcmBundle,
        String group,
        int notificationId
@@ -495,9 +494,8 @@ class GenerateNotification {
    private static void createSummaryNotification(OSNotificationGenerationJob notificationJob, OneSignalNotificationBuilder notifBuilder) {
       boolean updateSummary = notificationJob.isRestoring();
       JSONObject fcmJson = notificationJob.getJsonPayload();
-      GenerateNotificationOpenIntent intentGenerator = GenerateNotificationOpenIntentFromPushPayload.INSTANCE.create(
-           currentContext,
-           fcmJson
+      IntentGeneratorForAttachingToNotifications intentGenerator = new IntentGeneratorForAttachingToNotifications(
+           currentContext
       );
 
       String group = fcmJson.optString("grp", null);
@@ -706,7 +704,7 @@ class GenerateNotification {
    @RequiresApi(api = Build.VERSION_CODES.M)
    private static void createGrouplessSummaryNotification(
        OSNotificationGenerationJob notificationJob,
-       GenerateNotificationOpenIntent intentGenerator,
+       IntentGeneratorForAttachingToNotifications intentGenerator,
        int grouplessNotifCount
    ) {
       JSONObject fcmJson = notificationJob.getJsonPayload();
@@ -763,7 +761,7 @@ class GenerateNotification {
    
    private static Intent createBaseSummaryIntent(
        int summaryNotificationId,
-       GenerateNotificationOpenIntent intentGenerator,
+       IntentGeneratorForAttachingToNotifications intentGenerator,
        JSONObject fcmJson,
        String group
    ) {
@@ -1034,7 +1032,7 @@ class GenerateNotification {
 
    private static void addNotificationActionButtons(
        JSONObject fcmJson,
-       GenerateNotificationOpenIntent intentGenerator,
+       IntentGeneratorForAttachingToNotifications intentGenerator,
        NotificationCompat.Builder mBuilder,
        int notificationId,
        String groupSummary

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotificationOpenIntent.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotificationOpenIntent.kt
@@ -51,17 +51,11 @@ class GenerateNotificationOpenIntent(
             context,
             notificationOpenedClassAndroid22AndOlder
         )
-
-        if (getIntentVisible() == null) {
-            // If we don't show a visible Activity put OneSignal's invisible click tracking
-            // Activity on it's own task so it doesn't resume an existing one once it closes.
-            intent.addFlags(
-                Intent.FLAG_ACTIVITY_NEW_TASK or
-                Intent.FLAG_ACTIVITY_MULTIPLE_TASK or
-                Intent.FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET
-            )
-        }
-
+        intent.addFlags(
+            Intent.FLAG_ACTIVITY_NEW_TASK or
+            Intent.FLAG_ACTIVITY_MULTIPLE_TASK or
+            Intent.FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET
+        )
         return intent
     }
 
@@ -83,31 +77,10 @@ class GenerateNotificationOpenIntent(
         oneSignalIntent: Intent,
     ): PendingIntent? {
         val flags =  PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-        val launchIntent = getIntentVisible()
-            ?:
-            // Even though the default app open action is disabled we still need to attach OneSignal's
-            // invisible Activity to capture click event to report click counts and etc.
-            // You may be thinking why not use a BroadcastReceiver instead of an invisible
-            // Activity? This could be done in a 5.0.0 release but can't be changed now as it is
-            // unknown if the app developer will be starting there own Activity from their
-            // OSNotificationOpenedHandler and that would have side-effects.
-            return PendingIntent.getActivity(
-                context,
-                requestCode,
-                oneSignalIntent,
-                flags
-            )
-
-
-        // This setups up a "Reverse Activity Trampoline"
-        // The first Activity to launch will be oneSignalIntent, which is an invisible
-        // Activity to track the click, fire OSNotificationOpenedHandler, etc. This Activity
-        // will finish quickly and the destination Activity, launchIntent, will be shown to the user
-        // since it is the next in the back stack.
-        return PendingIntent.getActivities(
+        return PendingIntent.getActivity(
             context,
             requestCode,
-            arrayOf(launchIntent, oneSignalIntent),
+            oneSignalIntent,
             flags
         )
     }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotificationOpenIntent.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotificationOpenIntent.kt
@@ -86,7 +86,7 @@ class GenerateNotificationOpenIntent(
     }
 
     // Return the provide intent if one was set, otherwise default to opening the app.
-    private fun getIntentVisible(): Intent? {
+    fun getIntentVisible(): Intent? {
         if (intent != null) return intent
         return getIntentAppOpen()
     }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotificationOpenIntent.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotificationOpenIntent.kt
@@ -1,101 +1,31 @@
 package com.onesignal
 
-import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
-import androidx.annotation.RequiresApi
 
 class GenerateNotificationOpenIntent(
     private val context: Context,
     private val intent: Intent?,
     private val startApp: Boolean
 ) {
-
-    private val notificationOpenedClassAndroid23Plus: Class<*> = NotificationOpenedReceiver::class.java
-    private val notificationOpenedClassAndroid22AndOlder: Class<*> = NotificationOpenedReceiverAndroid22AndOlder::class.java
-
-    fun getNewBaseIntent(
-        notificationId: Int,
-    ): Intent {
-        val intent =
-            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M)
-                getNewBaseIntentAndroidAPI23Plus()
-            else
-                getNewBaseIntentAndroidAPI22AndOlder()
-
-        return intent
-        .putExtra(
-            GenerateNotification.BUNDLE_KEY_ANDROID_NOTIFICATION_ID,
-            notificationId
-        )
-        // We use SINGLE_TOP and CLEAR_TOP as we don't want more than one OneSignal invisible click
-        //   tracking Activity instance around.
-        .addFlags(
-            Intent.FLAG_ACTIVITY_SINGLE_TOP or
-            Intent.FLAG_ACTIVITY_CLEAR_TOP
-        )
-    }
-
-    @RequiresApi(android.os.Build.VERSION_CODES.M)
-    private fun getNewBaseIntentAndroidAPI23Plus(): Intent {
-        return Intent(
-            context,
-            notificationOpenedClassAndroid23Plus
-        )
-    }
-
-    // See NotificationOpenedReceiverAndroid22AndOlder.kt for details
-    @Deprecated("Use getNewBaseIntentAndroidAPI23Plus instead for Android 6+")
-    private fun getNewBaseIntentAndroidAPI22AndOlder(): Intent {
-        val intent = Intent(
-            context,
-            notificationOpenedClassAndroid22AndOlder
-        )
-        intent.addFlags(
-            Intent.FLAG_ACTIVITY_NEW_TASK or
-            Intent.FLAG_ACTIVITY_MULTIPLE_TASK or
-            Intent.FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET
-        )
-        return intent
-    }
-
-    /**
-     * Creates a PendingIntent to attach to the notification click and it's action button(s).
-     * If the user interacts with the notification this normally starts the app or resumes it
-     * unless the app developer disables this via a OneSignal meta-data AndroidManifest.xml setting
-     *
-     * The default behavior is to open the app in the same way an Android homescreen launcher does.
-     * This means we expect the following behavior:
-     * 1. Starts the Activity defined in the app's AndroidManifest.xml as "android.intent.action.MAIN"
-     * 2. If the app is already running, instead the last activity will be resumed
-     * 3. If the app is not running (due to being push out of memory), the last activity will be resumed
-     * 4. If the app is no longer in the recent apps list, it is not resumed, same as #1 above.
-     * - App is removed from the recent app's list if it is swiped away or "clear all" is pressed.
-     */
-    fun getNewActionPendingIntent(
-        requestCode: Int,
-        oneSignalIntent: Intent,
-    ): PendingIntent? {
-        val flags =  PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-        return PendingIntent.getActivity(
-            context,
-            requestCode,
-            oneSignalIntent,
-            flags
-        )
-    }
-
-    // Return the provide intent if one was set, otherwise default to opening the app.
     fun getIntentVisible(): Intent? {
         if (intent != null) return intent
         return getIntentAppOpen()
     }
 
-    // Provides the default launcher Activity, if the app has one.
-    //   - This is almost always true, one of the few exceptions being an app that is only a widget.
+    /**
+     * This opens the app in the same way an Android homescreen launcher does.
+     * This means we expect the following behavior:
+     * 1. Starts the Activity defined in the app's AndroidManifest.xml as "android.intent.action.MAIN"
+     * 2. If the app is already running, instead the last activity will be resumed
+     * 3. If the app is not running (due to being push out of memory), the last activity will be resumed
+     * 4. If the app is no longer in the recent apps list, it is not resumed, same as #1 above.
+     *   - App is removed from the recent app's list if it is swiped away or "clear all" is pressed.
+     */
     private fun getIntentAppOpen(): Intent? {
         if (!startApp) return null
 
+        // Is null for apps that only provide a widget for it's UI.
         val launchIntent =
             context.packageManager.getLaunchIntentForPackage(
                 context.packageName

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/IntentGeneratorForAttachingToNotifications.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/IntentGeneratorForAttachingToNotifications.kt
@@ -1,0 +1,71 @@
+package com.onesignal
+
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import androidx.annotation.RequiresApi
+
+class IntentGeneratorForAttachingToNotifications(
+    val context: Context
+) {
+    private val notificationOpenedClassAndroid23Plus: Class<*> = NotificationOpenedReceiver::class.java
+    private val notificationOpenedClassAndroid22AndOlder: Class<*> = NotificationOpenedReceiverAndroid22AndOlder::class.java
+
+    fun getNewBaseIntent(
+        notificationId: Int,
+    ): Intent {
+        val intent =
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M)
+                getNewBaseIntentAndroidAPI23Plus()
+            else
+                getNewBaseIntentAndroidAPI22AndOlder()
+
+        return intent
+            .putExtra(
+                GenerateNotification.BUNDLE_KEY_ANDROID_NOTIFICATION_ID,
+                notificationId
+            )
+            // We use SINGLE_TOP and CLEAR_TOP as we don't want more than one OneSignal invisible click
+            //   tracking Activity instance around.
+            .addFlags(
+                Intent.FLAG_ACTIVITY_SINGLE_TOP or
+                        Intent.FLAG_ACTIVITY_CLEAR_TOP
+            )
+    }
+
+    @RequiresApi(android.os.Build.VERSION_CODES.M)
+    private fun getNewBaseIntentAndroidAPI23Plus(): Intent {
+        return Intent(
+            context,
+            notificationOpenedClassAndroid23Plus
+        )
+    }
+
+    // See NotificationOpenedReceiverAndroid22AndOlder.kt for details
+    @Deprecated("Use getNewBaseIntentAndroidAPI23Plus instead for Android 6+")
+    private fun getNewBaseIntentAndroidAPI22AndOlder(): Intent {
+        val intent = Intent(
+            context,
+            notificationOpenedClassAndroid22AndOlder
+        )
+        intent.addFlags(
+            Intent.FLAG_ACTIVITY_NEW_TASK or
+                    Intent.FLAG_ACTIVITY_MULTIPLE_TASK or
+                    Intent.FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET
+        )
+        return intent
+    }
+
+    fun getNewActionPendingIntent(
+        requestCode: Int,
+        oneSignalIntent: Intent,
+    ): PendingIntent? {
+        val flags =  PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        return PendingIntent.getActivity(
+            context,
+            requestCode,
+            oneSignalIntent,
+            flags
+        )
+    }
+}

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
@@ -372,7 +372,7 @@ class NotificationBundleProcessor {
         bundleResult.setOneSignalPayload(true);
         maximizeButtonsFromBundle(bundle);
 
-        if (OSInAppMessagePreviewHandler.inAppMessagePreviewHandled(context, bundle)) {
+        if (OSInAppMessagePreviewHandler.notificationReceived(context, bundle)) {
             // Return early, we don't want the extender service or etc. to fire for IAM previews
             bundleResult.setInAppPreviewShown(true);
             bundleReceiverCallback.onBundleProcessed(bundleResult);

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationOpenedProcessor.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationOpenedProcessor.java
@@ -114,7 +114,7 @@ class NotificationOpenedProcessor {
          if (!(context instanceof Activity))
             OneSignal.onesignalLog(OneSignal.LOG_LEVEL.ERROR, "NotificationOpenedProcessor processIntent from an non Activity context: " + context);
          else OneSignal.handleNotificationOpen((Activity) context, intentExtras.getDataArray(),
-                 false, OSNotificationFormatHelper.getOSNotificationIdFromJson(intentExtras.getJsonData()));
+                 OSNotificationFormatHelper.getOSNotificationIdFromJson(intentExtras.getJsonData()));
       }
    }
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationOpenedProcessor.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationOpenedProcessor.java
@@ -126,7 +126,7 @@ class NotificationOpenedProcessor {
 
          if (!(context instanceof Activity))
             OneSignal.onesignalLog(OneSignal.LOG_LEVEL.ERROR, "NotificationOpenedProcessor processIntent from an non Activity context: " + context);
-         else if (handleIAMPreviewOpen((Activity) context, jsonData))
+         else if (OSInAppMessagePreviewHandler.notificationOpened((Activity) context, jsonData))
             return null;
 
          jsonData.put(BUNDLE_KEY_ANDROID_NOTIFICATION_ID, intent.getIntExtra(BUNDLE_KEY_ANDROID_NOTIFICATION_ID, 0));
@@ -141,15 +141,6 @@ class NotificationOpenedProcessor {
          addChildNotifications(dataArray, summaryGroup, dbHelper);
 
       return new OSNotificationIntentExtras(dataArray, jsonData);
-   }
-
-   static boolean handleIAMPreviewOpen(@NonNull Activity context, @NonNull JSONObject jsonData) {
-      String previewUUID = OSInAppMessagePreviewHandler.inAppPreviewPushUUID(jsonData);
-      if (previewUUID == null)
-         return false;
-
-      OneSignal.getInAppMessageController().displayPreviewMessage(previewUUID);
-      return true;
    }
 
    private static void addChildNotifications(JSONArray dataArray, String summaryGroup, OneSignalDbHelper writableDb) {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationPayloadProcessorHMS.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationPayloadProcessorHMS.java
@@ -68,7 +68,6 @@ class NotificationPayloadProcessorHMS {
         OneSignal.handleNotificationOpen(
             activity,
             new JSONArray().put(jsonData),
-            true,
             OSNotificationFormatHelper.getOSNotificationIdFromJson(jsonData)
         );
     }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationPayloadProcessorHMS.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationPayloadProcessorHMS.java
@@ -62,7 +62,7 @@ class NotificationPayloadProcessorHMS {
     }
 
     private static void handleProcessJsonOpenData(@NonNull Activity activity, @NonNull JSONObject jsonData) {
-        if (NotificationOpenedProcessor.handleIAMPreviewOpen(activity, jsonData))
+        if (OSInAppMessagePreviewHandler.notificationOpened(activity, jsonData))
             return;
 
         OneSignal.handleNotificationOpen(

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessagePreviewHandler.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessagePreviewHandler.kt
@@ -1,14 +1,17 @@
 package com.onesignal
 
+import android.app.Activity
 import android.content.Context
 import android.os.Build
 import android.os.Bundle
+import androidx.annotation.ChecksSdkIntAtLeast
+import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
 
 internal object OSInAppMessagePreviewHandler {
     @JvmStatic
-    fun inAppMessagePreviewHandled(context: Context?, bundle: Bundle?): Boolean {
+    fun notificationReceived(context: Context?, bundle: Bundle?): Boolean {
         val pushPayloadJson = NotificationBundleProcessor.bundleAsJSONObject(bundle)
         // Show In-App message preview it is in the payload & the app is in focus
         val previewUUID = inAppPreviewPushUUID(pushPayloadJson) ?: return false
@@ -20,6 +23,15 @@ internal object OSInAppMessagePreviewHandler {
             val generationJob = OSNotificationGenerationJob(context, pushPayloadJson)
             GenerateNotification.displayIAMPreviewNotification(generationJob)
         }
+        return true
+    }
+
+    @JvmStatic
+    fun notificationOpened(activity: Activity, jsonData: JSONObject): Boolean {
+        val previewUUID = inAppPreviewPushUUID(jsonData) ?: return false
+
+        OneSignal.openDestinationActivity(activity, JSONArray().put(jsonData))
+        OneSignal.getInAppMessageController().displayPreviewMessage(previewUUID)
         return true
     }
 
@@ -43,5 +55,6 @@ internal object OSInAppMessagePreviewHandler {
     }
 
     // Validate that the current Android device is Android 4.4 or higher
+    @ChecksSdkIntAtLeast(api = Build.VERSION_CODES.KITKAT)
     private fun shouldDisplayNotification(): Boolean = Build.VERSION.SDK_INT > Build.VERSION_CODES.JELLY_BEAN_MR2
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -2429,7 +2429,7 @@ public class OneSignal {
       runNotificationOpenedCallback(data);
    }
 
-   static private void openDestinationActivity(
+   static void openDestinationActivity(
       @NonNull final Activity activity,
       @NonNull final JSONArray pushPayloads
    ) {
@@ -2443,6 +2443,7 @@ public class OneSignal {
 
          Intent intent = intentGenerator.getIntentVisible();
          if (intent != null) {
+            logger.info("SDK running startActivity with Intent: " + intent);
             activity.startActivity(intent);
          }
          else {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -2394,7 +2394,7 @@ public class OneSignal {
    /**
     * Method called when opening a notification
     */
-   static void handleNotificationOpen(final Activity context, final JSONArray data, final boolean startLauncherActivity, @Nullable final String notificationId) {
+   static void handleNotificationOpen(final Activity context, final JSONArray data, @Nullable final String notificationId) {
       // Delay call until remote params are set
       if (taskRemoteController.shouldQueueTaskForInit(OSTaskRemoteController.HANDLE_NOTIFICATION_OPEN)) {
          logger.error("Waiting for remote params. " +
@@ -2404,7 +2404,7 @@ public class OneSignal {
             public void run() {
                if (appContext != null) {
                   logger.debug("Running " + OSTaskRemoteController.HANDLE_NOTIFICATION_OPEN + " operation from pending queue.");
-                  handleNotificationOpen(context, data, startLauncherActivity, notificationId);
+                  handleNotificationOpen(context, data, notificationId);
                }
             }
          });
@@ -2422,39 +2422,35 @@ public class OneSignal {
 
       if (shouldInitDirectSessionFromNotificationOpen(context, data)) {
          applicationOpenedByNotification(notificationId);
-
-         if (startLauncherActivity) {
-            // Start activity with an activity trampolining
-            startOrResumeApp(context);
-         }
       }
+
+      openDestinationActivity(context, data);
 
       runNotificationOpenedCallback(data);
    }
 
-   // Reverse activity trampolining is used for most notifications.
-   // This method is only used if the push provider does support it.
-   // This opens the app in the same way an Android home screen launcher does.
-   // This means we expect the following behavior:
-   //    1. Starts the Activity defined in the app's AndroidManifest.xml as "android.intent.action.MAIN"
-   //    2. If the app is already running, instead the last activity will be resumed
-   //    3. If the app is not running (due to being push out of memory), the last activity will be resumed
-   //    4. If the app is no longer in the recent apps list, it is not resumed, same as #1 above.
-   //        - App is removed from the recent app's list if it is swiped away or "clear all" is pressed.
-   static boolean startOrResumeApp(@NonNull Activity activity) {
-      Intent launchIntent = activity.getPackageManager().getLaunchIntentForPackage(activity.getPackageName());
-      logger.debug("startOrResumeApp from context: " + activity + " isRoot: " + activity.isTaskRoot() + " with launchIntent: " + launchIntent);
+   static private void openDestinationActivity(
+      @NonNull final Activity activity,
+      @NonNull final JSONArray pushPayloads
+   ) {
+      try {
+         // Always use the top most notification if user tapped on the summary notification
+         JSONObject firstPayloadItem = pushPayloads.getJSONObject(0);
+         GenerateNotificationOpenIntent intentGenerator = GenerateNotificationOpenIntentFromPushPayload.INSTANCE.create(
+            activity,
+            firstPayloadItem
+         );
 
-      // Not all apps have a launcher intent, such as one that only provides a homescreen widget
-      if (launchIntent == null)
-         return false;
-      // Removing package from the intent, this treats the app as if it was started externally.
-      // This gives us the resume app behavior noted above.
-      // Android 11 no longer requires nulling this out to get this behavior.
-      launchIntent.setPackage(null);
-
-      activity.startActivity(launchIntent);
-      return true;
+         Intent intent = intentGenerator.getIntentVisible();
+         if (intent != null) {
+            activity.startActivity(intent);
+         }
+         else {
+            logger.info("SDK not showing an Activity automatically due to it's settings.");
+         }
+      } catch (JSONException e) {
+         e.printStackTrace();
+      }
    }
 
    private static boolean shouldInitDirectSessionFromNotificationOpen(Activity context, final JSONArray data) {

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
@@ -129,8 +129,8 @@ public class OneSignalPackagePrivateHelper {
       return NotificationBundleProcessor.bundleAsJSONObject(bundle);
    }
 
-   public static void OneSignal_handleNotificationOpen(Activity context, final JSONArray data, final boolean fromHMSMessage, final String notificationId) {
-      OneSignal.handleNotificationOpen(context, data, fromHMSMessage, notificationId);
+   public static void OneSignal_handleNotificationOpen(Activity context, final JSONArray data, final String notificationId) {
+      OneSignal.handleNotificationOpen(context, data, notificationId);
    }
 
    public static BigInteger OneSignal_getAccentColor(JSONObject fcmJson) {

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
@@ -1308,11 +1308,17 @@ public class GenerateNotificationRunner {
          }});
       }}.toString());
 
+      // Grab activity to remove it from the unit test's tracked list.
+      shadowOf(blankActivity).getNextStartedActivity();
+
       Intent notificationOpenIntent = createOpenIntent(2, inAppPreviewMockPayloadBundle());
       NotificationOpenedProcessor_processFromContext(blankActivity, notificationOpenIntent);
       threadAndTaskWait();
       threadAndTaskWait();
       assertEquals("PGh0bWw+PC9odG1sPgoKPHNjcmlwdD4KICAgIHNldFBsYXllclRhZ3MobnVsbCk7Cjwvc2NyaXB0Pg==", ShadowOSWebView.lastData);
+
+      // Ensure the app is foregrounded.
+      assertNotNull(shadowOf(blankActivity).getNextStartedActivity());
    }
 
    @Test

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
@@ -1142,70 +1142,31 @@ public class GenerateNotificationRunner {
       threadAndTaskWait();
 
       Intent[] intents = lastNotificationIntents();
-      assertEquals("android.intent.action.MAIN", intents[0].getAction());
       assertEquals(
          com.onesignal.NotificationOpenedReceiver.class.getName(),
-         intents[1].getComponent().getClassName()
+         intents[0].getComponent().getClassName()
       );
-      assertEquals(2, intents.length);
-   }
-
-   @Test
-   @Config(shadows = { ShadowGenerateNotification.class })
-   public void shouldSetContentIntentForLaunchURL() throws Exception {
-      generateNotificationWithLaunchURL();
-
-      Intent[] intents = lastNotificationIntents();
-      assertEquals(2, intents.length);
-      Intent intentLaunchURL = intents[0];
-      assertEquals("android.intent.action.VIEW", intentLaunchURL.getAction());
-      assertEquals("https://google.com", intentLaunchURL.getData().toString());
-
-      assertNotificationOpenedReceiver(intents[1]);
-   }
-
-   @Test
-   @Config(shadows = { ShadowGenerateNotification.class })
-   public void shouldNotSetContentIntentForLaunchURLIfDefaultNotificationOpenIsDisabled() throws Exception {
-      OneSignalShadowPackageManager.addManifestMetaData("com.onesignal.NotificationOpened.DEFAULT", "DISABLE");
-      generateNotificationWithLaunchURL();
-
-      Intent[] intents = lastNotificationIntents();
       assertEquals(1, intents.length);
-      assertNotificationOpenedReceiver(intents[0]);
    }
 
    @Test
-   @Config(shadows = { ShadowGenerateNotification.class })
-   public void shouldNotSetContentIntentForLaunchURLIfSuppress() throws Exception {
-      OneSignalShadowPackageManager.addManifestMetaData("com.onesignal.suppressLaunchURLs", true);
-      generateNotificationWithLaunchURL();
+   @Config(sdk = 21, shadows = { ShadowGenerateNotification.class })
+   public void shouldUseCorrectActivityForLessThanAndroid23() throws Exception {
+      NotificationBundleProcessor_ProcessFromFCMIntentService(blankActivity, getBaseNotifBundle());
+      threadAndTaskWait();
 
       Intent[] intents = lastNotificationIntents();
-      assertEquals(2, intents.length);
-      assertOpenMainActivityIntent(intents[0]);
-      assertNotificationOpenedReceiver(intents[1]);
+      assertEquals(
+           com.onesignal.NotificationOpenedReceiverAndroid22AndOlder.class.getName(),
+           intents[0].getComponent().getClassName()
+      );
+      assertEquals(1, intents.length);
    }
 
    private Intent[] lastNotificationIntents() {
       PendingIntent pendingIntent = ShadowRoboNotificationManager.getLastNotif().contentIntent;
       // NOTE: This is fragile until this robolectric issue is fixed: https://github.com/robolectric/robolectric/issues/6660
       return shadowOf(pendingIntent).getSavedIntents();
-   }
-
-   private void generateNotificationWithLaunchURL() throws Exception {
-      Bundle bundle = launchURLMockPayloadBundle();
-      NotificationBundleProcessor_ProcessFromFCMIntentService(blankActivity, bundle);
-      threadAndTaskWait();
-   }
-
-   private void assertNotificationOpenedReceiver(@NonNull Intent intent) {
-      assertEquals(com.onesignal.NotificationOpenedReceiverAndroid22AndOlder.class.getName(), intent.getComponent().getClassName());
-   }
-
-   private void assertOpenMainActivityIntent(@NonNull Intent intent) {
-      assertEquals(Intent.ACTION_MAIN, intent.getAction());
-      assertTrue(intent.getCategories().contains(Intent.CATEGORY_LAUNCHER));
    }
 
    @Test
@@ -1308,17 +1269,6 @@ public class GenerateNotificationRunner {
          put("a", new JSONObject() {{
             put("os_in_app_message_preview_id", "UUID");
          }});
-      }}.toString());
-      return bundle;
-   }
-
-   @NonNull
-   private static Bundle launchURLMockPayloadBundle() throws JSONException {
-      Bundle bundle = new Bundle();
-      bundle.putString("alert", "test");
-      bundle.putString("custom", new JSONObject() {{
-         put("i", "UUID");
-         put("u", "https://google.com");
       }}.toString());
       return bundle;
    }

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/NotificationOpenedActivityHMSIntegrationTestsRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/NotificationOpenedActivityHMSIntegrationTestsRunner.java
@@ -155,6 +155,15 @@ public class NotificationOpenedActivityHMSIntegrationTestsRunner {
     }
 
     @Test
+    public void barebonesOSPayload_startsMainActivity() throws Exception {
+        helper_initSDKAndFireHMSNotificationBarebonesOSOpenIntent();
+
+        Intent startedActivity = shadowOf((Application) ApplicationProvider.getApplicationContext()).getNextStartedActivity();
+        assertNotNull(startedActivity);
+        assertEquals(startedActivity.getComponent().getClassName(), BlankActivity.class.getName());
+    }
+
+    @Test
     public void barebonesOSPayload_makesNotificationOpenRequest() throws Exception {
         helper_initSDKAndFireHMSNotificationBarebonesOSOpenIntent();
         assertNotificationOpenAtIndex(2, UserState.DEVICE_TYPE_HUAWEI);

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/OutcomeEventIntegrationTests.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/OutcomeEventIntegrationTests.java
@@ -24,7 +24,6 @@ import com.onesignal.ShadowGenerateNotification;
 import com.onesignal.ShadowJobService;
 import com.onesignal.ShadowNotificationManagerCompat;
 import com.onesignal.ShadowOSUtils;
-import com.onesignal.ShadowOneSignal;
 import com.onesignal.ShadowOneSignalRestClient;
 import com.onesignal.ShadowPushRegistratorFCM;
 import com.onesignal.ShadowTimeoutHandler;
@@ -181,7 +180,7 @@ public class OutcomeEventIntegrationTests {
         pauseActivity(blankActivityController);
 
         // Click notification
-        OneSignal_handleNotificationOpen(blankActivity, new JSONArray("[{ \"alert\": \"Test Msg\", \"custom\": { \"i\": \"UUID\" } }]"), false, ONESIGNAL_NOTIFICATION_ID + "2");
+        OneSignal_handleNotificationOpen(blankActivity, new JSONArray("[{ \"alert\": \"Test Msg\", \"custom\": { \"i\": \"UUID\" } }]"), ONESIGNAL_NOTIFICATION_ID + "2");
         threadAndTaskWait();
 
         // Foreground app
@@ -212,7 +211,7 @@ public class OutcomeEventIntegrationTests {
         time.advanceSystemTimeBy(31);
 
         // Click notification
-        OneSignal_handleNotificationOpen(blankActivity, new JSONArray("[{ \"alert\": \"Test Msg\", \"custom\": { \"i\": \"UUID\" } }]"), false, ONESIGNAL_NOTIFICATION_ID + "2");
+        OneSignal_handleNotificationOpen(blankActivity, new JSONArray("[{ \"alert\": \"Test Msg\", \"custom\": { \"i\": \"UUID\" } }]"), ONESIGNAL_NOTIFICATION_ID + "2");
         threadAndTaskWait();
 
         // Foreground app
@@ -531,7 +530,7 @@ public class OutcomeEventIntegrationTests {
         pauseActivity(blankActivityController);
 
         // Receive and open a notification
-        OneSignal_handleNotificationOpen(blankActivity, new JSONArray("[{ \"alert\": \"Test Msg\", \"custom\": { \"i\": \"UUID\" } }]"), false, ONESIGNAL_NOTIFICATION_ID);
+        OneSignal_handleNotificationOpen(blankActivity, new JSONArray("[{ \"alert\": \"Test Msg\", \"custom\": { \"i\": \"UUID\" } }]"), ONESIGNAL_NOTIFICATION_ID);
         threadAndTaskWait();
 
         // Foreground the application
@@ -564,7 +563,7 @@ public class OutcomeEventIntegrationTests {
         pauseActivity(blankActivityController);
 
         // Receive and open a notification
-        OneSignal_handleNotificationOpen(blankActivity, new JSONArray("[{ \"alert\": \"Test Msg\", \"custom\": { \"i\": \"UUID\" } }]"), false, ONESIGNAL_NOTIFICATION_ID);
+        OneSignal_handleNotificationOpen(blankActivity, new JSONArray("[{ \"alert\": \"Test Msg\", \"custom\": { \"i\": \"UUID\" } }]"), ONESIGNAL_NOTIFICATION_ID);
         threadAndTaskWait();
 
         // Foreground the application
@@ -587,7 +586,7 @@ public class OutcomeEventIntegrationTests {
         assertNull(notificationOpenedMessage);
 
         // Click notification
-        OneSignal_handleNotificationOpen(blankActivity, new JSONArray("[{ \"alert\": \"Test Msg\", \"custom\": { \"i\": \"UUID\" } }]"), false, ONESIGNAL_NOTIFICATION_ID);
+        OneSignal_handleNotificationOpen(blankActivity, new JSONArray("[{ \"alert\": \"Test Msg\", \"custom\": { \"i\": \"UUID\" } }]"), ONESIGNAL_NOTIFICATION_ID);
         threadAndTaskWait();
 
         // Check message String matches data sent in open handler
@@ -632,7 +631,7 @@ public class OutcomeEventIntegrationTests {
         sessionManager.onNotificationReceived(notificationID);
 
         // Click notification before new session
-        OneSignal_handleNotificationOpen(blankActivity, new JSONArray("[{ \"alert\": \"Test Msg\", \"custom\": { \"i\": \"" + notificationID + "\" } }]"), false, notificationID);
+        OneSignal_handleNotificationOpen(blankActivity, new JSONArray("[{ \"alert\": \"Test Msg\", \"custom\": { \"i\": \"" + notificationID + "\" } }]"), notificationID);
         threadAndTaskWait();
 
         assertNotNull(notificationOpenedResult);
@@ -673,7 +672,7 @@ public class OutcomeEventIntegrationTests {
         time.advanceSystemAndElapsedTimeBy(61);
 
         // Click notification before new session
-        OneSignal_handleNotificationOpen(blankActivity, new JSONArray("[{ \"alert\": \"Test Msg\", \"custom\": { \"i\": \"" + notificationID + "\" } }]"), false, notificationID);
+        OneSignal_handleNotificationOpen(blankActivity, new JSONArray("[{ \"alert\": \"Test Msg\", \"custom\": { \"i\": \"" + notificationID + "\" } }]"), notificationID);
         threadAndTaskWait();
 
         assertNotNull(notificationOpenedResult);
@@ -713,7 +712,7 @@ public class OutcomeEventIntegrationTests {
         ShadowTimeoutHandler.setMockDelayMillis(1);
 
         // Click notification before new session
-        OneSignal_handleNotificationOpen(blankActivity, new JSONArray("[{ \"alert\": \"Test Msg\", \"custom\": { \"i\": \"" + notificationID + "\" } }]"), false, notificationID);
+        OneSignal_handleNotificationOpen(blankActivity, new JSONArray("[{ \"alert\": \"Test Msg\", \"custom\": { \"i\": \"" + notificationID + "\" } }]"), notificationID);
         threadAndTaskWait();
 
         assertNotNull(notificationOpenedResult);
@@ -752,7 +751,7 @@ public class OutcomeEventIntegrationTests {
         time.advanceSystemAndElapsedTimeBy(61);
 
         // Click notification before new session
-        OneSignal_handleNotificationOpen(blankActivity, new JSONArray("[{ \"alert\": \"Test Msg\", \"custom\": { \"i\": \"" + notificationID + "\" } }]"), false, notificationID);
+        OneSignal_handleNotificationOpen(blankActivity, new JSONArray("[{ \"alert\": \"Test Msg\", \"custom\": { \"i\": \"" + notificationID + "\" } }]"), notificationID);
         threadAndTaskWait();
 
         assertNotNull(notificationOpenedResult);
@@ -782,7 +781,7 @@ public class OutcomeEventIntegrationTests {
         String notificationID = ONESIGNAL_NOTIFICATION_ID + "1";
         sessionManager.onNotificationReceived(notificationID);
         // Click notification before new session
-        OneSignal_handleNotificationOpen(blankActivity, new JSONArray("[{ \"alert\": \"Test Msg\", \"custom\": { \"i\": \"" + notificationID + "\" } }]"), false, notificationID);
+        OneSignal_handleNotificationOpen(blankActivity, new JSONArray("[{ \"alert\": \"Test Msg\", \"custom\": { \"i\": \"" + notificationID + "\" } }]"), notificationID);
         threadAndTaskWait();
 
         assertNotNull(notificationOpenedResult);
@@ -834,7 +833,7 @@ public class OutcomeEventIntegrationTests {
         pauseActivity(blankActivityController);
 
         // Click notification before new session
-        OneSignal_handleNotificationOpen(blankActivity, new JSONArray("[{ \"alert\": \"Test Msg\", \"custom\": { \"i\": \"UUID\" } }]"), false, ONESIGNAL_NOTIFICATION_ID + "2");
+        OneSignal_handleNotificationOpen(blankActivity, new JSONArray("[{ \"alert\": \"Test Msg\", \"custom\": { \"i\": \"UUID\" } }]"), ONESIGNAL_NOTIFICATION_ID + "2");
         threadAndTaskWait();
 
         // Foreground app
@@ -862,7 +861,7 @@ public class OutcomeEventIntegrationTests {
         pauseActivity(blankActivityController);
 
         // Click notification before new session
-        OneSignal_handleNotificationOpen(blankActivity, new JSONArray("[{ \"alert\": \"Test Msg\", \"custom\": { \"i\": \"UUID\" } }]"), false, ONESIGNAL_NOTIFICATION_ID + "2");
+        OneSignal_handleNotificationOpen(blankActivity, new JSONArray("[{ \"alert\": \"Test Msg\", \"custom\": { \"i\": \"UUID\" } }]"), ONESIGNAL_NOTIFICATION_ID + "2");
         threadAndTaskWait();
 
         // Check directNotificationId is set to clicked notification
@@ -1212,7 +1211,7 @@ public class OutcomeEventIntegrationTests {
         String notificationID = ONESIGNAL_NOTIFICATION_ID + "1";
         sessionManager.onNotificationReceived(notificationID);
         // Click notification before new session
-        OneSignal_handleNotificationOpen(blankActivity, new JSONArray("[{ \"alert\": \"Test Msg\", \"custom\": { \"i\": \"" + notificationID + "\" } }]"), false, notificationID);
+        OneSignal_handleNotificationOpen(blankActivity, new JSONArray("[{ \"alert\": \"Test Msg\", \"custom\": { \"i\": \"" + notificationID + "\" } }]"), notificationID);
         threadAndTaskWait();
 
         // App opened after clicking notification, but Robolectric needs this to simulate onAppFocus() code after a click


### PR DESCRIPTION
# Description
## One Line Summary
Reverts [Reverse Activity Trampoline](https://github.com/OneSignal/OneSignal-Android-SDK/pull/1377) back to standard Activity Trampoline, which executes on notification open.

## Details

### Motivation
It was discovered after Reverse Activity Trampoline was released in [version 4.5.0](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/4.5.0) that it was not compatible with Xiaomi devices and with HMS message type notifications.

For HMS we already went back to using an Activity Trampoline in PR #1533, this was required since the notification is generated by HMS core we don't have the level of control needed for it.
For Xiaomi devices [Reverse Activity Trampoline does not work](https://github.com/OneSignal/OneSignal-Android-SDK/issues/1494) due to [a bug](https://github.com/OneSignal/NotificationActivityBackstackExample) where the back stack is not persevered on notification open.

Reverse Activity Trampoline has limitations on where it can be used. Activity Trampoline is the only option which allows us to have the same implementation for all our features and platforms we support. All the other alternative options (listed below) need to use Activity Trampolining somewhere anyway to fill in gaps to track clicks for all types of notifications, devices, and push vendors.

### Scope
Reverting PR #1377 (Reverse Activity Trampoline) behavior while keeping any intended fixes and refactoring from it.

### Alternatives considered
#### Option 1 - Detect by MIUI version, do Normal Activity Trampling
This might not be possible, even if it is it through this would fragile and extra part to maintain a list of MIUI versions and possibly other manufactures.

#### Option 2 - Detect missing back stack entry on open
Detect if there is a back stack entry when the notification is opened with ActivityManager.getAppTasks(). If there isn't an entry we will need to check something Intent to know if that was really what was intended. If not we need re-parse some of the payload and open the desired Activity like we do for Huawei message notification types.

#### Option 3 - Direct Activity, use ActivityLifecycleCallbacks to get meta data
Opening the Activity directly and the SDK still being able to get the data is possible if we setup the `ActivityLifecycleCallbacks` on or before `Application.onCreate` so we don't mis any events.
The problem with this is if the target was another app (such as opening a URL in Chrome) this approach would not be able to capture the click.
   * For this specific case we could still use Activity Trampling, however this would be a different implementation so don't think it is worth it.
It is interesting to note that FCM Messaging does use [this approach](https://github.com/firebase/firebase-android-sdk/blob/672c6dcf0625c4e1585257ffc38ed2040bfa29b8/firebase-messaging/src/main/java/com/google/firebase/messaging/FcmLifecycleCallbacks.java) for their SDK. However it looks like they would have the same issue of not being able to track clicks for URLs that opens the browser / another app.

## Related
### Fixes Issues
* Fixes #1494
* Fixes #1576
### Previous PRs
* https://github.com/OneSignal/OneSignal-Android-SDK/pull/1377
   - Was released in version 4.5.0
* https://github.com/OneSignal/OneSignal-Android-SDK/pull/1469
  - Fixed Launch URL bug introduced in the PR above
* https://github.com/OneSignal/OneSignal-Android-SDK/pull/1533
  - Fixed opening HMS message notification types, also a bug introduced in PR 1377 above

# Background
## Xiaomi - Background Restrictions
The following was observed through testing on a Xiaomi Redmi 6A running Android 9 on MIUI Global 11.0.8 | Stable 11.0.8.0 (PCBMIXM):
* Reverse Activity Trampoline - Does not work due to MIUI Bug
   - `PendingIntent`s on a notification that include an `Activity` back stack gets lost, only keeps the top most `Activity` when it is rehydrated.
      - This is [a bug](https://github.com/OneSignal/NotificationActivityBackstackExample) but Xiaomi has not addressed it so therefore it is still a Restriction
* Activity Trampling - Must keep an Activity alive while trampolining
   -  If the app was swiped away AND the app process is not currently running, then a notification is tapped on that has a `PendingIntent` to start an `Activity` and then you trampoline to another `Activity` you MUST call `startActivity` BEFORE finishing the first `Activity`. Otherwise the `startActivity` is ignored.

# Testing
## Unit testing
Most of the unit test changes in this PR are not new, but rather a revert of the ones added and removed in PR #1377.

## Manual testing
* ✅ Android 5.0  Emulator
* ✅Android 6.0  Emulator
* ✅ Android 7.0  Emulator
* ⚠️ Android 9.0 - Xiaomi Redmi 6A - MIUI 11
   - Passes every scenario expect opening a notification after the app was been swiped away AND the process is not currently running.
       - Issue also existed in OneSignal 4.4.x (before Reverse Activity Trampoline).
       - Addressing in PR #1583
* ✅ Android 12.0 Samsung S21

### Default notification
* [X] App Foreground
* [X] App Background - by pressing back button
* [X] App Background - by pressing home button
* [X] App not running - Task still in recent list, resumes app's task correctly
* [X] App not running - Recent list cleared, app cold starts new task
* [ ] ⚠️ App not running - AND device offline
   - Does NOT focus the app due to bug introduced in 4.0.0 in PR #1076, [due to a check to ensure remote params have been checked.](https://github.com/OneSignal/OneSignal-Android-SDK/pull/1076/files#diff-2708f86f77e539cab647ecede9d5fcbead3bf0f954d7f9e536eafbc78ba760d6R559)
   - This bug persisted until PR #1377 (Reverse Activity Trampoline) version 4.5.0, but that PR wasn't try to fix this.
   - Addressing in PR #1583

### HTTPS URL notification
* [X] App Foreground
* [X] App Background - by pressing home button
* [X] App not running - Recent list cleared, app cold starts new task

### IAM Preview
* [X] App Foreground
* [X] App Background - by pressing home button

# Affected code checklist
   - [X] Notifications
      - [ ] Display
      - [X] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1581)
<!-- Reviewable:end -->
