### PR TITLE
[User Model] notification_types and model event rework

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/core/internal/backend/ISubscriptionBackendService.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/core/internal/backend/ISubscriptionBackendService.kt
@@ -13,10 +13,11 @@ internal interface ISubscriptionBackendService {
      * @param type The type of subscription to create.
      * @param enabled Whether this subscription is enabled.
      * @param address The subscription address.
+     * @param status The subscription status.
      *
      * @return The ID of the subscription created.
      */
-    suspend fun createSubscription(appId: String, aliasLabel: String, aliasValue: String, type: SubscriptionObjectType, enabled: Boolean, address: String): String
+    suspend fun createSubscription(appId: String, aliasLabel: String, aliasValue: String, type: SubscriptionObjectType, enabled: Boolean, address: String, status: Int): String
 
     /**
      * Update an existing subscription with the properties provided.
@@ -25,8 +26,9 @@ internal interface ISubscriptionBackendService {
      * @param subscriptionId The ID of the subscription to update.
      * @param enabled Whether this subscription is enabled.
      * @param address The subscription address.
+     * @param status The subscription status.
      */
-    suspend fun updateSubscription(appId: String, subscriptionId: String, enabled: Boolean, address: String)
+    suspend fun updateSubscription(appId: String, subscriptionId: String, enabled: Boolean, address: String, status: Int)
 
     /**
      * Delete an existing subscription.

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/core/internal/backend/impl/SubscriptionBackendService.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/core/internal/backend/impl/SubscriptionBackendService.kt
@@ -23,7 +23,7 @@ internal class SubscriptionBackendService(
     private val _http: IHttpClient
 ) : ISubscriptionBackendService {
 
-    override suspend fun createSubscription(appId: String, aliasLabel: String, aliasValue: String, type: SubscriptionObjectType, enabled: Boolean, address: String): String {
+    override suspend fun createSubscription(appId: String, aliasLabel: String, aliasValue: String, type: SubscriptionObjectType, enabled: Boolean, address: String, status: Int): String {
         // TODO: To Implement, temporarily using players endpoint when PUSH
         if (type == SubscriptionObjectType.SMS || type == SubscriptionObjectType.EMAIL) {
             return UUID.randomUUID().toString()
@@ -70,7 +70,7 @@ internal class SubscriptionBackendService(
         return responseJSON.getString("id")
     }
 
-    override suspend fun updateSubscription(appId: String, subscriptionId: String, enabled: Boolean, address: String) {
+    override suspend fun updateSubscription(appId: String, subscriptionId: String, enabled: Boolean, address: String, status: Int) {
         // TODO: To Implement
     }
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/core/internal/backend/impl/UserBackendService.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/core/internal/backend/impl/UserBackendService.kt
@@ -7,6 +7,7 @@ import com.onesignal.core.internal.backend.IdentityConstants
 import com.onesignal.core.internal.backend.PropertiesDeltasObject
 import com.onesignal.core.internal.backend.PropertiesObject
 import com.onesignal.core.internal.backend.SubscriptionObject
+import com.onesignal.core.internal.models.SubscriptionModel
 import org.json.JSONArray
 import org.json.JSONObject
 import java.util.*
@@ -34,7 +35,7 @@ internal class UserBackendService(
         // TODO: Temporarily using players endpoint via subscription backend to register the subscription, so we can drive push/IAMs.
         val subscriptionIDs = mutableListOf<String>()
         for (subscription in subscriptions) {
-            val subscriptionId = _subscriptionBackend.createSubscription(appId, "", "", subscription.type, subscription.enabled ?: true, subscription.token ?: "")
+            val subscriptionId = _subscriptionBackend.createSubscription(appId, "", "", subscription.type, subscription.enabled ?: true, subscription.token ?: "", subscription.notificationTypes ?: SubscriptionModel.STATUS_SUBSCRIBED)
             subscriptionIDs.add(subscriptionId)
         }
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/core/internal/common/AndroidUtils.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/core/internal/common/AndroidUtils.kt
@@ -12,6 +12,9 @@ import android.os.Bundle
 import android.os.Looper
 import android.text.TextUtils
 import androidx.annotation.Keep
+import androidx.core.app.JobIntentService
+import androidx.core.app.NotificationManagerCompat
+import androidx.legacy.content.WakefulBroadcastReceiver
 import com.onesignal.core.internal.application.IApplicationService
 import com.onesignal.core.internal.logging.Logging
 import java.util.Random
@@ -117,6 +120,33 @@ internal object AndroidUtils {
             e.printStackTrace()
         }
         return Build.VERSION_CODES.ICE_CREAM_SANDWICH_MR1
+    }
+
+    fun hasJobIntentService(): Boolean {
+        return try {
+            // noinspection ConstantConditions
+            JobIntentService::class.java != null
+        } catch (e: Throwable) {
+            false
+        }
+    }
+
+    fun hasWakefulBroadcastReceiver(): Boolean {
+        return try {
+            // noinspection ConstantConditions
+            WakefulBroadcastReceiver::class.java != null
+        } catch (e: Throwable) {
+            false
+        }
+    }
+
+    fun hasNotificationManagerCompat(): Boolean {
+        return try {
+            // noinspection ConstantConditions
+            NotificationManagerCompat::class.java != null
+        } catch (e: Throwable) {
+            false
+        }
     }
 
     fun openURLInBrowser(appContext: Context, url: String) {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/core/internal/device/IDeviceService.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/core/internal/device/IDeviceService.kt
@@ -13,4 +13,11 @@ internal interface IDeviceService {
     val isGMSInstalledAndEnabled: Boolean
     val hasAllHMSLibrariesForPushKit: Boolean
     val hasFCMLibrary: Boolean
+    val androidSupportLibraryStatus: AndroidSupportLibraryStatus
+
+    enum class AndroidSupportLibraryStatus {
+        MISSING,
+        OUTDATED,
+        OK
+    }
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/core/internal/http/impl/HttpClient.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/core/internal/http/impl/HttpClient.kt
@@ -56,7 +56,7 @@ internal class HttpClient(
         cacheKey: String?
     ): HttpResponse {
         // If privacy consent is required but not yet given, any non-GET request should be blocked.
-        if (method != null && _configModelStore.get().requiresPrivacyConsent == true && _configModelStore.get().givenPrivacyConsent != true) {
+        if (method != null && _configModelStore.model.requiresPrivacyConsent == true && _configModelStore.model.givenPrivacyConsent != true) {
             Logging.warn("$method `$url` was called before the user provided privacy consent. Your application is set to require the user's privacy consent before the OneSignal SDK can be initialized. Please ensure the user has provided consent before calling this method. You can check the latest OneSignal consent status by calling OneSignal.privacyConsent")
             return HttpResponse(0, null, null)
         }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/core/internal/influence/impl/InfluenceDataRepository.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/core/internal/influence/impl/InfluenceDataRepository.kt
@@ -124,23 +124,23 @@ internal class InfluenceDataRepository(
         }
 
     override val notificationLimit: Int
-        get() = _configModelStore.get().influenceParams.notificationLimit
+        get() = _configModelStore.model.influenceParams.notificationLimit
 
     override val iamLimit: Int
-        get() = _configModelStore.get().influenceParams.iamLimit
+        get() = _configModelStore.model.influenceParams.iamLimit
 
     override val notificationIndirectAttributionWindow: Int
-        get() = _configModelStore.get().influenceParams.indirectNotificationAttributionWindow
+        get() = _configModelStore.model.influenceParams.indirectNotificationAttributionWindow
 
     override val iamIndirectAttributionWindow: Int
-        get() = _configModelStore.get().influenceParams.indirectIAMAttributionWindow
+        get() = _configModelStore.model.influenceParams.indirectIAMAttributionWindow
 
     override val isDirectInfluenceEnabled: Boolean
-        get() = _configModelStore.get().influenceParams.isDirectEnabled
+        get() = _configModelStore.model.influenceParams.isDirectEnabled
 
     override val isIndirectInfluenceEnabled: Boolean
-        get() = _configModelStore.get().influenceParams.isIndirectEnabled
+        get() = _configModelStore.model.influenceParams.isIndirectEnabled
 
     override val isUnattributedInfluenceEnabled: Boolean
-        get() = _configModelStore.get().influenceParams.isUnattributedEnabled
+        get() = _configModelStore.model.influenceParams.isUnattributedEnabled
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/core/internal/language/impl/LanguageContext.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/core/internal/language/impl/LanguageContext.kt
@@ -10,6 +10,6 @@ internal class LanguageContext(
     private var _deviceLanguageProvider = LanguageProviderDevice()
 
     override var language: String
-        get() = _propertiesModelStore.get().language ?: _deviceLanguageProvider.language
-        set(value) { _propertiesModelStore.get().language = value }
+        get() = _propertiesModelStore.model.language ?: _deviceLanguageProvider.language
+        set(value) { _propertiesModelStore.model.language = value }
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/core/internal/listeners/IdentityModelStoreListener.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/core/internal/listeners/IdentityModelStoreListener.kt
@@ -21,9 +21,9 @@ internal class IdentityModelStoreListener(
 
     override fun getUpdateOperation(model: IdentityModel, path: String, property: String, oldValue: Any?, newValue: Any?): Operation {
         return if (newValue != null && newValue is String) {
-            SetAliasOperation(_configModelStore.get().appId, model.onesignalId, property, newValue)
+            SetAliasOperation(_configModelStore.model.appId, model.onesignalId, property, newValue)
         } else {
-            DeleteAliasOperation(_configModelStore.get().appId, model.onesignalId, property)
+            DeleteAliasOperation(_configModelStore.model.appId, model.onesignalId, property)
         }
     }
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/core/internal/listeners/ModelStoreListener.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/core/internal/listeners/ModelStoreListener.kt
@@ -3,6 +3,8 @@ package com.onesignal.core.internal.listeners
 import com.onesignal.core.internal.modeling.IModelStore
 import com.onesignal.core.internal.modeling.IModelStoreChangeHandler
 import com.onesignal.core.internal.modeling.Model
+import com.onesignal.core.internal.modeling.ModelChangeTags
+import com.onesignal.core.internal.modeling.ModelChangedArgs
 import com.onesignal.core.internal.operations.IOperationRepo
 import com.onesignal.core.internal.operations.Operation
 import com.onesignal.core.internal.startup.IBootstrapService
@@ -21,21 +23,33 @@ internal abstract class ModelStoreListener<TModel>(
         store.unsubscribe(this)
     }
 
-    override fun onAdded(model: TModel) {
+    override fun onModelAdded(model: TModel, tag: String) {
+        if (tag != ModelChangeTags.NORMAL) {
+            return
+        }
+
         val operation = getAddOperation(model)
         if (operation != null) {
             opRepo.enqueue(operation)
         }
     }
 
-    override fun onUpdated(model: TModel, path: String, property: String, oldValue: Any?, newValue: Any?) {
-        val operation = getUpdateOperation(model, path, property, oldValue, newValue)
+    override fun onModelUpdated(args: ModelChangedArgs, tag: String) {
+        if (tag != ModelChangeTags.NORMAL) {
+            return
+        }
+
+        val operation = getUpdateOperation(args.model as TModel, args.path, args.property, args.oldValue, args.newValue)
         if (operation != null) {
             opRepo.enqueue(operation)
         }
     }
 
-    override fun onRemoved(model: TModel) {
+    override fun onModelRemoved(model: TModel, tag: String) {
+        if (tag != ModelChangeTags.NORMAL) {
+            return
+        }
+
         val operation = getRemoveOperation(model)
         if (operation != null) {
             opRepo.enqueue(operation)

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/core/internal/listeners/PropertiesModelStoreListener.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/core/internal/listeners/PropertiesModelStoreListener.kt
@@ -23,12 +23,12 @@ internal class PropertiesModelStoreListener(
     override fun getUpdateOperation(model: PropertiesModel, path: String, property: String, oldValue: Any?, newValue: Any?): Operation? {
         if (path.startsWith(PropertiesModel::tags.name)) {
             return if (newValue != null && newValue is String) {
-                SetTagOperation(_configModelStore.get().appId, model.onesignalId, property, newValue)
+                SetTagOperation(_configModelStore.model.appId, model.onesignalId, property, newValue)
             } else {
-                DeleteTagOperation(_configModelStore.get().appId, model.onesignalId, property)
+                DeleteTagOperation(_configModelStore.model.appId, model.onesignalId, property)
             }
         }
 
-        return SetPropertyOperation(_configModelStore.get().appId, model.onesignalId, property, newValue)
+        return SetPropertyOperation(_configModelStore.model.appId, model.onesignalId, property, newValue)
     }
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/core/internal/listeners/SessionListener.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/core/internal/listeners/SessionListener.kt
@@ -39,10 +39,10 @@ internal class SessionListener(
     }
 
     override fun onSessionEnded(duration: Long) {
-        _operationRepo.enqueue(TrackSessionOperation(_configModelStore.get().appId, _identityModelStore.get().onesignalId, duration))
+        _operationRepo.enqueue(TrackSessionOperation(_configModelStore.model.appId, _identityModelStore.model.onesignalId, duration))
 
         suspendifyOnThread {
-            _outcomeEventsController.sendOutcomeEvent("__os_session_end")
+            _outcomeEventsController.sendOutcomeEvent("os__session_duration")
         }
     }
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/core/internal/listeners/SingletonModelStoreListener.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/core/internal/listeners/SingletonModelStoreListener.kt
@@ -3,6 +3,8 @@ package com.onesignal.core.internal.listeners
 import com.onesignal.core.internal.modeling.ISingletonModelStore
 import com.onesignal.core.internal.modeling.ISingletonModelStoreChangeHandler
 import com.onesignal.core.internal.modeling.Model
+import com.onesignal.core.internal.modeling.ModelChangeTags
+import com.onesignal.core.internal.modeling.ModelChangedArgs
 import com.onesignal.core.internal.operations.IOperationRepo
 import com.onesignal.core.internal.operations.Operation
 import com.onesignal.core.internal.startup.IBootstrapService
@@ -21,15 +23,23 @@ internal abstract class SingletonModelStoreListener<TModel>(
         store.unsubscribe(this)
     }
 
-    override fun onModelReplaced(model: TModel) {
+    override fun onModelReplaced(model: TModel, tag: String) {
+        if (tag != ModelChangeTags.NORMAL) {
+            return
+        }
+
         val operation = getReplaceOperation(model)
         if (operation != null) {
             opRepo.enqueue(operation)
         }
     }
 
-    override fun onModelUpdated(model: TModel, path: String, property: String, oldValue: Any?, newValue: Any?) {
-        val operation = getUpdateOperation(model, path, property, oldValue, newValue)
+    override fun onModelUpdated(args: ModelChangedArgs, tag: String) {
+        if (tag != ModelChangeTags.NORMAL) {
+            return
+        }
+
+        val operation = getUpdateOperation(args.model as TModel, args.path, args.property, args.oldValue, args.newValue)
         if (operation != null) {
             opRepo.enqueue(operation)
         }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/core/internal/listeners/SubscriptionModelStoreListener.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/core/internal/listeners/SubscriptionModelStoreListener.kt
@@ -18,14 +18,14 @@ internal class SubscriptionModelStoreListener(
 ) : ModelStoreListener<SubscriptionModel>(store, opRepo) {
 
     override fun getAddOperation(model: SubscriptionModel): Operation {
-        return CreateSubscriptionOperation(_configModelStore.get().appId, _identityModelStore.get().onesignalId, model.id, model.type, model.enabled, model.address)
+        return CreateSubscriptionOperation(_configModelStore.model.appId, _identityModelStore.model.onesignalId, model.id, model.type, model.enabled, model.address, model.status)
     }
 
     override fun getRemoveOperation(model: SubscriptionModel): Operation {
-        return DeleteSubscriptionOperation(_configModelStore.get().appId, _identityModelStore.get().onesignalId, model.id)
+        return DeleteSubscriptionOperation(_configModelStore.model.appId, _identityModelStore.model.onesignalId, model.id)
     }
 
     override fun getUpdateOperation(model: SubscriptionModel, path: String, property: String, oldValue: Any?, newValue: Any?): Operation {
-        return UpdateSubscriptionOperation(_configModelStore.get().appId, _identityModelStore.get().onesignalId, model.id, model.enabled, model.address)
+        return UpdateSubscriptionOperation(_configModelStore.model.appId, _identityModelStore.model.onesignalId, model.id, model.enabled, model.address, model.status)
     }
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/core/internal/modeling/IModelChangedHandler.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/core/internal/modeling/IModelChangedHandler.kt
@@ -10,8 +10,9 @@ internal interface IModelChangedHandler {
      * Called when the subscribed model has been changed.
      *
      * @param args Information related to what has changed.
+     * @param tag The tag which identifies how/why the model was changed.
      */
-    fun onChanged(args: ModelChangedArgs)
+    fun onChanged(args: ModelChangedArgs, tag: String)
 }
 
 /**

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/core/internal/modeling/IModelStore.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/core/internal/modeling/IModelStore.kt
@@ -18,9 +18,9 @@ internal interface IModelStore<TModel> : IEventNotifier<IModelStoreChangeHandler
     fun create(jsonObject: JSONObject? = null): TModel
 
     /**
-     * List the keys of the models that are owned by this model store.
+     * List the models that are owned by this model store.
      *
-     * @return The collection of keys.
+     * @return The collection of models.
      */
     fun list(): Collection<TModel>
 
