### PR TITLE
[Fix] set language callback

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStateSynchronizer.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserStateSynchronizer.java
@@ -275,6 +275,7 @@ abstract class UserStateSynchronizer {
                 currentUserState.persistStateAfterSync(dependDiff, null);
                 sendTagsHandlersPerformOnSuccess();
                 externalUserIdUpdateHandlersPerformOnSuccess();
+                deviceInfoHandlersPerformOnSuccess();
                 return;
             }
             getToSyncUserState().persistState();
@@ -349,6 +350,7 @@ abstract class UserStateSynchronizer {
             OneSignal.onesignalLog(getLogLevel(), "Error updating the user record because of the null user id");
             sendTagsHandlersPerformOnFailure(new SendTagsError(-1, "Unable to update tags: the current user is not registered with OneSignal"));
             externalUserIdUpdateHandlersPerformOnFailure();
+            deviceInfoHandlersPerformOnFailure(new OSDeviceInfoError(-1, "Unable to set Language: the current user is not registered with OneSignal"));
             return;
         }
 


### PR DESCRIPTION
# Description
## One Line Summary
Add device info handler success and failure callbacks to `internalSync`.

## Details

### Motivation
Adds device info handler success callback used as the `setLanguage` callback in the `internalSync` method and a device info handler failure callback in `doPutSync` method of `UserStateSynchronizer`

### Scope
* Add `deviceInfoHandlersPerformOnSuccess` in `internalSync` method of `UserStateSynchronizer`
* Add `deviceInfoHandlersPerformOnFailure` in `doPutSync` method of `UserStateSynchronizer`
* Use runnable to implement `OneSignalStateSynchronizer.updateDeviceInfo` in the `setLanguage` implementation of OneSignal Android

# Testing
## Unit testing
* Unit test for callbacks running successfully

## Manual testing
* Tested on Android device to successfully execute all intended callback

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [ ] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1593)
<!-- Reviewable:end -->
