### PR TITLE
[User Model] Migrate Purchase Tracking

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/onesignal/core/internal/CoreModule.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/onesignal/core/internal/CoreModule.kt
@@ -1,19 +1,17 @@
 package com.onesignal.onesignal.core.internal
 
-import com.onesignal.onesignal.core.internal.application.impl.ApplicationService
 import com.onesignal.onesignal.core.internal.application.IApplicationService
+import com.onesignal.onesignal.core.internal.application.impl.ApplicationService
 import com.onesignal.onesignal.core.internal.backend.IParamsBackendService
 import com.onesignal.onesignal.core.internal.backend.ParamsBackendService
 import com.onesignal.onesignal.core.internal.backend.http.HttpClient
 import com.onesignal.onesignal.core.internal.backend.http.IHttpClient
 import com.onesignal.onesignal.core.internal.background.IBackgroundManager
 import com.onesignal.onesignal.core.internal.background.impl.BackgroundManager
-import com.onesignal.onesignal.core.internal.time.ITime
-import com.onesignal.onesignal.core.internal.time.Time
 import com.onesignal.onesignal.core.internal.database.IDatabaseProvider
 import com.onesignal.onesignal.core.internal.database.impl.DatabaseProvider
-import com.onesignal.onesignal.core.internal.device.impl.DeviceService
 import com.onesignal.onesignal.core.internal.device.IDeviceService
+import com.onesignal.onesignal.core.internal.device.impl.DeviceService
 import com.onesignal.onesignal.core.internal.influence.IInfluenceManager
 import com.onesignal.onesignal.core.internal.influence.impl.InfluenceManager
 import com.onesignal.onesignal.core.internal.listeners.IdentityModelStoreListener
@@ -31,16 +29,23 @@ import com.onesignal.onesignal.core.internal.outcomes.IOutcomeEventsFactory
 import com.onesignal.onesignal.core.internal.outcomes.OutcomeEventsController
 import com.onesignal.onesignal.core.internal.outcomes.impl.OSOutcomeEventsCache
 import com.onesignal.onesignal.core.internal.outcomes.impl.OSOutcomeEventsFactory
-import com.onesignal.onesignal.core.internal.params.*
+import com.onesignal.onesignal.core.internal.params.IParamsService
+import com.onesignal.onesignal.core.internal.params.IWriteableParamsService
+import com.onesignal.onesignal.core.internal.params.ParamsService
+import com.onesignal.onesignal.core.internal.params.RefreshParamsService
 import com.onesignal.onesignal.core.internal.permissions.IRequestPermissionService
 import com.onesignal.onesignal.core.internal.permissions.impl.RequestPermissionService
 import com.onesignal.onesignal.core.internal.preferences.IPreferencesService
 import com.onesignal.onesignal.core.internal.preferences.PreferencesService
-import com.onesignal.onesignal.core.internal.startup.IStartableService
+import com.onesignal.onesignal.core.internal.purchases.TrackAmazonPurchase
+import com.onesignal.onesignal.core.internal.purchases.TrackGooglePurchase
 import com.onesignal.onesignal.core.internal.service.ServiceBuilder
 import com.onesignal.onesignal.core.internal.session.ISessionService
 import com.onesignal.onesignal.core.internal.session.SessionService
+import com.onesignal.onesignal.core.internal.startup.IStartableService
 import com.onesignal.onesignal.core.internal.startup.StartupService
+import com.onesignal.onesignal.core.internal.time.ITime
+import com.onesignal.onesignal.core.internal.time.Time
 import com.onesignal.onesignal.core.internal.user.ISubscriptionManager
 import com.onesignal.onesignal.core.internal.user.IUserSwitcher
 import com.onesignal.onesignal.core.internal.user.SubscriptionManager
