### PR TITLE
[Fix] FCM register retrying and correct types of errors handling

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSUtils.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSUtils.java
@@ -654,4 +654,17 @@ class OSUtils {
    static int getRandomDelay(int minDelay, int maxDelay) {
       return new Random().nextInt(maxDelay + 1 - minDelay) + minDelay;
    }
+
+   @NonNull
+   static Throwable getRootCauseThrowable(@NonNull Throwable subjectThrowable) {
+      Throwable throwable = subjectThrowable;
+      while (throwable.getCause() != null && throwable.getCause() != throwable) {
+         throwable = throwable.getCause();
+      }
+      return throwable;
+   }
+
+   static String getRootCauseMessage(@NonNull Throwable throwable) {
+      return getRootCauseThrowable(throwable).getMessage();
+   }
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/PushRegistratorFCM.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/PushRegistratorFCM.java
@@ -103,7 +103,7 @@ class PushRegistratorFCM extends PushRegistratorAbstractGoogle {
 
    @WorkerThread
    @Override
-   String getToken(String senderId) throws ExecutionException, InterruptedException, IOException {
+   String getToken(String senderId) throws Exception {
       initFirebaseApp(senderId);
 
       try {
@@ -151,14 +151,18 @@ class PushRegistratorFCM extends PushRegistratorAbstractGoogle {
    }
 
    @WorkerThread
-   private String getTokenWithClassFirebaseMessaging() throws ExecutionException, InterruptedException {
+   private String getTokenWithClassFirebaseMessaging() throws Exception {
       // We use firebaseApp.get(FirebaseMessaging.class) instead of FirebaseMessaging.getInstance()
       //   as the latter uses the default Firebase app. We need to use a custom Firebase app as
       //   the senderId is provided at runtime.
       FirebaseMessaging fcmInstance = firebaseApp.get(FirebaseMessaging.class);
       // FirebaseMessaging.getToken API was introduced in firebase-messaging:21.0.0
       Task<String> tokenTask = fcmInstance.getToken();
-      return Tasks.await(tokenTask);
+      try {
+         return Tasks.await(tokenTask);
+      } catch (ExecutionException e) {
+         throw tokenTask.getException();
+      }
    }
 
    private void initFirebaseApp(String senderId) {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserState.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/UserState.java
@@ -40,9 +40,9 @@ abstract class UserState {
     static final int PUSH_STATUS_INVALID_FCM_SENDER_ID = -6;
     static final int PUSH_STATUS_OUTDATED_GOOGLE_PLAY_SERVICES_APP = -7;
     static final int PUSH_STATUS_FIREBASE_FCM_INIT_ERROR = -8;
-    static final int PUSH_STATUS_FIREBASE_FCM_ERROR_SERVICE_NOT_AVAILABLE = -9;
+    static final int PUSH_STATUS_FIREBASE_FCM_ERROR_IOEXCEPTION_SERVICE_NOT_AVAILABLE = -9;
     // -10 is a server side detection only from FCM that the app is no longer installed
-    static final int PUSH_STATUS_FIREBASE_FCM_ERROR_IOEXCEPTION = -11;
+    static final int PUSH_STATUS_FIREBASE_FCM_ERROR_IOEXCEPTION_OTHER = -11;
     static final int PUSH_STATUS_FIREBASE_FCM_ERROR_MISC_EXCEPTION = -12;
     // -13 to -24 reserved for other platforms
     public static final int PUSH_STATUS_HMS_TOKEN_TIMEOUT = -25;
@@ -51,6 +51,7 @@ abstract class UserState {
     public static final int PUSH_STATUS_HMS_ARGUMENTS_INVALID = -26;
     public static final int PUSH_STATUS_HMS_API_EXCEPTION_OTHER = -27;
     public static final int PUSH_STATUS_MISSING_HMS_PUSHKIT_LIBRARY = -28;
+    public static final int PUSH_STATUS_FIREBASE_FCM_ERROR_IOEXCEPTION_AUTHENTICATION_FAILED = -29;
 
     private static final String[] LOCATION_FIELDS = new String[] { "lat", "long", "loc_acc", "loc_type", "loc_bg", "loc_time_stamp" };
     private static final Set<String> LOCATION_FIELDS_SET = new HashSet<>(Arrays.asList(LOCATION_FIELDS));


### PR DESCRIPTION
# Description
## One Line Summary
Fix not retrying to register for push when there is an FCM error. Also added additional handling for `AUTHENTICATION_FAILED`.

## Details
### Motivation
Some errors from FCM are temporary and we should retry them instead of waiting until the app is restarted. This retry logic is already in place but was broken. The fix and the additional `AUTHENTICATION_FAILED` will give better insight into the issue when we report them on the dashboard.

### Scope
Only affects handling errors from FCM when registering for push.

# Testing
## Unit testing
No existing unit tests, adding tests would be fragile when FCM's API changes.

## Manual testing
Tested on an Android 12 emulators having issues always throwing `AUTHENTICATION_FAILED`.

# Affected code checklist
   - [X] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
      - [X] FCM - Registering for push token
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1599)
<!-- Reviewable:end -->