@@ -28,12 +28,12 @@ internal interface IModelStore<TModel> : IEventNotifier<IModelStoreChangeHandler
      * Add a new model to this model store.  Once added, any changes to the
      * model will trigger calls to an [IModelStoreChangeHandler] that has
      * subscribed to this model store.  This same instance is also retrievable
-     * via [get].
+     * via [get] based on [Model.id].
      *
      * @param model The model being added to the model store.
-     * @param fireEvent Whether an event should be fired, defaults to true.
+     * @param tag The tag which identifies how/why the model is being added.
      */
-    fun add(model: TModel, fireEvent: Boolean = true)
+    fun add(model: TModel, tag: String = ModelChangeTags.NORMAL)
 
     /**
      * Retrieve the model associated to the id provided.
@@ -48,20 +48,39 @@ internal interface IModelStore<TModel> : IEventNotifier<IModelStoreChangeHandler
      * Remove the model associated to the id provided from the model store.
      *
      * @param id The unique identifier to the model to remove.
-     * @param fireEvent Whether an event should be fired, defaults to true.
+     * @param tag The tag which identifies how/why the model is being removed.
      */
-    fun remove(id: String, fireEvent: Boolean = true)
+    fun remove(id: String, tag: String = ModelChangeTags.NORMAL)
 
     /**
      * Remove all models from the store.
+     *
+     * @param tag The tag which identifies how/why the model store is being cleared.
      */
