### PR TITLE
[User Model] Update logic for detecting when to show fallback settings

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/permissions/impl/RequestPermissionService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/permissions/impl/RequestPermissionService.kt
@@ -9,12 +9,12 @@ import com.onesignal.core.internal.application.IApplicationService
 import com.onesignal.core.internal.permissions.IRequestPermissionService
 
 internal class RequestPermissionService(
-    private val _application: IApplicationService
+    private val _application: IApplicationService,
 ) : Activity(), IRequestPermissionService {
 
     var waiting = false
     var fallbackToSettings = false
-    var neverAskAgainClicked = false
+    var shouldShowRequestPermissionRationaleBeforeRequest = false
     private val callbackMap = HashMap<String?, IRequestPermissionService.PermissionCallback>()
 
     override fun registerAsCallback(

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/preferences/IPreferencesService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/preferences/IPreferencesService.kt
@@ -151,6 +151,13 @@ object PreferenceOneSignalKeys {
      */
     const val PREFS_OS_LAST_LOCATION_TIME = "OS_LAST_LOCATION_TIME"
 
+    // Permissions
+    /**
+     * (Boolean) A prefix key for the permission state. When true, the user has rejected this
+     * permission too many times and will not be prompted again.
+     */
+    const val PREFS_OS_USER_REJECTED_PERMISSION_PREFIX = "USER_REJECTED_PERMISSION_"
+
     // HTTP
     /**
      * (String) A prefix key for retrieving the ETAG for a given HTTP GET cache key. The cache

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/notifications/INotificationsManager.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/notifications/INotificationsManager.kt
@@ -10,6 +10,11 @@ interface INotificationsManager {
     val permission: Boolean
 
     /**
+     * Whether this app can request push notification permission.
+     */
+    val canRequestPermission: Boolean
+
+    /**
      * Prompt the user for permission to push notifications.  This will display the native
      * OS prompt to request push notification permission.  If the user enables, a push
      * subscription to this device will be automatically added to the user.

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/notifications/internal/MisconfiguredNotificationsManager.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/notifications/internal/MisconfiguredNotificationsManager.kt
@@ -12,6 +12,8 @@ import com.onesignal.notifications.IPermissionChangedHandler
 internal class MisconfiguredNotificationsManager : INotificationsManager {
     override val permission: Boolean
         get() = throw EXCEPTION
+    override val canRequestPermission: Boolean
+        get() = throw EXCEPTION
 
     override suspend fun requestPermission(fallbackToSettings: Boolean): Boolean = throw EXCEPTION
     override fun removeNotification(id: Int) = throw EXCEPTION

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/NotificationsManager.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/NotificationsManager.kt
@@ -45,6 +45,9 @@ internal class NotificationsManager(
 
     override var permission: Boolean = NotificationHelper.areNotificationsEnabled(_applicationService.appContext)
 
+    override val canRequestPermission: Boolean
+        get() = _notificationPermissionController.canRequestPermission
+
     private val _permissionChangedNotifier = EventProducer<IPermissionChangedHandler>()
 
     init {

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/permissions/INotificationPermissionController.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/permissions/INotificationPermissionController.kt
@@ -32,6 +32,11 @@ import com.onesignal.common.events.IEventNotifier
 internal interface INotificationPermissionController :
     IEventNotifier<INotificationPermissionChangedHandler> {
     /**
+     * Whether this app can request push notification permission.
+     */
+    val canRequestPermission: Boolean
+
+    /**
      * Prompt the user for notification permission.  Note it is possible the application
      * will be killed while the permission prompt is being displayed to the user. When the
      * app restarts it will begin with the permission prompt.  In this case this suspending

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/permissions/impl/NotificationPermissionController.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/permissions/impl/NotificationPermissionController.kt
@@ -36,6 +36,9 @@ import com.onesignal.core.internal.application.ApplicationLifecycleHandlerBase
 import com.onesignal.core.internal.application.IApplicationService
 import com.onesignal.core.internal.permissions.AlertDialogPrepromptForAndroidSettings
 import com.onesignal.core.internal.permissions.IRequestPermissionService
+import com.onesignal.core.internal.preferences.IPreferencesService
+import com.onesignal.core.internal.preferences.PreferenceOneSignalKeys
+import com.onesignal.core.internal.preferences.PreferenceStores
 import com.onesignal.notifications.R
 import com.onesignal.notifications.internal.common.NotificationHelper
 import com.onesignal.notifications.internal.permissions.INotificationPermissionChangedHandler
@@ -44,12 +47,20 @@ import com.onesignal.notifications.internal.permissions.INotificationPermissionC
 internal class NotificationPermissionController(
     private val _application: IApplicationService,
     private val _requestPermission: IRequestPermissionService,
-    private val _applicationService: IApplicationService
+    private val _applicationService: IApplicationService,
+    private val _preferenceService: IPreferencesService
 ) : IRequestPermissionService.PermissionCallback,
     INotificationPermissionController {
 
     private val _waiter = WaiterWithValue<Boolean>()
     private val _events = EventProducer<INotificationPermissionChangedHandler>()
+
+    override val canRequestPermission: Boolean
+        get() = !_preferenceService.getBool(
+            PreferenceStores.ONESIGNAL,
+            "${PreferenceOneSignalKeys.PREFS_OS_USER_REJECTED_PERMISSION_PREFIX}${ANDROID_PERMISSION_STRING}",
+            false
+        )!!
 
     init {
         _requestPermission.registerAsCallback(PERMISSION_TYPE, this)


### PR DESCRIPTION
# Description
## One Line Summary
Update logic for detecting when to show fallback settings for requesting permissions.  Detection requires persistence to preferences, which allows the addition of INotificationsManager.canRequestPermission.

## Details
When requesting permission, the user has the ability to (1) accept, (2) reject, or (3) close the native permission prompt.  The current logic was not properly detecting case (3). When the user closed the modal we would show the fallback settings prompt, which is not an ideal user experience.  After experimentation and observing how `AndroidSupportV4Compat.ActivityCompat.shouldShowRequestPermissionRationale` changes state, there was no way to detect when the native prompt will no longer be shown without adding a persistence layer to the logic.

`shouldShowRequestPermissionRationale` goes from `true` to `false` one time, when Android has determined never to prompt the user again.  Logic is added to detect and save this state to the OneSignal preference store for later lookups.

Now that we have this persisted, we can add to the API the `OneSignal.notifications.canRequestPermission` property, which will allow users to know whether `OneSignal.notifications.requestPermission` will provide a native prompt or not.

### Motivation
Fixes an issue where the permission fallback modal was shown immediately after the user closes the native prompt (without accepting or rejecting the permission).

### Scope
This should affect both `OneSignal.location.requestPermission` and `OneSignal.notifications.requestPermission`.  The fallback modal should only appear once Android has determined not to prompt the user with the native permission modal.

# Testing

## Manual testing
Tested both location and notification permission prompting, variations including clicking "Accept", "Don't Allow", and closing the modal.  Confirmed the fallback modal is only presented to the user when Android has determined not to present the native permission modal.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/1739)
<!-- Reviewable:end -->
