### PR TITLE
[User Model] Application Focus and Threading

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/config/ConfigModel.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/config/ConfigModel.kt
@@ -94,7 +94,7 @@ class ConfigModel : Model() {
      * the queue.
      */
     var opRepoExecutionInterval: Long
-        get() = getLongProperty(::opRepoExecutionInterval.name) { 10000 }
+        get() = getLongProperty(::opRepoExecutionInterval.name) { 5000 }
         set(value) { setLongProperty(::opRepoExecutionInterval.name, value) }
 
     /**

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/NotificationsManager.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/NotificationsManager.kt
@@ -18,6 +18,8 @@ import com.onesignal.notifications.internal.permissions.INotificationPermissionC
 import com.onesignal.notifications.internal.permissions.INotificationPermissionController
 import com.onesignal.notifications.internal.restoration.INotificationRestoreWorkManager
 import com.onesignal.notifications.internal.summary.INotificationSummaryManager
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import org.json.JSONArray
 import org.json.JSONException
 
@@ -81,7 +83,10 @@ internal class NotificationsManager(
 
     override suspend fun requestPermission(fallbackToSettings: Boolean): Boolean {
         Logging.debug("NotificationsManager.requestPermission()")
-        return _notificationPermissionController.prompt(fallbackToSettings)
+
+        return withContext(Dispatchers.Main) {
+            return@withContext _notificationPermissionController.prompt(fallbackToSettings)
+        }
     }
 
     private fun setPermissionStatusAndFire(isEnabled: Boolean) {

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/permissions/impl/NotificationPermissionController.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/permissions/impl/NotificationPermissionController.kt
@@ -40,7 +40,6 @@ import com.onesignal.notifications.R
 import com.onesignal.notifications.internal.common.NotificationHelper
 import com.onesignal.notifications.internal.permissions.INotificationPermissionChangedHandler
 import com.onesignal.notifications.internal.permissions.INotificationPermissionController
-import kotlinx.coroutines.yield
 
 internal class NotificationPermissionController(
     private val _application: IApplicationService,
@@ -74,10 +73,6 @@ internal class NotificationPermissionController(
      * to notify of the status.
      */
     override suspend fun prompt(fallbackToSettings: Boolean): Boolean {
-        // yield to force a suspension.  When there is no suspension the continuation will
-        // never be called
-        yield()
-
         if (notificationsEnabled()) {
             return true
         }


### PR DESCRIPTION
* Update ApplicationService to more accurately detect when the app goes in/out of focus
* Always switch to main thread for RequestPermission calls, to ensure that (1) a suspend occurs and (2) any UI operations happen on the main thread.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/1722)
<!-- Reviewable:end -->
