### PR TITLE
Remove OneSignal gradle plugin from build.gradle files

### DIFF
--- a/Examples/OneSignalDemo/build.gradle
+++ b/Examples/OneSignalDemo/build.gradle
@@ -11,7 +11,6 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:7.0.4'
         classpath 'com.google.gms:google-services:4.3.10'
-        classpath 'gradle.plugin.com.onesignal:onesignal-gradle-plugin:[0.14.0, 0.99.99]'
         classpath 'com.huawei.agconnect:agcp:1.6.2.300'
         
         // TODO: Do not place your application dependencies here; they belong

--- a/OneSignalSDK/build.gradle
+++ b/OneSignalSDK/build.gradle
@@ -15,19 +15,12 @@ buildscript {
         kotlinVersion = '1.4.32'
         ktlintVersion = '11.0.0'
         detektVersion = '1.21.0'
-        onesignalGradlePluginVersion = '[0.14.0, 0.99.99]'
     }
 
     repositories {
         google()
         mavenCentral()
-
-        // OneSignal-Gradle-Plugin - Local testing
-        // maven { url uri('../../repo') }
-
-        // OneSignal-Gradle-Plugin - Public version
         gradlePluginPortal()
-
         // Huawei maven
         maven { url 'https://developer.huawei.com/repo/' }
     }
@@ -39,12 +32,6 @@ buildscript {
 
         classpath "org.jlleitschuh.gradle:ktlint-gradle:$ktlintVersion"
         classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:$detektVersion"
-
-        // OneSignal-Gradle-Plugin - Local testing
-        // classpath 'com.onesignal:onesignal-gradle-plugin:[0.8.1, 0.99.99]'
-
-        // OneSignal-Gradle-Plugin - Public version
-        classpath "gradle.plugin.com.onesignal:onesignal-gradle-plugin:$onesignalGradlePluginVersion"
     }
 }
 


### PR DESCRIPTION
# Description
## One Line Summary
Remove the inclusion of the OneSignal gradle plugin from the example app.

## Details

### Motivation
The OneSignal gradle plugin for Android is designed to (1) ensure the compileSdkVersion is 31 or higher and (2) ensure (mostly) firebase dependent libraries in use by the app & onesignal are compatible. The dependent library compatibility problem has been less of an issue, making the plugin less useful. However inclusion of the plugin itself can sometimes cause side-effect issues during build.

As a result, including the OneSignal Gradle plugin is no longer considered standard when configuring an app to use the OneSignal SDK.

### Scope
The OneSignal gradle plugin is no longer added into the build scripts, and is therefore no longer part of the build process.

# Testing

## Manual testing
As this only affects the build scripts, testing focused on the building of the example app and general functionality was tested within the Android emulator.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1667)
<!-- Reviewable:end -->
