### PR TITLE
[User Model] Remove `retain_previous_owner` attribute from "Create User" and "Create Subscription"

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/backend/impl/SubscriptionBackendService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/backend/impl/SubscriptionBackendService.kt
@@ -15,7 +15,6 @@ internal class SubscriptionBackendService(
     override suspend fun createSubscription(appId: String, aliasLabel: String, aliasValue: String, subscription: SubscriptionObject): String? {
         val requestJSON = JSONObject()
             .put("subscription", JSONConverter.convertToJSON(subscription))
-            .put("retain_previous_owner", true)
 
         val response = _httpClient.post("apps/$appId/users/by/$aliasLabel/$aliasValue/subscriptions", requestJSON)
 

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/backend/impl/UserBackendService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/backend/impl/UserBackendService.kt
@@ -29,9 +29,6 @@ internal class UserBackendService(
         if (subscriptions.isNotEmpty()) {
             requestJSON
                 .put("subscriptions", JSONConverter.convertToJSON(subscriptions))
-                .putJSONObject("subscription_options") {
-                    it.put("retain_previous_owner", true)
-                }
         }
 
         val response = _httpClient.post("apps/$appId/users", requestJSON)


### PR DESCRIPTION
# Description
## One Line Summary
Remove `retain_previous_owner` parameter from "Create User" and "Create Subscription" REST calls. This parameter is no longer used.

## Details

### Motivation
The `retain_previous_owner` is no longer honored by the backend, it can be removed.

# Testing
## Manual testing
Using the example app tested flows that drive "Create User" and "Create Subscription" (i.e. Login, create subscription).

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/1740)
<!-- Reviewable:end -->
