### PR TITLE
User Model remove summary notifications

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/notification/internal/display/impl/SummaryNotificationDisplayer.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/notification/internal/display/impl/SummaryNotificationDisplayer.kt
@@ -261,6 +261,7 @@ internal class SummaryNotificationDisplayer(
         val group: String = NotificationHelper.grouplessSummaryKey
         val summaryMessage = "$grouplessNotifCount new messages"
         val summaryNotificationId: Int = NotificationHelper.grouplessSummaryId
+        _dataController.createSummaryNotification(summaryNotificationId!!, group)
         val summaryContentIntent: PendingIntent? = intentGenerator.getNewActionPendingIntent(
             random.nextInt(),
             createBaseSummaryIntent(summaryNotificationId, intentGenerator, fcmJson, group)

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
@@ -430,6 +430,26 @@ public class GenerateNotificationRunner {
       assertEquals(4, getNotificationsInGroup("os_group_undefined").size());
    }
 
+   @Test
+   @Config(sdk = Build.VERSION_CODES.N, shadows = { ShadowGenerateNotification.class })
+   public void testGrouplessSummaryNotificationIsDismissedOnClear() throws Exception {
+      OneSignal.setAppId("b2f7f966-d8cc-11e4-bed1-df8f05be55ba");
+      OneSignal.initWithContext(blankActivity.getApplicationContext());
+      threadAndTaskWait();
+
+      // Add 4 groupless notifications
+      postNotificationWithOptionalGroup(4, null);
+      threadAndTaskWait();
+
+      // Obtain the posted notifications
+      Map<Integer, PostedNotification> postedNotifs = ShadowRoboNotificationManager.notifications;
+      assertEquals(5, postedNotifs.size());
+      // Clear OneSignal Notifications
+      OneSignal.clearOneSignalNotifications();
+      threadAndTaskWait();
+      assertEquals(0, postedNotifs.size());
+   }
+
     @Test
     @Config(sdk = Build.VERSION_CODES.LOLLIPOP, shadows = { ShadowGenerateNotification.class })
     public void testNotifDismissAllOnGroupSummaryClickForAndroidUnderM() throws Exception {


### PR DESCRIPTION
# Description
## One Line Summary
Fix clearing groupless summary notifications using the clearOneSignalNotifications method

## Details
This is a fix we made on the previous major release and are migrating to User Model.


### Motivation
bug fix

### Scope
Notification Processing

# Testing
## Unit testing
Unit tests don't currently work, but I added the unit test from Main to this PR so that when unit tests are fixed this one will also be fixed.

# Affected code checklist
   - [x] Notifications
      - [ ] Display
      - [ ] Open
      - [x] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1648)
<!-- Reviewable:end -->
