### PR TITLE
Fix crash when `$` sign is in external user ID

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/JSONUtils.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/JSONUtils.java
@@ -13,6 +13,10 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static com.onesignal.UserStateSynchronizer.EXTERNAL_USER_ID;
 
 
 class JSONUtils {
@@ -128,6 +132,32 @@ class JSONUtils {
         } catch (JSONException ignored) {}
 
         return strArray + "]";
+    }
+
+    /**
+     * Returns the JSONObject as a String with the external user ID unescaped.
+     * Needed b/c the default JSONObject.toString() escapes (/) with (\/), which customers may not want.
+     */
+    static String toUnescapedEUIDString(JSONObject json) {
+        String strJsonBody = json.toString();
+
+        if (json.has(EXTERNAL_USER_ID)) {
+            // find the value of the external user ID
+            Pattern eidPattern = Pattern.compile("(?<=\"external_user_id\":\").*?(?=\")");
+            Matcher eidMatcher = eidPattern.matcher(strJsonBody);
+
+            if (eidMatcher.find()) {
+                String matched = eidMatcher.group(0);
+                if (matched != null) {
+                    String unescapedEID = matched.replace("\\/", "/");
+                    // backslashes (\) and dollar signs ($) in the replacement string will be treated literally
+                    unescapedEID = eidMatcher.quoteReplacement(unescapedEID);
+                    strJsonBody = eidMatcher.replaceAll(unescapedEID);
+                }
+            }
+        }
+
+        return strJsonBody;
     }
 
     static JSONObject getJSONObjectWithoutBlankValues(ImmutableJSONObject jsonObject, String getKey) {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalRestClient.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalRestClient.java
@@ -40,8 +40,6 @@ import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.Scanner;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import javax.net.ssl.HttpsURLConnection;
 
@@ -168,18 +166,7 @@ class OneSignalRestClient {
          }
 
          if (jsonBody != null) {
-            String strJsonBody = jsonBody.toString();
-
-            Pattern eidPattern = Pattern.compile("(?<=\"external_user_id\":\").*\\\\/.*?(?=\",|\"\\})");
-            Matcher eidMatcher = eidPattern.matcher(strJsonBody);
-
-            if (eidMatcher.find()) {
-               String matched = eidMatcher.group(0);
-               if (matched != null) {
-                  String unescapedEID = matched.replace("\\/", "/");
-                  strJsonBody = eidMatcher.replaceAll(unescapedEID);
-               }
-            }
+            String strJsonBody = JSONUtils.toUnescapedEUIDString(jsonBody);
 
             OneSignal.Log(OneSignal.LOG_LEVEL.DEBUG, "OneSignalRestClient: " + method + " SEND JSON: " + strJsonBody);
 

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
@@ -129,6 +129,10 @@ public class OneSignalPackagePrivateHelper {
       return NotificationBundleProcessor.bundleAsJSONObject(bundle);
    }
 
+   public static String toUnescapedEUIDString(JSONObject json) {
+      return JSONUtils.toUnescapedEUIDString(json);
+   }
+
    public static void OneSignal_handleNotificationOpen(Activity context, final JSONArray data, final String notificationId) {
       OneSignal.handleNotificationOpen(context, data, notificationId);
    }


### PR DESCRIPTION
# Description
## One Line Summary
Fix (1) a crash when a user has a dollar sign ($) in the external_user_id, and (2) only un-escape forward slashes in the `external_user_id` and not from others values such as `timezone` which can have a value with a slash like `England/London`.

## Question for Reviewers on Better Regex
I couldn't find the right regex that would match only **`$1$\/abc\/de$f\/`** from a string like the following. The previous regex of `(?<=\"external_user_id\":\").*\\\\/.*?(?=\",|\"\\})` would result in **`$1$\/abc\/de$f\/","app_id":"b4f7","timezone":"$Europe\/London`**
```json
{"external_user_id":"$1$\/abc\/de$f\/","app_id":"b4f7","timezone":"$Europe\/London"}
```
So I just matched the value of the external user ID, regardless of having any slashes in the value, and went from there.

## Details

### Motivation
A customer reported crashes when using a dollar sign ($) in an external user ID. Examples of the exception raised are:
```java
Illegal group reference
java.lang.IllegalArgumentException: Illegal group reference
	at java.base/java.util.regex.Matcher.appendExpandedReplacement(Matcher.java:1068)
	at java.base/java.util.regex.Matcher.appendReplacement(Matcher.java:998)
	at java.base/java.util.regex.Matcher.replaceAll(Matcher.java:1182)
```
```java
No group 1
java.lang.IndexOutOfBoundsException: No group 1
	at java.base/java.util.regex.Matcher.start(Matcher.java:483)
	at java.base/java.util.regex.Matcher.appendExpandedReplacement(Matcher.java:1091)
	at java.base/java.util.regex.Matcher.appendReplacement(Matcher.java:998)
	at java.base/java.util.regex.Matcher.replaceAll(Matcher.java:1182)
```

### Related PRs
`JSONObject.toString()` will escape any forward slashes `/` with `\/`, and this will be sent in a request, and show up in the dashboard as `\/`.  A previous related PR was made to to "unescape" this for a customer request where it is used in external user ID: https://github.com/OneSignal/OneSignal-Android-SDK/pull/1478.

### Scope and Background
Affects JSON serialization when sending the json string in a request, and in cases where there are forward slashes in an external user ID, those slashes are not escaped. After the changes in the previous PR mentioned above, we may have inadvertently been escaping `timezone` for many requests, but it doesn't seem to have been any ill effects. 

* Extracted the logic from the rest client to a helper method called `toUnescapedEUIDString()`.

* If a user has a dollar sign ($) in the external user ID, and our code is trying to escape the forward slashes via a string replacement, this will cause a crash as `$` has a non-literal meaning when used in the replacement string. The solution is to call `quoteReplacement` to escape any $ or \ signs. See https://docs.oracle.com/javase/8/docs/api/java/lang/String.html#replaceAll-java.lang.String-java.lang.String-

* Also fix the pattern matching for external user ID. Previously in a JSONObject like `{"app_id": "abc", "external_user_id": "user1", "timezone": "Europe/London"}`, the regex would match `user1", "timezone": "Europe/London`, grabbing the forward slash in ANY values that come after the external_user_id. This can lead to the above crash even if the user does not have any forward slashes themselves (because it can come from timezone). See https://regexr.com/6lmm0. This is fixed to match the external user ID value only.

* There may now be more calls to String methods than necessary as the method now finds the value for external_user_id in the JSON string first, and regardless of whether it has forward slashes or not, we replace all instances of `\/` with `/` (just no changes happen if it doesn't exist in the string). There is probably a better regex to use, but after trying for a while, I couldn't come up with it.

# Testing
## Unit testing
Added unit tests for the method `toUnescapedEUIDString()`, with different JSON values. The testing was primarily done via unit testing and examining the values throughout the life of the method call.

## Manual testing
No pertinent manual testing.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes
   - [x] Requests

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1589)
<!-- Reviewable:end -->
