### PR TITLE
[Fix] groupless heads-up style notifications from redisplaying previous

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalNotificationManager.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalNotificationManager.java
@@ -100,15 +100,11 @@ public class OneSignalNotificationManager {
     /**
      * All groupless notifications are assigned the GROUPLESS_SUMMARY_KEY and notify() is called
      */
-    @RequiresApi(api = Build.VERSION_CODES.M)
+    @RequiresApi(api = Build.VERSION_CODES.N)
     static void assignGrouplessNotifications(Context context, ArrayList<StatusBarNotification> grouplessNotifs) {
         for (StatusBarNotification grouplessNotif : grouplessNotifs) {
-            Notification.Builder grouplessNotifBuilder;
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-                grouplessNotifBuilder = Notification.Builder.recoverBuilder(context, grouplessNotif.getNotification());
-            } else {
-                grouplessNotifBuilder = new Notification.Builder(context);
-            }
+            Notification.Builder grouplessNotifBuilder =
+                Notification.Builder.recoverBuilder(context, grouplessNotif.getNotification());
 
             // Recreate the notification but with the groupless key instead
             Notification notif = grouplessNotifBuilder

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalNotificationManager.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalNotificationManager.java
@@ -113,6 +113,7 @@ public class OneSignalNotificationManager {
             // Recreate the notification but with the groupless key instead
             Notification notif = grouplessNotifBuilder
                     .setGroup(GROUPLESS_SUMMARY_KEY)
+                    .setOnlyAlertOnce(true)
                     .build();
 
             NotificationManagerCompat.from(context).notify(grouplessNotif.getId(), notif);


### PR DESCRIPTION
# Description
## One Line Summary
Fix bug where if a 4th, 5th, etc notification was displayed with the heads-up style and no group was set the previous notifications would re-display.

## Details

### Motivation
This bug can be confusing to end users and creates a lot of visual noise with old notification reshowing as heads-up.

### Scope
Only effects notification display when no group is used, and 4 or more are displayed for the app. Effects Android 7.0 and newer.

# Testing
## Unit testing
None, Robolectric does not simulate this specific detail.

## Manual testing
Tested on an Android 11 emulator, ensuring I could reproduce the issue and the issue no longer happens after the fix.

### Videos
#### Before Fix

https://user-images.githubusercontent.com/645861/174502740-21094648-2904-41d0-9a6c-110c7a88bcbd.mp4

#### After Fix

https://user-images.githubusercontent.com/645861/174502750-353f3f6d-8495-4f65-8723-8beac0f1f87d.mp4

# Affected code checklist
   - [X] Notifications
      - [X] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item
