### PR TITLE
[User Model] Don't show "Missing Google Project number!" error message until remote config loaded.

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/config/ConfigModel.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/config/ConfigModel.kt
@@ -6,6 +6,13 @@ import org.json.JSONObject
 
 class ConfigModel : Model() {
     /**
+     * Whether this config has been initialized with remote data.
+     */
+    var isInitializedWithRemote: Boolean
+        get() = getBooleanProperty(::isInitializedWithRemote.name) { false }
+        set(value) { setBooleanProperty(::isInitializedWithRemote.name, value) }
+
+    /**
      * The current OneSignal application ID provided to the SDK.
      */
     var appId: String

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/config/impl/ConfigModelStoreListener.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/config/impl/ConfigModelStoreListener.kt
@@ -68,6 +68,8 @@ internal class ConfigModelStoreListener(
                     val config = ConfigModel()
                     config.initializeFromModel(null, _configModelStore.model)
 
+                    config.isInitializedWithRemote = true
+
                     // these are always copied from the backend params
                     config.appId = appId
                     config.notificationChannels = params.notificationChannels

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorAbstractGoogle.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorAbstractGoogle.kt
@@ -51,6 +51,10 @@ internal abstract class PushRegistratorAbstractGoogle(
     abstract suspend fun getToken(senderId: String): String
 
     override suspend fun registerForPush(): IPushRegistrator.RegisterResult {
+        if(!_configModelStore.model.isInitializedWithRemote) {
+            return IPushRegistrator.RegisterResult(null, SubscriptionStatus.FIREBASE_FCM_INIT_ERROR)
+        }
+
         if (!_deviceService.hasFCMLibrary) {
             Logging.fatal("The Firebase FCM library is missing! Please make sure to include it in your project.")
             return IPushRegistrator.RegisterResult(null, SubscriptionStatus.MISSING_FIREBASE_FCM_LIBRARY)


### PR DESCRIPTION
# Description
## One Line Summary
Don't show "Missing Google Project number!" error message until remote config loaded.

## Details

### Motivation
Retrieving the FCM push token occurs on initialization. The first time the SDK is initialized this *might* happen before the remote config has been pulled down, causing error message "Missing Google Project number!" to be logged.  Once the configuration has been pulled down the FCM push token is again attempted to be retrieved and (assuming no other issues) will succeed, so no long term underlying issue.  Rather than attempt to synchronize token retrieval to always be after config retrieval, we continue to allow this as a possibility but fail early on token retrieval when there is not yet a config.

### Scope
This change affects when an error message is logged due to a bad google project number.  We no longer consider "Has not yet retrieved the google project number" as reason to log an error. 

# Testing
## Manual testing
Using the example app, tested SDK initialization on a new and existing app and manually inspected state/logs to determine correct behavior.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.
