### PR TITLE
Update assertEquals values in failed unit tests

### DIFF
--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java
@@ -1310,7 +1310,7 @@ public class GenerateNotificationRunner {
       new FCMBroadcastReceiver().onReceive(blankActivity, intent);
       threadAndTaskWait();
       threadAndTaskWait();
-      assertEquals("PGh0bWw+PC9odG1sPgoKPHNjcmlwdD4KICAgIHNldFBsYXllclRhZ3MobnVsbCk7Cjwvc2NyaXB0Pg==", ShadowOSWebView.lastData);
+      assertEquals("PGh0bWw+PC9odG1sPgoKPHNjcmlwdD4KICAgIHNldFBsYXllclRhZ3MoKTsKPC9zY3JpcHQ+", ShadowOSWebView.lastData);
    }
 
    @Test
@@ -1336,7 +1336,7 @@ public class GenerateNotificationRunner {
       NotificationOpenedProcessor_processFromContext(blankActivity, notificationOpenIntent);
       threadAndTaskWait();
       threadAndTaskWait();
-      assertEquals("PGh0bWw+PC9odG1sPgoKPHNjcmlwdD4KICAgIHNldFBsYXllclRhZ3MobnVsbCk7Cjwvc2NyaXB0Pg==", ShadowOSWebView.lastData);
+      assertEquals("PGh0bWw+PC9odG1sPgoKPHNjcmlwdD4KICAgIHNldFBsYXllclRhZ3MoKTsKPC9zY3JpcHQ+", ShadowOSWebView.lastData);
 
       // Ensure the app is foregrounded.
       assertNotNull(shadowOf(blankActivity).getNextStartedActivity());

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/NotificationOpenedActivityHMSIntegrationTestsRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/NotificationOpenedActivityHMSIntegrationTestsRunner.java
@@ -211,6 +211,6 @@ public class NotificationOpenedActivityHMSIntegrationTestsRunner {
         helper_startHMSOpenActivity(intent);
         threadAndTaskWait();
         threadAndTaskWait();
-        assertEquals("PGh0bWw+PC9odG1sPgoKPHNjcmlwdD4KICAgIHNldFBsYXllclRhZ3MobnVsbCk7Cjwvc2NyaXB0Pg==", ShadowOSWebView.lastData);
+        assertEquals("PGh0bWw+PC9odG1sPgoKPHNjcmlwdD4KICAgIHNldFBsYXllclRhZ3MoKTsKPC9zY3JpcHQ+", ShadowOSWebView.lastData);
     }
 }


### PR DESCRIPTION
# Description
## One Line Summary
Update assertEquals values in failed unit tests.

## Details

### Motivation
Fix failed unit tests caused by #1698 . Failures were due to a comparison failure of `assertEquals` values in three tests involving IAM previews.

### Scope
Tests and methods impacted:

GenerateNotificationRunner
-  [`shouldShowInAppPreviewWhenInFocus()`](https://github.com/OneSignal/OneSignal-Android-SDK/blob/e292d5a1afd46f5d56eeeb613d63dbc294a3300d/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java#L1299)
-  [`shouldShowInAppPreviewWhenOpeningPreviewNotification()`](https://github.com/OneSignal/OneSignal-Android-SDK/blob/e292d5a1afd46f5d56eeeb613d63dbc294a3300d/OneSignalSDK/unittest/src/test/java/com/test/onesignal/GenerateNotificationRunner.java#L1318)

NotificationOpenedActivityHMSIntegrationTestsRunner
- [`osIAMPreview_showsPreview()`](https://github.com/OneSignal/OneSignal-Android-SDK/blob/e292d5a1afd46f5d56eeeb613d63dbc294a3300d/OneSignalSDK/unittest/src/test/java/com/test/onesignal/NotificationOpenedActivityHMSIntegrationTestsRunner.java#L190)

# Testing
## Unit testing
Affected tests updated, re-run, and passed.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [X] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-android-sdk/1699)
<!-- Reviewable:end -->
