### PR TITLE
Fix NPE: use a getter for the current UserState

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStateSynchronizer.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStateSynchronizer.java
@@ -266,7 +266,7 @@ abstract class UserStateSynchronizer {
         final boolean isSessionCall = !fromSyncService && isSessionCall();
         JSONObject jsonBody, dependDiff;
         synchronized (LOCK) {
-            jsonBody = currentUserState.generateJsonDiff(getToSyncUserState(), isSessionCall);
+            jsonBody = getCurrentUserState().generateJsonDiff(getToSyncUserState(), isSessionCall);
             UserState toSyncState = getToSyncUserState();
             dependDiff = currentUserState.generateJsonDiffFromDependValues(toSyncState, null);;
             OneSignal.onesignalLog(OneSignal.LOG_LEVEL.DEBUG, "UserStateSynchronizer internalSyncUserState from session call: "+ isSessionCall + " jsonBody: " + jsonBody);
@@ -290,7 +290,7 @@ abstract class UserStateSynchronizer {
         String urlStr = "players/" + userId + "/email_logout";
         JSONObject jsonBody = new JSONObject();
         try {
-            ImmutableJSONObject dependValues = currentUserState.getDependValues();
+            ImmutableJSONObject dependValues = getCurrentUserState().getDependValues();
             if (dependValues.has(EMAIL_AUTH_HASH_KEY))
                 jsonBody.put(EMAIL_AUTH_HASH_KEY, dependValues.optString(EMAIL_AUTH_HASH_KEY));
 
@@ -333,7 +333,7 @@ abstract class UserStateSynchronizer {
         toSyncUserState.removeFromSyncValues(EMAIL_KEY);
         toSyncUserState.persistState();
 
-        currentUserState.removeFromDependValues(EMAIL_AUTH_HASH_KEY);
+        getCurrentUserState().removeFromDependValues(EMAIL_AUTH_HASH_KEY);
         currentUserState.removeFromSyncValues(PARENT_PLAYER_ID);
         String emailLoggedOut = currentUserState.getSyncValues().optString(EMAIL_KEY);
         currentUserState.removeFromSyncValues(EMAIL_KEY);
@@ -379,7 +379,7 @@ abstract class UserStateSynchronizer {
             @Override
             void onSuccess(String response) {
                 synchronized (LOCK) {
-                    currentUserState.persistStateAfterSync(dependDiff, jsonBody);
+                    getCurrentUserState().persistStateAfterSync(dependDiff, jsonBody);
                     onSuccessfulSync(jsonBody);
                 }
 
@@ -422,7 +422,7 @@ abstract class UserStateSynchronizer {
             void onSuccess(String response) {
                 synchronized (LOCK) {
                     waitingForSessionResponse = false;
-                    currentUserState.persistStateAfterSync(dependDiff, jsonBody);
+                    getCurrentUserState().persistStateAfterSync(dependDiff, jsonBody);
 
                     try {
                         OneSignal.onesignalLog(OneSignal.LOG_LEVEL.DEBUG, "doCreateOrNewSession:response: " + response);
@@ -468,7 +468,7 @@ abstract class UserStateSynchronizer {
     }
 
     private void fireNetworkFailureEvents() {
-        final JSONObject jsonBody = currentUserState.generateJsonDiff(toSyncUserState, false);
+        final JSONObject jsonBody = getCurrentUserState().generateJsonDiff(toSyncUserState, false);
         if (jsonBody != null)
             fireEventsForUpdateFailure(jsonBody);
 
@@ -570,7 +570,7 @@ abstract class UserStateSynchronizer {
     }
 
     void resetCurrentState() {
-        currentUserState.setSyncValues(new JSONObject());
+        getCurrentUserState().setSyncValues(new JSONObject());
         currentUserState.persistState();
     }
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStateSynchronizer.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStateSynchronizer.java
@@ -268,11 +268,11 @@ abstract class UserStateSynchronizer {
         synchronized (LOCK) {
             jsonBody = getCurrentUserState().generateJsonDiff(getToSyncUserState(), isSessionCall);
             UserState toSyncState = getToSyncUserState();
-            dependDiff = currentUserState.generateJsonDiffFromDependValues(toSyncState, null);;
+            dependDiff = getCurrentUserState().generateJsonDiffFromDependValues(toSyncState, null);;
             OneSignal.onesignalLog(OneSignal.LOG_LEVEL.DEBUG, "UserStateSynchronizer internalSyncUserState from session call: "+ isSessionCall + " jsonBody: " + jsonBody);
             // Updates did not result in a server side change, skipping network call
             if (jsonBody == null) {
-                currentUserState.persistStateAfterSync(dependDiff, null);
+                getCurrentUserState().persistStateAfterSync(dependDiff, null);
                 sendTagsHandlersPerformOnSuccess();
                 externalUserIdUpdateHandlersPerformOnSuccess();
                 return;
@@ -294,7 +294,7 @@ abstract class UserStateSynchronizer {
             if (dependValues.has(EMAIL_AUTH_HASH_KEY))
                 jsonBody.put(EMAIL_AUTH_HASH_KEY, dependValues.optString(EMAIL_AUTH_HASH_KEY));
 
-            ImmutableJSONObject syncValues = currentUserState.getSyncValues();
+            ImmutableJSONObject syncValues = getCurrentUserState().getSyncValues();
             if (syncValues.has(PARENT_PLAYER_ID))
                 jsonBody.put(PARENT_PLAYER_ID, syncValues.optString(PARENT_PLAYER_ID));
 
@@ -334,9 +334,9 @@ abstract class UserStateSynchronizer {
         toSyncUserState.persistState();
 
         getCurrentUserState().removeFromDependValues(EMAIL_AUTH_HASH_KEY);
-        currentUserState.removeFromSyncValues(PARENT_PLAYER_ID);
-        String emailLoggedOut = currentUserState.getSyncValues().optString(EMAIL_KEY);
-        currentUserState.removeFromSyncValues(EMAIL_KEY);
+        getCurrentUserState().removeFromSyncValues(PARENT_PLAYER_ID);
+        String emailLoggedOut = getCurrentUserState().getSyncValues().optString(EMAIL_KEY);
+        getCurrentUserState().removeFromSyncValues(EMAIL_KEY);
 
         OneSignalStateSynchronizer.setNewSessionForEmail();
 
@@ -571,7 +571,7 @@ abstract class UserStateSynchronizer {
 
     void resetCurrentState() {
         getCurrentUserState().setSyncValues(new JSONObject());
-        currentUserState.persistState();
+        getCurrentUserState().persistState();
     }
 
     public abstract boolean getUserSubscribePreference();


### PR DESCRIPTION
# Description
## One Line Summary
Use a getter for the `currentUserState` to avoid a null pointer exception.

## Details

### Motivation
A customer reported 3 separate crashes for the app's users when (1) a device is logging out of email, or, (2) has logged out of email and is logging into a different email. The `currentUserState` is apparently `null`. To address these crash reports, replace currentUserState with `getCurrentUserState()` to avoid these NPE's.

I also replaced more instances of `currentUserState` with `getCurrentUserState()` than the 3 cases below reported by the user. These are other places in UserStateSynchronizer that access currentUserState and it could possibly be null.

#### Crash 1: Not reproducible

The obfuscated method seems to be [this line](https://github.com/OneSignal/OneSignal-Android-SDK/blob/d3acf89bc0ac7b56991675e47e93dc5a5c7df8f9/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStateSynchronizer.java#L293).
```java
Fatal Exception: java.lang.NullPointerException: 
Attempt to invoke virtual method 'i.g.u i.g.k4.e()' on a null object reference // probably currentUserState.getDependValues();
      at com.onesignal.UserStateSynchronizer.doEmailLogout(UserStateSynchronizer.java:261)
      at com.onesignal.UserStateSynchronizer.internalSyncUserState(UserStateSynchronizer.java:227)
      at com.onesignal.UserStateSynchronizer.syncUserState(UserStateSynchronizer.java:219)
      at com.onesignal.UserStateSynchronizer$NetworkHandlerThread$1.run(UserStateSynchronizer.java:110)
      at android.os.Handler.handleCallback(Handler.java:938)
      at android.os.Handler.dispatchMessage(Handler.java:99)
      at android.os.Looper.loopOnce(Looper.java:226)
      at android.os.Looper.loop(Looper.java:313)
      at android.os.HandlerThread.run(HandlerThread.java:67)
```

#### Crash 2: Not reproducible
```java
Attempt to invoke virtual method 'org.json.JSONObject com.onesignal.UserState.generateJsonDiff(com.onesignal.UserState, boolean)' on a null object reference
```

#### Crash 3: Reproducible by the reporter, not reproducible on my end
```java
java.lang.NullPointerException: Attempt to invoke virtual method
'void com.onesignal.UserState.setSyncValues(org.json.JSONObject)' on a null object reference
        at com.onesignal.UserStateSynchronizer.resetCurrentState(UserStateSynchronizer.java:573)
        at com.onesignal.UserStateSecondaryChannelSynchronizer.setChannelId(UserStateSecondaryChannelSynchronizer.java:156)
        at com.onesignal.OneSignalStateSynchronizer.setEmail(OneSignalStateSynchronizer.java:195)
        at com.onesignal.OneSignal.setEmail(OneSignal.java:1699)
        at com.onesignal.OneSignal.setEmail(OneSignal.java:1640)
```

### Scope
In the places we were accessing `currentUserState`, it should not be null anyway. Using a getter just ensures this, and creates it if it is `null`.

# Testing
## Unit testing
No new unit testing done.

## Manual testing
Because I couldn't reproduce any of these exceptions, it was not testable. 

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes
   - [x] Device State

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1590)
<!-- Reviewable:end -->