@@ -65,6 +70,7 @@ object CoreModule {
                .provides<IParamsService>()
                .provides<IWriteableParamsService>()
         builder.register<ParamsBackendService>().provides<IParamsBackendService>()
+        builder.register<RefreshParamsService>().provides<IStartableService>()
 
         // Operations
         builder.register<OperationRepo>()
@@ -109,6 +115,10 @@ object CoreModule {
         builder.register<IdentityModelStoreListener>().provides<IStartableService>()
         builder.register<SubscriptionModelStoreListener>().provides<IStartableService>()
         builder.register<PropertiesModelStoreListener>().provides<IStartableService>()
+
+        // Purchase Tracking
+        builder.register<TrackAmazonPurchase>().provides<IStartableService>()
+        builder.register<TrackGooglePurchase>().provides<IStartableService>()
 
         // User
         builder.register<SubscriptionManager>().provides<ISubscriptionManager>()

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/onesignal/core/internal/OneSignalImp.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/onesignal/core/internal/OneSignalImp.kt
@@ -62,6 +62,7 @@ class OneSignalImp() : IOneSignal, IServiceProvider {
     private var _configModel: ConfigModel? = null
     private var _sessionModel: SessionModel? = null
     private var _requiresPrivacyConsent: Boolean? = null
+    private var _haveServicesStarted: Boolean = false
 
     init {
         var serviceBuilder = ServiceBuilder()
@@ -103,14 +104,11 @@ class OneSignalImp() : IOneSignal, IServiceProvider {
         _propertiesModelStore = _services.getService()
         _identityModelStore = _services.getService()
 
-        // Instantiate and call the IStartableServices
-        _startupService = _services.getService()
-        _startupService!!.start()
-
         isInitialized = true
 
         if(_appId != null) {
-            _configModel!!.appId = _appId!!;
+            _configModel!!.appId = _appId!!
+            startServices()
         }
     }
 
@@ -123,7 +121,17 @@ class OneSignalImp() : IOneSignal, IServiceProvider {
             _appId = appId
         }
         else {
-            _configModel!!.appId = _appId!!;
+            _configModel!!.appId = _appId!!
+            startServices()
+        }
+    }
+
+    private fun startServices() {
+        if(!_haveServicesStarted) {
+            _haveServicesStarted = true
+            // Instantiate and call the IStartableServices
+            _startupService = _services.getService()
+            _startupService!!.start()
         }
     }
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/onesignal/core/internal/operations/TrackPurchaseOperation.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/onesignal/core/internal/operations/TrackPurchaseOperation.kt
@@ -1,0 +1,39 @@
+package com.onesignal.onesignal.core.internal.operations
+
+import com.onesignal.onesignal.core.internal.operations.executors.UserOperationExecutor
+import java.math.BigDecimal
+
+/**
+ * An [Operation] to track the purchase of one or more items within an app by a specific
+ * user.
+ */
+class TrackPurchaseOperation(
+    /**
+     * The OneSignal appId the purchase was captured under.
+     */
+    val appId: String,
+
+    /**
+     * The OneSignal ID the purchase was captured under.
+     */
+    val userId: String,
+
+    /**
+     * Whether to treat new purchases as an existing purchase.
+     */
+    val treatNewAsExisting: Boolean,
+
+    /**
+     * The list of purchases that have been made.
+     */
+    val purchases: List<PurchaseInfo>) : Operation(UserOperationExecutor.TRACK_PURCHASE)  {
+}
+
+/**
+ * Information about a specific purchase.
+ */
+class PurchaseInfo(
+    val sku: String,
+    val iso: String,
+    val amount: BigDecimal,
+)

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/onesignal/core/internal/operations/executors/UserOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/onesignal/core/internal/operations/executors/UserOperationExecutor.kt
@@ -4,24 +4,39 @@ import com.onesignal.onesignal.core.LogLevel
 import com.onesignal.onesignal.core.internal.backend.http.IHttpClient
 import com.onesignal.onesignal.core.internal.logging.Logging
 import com.onesignal.onesignal.core.internal.operations.*
+import org.json.JSONArray
+import org.json.JSONObject
 
 class UserOperationExecutor(
     private val _http: IHttpClient) : IOperationExecutor {
 
     override val operations: List<String>
-        get() = listOf(CREATE_USER, UPDATE_USER, DELETE_USER)
+        get() = listOf(CREATE_USER, UPDATE_USER, DELETE_USER, TRACK_PURCHASE)
 
     override suspend fun executeAsync(operation: Operation) {
         Logging.log(LogLevel.DEBUG, "UserOperationExecutor(operation: $operation)")
 
-        if(operation is CreateUserOperation) {
-//            _http.createUserAsync(null)
-        }
-        else if(operation is DeleteUserOperation) {
-//            _http.deleteUserAsync("external_id", operation.id)
-        }
-        else if(operation is UpdateUserOperation) {
-//            _http.updateUserAsync("external_id", operation.id, null)
+        when (operation) {
+            is CreateUserOperation -> {
+    //            _http.createUserAsync(null)
+            }
+            is DeleteUserOperation -> {
+    //            _http.deleteUserAsync("external_id", operation.id)
+            }
+            is UpdateUserOperation -> {
+    //            _http.updateUserAsync("external_id", operation.id, null)
+            }
+            is TrackPurchaseOperation -> {
+                val purchasesArray = JSONArray()
+                for (purchase in operation.purchases) {
+                    val jsonItem = JSONObject()
+                    jsonItem.put("sku", purchase.sku)
+                    jsonItem.put("iso", purchase.iso)
+                    jsonItem.put("amount", purchase.amount.toString())
+                    purchasesArray.put(jsonItem)
+                }
+                // TODO: put purchaseArray into the update user payload.
+            }
         }
     }
 
@@ -29,5 +44,6 @@ class UserOperationExecutor(
         const val CREATE_USER = "create-user"
         const val UPDATE_USER = "update-user"
         const val DELETE_USER = "delete-user"
+        const val TRACK_PURCHASE = "track-purchase"
     }
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/onesignal/core/internal/params/RefreshParamsService.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/onesignal/core/internal/params/RefreshParamsService.kt
@@ -1,0 +1,50 @@
+package com.onesignal.onesignal.core.internal.params
+
+import com.onesignal.onesignal.core.LogLevel
+import com.onesignal.onesignal.core.internal.backend.IParamsBackendService
+import com.onesignal.onesignal.core.internal.common.suspendifyOnThread
+import com.onesignal.onesignal.core.internal.logging.Logging
+import com.onesignal.onesignal.core.internal.modeling.ISingletonModelStoreChangeHandler
+import com.onesignal.onesignal.core.internal.models.ConfigModel
+import com.onesignal.onesignal.core.internal.models.ConfigModelStore
+import com.onesignal.onesignal.core.internal.startup.IStartableService
+import com.onesignal.onesignal.core.internal.user.ISubscriptionManager
+
+/**
+ * This is responsible for refreshing the parameters of the current OneSignal appId, whenever
+ * required.  A refresh is required when:
+ *
+ * 1. The SDK has been started and an appId first assigned.
+ * 2. The SDK has had it's appId changed.
+ */
+internal class RefreshParamsService(
+    private val _configModelStore: ConfigModelStore,
+    private val _paramsBackendService: IParamsBackendService,
+    private val _subscriptionManager: ISubscriptionManager
+) : IStartableService, ISingletonModelStoreChangeHandler<ConfigModel> {
+
+    override fun start() {
+        _configModelStore.subscribe(this)
+        fetchParams()
+    }
+
+    override fun onModelUpdated(model: ConfigModel, property: String, oldValue: Any?, newValue: Any?) {
+        if (property != ConfigModel::appId.name)
+            return
+
+        fetchParams()
+    }
+
+    private fun fetchParams() {
+        val appId = _configModelStore.get().appId
+
+        if(appId == null || appId.isEmpty())
+            return
+
+        suspendifyOnThread {
+            Logging.log(LogLevel.DEBUG, "StartupService fetching parameters for appId: $appId")
+
+            _paramsBackendService.fetchAndSaveRemoteParams(appId, _subscriptionManager.subscriptions.push?.id.toString())
+        }
+    }
+}

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/onesignal/core/internal/purchases/TrackAmazonPurchase.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/onesignal/core/internal/purchases/TrackAmazonPurchase.kt
@@ -1,0 +1,210 @@
+/**
+ * Modified MIT License
+ *
+ * Copyright 2017 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.onesignal.onesignal.core.internal.purchases
+
+import com.amazon.device.iap.PurchasingService
+import com.amazon.device.iap.PurchasingListener
+import com.amazon.device.iap.model.RequestId
+import com.amazon.device.iap.model.ProductDataResponse
+import com.amazon.device.iap.model.PurchaseResponse
+import com.amazon.device.iap.model.PurchaseUpdatesResponse
+import com.amazon.device.iap.model.UserDataResponse
+import com.onesignal.onesignal.core.internal.application.IApplicationLifecycleHandler
+import com.onesignal.onesignal.core.internal.application.IApplicationService
+import com.onesignal.onesignal.core.internal.logging.Logging
+import com.onesignal.onesignal.core.internal.models.ConfigModelStore
+import com.onesignal.onesignal.core.internal.operations.IOperationRepo
+import com.onesignal.onesignal.core.internal.operations.PurchaseInfo
+import com.onesignal.onesignal.core.internal.operations.TrackPurchaseOperation
+import com.onesignal.onesignal.core.internal.startup.IStartableService
+import com.onesignal.onesignal.core.internal.user.IUserSwitcher
+import java.lang.ClassCastException
+import java.lang.Exception
+import java.lang.NullPointerException
+import java.lang.reflect.Field
+import java.lang.reflect.InvocationTargetException
+import java.math.BigDecimal
+import java.util.HashSet
+
+internal class TrackAmazonPurchase(
+    private val _applicationService: IApplicationService,
+    private val _operationRepo: IOperationRepo,
+    private val _configModelStore: ConfigModelStore,
+    private val _userSwitcher: IUserSwitcher
+): IStartableService, IApplicationLifecycleHandler {
+    private var canTrack = false
+    private var osPurchasingListener: OSPurchasingListener? = null
+    private var listenerHandlerObject: Any? = null
+    private var listenerHandlerField: Field? = null
+
+    override fun start() {
+        if(!canTrack())
+            return
+
+        try {
+            // 2.0.1
+            val listenerHandlerClass = Class.forName("com.amazon.device.iap.internal.d")
+            listenerHandlerObject = try {
+                //iap v2.x
+                listenerHandlerClass.getMethod("d").invoke(null)
+            } catch (e: NullPointerException) {
+                //appstore v3.x
+                listenerHandlerClass.getMethod("e").invoke(null)
+            }
+            val locListenerHandlerField = listenerHandlerClass.getDeclaredField("f")
+            locListenerHandlerField.isAccessible = true
+            osPurchasingListener = OSPurchasingListener(_operationRepo, _configModelStore, _userSwitcher)
+            osPurchasingListener!!.orgPurchasingListener = locListenerHandlerField.get(listenerHandlerObject) as PurchasingListener
+
+            listenerHandlerField = locListenerHandlerField
+            canTrack = true
+            setListener()
+            // Can replace all catches with ReflectiveOperationException win min API is 19
+        } catch (e: ClassNotFoundException) {
+            logAmazonIAPListenerError(e)
+        } catch (e: IllegalAccessException) {
+            logAmazonIAPListenerError(e)
+        } catch (e: InvocationTargetException) {
+            logAmazonIAPListenerError(e)
+        } catch (e: NoSuchMethodException) {
+            logAmazonIAPListenerError(e)
+        } catch (e: NoSuchFieldException) {
+            logAmazonIAPListenerError(e)
+        } catch (e: ClassCastException) {
+            logAmazonIAPListenerError(e)
+        }
+
+        _applicationService.addApplicationLifecycleHandler(this)
+    }
+
+    private fun logAmazonIAPListenerError(e: Exception) {
+        Logging.error("Error adding Amazon IAP listener.", e)
+        e.printStackTrace()
+    }
+
+    override fun onFocus() { }
+
+    override fun onUnfocused() {
+        if (!canTrack) return
+        try {
+            val curPurchasingListener =
+                listenerHandlerField!![listenerHandlerObject] as PurchasingListener
+            if (curPurchasingListener !== osPurchasingListener) {
+                osPurchasingListener!!.orgPurchasingListener = curPurchasingListener
+                setListener()
+            }
+        } catch (e: IllegalAccessException) {
+            e.printStackTrace()
+        }
+    }
+
+    private fun setListener() {
+        PurchasingService.registerListener(_applicationService.appContext, osPurchasingListener)
+    }
+
+    private inner class OSPurchasingListener(
+        private val _operationRepo: IOperationRepo,
+        private val _configModelStore: ConfigModelStore,
+        private val _userSwitcher: IUserSwitcher
+    ) : PurchasingListener {
+        var orgPurchasingListener: PurchasingListener? = null
+        private var lastRequestId: RequestId? = null
+        private var currentMarket: String? = null
+        private fun marketToCurrencyCode(market: String?): String {
+            when (market) {
+                "US" -> return "USD"
+                "GB" -> return "GBP"
+                "DE", "FR", "ES", "IT" -> return "EUR"
+                "JP" -> return "JPY"
+                "CA" -> return "CDN"
+                "BR" -> return "BRL"
+                "AU" -> return "AUD"
+            }
+            return ""
+        }
+
+        override fun onProductDataResponse(response: ProductDataResponse) {
+            if (lastRequestId != null && lastRequestId.toString() == response.requestId.toString()) {
+                when (response.requestStatus) {
+                    ProductDataResponse.RequestStatus.SUCCESSFUL -> {
+                        val purchasesToReport = mutableListOf<PurchaseInfo>()
+                        val products = response.productData
+                        for (key in products.keys) {
+                            val product = products[key]
+                            val sku = product!!.sku
+                            val iso = marketToCurrencyCode(currentMarket)
+                            var priceStr = product.price
+
+                            if (!priceStr.matches("^[0-9]".toRegex()))
+                                priceStr = priceStr.substring(1)
+
+                            val price = BigDecimal(priceStr)
+
+                            purchasesToReport.add(PurchaseInfo(sku, iso, price))
+                        }
+
+                        _operationRepo.enqueue(TrackPurchaseOperation(_configModelStore.get().appId!!, _userSwitcher.identityModel.oneSignalId.toString(), false, purchasesToReport))
+                    }
+                }
+            } else if (orgPurchasingListener != null) orgPurchasingListener!!.onProductDataResponse(
+                response
+            )
+        }
+
+        override fun onPurchaseResponse(response: PurchaseResponse) {
+            val status = response.requestStatus
+            if (status == PurchaseResponse.RequestStatus.SUCCESSFUL) {
+                currentMarket = response.userData.marketplace
+                val productSkus: MutableSet<String> = HashSet()
+                productSkus.add(response.receipt.sku)
+                lastRequestId = PurchasingService.getProductData(productSkus)
+            }
+            if (orgPurchasingListener != null) orgPurchasingListener!!.onPurchaseResponse(response)
+        }
+
+        override fun onPurchaseUpdatesResponse(response: PurchaseUpdatesResponse) {
+            if (orgPurchasingListener != null) orgPurchasingListener!!.onPurchaseUpdatesResponse(
+                response
+            )
+        }
+
+        override fun onUserDataResponse(response: UserDataResponse) {
+            if (orgPurchasingListener != null) orgPurchasingListener!!.onUserDataResponse(response)
+        }
+    }
+
+    companion object {
+        fun canTrack(): Boolean {
+            try {
+                Class.forName("com.amazon.device.iap.PurchasingListener")
+                return true
+            } catch (e: ClassNotFoundException) {
+            }
+            return false
+        }
+    }
+}

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/onesignal/core/internal/purchases/TrackGooglePurchase.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/onesignal/core/internal/purchases/TrackGooglePurchase.kt
@@ -1,0 +1,275 @@
+/**
+ * Modified MIT License
+ *
+ * Copyright 2016 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.onesignal.onesignal.core.internal.purchases
+
+import android.content.ServiceConnection
+import android.content.ComponentName
+import android.content.Context
+import android.os.IBinder
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Bundle
+import com.onesignal.onesignal.core.internal.application.IApplicationLifecycleHandler
+import org.json.JSONObject
+import org.json.JSONArray
+import com.onesignal.onesignal.core.internal.application.IApplicationService
+import com.onesignal.onesignal.core.internal.logging.Logging
+import com.onesignal.onesignal.core.internal.models.ConfigModelStore
+import com.onesignal.onesignal.core.internal.operations.IOperationRepo
+import com.onesignal.onesignal.core.internal.operations.PurchaseInfo
+import com.onesignal.onesignal.core.internal.operations.TrackPurchaseOperation
+import com.onesignal.onesignal.core.internal.preferences.IPreferencesService
+import com.onesignal.onesignal.core.internal.preferences.PreferencePlayerPurchasesKeys
+import com.onesignal.onesignal.core.internal.preferences.PreferenceStores
+import com.onesignal.onesignal.core.internal.startup.IStartableService
+import com.onesignal.onesignal.core.internal.user.IUserSwitcher
+import org.json.JSONException
+import java.lang.reflect.Method
+import java.math.BigDecimal
+import java.util.ArrayList
+
+internal class TrackGooglePurchase(
+    private val _applicationService: IApplicationService,
+    private val _prefs: IPreferencesService,
+    private val _operationRepo: IOperationRepo,
+    private val _configModelStore: ConfigModelStore,
+    private val _userSwitcher: IUserSwitcher
+    ) : IStartableService, IApplicationLifecycleHandler {
+    private var mServiceConn: ServiceConnection? = null
+    private var mIInAppBillingService: Any? = null
+    private var getPurchasesMethod: Method? = null
+    private var getSkuDetailsMethod: Method? = null
+    private val purchaseTokens: MutableList<String> = mutableListOf()
+
+    // Any new purchases found count as pre-existing.
+    // The constructor sets it to false if we already saved any purchases or already found out there isn't any.
+    private var newAsExisting = true
+    private var isWaitingForPurchasesRequest = false
+
+    override fun start() {
+
+        if(!canTrack(_applicationService.appContext))
+            return
+
+        try {
+            val purchaseTokensString = _prefs.getString(PreferenceStores.PLAYER_PURCHASES, PreferencePlayerPurchasesKeys.PREFS_PURCHASE_TOKENS, "[]")
+            val jsonPurchaseTokens = JSONArray(purchaseTokensString)
+
+            for (i in 0 until jsonPurchaseTokens.length())
+                purchaseTokens.add(jsonPurchaseTokens[i].toString())
+
+            newAsExisting = jsonPurchaseTokens.length() == 0
+            if (newAsExisting)
+                newAsExisting = _prefs.getBool(PreferenceStores.PLAYER_PURCHASES, PreferencePlayerPurchasesKeys.PREFS_EXISTING_PURCHASES, true)!!
+
+        } catch (e: JSONException) {
+            e.printStackTrace()
+        }
+
+        _applicationService.addApplicationLifecycleHandler(this)
+        trackIAP()
+    }
+
+    override fun onFocus() {
+        trackIAP()
+    }
+
+    override fun onUnfocused() {}
+
+    private fun trackIAP() {
+        if (mServiceConn == null) {
+            val serviceConn = object : ServiceConnection {
+                override fun onServiceDisconnected(name: ComponentName) {
+                    iapEnabled = -99
+                    mIInAppBillingService = null
+                }
+
+                override fun onServiceConnected(name: ComponentName, service: IBinder) {
+                    try {
+                        val stubClass =
+                            Class.forName("com.android.vending.billing.IInAppBillingService\$Stub")
+                        val asInterfaceMethod = getAsInterfaceMethod(stubClass)
+                        asInterfaceMethod!!.isAccessible = true
+                        mIInAppBillingService = asInterfaceMethod.invoke(null, service)
+                        queryBoughtItems()
+                    } catch (t: Throwable) {
+                        t.printStackTrace()
+                    }
+                }
+            }
+            mServiceConn = serviceConn
+            val serviceIntent = Intent("com.android.vending.billing.InAppBillingService.BIND")
+            serviceIntent.setPackage("com.android.vending")
+            _applicationService.appContext.bindService(serviceIntent, serviceConn, Context.BIND_AUTO_CREATE)
+        } else if (mIInAppBillingService != null)
+            queryBoughtItems()
+    }
+
+    private fun queryBoughtItems() {
+        if (isWaitingForPurchasesRequest) return
+        Thread {
+            isWaitingForPurchasesRequest = true
+            try {
+                if (getPurchasesMethod == null) {
+                    getPurchasesMethod = getGetPurchasesMethod(IInAppBillingServiceClass)
+                    getPurchasesMethod!!.isAccessible = true
+                }
+                val ownedItems = getPurchasesMethod!!.invoke(
+                    mIInAppBillingService,
+                    3,
+                    _applicationService.appContext.packageName,
+                    "inapp",
+                    null
+                ) as Bundle
+                if (ownedItems.getInt("RESPONSE_CODE") == 0) {
+                    val skusToAdd = ArrayList<String>()
+                    val newPurchaseTokens = ArrayList<String>()
+                    val ownedSkus = ownedItems.getStringArrayList("INAPP_PURCHASE_ITEM_LIST")
+                    val purchaseDataList = ownedItems.getStringArrayList("INAPP_PURCHASE_DATA_LIST")
+                    for (i in purchaseDataList!!.indices) {
+                        val purchaseData = purchaseDataList[i]
+                        val sku = ownedSkus!![i]
+                        val itemPurchased = JSONObject(purchaseData)
+                        val purchaseToken = itemPurchased.getString("purchaseToken")
+                        if (!purchaseTokens.contains(purchaseToken) && !newPurchaseTokens.contains(
+                                purchaseToken
+                            )
+                        ) {
+                            newPurchaseTokens.add(purchaseToken)
+                            skusToAdd.add(sku)
+                        }
+                    }
+                    if (skusToAdd.size > 0) sendPurchases(
+                        skusToAdd,
+                        newPurchaseTokens
+                    ) else if (purchaseDataList.size == 0) {
+                        newAsExisting = false
+                        _prefs.saveBool(PreferenceStores.PLAYER_PURCHASES, PreferencePlayerPurchasesKeys.PREFS_EXISTING_PURCHASES, false)
+                    }
+
+                    // TODO: Handle very large list. Test for continuationToken != null then call getPurchases again
+                }
+            } catch (e: Throwable) {
+                e.printStackTrace()
+            }
+            isWaitingForPurchasesRequest = false
+        }.start()
+    }
+
+    private fun sendPurchases(skusToAdd: ArrayList<String>, newPurchaseTokens: ArrayList<String>) {
+        try {
+            if (getSkuDetailsMethod == null) {
+                getSkuDetailsMethod = getGetSkuDetailsMethod(IInAppBillingServiceClass)
+                getSkuDetailsMethod!!.isAccessible = true
+            }
+            val querySkus = Bundle()
+            querySkus.putStringArrayList("ITEM_ID_LIST", skusToAdd)
+            val skuDetails = getSkuDetailsMethod!!.invoke(
+                mIInAppBillingService,
+                3,
+                _applicationService.appContext.packageName,
+                "inapp",
+                querySkus
+            ) as Bundle
+            val response = skuDetails.getInt("RESPONSE_CODE")
+            if (response == 0) {
+                val responseList = skuDetails.getStringArrayList("DETAILS_LIST")
+                val currentSkus: MutableMap<String, PurchaseInfo> = mutableMapOf()
+
+                for (thisResponse in responseList!!) {
+                    val `object` = JSONObject(thisResponse)
+                    val sku = `object`.getString("productId")
+                    val iso = `object`.getString("price_currency_code")
+                    var price = BigDecimal(`object`.getString("price_amount_micros"))
+                    price = price.divide(BigDecimal(1000000))
+
+                    currentSkus[sku] = PurchaseInfo(sku, iso, price)
+                }
+
+                val purchasesToReport = mutableListOf<PurchaseInfo>()
+                for (sku in skusToAdd) {
+                    if (!currentSkus.containsKey(sku)) continue
+                    purchasesToReport.add(currentSkus[sku]!!)
+                }
+
+                // New purchases to report. If successful then mark them as tracked.
+                if (purchasesToReport.isNotEmpty()) {
+                    _operationRepo.enqueue(TrackPurchaseOperation(_configModelStore.get().appId!!, _userSwitcher.identityModel.oneSignalId.toString(), newAsExisting, purchasesToReport))
+                    purchaseTokens.addAll(newPurchaseTokens)
+                    _prefs.saveString(PreferenceStores.PLAYER_PURCHASES, PreferencePlayerPurchasesKeys.PREFS_PURCHASE_TOKENS, purchaseTokens.toString())
+                    _prefs.saveBool(PreferenceStores.PLAYER_PURCHASES, PreferencePlayerPurchasesKeys.PREFS_EXISTING_PURCHASES, true)
+                    newAsExisting = false
+                    isWaitingForPurchasesRequest = false
+                }
+            }
+        } catch (t: Throwable) {
+            Logging.warn("Failed to track IAP purchases", t)
+        }
+    }
+
+    companion object {
+        private var iapEnabled = -99
+        private var IInAppBillingServiceClass: Class<*>? = null
+        fun canTrack(context: Context): Boolean {
+            if (iapEnabled == -99) iapEnabled =
+                context.checkCallingOrSelfPermission("com.android.vending.BILLING")
+            try {
+                if (iapEnabled == PackageManager.PERMISSION_GRANTED) IInAppBillingServiceClass =
+                    Class.forName("com.android.vending.billing.IInAppBillingService")
+            } catch (t: Throwable) {
+                iapEnabled = 0
+                return false
+            }
+            return iapEnabled == PackageManager.PERMISSION_GRANTED
+        }
+
+        private fun getAsInterfaceMethod(clazz: Class<*>): Method? {
+            for (method in clazz.methods) {
+                val args = method.parameterTypes
+                if (args.size == 1 && args[0] == IBinder::class.java) return method
+            }
+            return null
+        }
+
+        private fun getGetPurchasesMethod(clazz: Class<*>?): Method? {
+            for (method in clazz!!.methods) {
+                val args = method.parameterTypes
+                if (args.size == 4 && args[0] == Int::class.javaPrimitiveType && args[1] == String::class.java && args[2] == String::class.java && args[3] == String::class.java) return method
+            }
+            return null
+        }
+
+        private fun getGetSkuDetailsMethod(clazz: Class<*>?): Method? {
+            for (method in clazz!!.methods) {
+                val args = method.parameterTypes
+                val returnType = method.returnType
+                if (args.size == 4 && args[0] == Int::class.javaPrimitiveType && args[1] == String::class.java && args[2] == String::class.java && args[3] == Bundle::class.java && returnType == Bundle::class.java) return method
+            }
+            return null
+        }
+    }
+}

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/onesignal/core/internal/startup/IStartableService.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/onesignal/core/internal/startup/IStartableService.kt
@@ -1,23 +1,29 @@
 package com.onesignal.onesignal.core.internal.startup
 
-import androidx.annotation.WorkerThread
 import com.onesignal.onesignal.core.OneSignal
+import com.onesignal.onesignal.core.internal.application.IApplicationService
+import com.onesignal.onesignal.core.internal.models.ConfigModel
+import com.onesignal.onesignal.core.internal.models.ConfigModelStore
 
 /**
  * Implement and provide this interface as part of service registration to indicate the service
  * wants to be instantiated and its [start] function called during the initialization process.
- * When the SDK is initialized via [OneSignal.initWithContext], all "startable" services will be
- * processed.
  *
- * When started there is no guarantee that any data is available.  Typically a startable service
+ * When [IStartableService.start] is called, both [OneSignal.initWithContext] and [OneSignal.setAppId]
+ * have been called.  This means the following is true:
+ *
+ *  1) An appContext is available in [IApplicationService.appContext].
+ *  2) An appId is available in [ConfigModel.appId] via [ConfigModelStore.get]
+ *
+ * When started there is no guarantee that any other data is available.  Typically a startable service
  * must be instantiated immediately and will add their appropriate hooks to then respond to changes
  * in the system.
  */
 interface IStartableService {
 
     /**
-     * Called when the service is to be started.
+     * Called when the service is to be started.  The appId and appContext have already been
+     * established.
      */
-    @WorkerThread
     fun start()
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/onesignal/core/internal/startup/StartupService.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/onesignal/core/internal/startup/StartupService.kt
@@ -1,42 +1,11 @@
 package com.onesignal.onesignal.core.internal.startup
 
-import com.onesignal.onesignal.core.LogLevel
-import com.onesignal.onesignal.core.internal.backend.IParamsBackendService
-import com.onesignal.onesignal.core.internal.common.suspendifyOnThread
-import com.onesignal.onesignal.core.internal.logging.Logging
-import com.onesignal.onesignal.core.internal.modeling.ISingletonModelStoreChangeHandler
-import com.onesignal.onesignal.core.internal.models.ConfigModel
-import com.onesignal.onesignal.core.internal.models.ConfigModelStore
-import com.onesignal.onesignal.core.internal.user.ISubscriptionManager
-
 internal class StartupService(
-    private val _paramsBackendService: IParamsBackendService,
-    private val _configModelStore: ConfigModelStore,
-    private val _subscriptionManager: ISubscriptionManager,
     private val _startableServices: List<IStartableService>,
-) : ISingletonModelStoreChangeHandler<ConfigModel> {
-
+) {
     fun start() {
-        _configModelStore.subscribe(this)
-
         // now that we have the params initialized, start everything else up
         for(startableService in _startableServices)
             startableService.start()
-    }
-
-    override fun onModelUpdated(model: ConfigModel, property: String, oldValue: Any?, newValue: Any?) {
-        if (property != ConfigModel::appId.name)
-            return
-
-        val appId = model.appId
-
-        if(appId == null || appId.isEmpty())
-            return
-
-        suspendifyOnThread {
-            Logging.log(LogLevel.DEBUG, "StartupService fetching parameters for appId: $appId")
-
-            _paramsBackendService.fetchAndSaveRemoteParams(appId, _subscriptionManager.subscriptions.push?.id.toString())
-        }
     }
 }


### PR DESCRIPTION
* Adjust IStartableService so it is called *after* the appId has been established. This is done to remove the extra step of having startable services register a listener to wait for the appId to be set.
* Create RefreshParamsService as a startable service to pull the remote parameters from the backend. This was previously part of StartupService, separated as a refactor.
* Migrate TrackAmazonPurchase and TrackGooglePurchase which are startable services that track amazon and google purchases (respectively).  When captured these get pushed to the operation repo via TrackPurchaseOperation.  The execution of that operation to-be-implemented.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1633)
<!-- Reviewable:end -->
