### PR TITLE
[User Model] Change `addTrigger` to accept a `String` instead of `Any`

### DIFF
--- a/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/adapter/PairRecyclerViewAdapter.java
+++ b/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/adapter/PairRecyclerViewAdapter.java
@@ -81,8 +81,10 @@ public class PairRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerView.V
 
             if (Util.isBoolean(value))
                 value += " (bool)";
-            else if (Util.isNumeric(value))
-                value += " (num)";
+            else if (Util.isInteger(value))
+                value += " (int)";
+            else if (Util.isFloat(value))
+                value += " (float)";
             else
                 value += " (str)";
             pairValueTextView.setText(value);

--- a/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/adapter/SingleRecyclerViewAdapter.java
+++ b/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/adapter/SingleRecyclerViewAdapter.java
@@ -76,8 +76,10 @@ public class SingleRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerView
 
             if (Util.isBoolean(value))
                 value += " (bool)";
-            else if (Util.isNumeric(value))
-                value += " (num)";
+            else if (Util.isInteger(value))
+                value += " (int)";
+            else if (Util.isFloat(value))
+                value += " (float)";
             else
                 value += " (str)";
             singleTextView.setText(value);

--- a/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/model/MainActivityViewModel.java
+++ b/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/model/MainActivityViewModel.java
@@ -719,7 +719,7 @@ public class MainActivityViewModel implements ActivityViewModel, ISubscriptionCh
                     triggerSet.remove(pair.first);
                     toaster.makeCustomViewToast("Deleted trigger " + pair.first, ToastType.SUCCESS);
                 } else {
-                    OneSignal.getInAppMessages().addTrigger(pair.first, pair.second);
+                    OneSignal.getInAppMessages().addTrigger(pair.first, pair.second.toString());
                     triggerSet.put(pair.first, pair.second);
                     toaster.makeCustomViewToast("Added trigger " + pair.first, ToastType.SUCCESS);
                 }

