### PR TITLE
Release 4.7.4

### DIFF
--- a/OneSignalSDK/onesignal/maven-push.gradle
+++ b/OneSignalSDK/onesignal/maven-push.gradle
@@ -32,7 +32,7 @@ class Global {
     static def POM_NAME = 'OneSignal'
     static def POM_ARTIFACT_ID = 'OneSignal'
     static def POM_PACKAGING = 'aar'
-    static def VERSION_NAME = '4.7.3'
+    static def VERSION_NAME = '4.7.4'
 
     static def GROUP_ID = 'com.onesignal'
     static def POM_DESCRIPTION = 'OneSignal Android SDK'

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -424,7 +424,7 @@ public class OneSignal {
    private static TrackAmazonPurchase trackAmazonPurchase;
    private static TrackFirebaseAnalytics trackFirebaseAnalytics;
 
-   private static final String VERSION = "040703";
+   private static final String VERSION = "040704";
    public static String getSdkVersionRaw() {
       return VERSION;
    }


### PR DESCRIPTION
* [Fix] set language callback by @tanaynigam in https://github.com/OneSignal/OneSignal-Android-SDK/pull/1593
* [Change] After opening a notification with a URL deeplink, the back button will return to the previous Activity by @jkasten2 in https://github.com/OneSignal/OneSignal-Android-SDK/pull/1598
* Fix issue where a notification's android ID is not available to OSRemoteNotificationReceivedHandler by @brismithers in https://github.com/OneSignal/OneSignal-Android-SDK/pull/1597
* [Fix] FCM register retrying and correct types of errors handling by @jkasten2 in https://github.com/OneSignal/OneSignal-Android-SDK/pull/1599
* [Fix] groupless heads-up style notifications from redisplaying previous by @jkasten2 in https://github.com/OneSignal/OneSignal-Android-SDK/pull/1603