### PR TITLE
[User Model] Safeguard against activities/services/receivers being called before initialization

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/IOneSignal.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/IOneSignal.kt
@@ -80,8 +80,10 @@ interface IOneSignal {
      *
      * @param context The Android context the SDK should use.
      * @param appId The application ID the OneSignal SDK is bound to.
+     *
+     * @return true if the SDK could be successfully initialized, false otherwise.
      */
-    fun initWithContext(context: Context, appId: String?)
+    fun initWithContext(context: Context, appId: String?) : Boolean
 
     /**
      * Login to OneSignal under the user identified by the [externalId] provided. The act of

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/OneSignal.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/OneSignal.kt
@@ -192,8 +192,8 @@ object OneSignal {
      * THIS IS AN INTERNAL INTERFACE AND SHOULD NOT BE USED DIRECTLY.
      */
     @JvmStatic
-    fun initWithContext(context: Context) {
-        oneSignal.initWithContext(context, null)
+    fun initWithContext(context: Context) : Boolean {
+        return oneSignal.initWithContext(context, null)
     }
 
     /**

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/activities/PermissionsActivity.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/activities/PermissionsActivity.kt
@@ -22,7 +22,10 @@ class PermissionsActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        OneSignal.initWithContext(this)
+        
+        if(!OneSignal.initWithContext(this)) {
+            return
+        }
 
         _requestPermissionService = OneSignal.getService()
         _preferenceService = OneSignal.getService()

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/services/SyncJobService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/services/SyncJobService.kt
@@ -38,7 +38,9 @@ import com.onesignal.debug.internal.logging.Logging
 @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
 class SyncJobService : JobService() {
     override fun onStartJob(jobParameters: JobParameters): Boolean {
-        OneSignal.initWithContext(this)
+        if(!OneSignal.initWithContext(this)) {
+            return false
+        }
 
         var backgroundService = OneSignal.getService<IBackgroundManager>()
 

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/services/SyncService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/services/SyncService.kt
@@ -36,7 +36,9 @@ import com.onesignal.debug.internal.logging.Logging
 
 class SyncService : Service() {
     override fun onStartCommand(intent: Intent, flags: Int, startId: Int): Int {
-        OneSignal.initWithContext(this)
+        if(!OneSignal.initWithContext(this)) {
+            return START_STICKY
+        }
 
         var backgroundService = OneSignal.getService<IBackgroundManager>()
 

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
@@ -135,12 +135,12 @@ internal class OneSignalImp : IOneSignal, IServiceProvider {
         _services = serviceBuilder.build()
     }
 
-    override fun initWithContext(context: Context, appId: String?) {
+    override fun initWithContext(context: Context, appId: String?) : Boolean {
         Logging.log(LogLevel.DEBUG, "initWithContext(context: $context, appId: $appId)")
 
         // do not do this again if already initialized
         if (isInitialized) {
-            return
+            return true
         }
 
         // start the application service. This is called explicitly first because we want
@@ -155,6 +155,14 @@ internal class OneSignalImp : IOneSignal, IServiceProvider {
         // get the current config model, if there is one
         _configModel = _services.getService<ConfigModelStore>().model
         _sessionModel = _services.getService<SessionModelStore>().model
+
+        // initWithContext is called by our internal services/receivers/activites but they do not provide
+        // an appId (they don't know it).  If the app has never called the external initWithContext
+        // prior to our services/receivers/activities we will blow up, as no appId has been established.
+        if (appId == null && !_configModel!!.hasProperty(ConfigModel::appId.name)) {
+            Logging.warn("initWithContext called without providing appId, and no appId has been established!")
+            return false
+        }
 
         var forceCreateUser = false
         // if the app id was specified as input, update the config model with it
@@ -239,6 +247,8 @@ internal class OneSignalImp : IOneSignal, IServiceProvider {
         _startupService!!.start()
 
         isInitialized = true
+
+        return true
     }
 
     override fun login(externalId: String, jwtBearerToken: String?) {

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/activities/NotificationOpenedActivityBase.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/activities/NotificationOpenedActivityBase.kt
@@ -36,7 +36,9 @@ import com.onesignal.notifications.internal.open.INotificationOpenedProcessor
 abstract class NotificationOpenedActivityBase : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        OneSignal.initWithContext(applicationContext)
+        if(!OneSignal.initWithContext(applicationContext)) {
+            return
+        }
 
         var self = this
 
@@ -50,7 +52,9 @@ abstract class NotificationOpenedActivityBase : Activity() {
 
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
-        OneSignal.initWithContext(applicationContext)
+        if(!OneSignal.initWithContext(applicationContext)) {
+            return
+        }
 
         var self = this
         suspendifyOnThread {

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/activities/NotificationOpenedActivityHMS.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/activities/NotificationOpenedActivityHMS.kt
@@ -72,7 +72,9 @@ class NotificationOpenedActivityHMS : Activity() {
     }
 
     private fun processOpen(intent: Intent?) {
-        OneSignal.initWithContext(applicationContext)
+        if (!OneSignal.initWithContext(applicationContext)) {
+            return
+        }
 
         var notificationPayloadProcessorHMS = OneSignal.getService<INotificationOpenedProcessorHMS>()
         val self = this

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/bridges/OneSignalHmsEventBridge.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/bridges/OneSignalHmsEventBridge.kt
@@ -53,7 +53,9 @@ object OneSignalHmsEventBridge {
     }
 
     fun onMessageReceived(context: Context, message: RemoteMessage) {
-        OneSignal.initWithContext(context)
+        if(!OneSignal.initWithContext(context)) {
+            return
+        }
 
         var time = OneSignal.getService<ITime>()
         val bundleProcessor = OneSignal.getService<INotificationBundleProcessor>()

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/restoration/impl/NotificationRestoreWorkManager.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/restoration/impl/NotificationRestoreWorkManager.kt
@@ -45,8 +45,8 @@ internal class NotificationRestoreWorkManager : INotificationRestoreWorkManager 
         override suspend fun doWork(): Result {
             val context = applicationContext
 
-            if (!OneSignal.isInitialized) {
-                OneSignal.initWithContext(context)
+            if (!OneSignal.initWithContext(context)) {
+                return Result.success();
             }
 
             if (!NotificationHelper.areNotificationsEnabled(context)) {

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/receivers/BootUpReceiver.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/receivers/BootUpReceiver.kt
@@ -34,11 +34,10 @@ import com.onesignal.notifications.internal.restoration.INotificationRestoreWork
 
 class BootUpReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
-        if (!OneSignal.isInitialized) {
-            OneSignal.initWithContext(context)
-        }
+        if(!OneSignal.initWithContext(context))
+            return
 
-        var restoreWorkManager = OneSignal.getService<INotificationRestoreWorkManager>()
+        val restoreWorkManager = OneSignal.getService<INotificationRestoreWorkManager>()
 
         restoreWorkManager.beginEnqueueingWork(context, true)
     }

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/receivers/FCMBroadcastReceiver.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/receivers/FCMBroadcastReceiver.kt
@@ -21,7 +21,9 @@ class FCMBroadcastReceiver : BroadcastReceiver() {
             return
         }
 
-        OneSignal.initWithContext(context)
+        if(!OneSignal.initWithContext(context)) {
+            return
+        }
 
         val bundleProcessor = OneSignal.getService<INotificationBundleProcessor>()
 

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/receivers/NotificationDismissReceiver.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/receivers/NotificationDismissReceiver.kt
@@ -33,7 +33,9 @@ import com.onesignal.notifications.internal.open.INotificationOpenedProcessor
 
 class NotificationDismissReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
-        OneSignal.initWithContext(context.applicationContext)
+        if(!OneSignal.initWithContext(context.applicationContext)) {
+            return
+        }
 
         var notificationOpenedProcessor = OneSignal.getService<INotificationOpenedProcessor>()
 

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/receivers/UpgradeReceiver.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/receivers/UpgradeReceiver.kt
@@ -43,12 +43,11 @@ class UpgradeReceiver : BroadcastReceiver() {
             return
         }
 
-        if (!OneSignal.isInitialized) {
-            OneSignal.initWithContext(context)
+        if(!OneSignal.initWithContext(context)) {
+            return
         }
 
-        var restoreWorkManager = OneSignal.getService<INotificationRestoreWorkManager>()
-
+        val restoreWorkManager = OneSignal.getService<INotificationRestoreWorkManager>()
         restoreWorkManager.beginEnqueueingWork(context, true)
     }
 }


### PR DESCRIPTION
# Description
## One Line Summary
Safeguard against activities/services/receivers being called before initialization.

### Motivation
* Update `IOneSignal.initWithContext` interface to return whether initialization was successful or not.
* Implementation fails initialization if no app ID is provided and no app ID has been saved.
* Update all activities/services/receivers to check and not proceed when initialization unsuccessful.

### Scope
Fixes #1745 
Covers all SDK services/receivers/activities initialization flows, which call `OneSignal.initWithContext` without an appId (as they don't know the appId) on the assumption the appId has already been provided by the external `OneSignal.initWithContext`.  Now these services/receivers/activities can bail out if this is not the case, rather than blow up.

# Testing
## Manual testing
Test various scenarios related to initializing (or not initializing) the OneSignal SDK and driving the services/receivers/activities that exist within the SDK.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/1746)
<!-- Reviewable:end -->
