### PR TITLE
Fix default values in liquid IAMs

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageController.java
@@ -80,7 +80,7 @@ class OSInAppMessageController extends OSBackgroundManager implements OSDynamicT
     private boolean inAppMessageShowing = false;
 
     @Nullable
-    private String userTagsString = null;
+    private String userTagsString = "";
 
     @Nullable
     private OSInAppMessageContent pendingMessageContent = null;


### PR DESCRIPTION
# Description
## Fix default values in liquid IAMs

## Details

### Motivation
Bug with In-App Messages where the liquid syntax for tag substitution was showing up in IAMs of users with no tags. String formatting failed when a user has no tags due to trying to format null instead of empty string.

### Scope
In-App Messages

# Testing
## Unit testing
No unit tests available.

## Manual testing
Tested updating the value of userTagsSent to an empty string and the In-App Message displays as expected on Android 12.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [X] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item