--- a/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/util/Dialog.java
+++ b/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/util/Dialog.java
@@ -167,7 +167,9 @@ public class Dialog {
                 Object pairValue = pairStringValue;
                 if (Util.isBoolean(pairStringValue)) {
                     pairValue = Boolean.parseBoolean(pairStringValue.toLowerCase());
-                } else if (Util.isNumeric(pairStringValue)) {
+                } else if (Util.isInteger(pairStringValue)) {
+                    pairValue = Long.parseLong(pairStringValue);
+                } else if (Util.isFloat(pairStringValue)) {
                     pairValue = Double.parseDouble(pairStringValue);
                 }
 

--- a/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/util/Util.java
+++ b/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/util/Util.java
@@ -7,7 +7,16 @@ public class Util {
         return (string.equals("true") || string.equals("false"));
     }
 
-    public static boolean isNumeric(String string) {
+    public static boolean isInteger(String string) {
+        try {
+            Long.parseLong(string);
+            return true;
+        } catch (NumberFormatException e) {
+            return false;
+        }
+    }
+
+    public static boolean isFloat(String string) {
         try {
             Double.parseDouble(string);
             return true;

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/inAppMessages/IInAppMessagesManager.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/inAppMessages/IInAppMessagesManager.kt
@@ -25,10 +25,9 @@ interface IInAppMessagesManager {
      * to the current user.
      *
      * @param key The key of the trigger that is to be set.
-     * @param value The value of the trigger. Although this is defined as [Any] its [Any.toString]
-     * will be used for evaluation purposes.
+     * @param value The value of the trigger.
      */
-    fun addTrigger(key: String, value: Any)
+    fun addTrigger(key: String, value: String)
 
     /**
      * Add multiple triggers for the current user.  Triggers are currently explicitly used to determine
@@ -38,11 +37,9 @@ interface IInAppMessagesManager {
      * triggers are not persisted to the backend. They only exist on the local device and are applicable
      * to the current user.
      *
-     * @param triggers The map of triggers that are to be added to the current user.  Although the
-     * value of the [Map] is defined as [Any] its [Any.toString] will be used for evaluation
-     * purposes.
+     * @param triggers The map of triggers that are to be added to the current user.
      */
-    fun addTriggers(triggers: Map<String, Any>)
+    fun addTriggers(triggers: Map<String, String>)
 
     /**
      * Remove the trigger with the provided key from the current user.

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/inAppMessages/internal/MisconfiguredIAMManager.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/inAppMessages/internal/MisconfiguredIAMManager.kt
@@ -13,8 +13,8 @@ internal class MisconfiguredIAMManager : IInAppMessagesManager {
         get() = throw EXCEPTION
         set(value) = throw EXCEPTION
 
-    override fun addTrigger(key: String, value: Any) = throw EXCEPTION
-    override fun addTriggers(triggers: Map<String, Any>) = throw EXCEPTION
+    override fun addTrigger(key: String, value: String) = throw EXCEPTION
+    override fun addTriggers(triggers: Map<String, String>) = throw EXCEPTION
     override fun removeTrigger(key: String) = throw EXCEPTION
     override fun removeTriggers(keys: Collection<String>) = throw EXCEPTION
     override fun clearTriggers() = throw EXCEPTION

--- a/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/DummyInAppMessagesManager.kt
+++ b/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/DummyInAppMessagesManager.kt
@@ -6,10 +6,10 @@ import com.onesignal.inAppMessages.IInAppMessagesManager
 
 internal class DummyInAppMessagesManager : IInAppMessagesManager {
     override var paused: Boolean = true
-    override fun addTrigger(key: String, value: Any) {
+    override fun addTrigger(key: String, value: String) {
     }
 
-    override fun addTriggers(triggers: Map<String, Any>) {
+    override fun addTriggers(triggers: Map<String, String>) {
     }
 
     override fun removeTrigger(key: String) {

--- a/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/InAppMessagesManager.kt
+++ b/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/InAppMessagesManager.kt
@@ -442,13 +442,13 @@ internal class InAppMessagesManager(
         Logging.debug("InAppMessagesManager.persistInAppMessage: $message with msg array data: $_redisplayedInAppMessages")
     }
 
-    override fun addTriggers(triggers: Map<String, Any>) {
+    override fun addTriggers(triggers: Map<String, String>) {
         Logging.debug("InAppMessagesManager.addTriggers(triggers: $triggers)")
 
         triggers.forEach { addTrigger(it.key, it.value) }
     }
 
-    override fun addTrigger(key: String, value: Any) {
+    override fun addTrigger(key: String, value: String) {
         Logging.debug("InAppMessagesManager.addTrigger(key: $key, value: $value)")
 
         var triggerModel = _triggerModelStore.get(key)


### PR DESCRIPTION
# Description
## One Line Summary
Change `addTrigger` to accept a `String` instead of `Any`

## Details

### Motivation
In order to make the SDK as intuitive as possible the values for a trigger in `OneSignal.inAppMessages.SetTrigger` and `OneSignal.inAppMessages.setTriggers` are now of type `string`. The underlying management of the device triggers hasn't changed and can still technically hold any trigger value, now only string types are added.  This was **not** changed to keep the SDK internals as flexible as possible.  When appropriate integer/double comparisons will continue to be done (when the criteria is a `>`, `>=`, `<`, or `<=`).

The example app was updated to support capturing integers.  The current code would convert all numbers to a double, which was not correct when comparing against a non-double (`Double.toString()` adds a decimal point and zero).

# Testing

## Manual testing
Manually tested different testing scenarios:

Dashboard  | Device | Result
--- | --- | --- 
EQUALS 6 | 6 | true
EQUALS 6 | 6.1 | false
EQUALS 6.1 | 6.1 | true
EQUALS 6.1 | 6 | false
EQUALS true | true  | true
EQUALS true | false | false
GT 6.2 | 6.2 | true <-- This was true because of floating point rounding
GT 6.2 | 6.1 | false

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [x] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/1754)
<!-- Reviewable:end -->
