### PR TITLE
[Add] notification permission prompting callback and In-App Message support

### DIFF
--- a/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/model/MainActivityViewModel.java
+++ b/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/model/MainActivityViewModel.java
@@ -560,8 +560,17 @@ public class MainActivityViewModel implements ActivityViewModel {
 
         subscriptionSwitch.setOnClickListener(v -> {
             OneSignal.disablePush(!subscriptionSwitch.isChecked());
-            if (subscriptionSwitch.isChecked())
-                OneSignal.promptForPushNotifications(true);
+            if (subscriptionSwitch.isChecked()) {
+                OneSignal.promptForPushNotifications(
+                        true,
+                        new OneSignal.PromptForPushNotificationPermissionResponseHandler() {
+                            @Override
+                            public void response(boolean accepted) {
+                                System.out.println("APP promptForPushNotifications:" + this + ":accepted: " + accepted);
+                            }
+                        }
+                );
+            }
         });
     }
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageAction.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageAction.java
@@ -10,8 +10,6 @@ import org.json.JSONObject;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.onesignal.OSInAppMessageLocationPrompt.LOCATION_PROMPT_KEY;
-
 public class OSInAppMessageAction {
 
     private static final String ID = "id";
@@ -117,8 +115,14 @@ public class OSInAppMessageAction {
     private void parsePrompts(JSONObject json) throws JSONException {
         JSONArray promptsJsonArray = json.getJSONArray(PROMPTS);
         for (int i = 0; i < promptsJsonArray.length(); i++) {
-            if (promptsJsonArray.get(i).equals(LOCATION_PROMPT_KEY) ) {
-                prompts.add(new OSInAppMessageLocationPrompt());
+            String promptType = promptsJsonArray.getString(i);
+            switch (promptType) {
+                case OSInAppMessagePushPrompt.PUSH_PROMPT_KEY:
+                    prompts.add(new OSInAppMessagePushPrompt());
+                    break;
+                case OSInAppMessageLocationPrompt.LOCATION_PROMPT_KEY:
+                    prompts.add(new OSInAppMessageLocationPrompt());
+                    break;
             }
         }
     }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessagePushPrompt.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessagePushPrompt.java
@@ -1,0 +1,25 @@
+package com.onesignal;
+
+public class OSInAppMessagePushPrompt extends OSInAppMessagePrompt {
+
+    static final String PUSH_PROMPT_KEY = "push";
+
+    @Override
+    void handlePrompt(OneSignal.OSPromptActionCompletionCallback callback) {
+        OneSignal.promptForPushNotifications(
+            true,
+            accepted -> {
+                OneSignal.PromptActionResult result = accepted ?
+                    OneSignal.PromptActionResult.PERMISSION_GRANTED :
+                    OneSignal.PromptActionResult.PERMISSION_DENIED;
+                callback.onCompleted(result);
+            }
+        );
+    }
+
+    @Override
+    String getPromptKey() {
+        return PUSH_PROMPT_KEY;
+    }
+
+}

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -349,6 +349,13 @@ public class OneSignal {
       void onFailure(JSONObject response);
    }
 
+   /**
+    * Fires when the User accepts or declines the notification permission prompt.
+    */
+   public interface PromptForPushNotificationPermissionResponseHandler {
+      void response(boolean accepted);
+   }
+
    interface EntryStateListener {
       // Fire with the last appEntryState that just ended.
       void onEntryStateChange(AppEntryAction appEntryState);
@@ -1400,6 +1407,7 @@ public class OneSignal {
       }
 
       LocationController.onFocusChange();
+      NotificationPermissionController.INSTANCE.onAppForegrounded();
 
       if (OSUtils.shouldLogMissingAppIdError(appId))
          return;
@@ -2856,7 +2864,23 @@ public class OneSignal {
     *                           settings if they have declined before.
     */
    public static void promptForPushNotifications(boolean fallbackToSettings) {
-      NotificationPermissionController.INSTANCE.prompt(fallbackToSettings);
+      promptForPushNotifications(fallbackToSettings, null);
+   }
+
+   /**
+    * On Android 13 shows the system notification permission prompt to enable displaying
+    * notifications. This is required for apps that target Android API level 33 / "Tiramisu"
+    * to subscribe the device for push notifications.
+    *
+    * @param fallbackToSettings whether to show a Dialog to direct users to the App's notification
+    *                           settings if they have declined before.
+    * @param handler fires when the user declines ore accepts the notification permission prompt.
+    */
+   public static void promptForPushNotifications(
+      boolean fallbackToSettings,
+      @Nullable PromptForPushNotificationPermissionResponseHandler handler
+   ) {
+      NotificationPermissionController.INSTANCE.prompt(fallbackToSettings, handler);
    }
 
    /**


### PR DESCRIPTION
# Description
## One Line Summary
Adds optional notification permission prompting callback to `promptForPushNotifications` and adds support to prompt from In-App Messages as well.

## Details

### Motivation
Since Android 13 now requires permission just like iOS we are want the features set to match 1-to-1 with our OneSignal-iOS-SDK.

### Scope
Only affects notification permission prompting and prompting from In-App Messages.

# Testing

## Manual testing
Tested on Android 13 Beta 3 (API 33) Emulator to ensure the callback fires when it should.
New IAM notification prompt not tested, however it is essentially behind a feature flag. If something is wrong we can omit this specific SDK version and make another PR to address any bug fixes.

# Affected code checklist
   - [X] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
      - [X] Prompting
   - [ ] Outcomes
   - [ ] Sessions
   - [X] In-App Messaging
   - [ ] REST API requests
   - [X] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1607)
<!-- Reviewable:end -->
