### PR TITLE
[User Model] Properly set `isUnattributedEnabled` to config when specified in the params

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/config/impl/ConfigModelStoreListener.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/config/impl/ConfigModelStoreListener.kt
@@ -94,7 +94,7 @@ internal class ConfigModelStoreListener(
                     params.influenceParams.indirectIAMAttributionWindow?.let { config.influenceParams.indirectIAMAttributionWindow = it }
                     params.influenceParams.isDirectEnabled?.let { config.influenceParams.isDirectEnabled = it }
                     params.influenceParams.isIndirectEnabled?.let { config.influenceParams.isIndirectEnabled = it }
-                    params.influenceParams.isUnattributedEnabled?.let { config.influenceParams.isUnattributedEnabled }
+                    params.influenceParams.isUnattributedEnabled?.let { config.influenceParams.isUnattributedEnabled = it }
 
                     _configModelStore.replace(config, ModelChangeTags.HYDRATE)
                     success = true


### PR DESCRIPTION
# Description
## One Line Summary
Stop re-enabling push subscriptions that were disabled through the REST API (`notification_types` -31).

## Details

### Motivation
Customers who suppress users by disabling subscriptions via the REST API see them come back subscribed. The SDK never hydrated the server's disable onto an existing push subscription (`parseFetchUserResponse` is gated on `subscriptionId == nil`), and every Create User and PATCH body recomputed `enabled` from device state, so a login or a routine device-metadata update silently re-enabled the subscription. Tracked internally as SDK-5099.

### Scope
Push subscriptions only; email/SMS hydration is unchanged. The model gains a server-owned `restApiDisabledReason` field that mirrors the server's `notification_types`. A response reporting -31 records it, any other reported value clears it, and it also clears when the subscription ID resets (the record it describes is gone) or on an explicit `optIn()`, whose clear outranks stale in-flight hydration until the server confirms. While recorded, Create User and PATCH payloads send `enabled: false` with -31 instead of device values; both builders share one snapshot-based body (`updateParams()` / `outboundNotificationTypes`), and each record/clear transition is a single critical section. No public API signature changes; `OSPushSubscription.optedIn` gains a doc line.

### Decisions from review
`optedIn` stays user preference plus OS permission and is documented as such; a server-side disable does not flip it. `optIn()` overrides the suppression only when it changes local state; an unconditional override was declined because apps that call `optIn()` on every launch could then never be suppressed. An opt-out recorded during a suppression goes out on the next routine update rather than outranking the recorded disable, consistent with every other offline edit. Known limit: a metadata PATCH flushed before a session's first fetch can send `enabled: true` once, bounded to one message and corrected by the next sync. Matches the companion PR in OneSignal-Android-SDK.

# Testing
## Unit testing
Nine model-level tests cover recording, mirror clearing, ID-reset clearing, optIn precedence over stale hydration, payload override, NSCoding round-trip, and device-state refresh survival. An integration test reproduces the customer scenario end to end: fetch reports -31, login to a different external ID, and the Create User body still sends `enabled: false` / `notification_types: -31`.

## Manual testing
Not device-tested; the reported scenarios are reproduced by the integration test above.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [x] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

