### PR TITLE
[Fix] notification permission prompt callback firing when app is foregrounded

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationPermissionController.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationPermissionController.kt
@@ -36,6 +36,7 @@ object NotificationPermissionController : PermissionsActivity.PermissionCallback
 
     private val callbacks:
             MutableSet<OneSignal.PromptForPushNotificationPermissionResponseHandler> = HashSet()
+    private var awaitingForReturnFromSystemSettings = false
 
     init {
         PermissionsActivity.registerAsCallback(PERMISSION_TYPE, this)
@@ -97,6 +98,7 @@ object NotificationPermissionController : PermissionsActivity.PermissionCallback
             object : AlertDialogPrepromptForAndroidSettings.Callback {
                 override fun onAccept() {
                     NavigateToAndroidSettingsForNotifications.show(activity)
+                    awaitingForReturnFromSystemSettings = true
                 }
                 override fun onDecline() {
                     fireCallBacks(false)
@@ -113,6 +115,8 @@ object NotificationPermissionController : PermissionsActivity.PermissionCallback
     }
 
     fun onAppForegrounded() {
+        if (!awaitingForReturnFromSystemSettings) return
+        awaitingForReturnFromSystemSettings = false
         fireCallBacks(notificationsEnabled())
     }
 


### PR DESCRIPTION
## Details
### One Line Summary
Fixes a bug where `OneSignal.promptForPushNotifications` would fire before the user answers the prompt if the app was background and then foregrounded when showing.

### Motivation
The bug also happens even if the app is not backgrounded on some of the OneSignal wrapper / binder SDKs due their initialization flows.

### Scope
Only effects notification permission prompting on Android 13. This fixes a bug were this feature was first introduced in #1607.

# Testing
## Unit testing
No existing tests.
## Manual testing
Tested on an Android 13 Beta 3 emulator. Ensured I could reproduce the issue before the fix by backgrounding the app then foregrounding it. Also ensured the callback still fires when it should when returning from the system notification permission screen.

# Affected code checklist
   - [X] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
      - [X] Permissions
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1615)
<!-- Reviewable:end -->
