### PR TITLE
Release 4.7.3

### DIFF
--- a/OneSignalSDK/onesignal/maven-push.gradle
+++ b/OneSignalSDK/onesignal/maven-push.gradle
@@ -32,7 +32,7 @@ class Global {
     static def POM_NAME = 'OneSignal'
     static def POM_ARTIFACT_ID = 'OneSignal'
     static def POM_PACKAGING = 'aar'
-    static def VERSION_NAME = '4.7.2'
+    static def VERSION_NAME = '4.7.3'
 
     static def GROUP_ID = 'com.onesignal'
     static def POM_DESCRIPTION = 'OneSignal Android SDK'

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -424,7 +424,7 @@ public class OneSignal {
    private static TrackAmazonPurchase trackAmazonPurchase;
    private static TrackFirebaseAnalytics trackFirebaseAnalytics;
 
-   private static final String VERSION = "040702";
+   private static final String VERSION = "040703";
    public static String getSdkVersionRaw() {
       return VERSION;
    }


### PR DESCRIPTION
* [Fix] Heads-Up Displaying Previous Notification When Grouped on some devices by @jkasten2 in https://github.com/OneSignal/OneSignal-Android-SDK/pull/1578
* [Change] Notification Activity Trampoline forward instead of reverse by @jkasten2 in https://github.com/OneSignal/OneSignal-Android-SDK/pull/1581
   - Fixes https://github.com/OneSignal/OneSignal-Android-SDK/issues/1494
* [Fix] Network Delayed Activity Trampoline by @jkasten2 in https://github.com/OneSignal/OneSignal-Android-SDK/pull/1583
* [Fix] crash when `$` sign is in external user ID by @nan-li in https://github.com/OneSignal/OneSignal-Android-SDK/pull/1589
* [Fix] NPE: use a getter for the current UserState by @nan-li in https://github.com/OneSignal/OneSignal-Android-SDK/pull/1590

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1591)
<!-- Reviewable:end -->