-    fun clear(fireEvent: Boolean = true)
+    fun clear(tag: String = ModelChangeTags.NORMAL)
 
     /**
      * Replace all models in the store with the provided models.
      *
      * @param models The models to track in the model store.
-     * @param fireEvent Whether an event should be fired, defaults to true.
+     * @param tag The tag which identifies how/why the model store is being replaced.
      */
-    fun replaceAll(models: List<TModel>, fireEvent: Boolean = true)
+    fun replaceAll(models: List<TModel>, tag: String = ModelChangeTags.NORMAL)
+}
+
+internal object ModelChangeTags {
+    /**
+     * A change was performed through normal means.
+     */
+    const val NORMAL = "NORMAL"
+
+    /**
+     * A change was performed that should *not* be propogated to the backend.
+     */
+    const val NO_PROPOGATE = "NO_PROPOGATE"
+
+    /**
+     * A change was performed through the backend hydrating the model.
+     */
+    const val HYDRATE = "HYDRATE"
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/core/internal/modeling/IModelStoreChangeHandler.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/core/internal/modeling/IModelStoreChangeHandler.kt
@@ -9,26 +9,25 @@ internal interface IModelStoreChangeHandler<TModel> where TModel : Model {
      * Called when a model has been added to the model store.
      *
      * @param model The model that has been added.
+     * @param tag The tag which identifies how/why the model was added.
      */
-    fun onAdded(model: TModel)
+    fun onModelAdded(model: TModel, tag: String)
 
     /**
      * Called when a model has been updated.  This callback wraps [IModelChangedHandler.onChanged]
      * so users of the model store does not need to manage subscriptions to each individual [Model]
      * within the store.
      *
-     * @param model The model that has been updated (includes the updates).
-     * @param path The path to the property of the model that has been updated.
-     * @param property The property of the model that has been updated.
-     * @param oldValue The old value of the property that has changed.
-     * @param newValue The new value of the property that has changed.
+     * @param args The model changed arguments.
+     * @param tag The tag which identifies how/why the model was updated.
      */
-    fun onUpdated(model: TModel, path: String, property: String, oldValue: Any?, newValue: Any?)
+    fun onModelUpdated(args: ModelChangedArgs, tag: String)
 
     /**
      * Called when a model has been removed from the model store.
      *
      * @param model The model that has been removed.
+     * @param tag The tag which identifies how/why the model was removed.
      */
-    fun onRemoved(model: TModel)
+    fun onModelRemoved(model: TModel, tag: String)
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/core/internal/modeling/ISingletonModelStore.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/core/internal/modeling/ISingletonModelStore.kt
@@ -10,17 +10,15 @@ import com.onesignal.core.internal.common.events.IEventNotifier
 internal interface ISingletonModelStore<TModel> :
     IEventNotifier<ISingletonModelStoreChangeHandler<TModel>> where TModel : Model {
     /**
-     * Retrieve the model managed by this singleton model store.
-     *
-     * @return The single model managed by this store.
+     * The model managed by this singleton model store.
      */
-    fun get(): TModel
+    val model: TModel
 
     /**
      * Replace the existing model with the new model provided.
      *
      * @param model A model that contains all the data for the new effective model.
-     * @param fireEvent Whether an event should be fired for this update action.
+     * @param tag The tag which identifies how/why the model is being replaced.
      */
-    fun replace(model: TModel, fireEvent: Boolean = true)
+    fun replace(model: TModel, tag: String = ModelChangeTags.NORMAL)
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/core/internal/modeling/ISingletonModelStoreChangeHandler.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/core/internal/modeling/ISingletonModelStoreChangeHandler.kt
@@ -10,19 +10,17 @@ internal interface ISingletonModelStoreChangeHandler<TModel> where TModel : Mode
      * Called when the model has been replaced.
      *
      * @param model The model
+     * @param tag The tag which identifies how/why the model was replaced.
      */
-    fun onModelReplaced(model: TModel)
+    fun onModelReplaced(model: TModel, tag: String)
 
     /**
      * Called when a property within the model has been updated. This callback wraps [IModelChangedHandler.onChanged]
      * so users of the model store does not need to manage subscriptions to the individual [Model]
      * within the store.
      *
-     * @param model The model that has been updated (includes the updates).
-     * @param path The path to the property of the model that has been updated.
-     * @param property The property of the model that has been updated.
-     * @param oldValue The old value of the property that has changed.
-     * @param newValue The new value of the property that has changed.
+     * @param args The model changed arguments.
+     * @param tag The tag which identifies how/why the model was updated.
      */
-    fun onModelUpdated(model: TModel, path: String, property: String, oldValue: Any?, newValue: Any?)
+    fun onModelUpdated(args: ModelChangedArgs, tag: String)
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/core/internal/modeling/MapModel.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/core/internal/modeling/MapModel.kt
@@ -2,8 +2,8 @@ package com.onesignal.core.internal.modeling
 
 /**
  * A Map Model is a [MutableMap] that has a key of type string and a generically-specified
- * value.  It is a [Model] which hooks the map into the model framework and allows for change
- * notification propagation for any adds, removes, or updates to the map.
+ * value.  It is a [Model] which hooks the [MutableMap] into the model framework and allows for change
+ * notification propagation for any adds, removes, or updates to the [MutableMap].
  */
 internal open class MapModel<V>(
     parentModel: Model? = null,

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/core/internal/models/SubscriptionModel.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/core/internal/models/SubscriptionModel.kt
@@ -20,4 +20,35 @@ internal class SubscriptionModel : Model() {
     var address: String
         get() = getProperty(::address.name)
         set(value) { setProperty(::address.name, value) }
+
+    var status: Int
+        get() = getProperty(::status.name) { STATUS_SUBSCRIBED }
+        set(value) { setProperty(::status.name, value) }
+
+    companion object {
+        const val STATUS_SUBSCRIBED = 1
+        const val STATUS_NO_PERMISSION = 0
+        const val STATUS_UNSUBSCRIBE = -2
+        const val STATUS_MISSING_ANDROID_SUPPORT_LIBRARY = -3
+        const val STATUS_MISSING_FIREBASE_FCM_LIBRARY = -4
+        const val STATUS_OUTDATED_ANDROID_SUPPORT_LIBRARY = -5
+        const val STATUS_INVALID_FCM_SENDER_ID = -6
+        const val STATUS_OUTDATED_GOOGLE_PLAY_SERVICES_APP = -7
+        const val STATUS_FIREBASE_FCM_INIT_ERROR = -8
+        const val STATUS_FIREBASE_FCM_ERROR_IOEXCEPTION_SERVICE_NOT_AVAILABLE = -9
+
+        // -10 is a server side detection only from FCM that the app is no longer installed
+        const val STATUS_FIREBASE_FCM_ERROR_IOEXCEPTION_OTHER = -11
+        const val STATUS_FIREBASE_FCM_ERROR_MISC_EXCEPTION = -12
+
+        // -13 to -24 reserved for other platforms
+        const val STATUS_HMS_TOKEN_TIMEOUT = -25
+
+        // Most likely missing "client/app_id".
+        // Check that there is "apply plugin: 'com.huawei.agconnect'" in your app/build.gradle
+        const val STATUS_HMS_ARGUMENTS_INVALID = -26
+        const val STATUS_HMS_API_EXCEPTION_OTHER = -27
+        const val STATUS_MISSING_HMS_PUSHKIT_LIBRARY = -28
+        const val STATUS_FIREBASE_FCM_ERROR_IOEXCEPTION_AUTHENTICATION_FAILED = -29
+    }
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/core/internal/operations/CreateSubscriptionOperation.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/core/internal/operations/CreateSubscriptionOperation.kt
@@ -58,17 +58,25 @@ internal class CreateSubscriptionOperation() : Operation(SubscriptionOperationEx
         get() = getProperty(::address.name)
         private set(value) { setProperty(::address.name, value) }
 
+    /**
+     * The status of this subscription.
+     */
+    var status: Int
+        get() = getProperty(::status.name)
+        private set(value) { setProperty(::status.name, value) }
+
     override val createComparisonKey: String get() = "$appId.User.$onesignalId"
     override val modifyComparisonKey: String get() = "$appId.User.$onesignalId.Subscription.$subscriptionId"
     override val groupComparisonType: GroupComparisonType = GroupComparisonType.ALTER
     override val canStartExecute: Boolean get() = !IDManager.isIdLocalOnly(onesignalId)
 
-    constructor(appId: String, onesignalId: String, subscriptionId: String, type: SubscriptionType, enabled: Boolean, address: String) : this() {
+    constructor(appId: String, onesignalId: String, subscriptionId: String, type: SubscriptionType, enabled: Boolean, address: String, status: Int) : this() {
         this.appId = appId
         this.onesignalId = onesignalId
         this.subscriptionId = subscriptionId
         this.type = type
         this.enabled = enabled
         this.address = address
+        this.status = status
     }
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/core/internal/operations/UpdateSubscriptionOperation.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/core/internal/operations/UpdateSubscriptionOperation.kt
@@ -50,16 +50,24 @@ internal class UpdateSubscriptionOperation() : Operation(SubscriptionOperationEx
         get() = getProperty(::address.name)
         private set(value) { setProperty(::address.name, value) }
 
+    /**
+     * The status of this subscription.
+     */
+    var status: Int
+        get() = getProperty(::status.name)
+        private set(value) { setProperty(::status.name, value) }
+
     override val createComparisonKey: String get() = "$appId.User.$onesignalId"
     override val modifyComparisonKey: String get() = "$appId.User.$onesignalId.Subscription.$subscriptionId"
     override val groupComparisonType: GroupComparisonType = GroupComparisonType.ALTER
     override val canStartExecute: Boolean get() = !IDManager.isIdLocalOnly(onesignalId) && !IDManager.isIdLocalOnly(onesignalId)
 
-    constructor(appId: String, onesignalId: String, subscriptionId: String, enabled: Boolean, address: String) : this() {
+    constructor(appId: String, onesignalId: String, subscriptionId: String, enabled: Boolean, address: String, status: Int) : this() {
         this.appId = appId
         this.onesignalId = onesignalId
         this.subscriptionId = subscriptionId
         this.enabled = enabled
         this.address = address
+        this.status = status
     }
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/core/internal/operations/impl/UserOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/core/internal/operations/impl/UserOperationExecutor.kt
@@ -17,6 +17,7 @@ import com.onesignal.core.internal.common.OneSignalUtils
 import com.onesignal.core.internal.common.RootToolsInternalMethods
 import com.onesignal.core.internal.device.IDeviceService
 import com.onesignal.core.internal.logging.Logging
+import com.onesignal.core.internal.modeling.ModelChangeTags
 import com.onesignal.core.internal.models.IdentityModelStore
 import com.onesignal.core.internal.models.PropertiesModel
 import com.onesignal.core.internal.models.PropertiesModelStore
@@ -98,25 +99,23 @@ internal class UserOperationExecutor(
 
             IDManager.setLocalToBackendIdTranslation(createUserOperation.onesignalId, backendOneSignalId)
 
-            val identityModel = _identityModelStore.get()
-            val propertiesModel = _propertiesModelStore.get()
+            val identityModel = _identityModelStore.model
+            val propertiesModel = _propertiesModelStore.model
 
             if (identityModel.onesignalId == createUserOperation.onesignalId) {
-                identityModel.setProperty(IdentityConstants.ONESIGNAL_ID, backendOneSignalId, false)
+                identityModel.setProperty(IdentityConstants.ONESIGNAL_ID, backendOneSignalId, ModelChangeTags.HYDRATE)
 
                 // TODO: hydrate any additional aliases from the backend...
-                _identityModelStore.persist()
             }
 
             if (propertiesModel.onesignalId == createUserOperation.onesignalId) {
-                propertiesModel.setProperty(PropertiesModel::onesignalId.name, backendOneSignalId, notify = false)
+                propertiesModel.setProperty(PropertiesModel::onesignalId.name, backendOneSignalId, ModelChangeTags.HYDRATE)
 
                 // TODO: hydrate the models from the backend create response.  Temporarily inject dummy stuff to
                 //       show that it's working.
 //                propertiesModel.setProperty(PropertiesModel::language.name, "en", notify = false)
-                propertiesModel.setProperty(PropertiesModel::country.name, "US", notify = false)
-                propertiesModel.tags.setProperty("foo", UUID.randomUUID().toString(), notify = false)
-                _propertiesModelStore.persist()
+                propertiesModel.setProperty(PropertiesModel::country.name, "US", ModelChangeTags.HYDRATE)
+                propertiesModel.tags.setProperty("foo", UUID.randomUUID().toString(), ModelChangeTags.HYDRATE)
             }
 
             // TODO: assumption that the response.subscriptionIDs will associate to the input subscriptionList...to confirm
@@ -130,9 +129,8 @@ internal class UserOperationExecutor(
                 IDManager.setLocalToBackendIdTranslation(subscriptionList[index].id, backendSubscriptionId)
 
                 val subscriptionModel = _subscriptionsModelStore.get(subscriptionList[index].id)
-                subscriptionModel?.setProperty(SubscriptionModel::id.name, backendSubscriptionId, false)
+                subscriptionModel?.setProperty(SubscriptionModel::id.name, backendSubscriptionId, ModelChangeTags.HYDRATE)
             }
-            _subscriptionsModelStore.persist()
         } catch (ex: BackendException) {
         }
     }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/core/internal/outcomes/impl/OutcomeEventsController.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/core/internal/outcomes/impl/OutcomeEventsController.kt
@@ -65,7 +65,7 @@ internal class OutcomeEventsController(
 
     private suspend fun sendSavedOutcomeEvent(event: OutcomeEventParams) {
         val deviceType: Int = _deviceService.deviceType
-        val appId: String = _configModelStore.get().appId
+        val appId: String = _configModelStore.model.appId
 
         try {
             requestMeasureOutcomeEvent(appId, deviceType, event)
@@ -159,7 +159,7 @@ Outcome event was cached and will be reattempted on app cold start"""
     ): OutcomeEvent? {
         val timestampSeconds: Long = _time.currentTimeMillis / 1000
         val deviceType: Int = _deviceService.deviceType
-        val appId: String = _configModelStore.get().appId
+        val appId: String = _configModelStore.model.appId
         var directSourceBody: OutcomeSourceBody? = null
         var indirectSourceBody: OutcomeSourceBody? = null
         var unattributed = false

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/core/internal/preferences/PreferencesService.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/core/internal/preferences/PreferencesService.kt
@@ -60,13 +60,17 @@ internal class PreferencesService(
 
         val prefs = getSharedPrefsByName(store)
         if (prefs != null) {
-            return when (type) {
-                String::class.java -> prefs.getString(key, defValue as String?)
-                Boolean::class.java -> prefs.getBoolean(key, (defValue as Boolean?) ?: false)
-                Int::class.java -> prefs.getInt(key, (defValue as Int?) ?: 0)
-                Long::class.java -> prefs.getLong(key, (defValue as Long?) ?: 0)
-                Set::class.java -> prefs.getStringSet(key, defValue as Set<String>?)
-                else -> null
+            try {
+                return when (type) {
+                    String::class.java -> prefs.getString(key, defValue as String?)
+                    Boolean::class.java -> prefs.getBoolean(key, (defValue as Boolean?) ?: false)
+                    Int::class.java -> prefs.getInt(key, (defValue as Int?) ?: 0)
+                    Long::class.java -> prefs.getLong(key, (defValue as Long?) ?: 0)
+                    Set::class.java -> prefs.getStringSet(key, defValue as Set<String>?)
+                    else -> null
+                }
+            } catch (ex: Exception) {
+                // any issues retrieving the preference, return the default value.
             }
         }
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/core/internal/purchases/TrackAmazonPurchase.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/core/internal/purchases/TrackAmazonPurchase.kt
@@ -181,7 +181,7 @@ internal class TrackAmazonPurchase(
                         }
 
                         // TODO: amount spent?
-                        _operationRepo.enqueue(TrackPurchaseOperation(_configModelStore.get().appId, _identityModelStore.get().onesignalId, false, BigDecimal(0), purchasesToReport))
+                        _operationRepo.enqueue(TrackPurchaseOperation(_configModelStore.model.appId, _identityModelStore.model.onesignalId, false, BigDecimal(0), purchasesToReport))
                     }
                 }
             } else if (orgPurchasingListener != null) {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/core/internal/purchases/TrackGooglePurchase.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/core/internal/purchases/TrackGooglePurchase.kt
@@ -221,7 +221,7 @@ internal class TrackGooglePurchase(
 
                 // New purchases to report. If successful then mark them as tracked.
                 if (purchasesToReport.isNotEmpty()) {
-                    _operationRepo.enqueue(TrackPurchaseOperation(_configModelStore.get().appId, _identityModelStore.get().onesignalId, newAsExisting, BigDecimal(0), purchasesToReport))
+                    _operationRepo.enqueue(TrackPurchaseOperation(_configModelStore.model.appId, _identityModelStore.model.onesignalId, newAsExisting, BigDecimal(0), purchasesToReport))
                     purchaseTokens.addAll(newPurchaseTokens)
                     _prefs.saveString(PreferenceStores.PLAYER_PURCHASES, PreferencePlayerPurchasesKeys.PREFS_PURCHASE_TOKENS, purchaseTokens.toString())
                     _prefs.saveBool(PreferenceStores.PLAYER_PURCHASES, PreferencePlayerPurchasesKeys.PREFS_EXISTING_PURCHASES, true)

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/core/internal/session/impl/SessionService.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/core/internal/session/impl/SessionService.kt
@@ -48,8 +48,8 @@ internal class SessionService(
     private var _config: ConfigModel? = null
 
     override fun start() {
-        _session = _sessionModelStore.get()
-        _config = _configModelStore.get()
+        _session = _sessionModelStore.model
+        _config = _configModelStore.model
         _applicationService.addApplicationLifecycleHandler(this)
     }
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/core/internal/user/UserManager.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/core/internal/user/UserManager.kt
@@ -41,10 +41,10 @@ internal open class UserManager(
         get() = _subscriptionManager.subscriptions
 
     private val _identityModel: IdentityModel
-        get() = _identityModelStore.get()
+        get() = _identityModelStore.model
 
     private val _propertiesModel: PropertiesModel
-        get() = _propertiesModelStore.get()
+        get() = _propertiesModelStore.model
 
     override fun addAlias(label: String, id: String): com.onesignal.core.user.IUserManager {
         Logging.log(LogLevel.DEBUG, "setAlias(label: $label, id: $id)")

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/iam/internal/display/impl/InAppDisplayer.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/iam/internal/display/impl/InAppDisplayer.kt
@@ -45,7 +45,7 @@ internal class InAppDisplayer(
     private var lastInstance: WebViewManager? = null
 
     override suspend fun displayMessage(message: InAppMessage): Boolean? {
-        var response = _backend.getIAMData(_configModelStore.get().appId, message.messageId, InAppHelper.variantIdForMessage(message, _languageContext))
+        var response = _backend.getIAMData(_configModelStore.model.appId, message.messageId, InAppHelper.variantIdForMessage(message, _languageContext))
 
         if (response.content != null) {
             message.displayDuration = response.content!!.displayDuration!!
@@ -66,7 +66,7 @@ internal class InAppDisplayer(
 
     override suspend fun displayPreviewMessage(previewUUID: String): Boolean {
         val message = InAppMessage(true, _time)
-        val content = _backend.getIAMPreviewData(_configModelStore.get().appId, previewUUID)
+        val content = _backend.getIAMPreviewData(_configModelStore.model.appId, previewUUID)
 
         return if (content == null) {
             false

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/iam/internal/triggers/impl/TriggerController.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/iam/internal/triggers/impl/TriggerController.kt
@@ -2,6 +2,7 @@ package com.onesignal.iam.internal.triggers.impl
 
 import com.onesignal.core.internal.logging.Logging
 import com.onesignal.core.internal.modeling.IModelStoreChangeHandler
+import com.onesignal.core.internal.modeling.ModelChangedArgs
 import com.onesignal.core.internal.models.TriggerModel
 import com.onesignal.core.internal.models.TriggerModelStore
 import com.onesignal.iam.internal.InAppMessage
@@ -206,17 +207,18 @@ internal class TriggerController(
         return true
     }
 
-    override fun onAdded(model: TriggerModel) {
+    override fun onModelAdded(model: TriggerModel, tag: String) {
         addTriggers(model.key, model.value)
         _dynamicTriggerController.events.fire { it.onTriggerChanged(model.key) }
     }
 
-    override fun onUpdated(model: TriggerModel, path: String, property: String, oldValue: Any?, newValue: Any?) {
+    override fun onModelUpdated(args: ModelChangedArgs, tag: String) {
+        val model = args.model as TriggerModel
         addTriggers(model.key, model.value)
         _dynamicTriggerController.events.fire { it.onTriggerChanged(model.key) }
     }
 
-    override fun onRemoved(model: TriggerModel) {
+    override fun onModelRemoved(model: TriggerModel, tag: String) {
         removeTriggersForKeys(model.key)
     }
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/location/internal/capture/impl/LocationCapturer.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/location/internal/capture/impl/LocationCapturer.kt
@@ -60,7 +60,7 @@ internal class LocationCapturer(
             point.log = location.longitude
         }
 
-        var userProperties = _propertiesModelStore.get()
+        var userProperties = _propertiesModelStore.model
         userProperties.locationLongitude = point.log
         userProperties.locationLatitude = point.lat
         userProperties.locationAccuracy = point.accuracy

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/notification/internal/data/impl/NotificationQueryHelper.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/notification/internal/data/impl/NotificationQueryHelper.kt
@@ -19,7 +19,7 @@ internal class NotificationQueryHelper(
                 OneSignalDbContract.NotificationTable.COLUMN_NAME_OPENED + " = 0 AND " +
                 OneSignalDbContract.NotificationTable.COLUMN_NAME_IS_SUMMARY + " = 0"
         )
-        val useTtl = _configModelStore.get().restoreTTLFilter
+        val useTtl = _configModelStore.model.restoreTTLFilter
         if (useTtl) {
             val expireTimeWhere =
                 " AND " + OneSignalDbContract.NotificationTable.COLUMN_NAME_EXPIRE_TIME + " > " + currentTimeSec

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/notification/internal/generation/impl/NotificationGenerationProcessor.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/notification/internal/generation/impl/NotificationGenerationProcessor.kt
@@ -163,7 +163,7 @@ internal class NotificationGenerationProcessor(
 
     // If available TTL times comes in seconds, by default is 3 days in seconds
     private fun isNotificationWithinTTL(notification: Notification): Boolean {
-        val useTtl = _configModelStore.get().restoreTTLFilter
+        val useTtl = _configModelStore.model.restoreTTLFilter
         if (!useTtl) return true
         val currentTimeInSeconds = _time.currentTimeMillis / 1000
         val sentTime = notification.sentTime

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/notification/internal/listeners/ConfigModelStoreListener.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/notification/internal/listeners/ConfigModelStoreListener.kt
@@ -2,6 +2,8 @@ package com.onesignal.notification.internal.listeners
 
 import com.onesignal.core.internal.common.suspendifyOnThread
 import com.onesignal.core.internal.modeling.ISingletonModelStoreChangeHandler
+import com.onesignal.core.internal.modeling.ModelChangeTags
+import com.onesignal.core.internal.modeling.ModelChangedArgs
 import com.onesignal.core.internal.models.ConfigModel
 import com.onesignal.core.internal.models.ConfigModelStore
 import com.onesignal.core.internal.startup.IStartableService
@@ -18,7 +20,13 @@ internal class ConfigModelStoreListener(
         _configModelStore.subscribe(this)
     }
 
-    override fun onModelReplaced(model: ConfigModel) {
+    override fun onModelReplaced(model: ConfigModel, tag: String) {
+        // we only need to do things when the config model was replaced
+        // via a hydration from the backend.
+        if (tag != ModelChangeTags.HYDRATE) {
+            return
+        }
+
         // Refresh the notification permissions whenever we come back into focus
         _channelManager.processChannelList(model.notificationChannels)
 
@@ -27,6 +35,6 @@ internal class ConfigModelStoreListener(
         }
     }
 
-    override fun onModelUpdated(model: ConfigModel, path: String, property: String, oldValue: Any?, newValue: Any?) {
+    override fun onModelUpdated(args: ModelChangedArgs, tag: String) {
     }
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/notification/internal/listeners/NotificationListener.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/notification/internal/listeners/NotificationListener.kt
@@ -67,7 +67,7 @@ internal class NotificationListener(
         data: JSONArray,
         notificationId: String
     ) {
-        val config = _configModelStore.get()
+        val config = _configModelStore.model
         val appId: String = config.appId ?: ""
         val subscriptionId: String = _subscriptionManager.subscriptions.push?.id.toString()
         val deviceType = _deviceService.deviceType

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/notification/internal/listeners/PushTokenListener.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/notification/internal/listeners/PushTokenListener.kt
@@ -5,6 +5,7 @@ import com.onesignal.core.internal.user.ISubscriptionManager
 import com.onesignal.notification.internal.INotificationStateRefresher
 import com.onesignal.notification.internal.pushtoken.IPushTokenChangedHandler
 import com.onesignal.notification.internal.pushtoken.IPushTokenManager
+import com.onesignal.notification.internal.registration.IPushRegistrator
 
 internal class PushTokenListener(
     private val _pushTokenManager: IPushTokenManager,
@@ -16,12 +17,8 @@ internal class PushTokenListener(
         _pushTokenManager.subscribe(this)
     }
 
-    override fun onPushTokenChanged(pushToken: String?) {
-        if (pushToken == null || pushToken.isEmpty()) {
-            return
-        }
-
-        _subscriptionManager.addOrUpdatePushSubscription(_pushTokenManager.pushToken)
+    override fun onPushTokenChanged(pushToken: String?, pushTokenStatus: IPushRegistrator.RegisterStatus) {
+        _subscriptionManager.addOrUpdatePushSubscription(pushToken, pushTokenStatus.value)
         _notificationStateRefresher.refreshNotificationState()
     }
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/notification/internal/open/impl/NotificationOpenedProcessor.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/notification/internal/open/impl/NotificationOpenedProcessor.kt
@@ -178,7 +178,7 @@ internal class NotificationOpenedProcessor(
             intent.getIntExtra(NotificationConstants.BUNDLE_KEY_ANDROID_NOTIFICATION_ID, 0),
             dismissed,
             summaryGroup,
-            _configModelStore.get().clearGroupOnSummaryClick
+            _configModelStore.model.clearGroupOnSummaryClick
         )
     }
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/notification/internal/permissions/INotificationPermissionController.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/notification/internal/permissions/INotificationPermissionController.kt
@@ -27,7 +27,9 @@
 
 package com.onesignal.notification.internal.permissions
 
-internal interface INotificationPermissionController {
+import com.onesignal.core.internal.common.events.IEventNotifier
+
+internal interface INotificationPermissionController : IEventNotifier<INotificationPermissionChangedHandler> {
     /**
      * Prompt the user for notification permission.  Note it is possible the application
      * will be killed while the permission prompt is being displayed to the user. When the
@@ -41,4 +43,8 @@ internal interface INotificationPermissionController {
      * to notify of the status.
      */
     suspend fun prompt(fallbackToSettings: Boolean): Boolean
+}
+
+internal interface INotificationPermissionChangedHandler {
+    fun onNotificationPermissionChanged(enabled: Boolean)
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/notification/internal/pushtoken/IPushTokenManager.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/notification/internal/pushtoken/IPushTokenManager.kt
@@ -1,14 +1,15 @@
 package com.onesignal.notification.internal.pushtoken
 
 import com.onesignal.core.internal.common.events.IEventNotifier
+import com.onesignal.notification.internal.registration.IPushRegistrator
 
 internal interface IPushTokenManager : IEventNotifier<IPushTokenChangedHandler> {
     /** The push token for this device **/
     val pushToken: String?
-
+    val pushTokenStatus: IPushRegistrator.RegisterStatus
     suspend fun retrievePushToken()
 }
 
 internal interface IPushTokenChangedHandler {
-    fun onPushTokenChanged(pushToken: String?)
+    fun onPushTokenChanged(pushToken: String?, pushTokenStatus: IPushRegistrator.RegisterStatus)
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/notification/internal/pushtoken/PushTokenManager.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/notification/internal/pushtoken/PushTokenManager.kt
@@ -1,6 +1,8 @@
 package com.onesignal.notification.internal.pushtoken
 
 import com.onesignal.core.internal.common.events.EventProducer
+import com.onesignal.core.internal.device.IDeviceService
+import com.onesignal.core.internal.logging.Logging
 import com.onesignal.notification.internal.registration.IPushRegistrator
 
 /**
@@ -8,38 +10,54 @@ import com.onesignal.notification.internal.registration.IPushRegistrator
  * on the current device (not the user).
  */
 internal class PushTokenManager(
-    private val _pushRegistrator: IPushRegistrator
+    private val _pushRegistrator: IPushRegistrator,
+    private val _deviceService: IDeviceService
 ) : IPushTokenManager {
 
     private val _pushTokenChangedNotifier = EventProducer<IPushTokenChangedHandler>()
+
+    override var pushTokenStatus: IPushRegistrator.RegisterStatus = IPushRegistrator.RegisterStatus.PUSH_STATUS_SUBSCRIBED
     override var pushToken: String? = null
 
     override suspend fun retrievePushToken() {
-        // if there's already a push token, nothing to do.
-        if (pushToken != null) {
-            return
+        when (_deviceService.androidSupportLibraryStatus) {
+            IDeviceService.AndroidSupportLibraryStatus.MISSING -> {
+                Logging.fatal("Could not find the Android Support Library. Please make sure it has been correctly added to your project.")
+                pushTokenStatus = IPushRegistrator.RegisterStatus.PUSH_STATUS_MISSING_ANDROID_SUPPORT_LIBRARY
+            }
+            IDeviceService.AndroidSupportLibraryStatus.OUTDATED -> {
+                Logging.fatal("The included Android Support Library is to old or incomplete. Please update to the 26.0.0 revision or newer.")
+                pushTokenStatus = IPushRegistrator.RegisterStatus.PUSH_STATUS_OUTDATED_ANDROID_SUPPORT_LIBRARY
+            }
+            else -> {
+                val registerResult = _pushRegistrator.registerForPush()
+
+                if (registerResult.status.value < IPushRegistrator.RegisterStatus.PUSH_STATUS_SUBSCRIBED.value) {
+                    // Only allow errored statuses if we have never gotten a token. This ensures the
+                    // device will not later be marked unsubscribed due to any inconsistencies returned
+                    // by Google Play services. Also do not override a config error status if we got a
+                    // runtime error
+                    if (pushToken == null &&
+                        (
+                            pushTokenStatus == IPushRegistrator.RegisterStatus.PUSH_STATUS_SUBSCRIBED ||
+                                pushStatusRuntimeError(pushTokenStatus)
+                            )
+                    ) {
+                        pushTokenStatus = registerResult.status
+                    }
+                } else if (pushStatusRuntimeError(pushTokenStatus)) {
+                    pushTokenStatus = registerResult.status
+                }
+
+                pushToken = registerResult.id
+            }
         }
 
-        val registerResult = _pushRegistrator.registerForPush()
+        _pushTokenChangedNotifier.fire { it.onPushTokenChanged(pushToken, pushTokenStatus) }
+    }
 
-        if (registerResult.status < IPushRegistrator.RegisterStatus.PUSH_STATUS_SUBSCRIBED) {
-            // Only allow errored subscribableStatuses if we have never gotten a token.
-            //   This ensures the device will not later be marked unsubscribed due to a
-            //   any inconsistencies returned by Google Play services.
-            // Also do not override a config error status if we got a runtime error
-//  TODO          if (OneSignalStateSynchronizer.getRegistrationId() == null &&
-//                (OneSignal.subscribableStatus == UserState.PUSH_STATUS_SUBSCRIBED ||
-//                        OneSignal.pushStatusRuntimeError(OneSignal.subscribableStatus))
-//            ) OneSignal.subscribableStatus = status
-        }
-//  TODO    else if (OneSignal.pushStatusRuntimeError(OneSignal.subscribableStatus))
-//            OneSignal.subscribableStatus = status
-
-        // TODO: What if no result or the push registration fails?
-        if (registerResult.status == IPushRegistrator.RegisterStatus.PUSH_STATUS_SUBSCRIBED) {
-            pushToken = registerResult.id!!
-            _pushTokenChangedNotifier.fire { it.onPushTokenChanged(pushToken) }
-        }
+    private fun pushStatusRuntimeError(status: IPushRegistrator.RegisterStatus): Boolean {
+        return status.value < -6
     }
 
     override fun subscribe(handler: IPushTokenChangedHandler) = _pushTokenChangedNotifier.subscribe(handler)

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/notification/internal/receivereceipt/impl/ReceiveReceiptWorkManager.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/notification/internal/receivereceipt/impl/ReceiveReceiptWorkManager.kt
@@ -29,12 +29,12 @@ internal class ReceiveReceiptWorkManager(
     private val maxDelay = 25
 
     override fun enqueueReceiveReceipt(notificationId: String) {
-        if (!_configModelStore.get().receiveReceiptEnabled) {
+        if (!_configModelStore.model.receiveReceiptEnabled) {
             Logging.debug("sendReceiveReceipt disabled")
             return
         }
 
-        val appId: String = _configModelStore.get().appId
+        val appId: String = _configModelStore.model.appId
         val subscriptionId: String? = _subscriptionManager.subscriptions.push?.id
 
         if (subscriptionId == null || appId.isEmpty()) {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/notification/internal/registration/impl/GooglePlayServicesUpgradePrompt.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/notification/internal/registration/impl/GooglePlayServicesUpgradePrompt.kt
@@ -43,7 +43,7 @@ internal class GooglePlayServicesUpgradePrompt(
             return
         }
 
-        if (!isGooglePlayStoreInstalled || _configModelStore.get().disableGMSMissingPrompt) {
+        if (!isGooglePlayStoreInstalled || _configModelStore.model.disableGMSMissingPrompt) {
             return
         }
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/notification/internal/registration/impl/PushRegistratorAbstractGoogle.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/notification/internal/registration/impl/PushRegistratorAbstractGoogle.kt
@@ -50,14 +50,19 @@ internal abstract class PushRegistratorAbstractGoogle(
     abstract suspend fun getToken(senderId: String): String
 
     override suspend fun registerForPush(): IPushRegistrator.RegisterResult {
-        return if (!isValidProjectNumber(_configModelStore.get().googleProjectNumber)) {
+        if (!_deviceService.hasFCMLibrary) {
+            Logging.fatal("The Firebase FCM library is missing! Please make sure to include it in your project.")
+            return IPushRegistrator.RegisterResult(null, IPushRegistrator.RegisterStatus.PUSH_STATUS_MISSING_FIREBASE_FCM_LIBRARY)
+        }
+
+        return if (!isValidProjectNumber(_configModelStore.model.googleProjectNumber)) {
             Logging.error("Missing Google Project number!\nPlease enter a Google Project number / Sender ID on under App Settings > Android > Configuration on the OneSignal dashboard.")
             IPushRegistrator.RegisterResult(
                 null,
                 IPushRegistrator.RegisterStatus.PUSH_STATUS_INVALID_FCM_SENDER_ID
             )
         } else {
-            internalRegisterForPush(_configModelStore.get().googleProjectNumber!!)
+            internalRegisterForPush(_configModelStore.model.googleProjectNumber!!)
         }
     }
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/notification/internal/registration/impl/PushRegistratorFCM.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/notification/internal/registration/impl/PushRegistratorFCM.kt
@@ -48,7 +48,7 @@ internal class PushRegistratorFCM(
         get() = "FCM"
 
     init {
-        val fcpParams = _configModelStore.get().fcmParams
+        val fcpParams = _configModelStore.model.fcmParams
 
         this.projectId = fcpParams.projectId ?: FCM_DEFAULT_PROJECT_ID
         this.appId = fcpParams.appId ?: FCM_DEFAULT_APP_ID

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/notification/internal/summary/impl/NotificationSummaryManager.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/notification/internal/summary/impl/NotificationSummaryManager.kt
@@ -91,7 +91,7 @@ internal class NotificationSummaryManager(
         // Obtain the most recent notification id
         val mostRecentId = _dataController.getAndroidIdForGroup(group, false)
         if (mostRecentId != null) {
-            val shouldDismissAll = _configModelStore.get().clearGroupOnSummaryClick
+            val shouldDismissAll = _configModelStore.model.clearGroupOnSummaryClick
             if (shouldDismissAll) {
                 val groupId = if (group == NotificationHelper.grouplessSummaryKey) {
                     // If the group is groupless, obtain the hardcoded groupless summary id


### PR DESCRIPTION
* Update `ISingletonModelStore.get()` function to be `ISingletonModelStore.model` property
* Rework the model store change event system to always fire, using tags to differentiate why changes occurred.
* Add `SubscriptionModel.status` to capture the subscription status, for when retrieving push token fails for some reason.
* Drive event callback when app killed during request notification permission activity.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1673)
<!-- Reviewable:end -->
