### PR TITLE
Speculative Fix for WorkManager not Initialized Crash

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSFocusHandler.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSFocusHandler.kt
@@ -32,7 +32,6 @@ import androidx.work.Constraints
 import androidx.work.ExistingWorkPolicy
 import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequest
-import androidx.work.WorkManager
 import androidx.work.Worker
 import androidx.work.WorkerParameters
 import java.util.concurrent.TimeUnit
@@ -87,7 +86,8 @@ class OSFocusHandler {
             .setInitialDelay(delay, TimeUnit.MILLISECONDS)
             .addTag(tag)
             .build()
-        WorkManager.getInstance(context)
+
+        OSWorkManagerHelper.getInstance(context)
             .enqueueUniqueWork(
                 tag,
                 ExistingWorkPolicy.KEEP,
@@ -96,7 +96,7 @@ class OSFocusHandler {
     }
 
     fun cancelOnLostFocusWorker(tag: String, context: Context) {
-        WorkManager.getInstance(context).cancelAllWorkByTag(tag)
+        OSWorkManagerHelper.getInstance(context).cancelAllWorkByTag(tag)
     }
 
     private fun resetStopState() {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationRestoreWorkManager.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationRestoreWorkManager.java
@@ -9,7 +9,6 @@ import android.text.TextUtils;
 import androidx.annotation.NonNull;
 import androidx.work.ExistingWorkPolicy;
 import androidx.work.OneTimeWorkRequest;
-import androidx.work.WorkManager;
 import androidx.work.Worker;
 import androidx.work.WorkerParameters;
 
@@ -45,7 +44,7 @@ class OSNotificationRestoreWorkManager {
                 .setInitialDelay(restoreDelayInSeconds, TimeUnit.SECONDS)
                 .build();
 
-        WorkManager.getInstance(context)
+        OSWorkManagerHelper.getInstance(context)
                 .enqueueUniqueWork(NOTIFICATION_RESTORE_WORKER_IDENTIFIER, ExistingWorkPolicy.KEEP, workRequest);
     }
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationWorkManager.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationWorkManager.java
@@ -6,7 +6,6 @@ import androidx.annotation.NonNull;
 import androidx.work.Data;
 import androidx.work.ExistingWorkPolicy;
 import androidx.work.OneTimeWorkRequest;
-import androidx.work.WorkManager;
 import androidx.work.Worker;
 import androidx.work.WorkerParameters;
 
@@ -63,8 +62,9 @@ class OSNotificationWorkManager {
                 .build();
 
         OneSignal.Log(OneSignal.LOG_LEVEL.DEBUG, "OSNotificationWorkManager enqueueing notification work with notificationId: " + osNotificationId + " and jsonPayload: " + jsonPayload);
-        WorkManager.getInstance(context)
-                .enqueueUniqueWork(osNotificationId, ExistingWorkPolicy.KEEP, workRequest);
+
+        OSWorkManagerHelper.getInstance(context).
+                enqueueUniqueWork(osNotificationId, ExistingWorkPolicy.KEEP, workRequest);
     }
 
     public static class NotificationWorker extends Worker {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSReceiveReceiptController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSReceiveReceiptController.java
@@ -35,7 +35,6 @@ import androidx.work.Data;
 import androidx.work.ExistingWorkPolicy;
 import androidx.work.NetworkType;
 import androidx.work.OneTimeWorkRequest;
-import androidx.work.WorkManager;
 import androidx.work.Worker;
 import androidx.work.WorkerParameters;
 
@@ -82,7 +81,7 @@ class OSReceiveReceiptController {
 
         OneSignal.Log(OneSignal.LOG_LEVEL.DEBUG, "OSReceiveReceiptController enqueueing send receive receipt work with notificationId: " + osNotificationId + " and delay: " + delay + " seconds");
 
-        WorkManager.getInstance(context)
+        OSWorkManagerHelper.getInstance(context)
                 .enqueueUniqueWork(osNotificationId + "_receive_receipt", ExistingWorkPolicy.KEEP, workRequest);
     }
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSWorkManagerHelper.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSWorkManagerHelper.kt
@@ -1,0 +1,68 @@
+/**
+ * Modified MIT License
+ * <p>
+ * Copyright 2023 OneSignal
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * <p>
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * <p>
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ * <p>
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.onesignal
+
+import android.annotation.SuppressLint
+import android.content.Context
+import androidx.work.Configuration
+import androidx.work.WorkManager
+import androidx.work.impl.WorkManagerImpl
+
+object OSWorkManagerHelper {
+    /**
+     * Helper method to provide a way to check if WorkManager is initialized in this process.
+     *
+     * This is effectively the `WorkManager.isInitialized()` public method introduced in androidx.work:work-*:2.8.0-alpha02.
+     * Please see https://android-review.googlesource.com/c/platform/frameworks/support/+/1941186.
+     *
+     * @return `true` if WorkManager has been initialized in this process.
+     */
+    @SuppressWarnings("deprecation")
+    @SuppressLint("RestrictedApi")
+    private fun isInitialized(): Boolean {
+        val instance = WorkManagerImpl.getInstance()
+        return instance != null
+    }
+
+    /**
+     * If there is an instance of WorkManager available, use it. Else, in rare cases, initialize it ourselves.
+     *
+     * Calling `WorkManager.getInstance(context)` directly can cause an exception if it is null.
+     *
+     * @return an instance of WorkManager
+     */
+    @JvmStatic
+    fun getInstance(context: Context): WorkManager {
+        return if (isInitialized()) {
+            WorkManager.getInstance(context)
+        } else {
+            WorkManager.initialize(context, Configuration.Builder().build())
+            WorkManager.getInstance(context)
+        }
+    }
+}

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSWorkManagerHelper.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSWorkManagerHelper.kt
@@ -45,8 +45,7 @@ object OSWorkManagerHelper {
     @SuppressWarnings("deprecation")
     @SuppressLint("RestrictedApi")
     private fun isInitialized(): Boolean {
-        val instance = WorkManagerImpl.getInstance()
-        return instance != null
+        return WorkManagerImpl.getInstance() != null
     }
 
     /**
@@ -57,12 +56,11 @@ object OSWorkManagerHelper {
      * @return an instance of WorkManager
      */
     @JvmStatic
+    @Synchronized
     fun getInstance(context: Context): WorkManager {
-        return if (isInitialized()) {
-            WorkManager.getInstance(context)
-        } else {
+        if (!isInitialized()) {
             WorkManager.initialize(context, Configuration.Builder().build())
-            WorkManager.getInstance(context)
         }
+        return WorkManager.getInstance(context)
     }
 }


### PR DESCRIPTION
# Description
## One Line Summary
This is a speculative fix for the non-reproducible WorkManager is not Initialized Crash we have been seeing many reports of.

## Details

### Motivation
Please see issue this aims to address: https://github.com/OneSignal/OneSignal-Android-SDK/issues/1672.

We don't completely understand this crash, so this fix is speculative and based off a [response from Google Issue Tracker](https://issuetracker.google.com/issues/258176803#comment7), though the responder may not completely understand how OneSignal is used in applications. 

### Scope
* Before using WorkManager, we will check for its existence. Else, in rare cases that were crashing, initialize it ourselves.
* We use a method to check if WorkManager is initialized in the process.
  - This is effectively the `WorkManager.isInitialized()` public method introduced in `androidx.work:work-*:2.8.0-alpha02`.
  - Please see https://android-review.googlesource.com/c/platform/frameworks/support/+/1941186 for the library's implementation

### ⚠️ Concerns ⚠️
We take over and initialize WorkManager if we see it is `nil`, which so far is rare.

Perhaps this crash happens because the default WorkManager initializer hasn't run yet, but is about to... In which case, right after we initialize WorkManager, the default initializer will trigger a `WorkManager is already initialized` exception. But, maybe that's not what is happening and this secondary crash doesn't happen.

Before accessing and initializing WorkManager ourselves, we check if it's already initialized using the same logic that the `work` library provides in a `2.8.0-alpha02` release. However, could we have a race condition such that when we check, it is `nil`, but momentarily after, it becomes initialized, while we go and try to initialize it? This could create issues that didn't exist before. Dig into source code and their `synchronized` blocks.

# Testing
## Unit testing
No unit test was added as it is hard to unit test this. 
- we would have to test double Android library components
- `androidx.work.testing` package didn't have anything for our use case either

## Manual testing
Limited ability to test manually.
- Tested normal app flow in an emulator

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/1721)
<!-- Reviewable:end -->
