### PR TITLE
[Fix Tests] Top Flaky tests; shouldSetExpireTimeCorrectlyWhenMissingFromPayload and HMS osIAMPreview_showsPreview

### DIFF
--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/MockOSTimeImpl.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/MockOSTimeImpl.java
@@ -20,6 +20,11 @@ public class MockOSTimeImpl extends OSTimeImpl {
         return mockedElapsedTime != null ? mockedElapsedTime : super.getElapsedRealtime();
     }
 
+    public void freezeTime() {
+        mockedTime = getCurrentTimeMillis();
+        mockedElapsedTime = getElapsedRealtime();
+    }
+
     public void setMockedTime(Long mockedTime) {
         this.mockedTime = mockedTime;
     }

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
@@ -1271,11 +1271,14 @@ public class GenerateNotificationRunner {
    @Test
    @Config(shadows = { ShadowGenerateNotification.class })
    public void shouldSetExpireTimeCorrectlyWhenMissingFromPayload() throws Exception {
+      time.freezeTime();
       NotificationBundleProcessor_ProcessFromFCMIntentService(blankActivity, getBaseNotifBundle());
       threadAndTaskWait();
 
+      long currentTime = time.getCurrentTimeMillis() / 1_000L;
       long expireTime = (Long)TestHelpers.getAllNotificationRecords(dbHelper).get(0).get(NotificationTable.COLUMN_NAME_EXPIRE_TIME);
-      assertEquals((System.currentTimeMillis() / 1_000L) + 259_200, expireTime);
+      long expectedExpireTime = currentTime + 259_200;
+      assertEquals(expectedExpireTime, expireTime);
    }
 
    // TODO: Once we figure out the correct way to process notifications with high priority using the WorkManager

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/NotificationOpenedActivityHMSIntegrationTestsRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/NotificationOpenedActivityHMSIntegrationTestsRunner.java
@@ -200,6 +200,8 @@ public class NotificationOpenedActivityHMSIntegrationTestsRunner {
                 );
 
         helper_startHMSOpenActivity(intent);
+        threadAndTaskWait();
+        threadAndTaskWait();
         assertEquals("PGh0bWw+PC9odG1sPgoKPHNjcmlwdD4KICAgIHNldFBsYXllclRhZ3MobnVsbCk7Cjwvc2NyaXB0Pg==", ShadowOSWebView.lastData);
     }
 }


### PR DESCRIPTION
# Description
## One Line Summary
Fix top flaky tests; `shouldSetExpireTimeCorrectlyWhenMissingFromPayload` due to not using mock time; And HMS `osIAMPreview_showsPreview` due missing thread wait.

## Details

### Motivation
Seems fail our travis CI tests 1 out 4 times.

### Scope
Only fixing `shouldSetExpireTimeCorrectlyWhenMissingFromPayload` and `osIAMPreview_showsPreview` tests.

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1584)
<!-- Reviewable:end -->
