### PR TITLE
[Fix] Network Delayed Activity Trampoline

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -2395,22 +2395,6 @@ public class OneSignal {
     * Method called when opening a notification
     */
    static void handleNotificationOpen(final Activity context, final JSONArray data, @Nullable final String notificationId) {
-      // Delay call until remote params are set
-      if (taskRemoteController.shouldQueueTaskForInit(OSTaskRemoteController.HANDLE_NOTIFICATION_OPEN)) {
-         logger.error("Waiting for remote params. " +
-                 "Moving " + OSTaskRemoteController.HANDLE_NOTIFICATION_OPEN + " operation to a pending queue.");
-         taskRemoteController.addTaskToQueue(new Runnable() {
-            @Override
-            public void run() {
-               if (appContext != null) {
-                  logger.debug("Running " + OSTaskRemoteController.HANDLE_NOTIFICATION_OPEN + " operation from pending queue.");
-                  handleNotificationOpen(context, data, notificationId);
-               }
-            }
-         });
-         return;
-      }
-
       // If applicable, check if the user provided privacy consent
       if (shouldLogUserPrivacyConsentErrorMessageForMethodName(null))
          return;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalRemoteParams.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalRemoteParams.java
@@ -139,9 +139,14 @@ public class OneSignalRemoteParams {
                      sleepTime = MAX_WAIT_BETWEEN_RETRIES;
 
                   OneSignal.Log(OneSignal.LOG_LEVEL.INFO, "Failed to get Android parameters, trying again in " + (sleepTime / 1_000) +  " seconds.");
-                  OSUtils.sleep(sleepTime);
-                  androidParamsRetries++;
-                  makeAndroidParamsRequest(appId, userId, callback);
+                  try {
+                     Thread.sleep(sleepTime);
+                     androidParamsRetries++;
+                     makeAndroidParamsRequest(appId, userId, callback);
+                  } catch (InterruptedException e) {
+                     // Don't retry if something intentionally wants to stop this action
+                     e.printStackTrace();
+                  }
                }
             }, "OS_PARAMS_REQUEST").start();
          }

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
@@ -1078,6 +1078,25 @@ public class MainOneSignalClassRunner {
    }
 
    @Test
+   public void testOpeningLauncherActivityWhenOffline() throws Exception {
+      ShadowOneSignalRestClient.failGetParams = true;
+      AddLauncherIntentFilter();
+
+      OneSignalInit();
+      // This removes Activity from the unit test's state
+      assertNotNull(shadowOf(blankActivity).getNextStartedActivity());
+
+      // Background the app
+      blankActivityController.pause();
+
+      // Open a notification
+      OneSignal_handleNotificationOpen(blankActivity, new JSONArray("[{ \"alert\": \"Test Msg\", \"custom\": { \"i\": \"UUID\" } }]"), ONESIGNAL_NOTIFICATION_ID);
+
+      // Ensure the app is foregrounded
+      assertNotNull(shadowOf(blankActivity).getNextStartedActivity());
+   }
+
+   @Test
    public void testOpeningLaunchUrl() throws Exception {
       // First init run for appId to be saved
       // At least OneSignal was init once for user to be subscribed


### PR DESCRIPTION
# Description
## One Line Summary
Removes a network call dependency on notification open logic which effects foregrounding the app.

## Details
### Motivation
* After the changes in PR #1581 this becomes critical this is resolved so the app still foregrounds when tapping on a notification while offline.
* This also resolves a Xiaomi compatibility issue where if the app is swiped away then a notification is opened it won't foreground either. _unless something starts the app process in the background later and is still running when you open the notification oddly enough_

### Scope
Target scope is the fix the bug noted above.
A secondary fix was made to improve the app shutdown process to stop retrying to get remote params when its thread is interrupted. _This fix was only required in this PR to resolve a test carry over issue with the test added in this PR._

### Background
The fixes in this PR fixes a discovered issue in 4.0.0 to 4.4.x, but is not an issue in 4.5.0 to 4.7.2. However this fix needs to be shipped with #1581 as it reverts most of the changes in #1377 that was shipped in 4.5.0.

## Xiaomi - Background Restrictions
The following was observed through testing on a Xiaomi Redmi 6A running Android 9 on MIUI Global 11.0.8 | Stable 11.0.8.0 (PCBMIXM):
* Activity Trampling - Must keep an Activity alive while trampolining
   -  If the app was swiped away AND the app process is not currently running, then a notification is tapped on that has a `PendingIntent` to start an `Activity` and then you trampoline to another `Activity` you MUST call `startActivity` BEFORE finishing the first `Activity`. Otherwise the `startActivity` is ignored.

# Testing
## Unit testing
* A new test was added.
## Manual testing
Tested on:
* Android 12 - Samsung S21 - OneUI 4.1
* Android 9 - Xiaomi Redmi 6A - MIUI 11

Test both offline and online.

# Affected code checklist
   - [X] Notifications
      - [ ] Display
      - [X] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [X] REST API requests
      - [X] Remote Parameters
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1583)
<!-- Reviewable:end -->
