### PR TITLE
Update high level components to be accessed via pascal case

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -59,11 +59,11 @@ The OneSignal SDK has been updated to be more modular in nature.  The SDK has be
 | Namespace     | Module                        | Kotlin                    | Java                           |
 | ------------- | ----------------------------- | ------------------------- | ------------------------------ |
 | User          | com.onesignal:core            | `OneSignal.User`          | `OneSignal.getUser()`          |
-| Session       | com.onesignal:core            | `OneSignal.session`       | `OneSignal.getSession()`       |
-| Notifications | com.onesignal:notifications   | `OneSignal.notifications` | `OneSignal.getNotifications()` |
-| Location      | com.onesignal:location        | `OneSignal.location`      | `OneSignal.getLocation()`      |
-| InAppMessages | com.onesignal:in-app-messages | `OneSignal.inAppMessages` | `OneSignal.getInAppMessages()` |
-| Debug         | com.onesignal:core            | `OneSignal.debug`         | `OneSignal.getDebug()`         |
+| Session       | com.onesignal:core            | `OneSignal.Session`       | `OneSignal.getSession()`       |
+| Notifications | com.onesignal:notifications   | `OneSignal.Notifications` | `OneSignal.getNotifications()` |
+| Location      | com.onesignal:location        | `OneSignal.Location`      | `OneSignal.getLocation()`      |
+| InAppMessages | com.onesignal:in-app-messages | `OneSignal.InAppMessages` | `OneSignal.getInAppMessages()` |
+| Debug         | com.onesignal:core            | `OneSignal.Debug`         | `OneSignal.getDebug()`         |
 
 
 
@@ -83,7 +83,7 @@ Initialization of the OneSignal SDK, although similar to past versions, has chan
     OneSignal.initWithContext(this, ONESIGNAL_APP_ID)
     // requestPermission will show the native Android notification permission prompt.
     // We recommend removing the following code and instead using an In-App Message to prompt for notification permission.
-    OneSignal.notifications.requestPermission(true)
+    OneSignal.Notifications.requestPermission(true)
 
 If your integration is not user-centric, there is no additional startup code required.  A user is automatically created as part of the push subscription creation, both of which are only accessible from the current device and the OneSignal dashboard.
 
@@ -246,7 +246,7 @@ The user name space is accessible via `OneSignal.User` (in Kotlin) or `OneSignal
 
 
 **Session Namespace**
-The session namespace is accessible via `OneSignal.session` (in Kotlin) or `OneSignal.getSession()` (in Java) and provides access to session-scoped functionality.
+The session namespace is accessible via `OneSignal.Session` (in Kotlin) or `OneSignal.getSession()` (in Java) and provides access to session-scoped functionality.
 
 | **Kotlin**                                            | **Java**                                             | **Description**                                                                          |
 | ----------------------------------------------------- | ---------------------------------------------------- | ---------------------------------------------------------------------------------------- |
@@ -256,7 +256,7 @@ The session namespace is accessible via `OneSignal.session` (in Kotlin) or `OneS
 
 
 **Notifications Namespace**
-The notification namespace is accessible via `OneSignal.notifications` (in Kotlin) or `OneSignal.getNotifications()` (in Java) and provides access to notification-scoped functionality.
+The notification namespace is accessible via `OneSignal.Notifications` (in Kotlin) or `OneSignal.getNotifications()` (in Java) and provides access to notification-scoped functionality.
 
 | **Kotlin**                                                                                           | **Java**                                                                                             | **Description**                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -272,7 +272,7 @@ The notification namespace is accessible via `OneSignal.notifications` (in Kotli
 
 
 **Location Namespace**
-The location namespace is accessible via `OneSignal.location` (in Kotlin) or `OneSignal.getLocation()` (in Java) and provide access to location-scoped functionality.
+The location namespace is accessible via `OneSignal.Location` (in Kotlin) or `OneSignal.getLocation()` (in Java) and provide access to location-scoped functionality.
 
 | **Kotlin**                                 | **Java**                                                           | **Description**                                                                                                                                          |
 | -------------------------------------------| -------------------------------------------------------------------| -------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -281,7 +281,7 @@ The location namespace is accessible via `OneSignal.location` (in Kotlin) or `On
 
 
 **InAppMessages Namespace**
-The In App Messages namespace is accessible via `OneSignal.inAppMessages` (in Kotlin) or `OneSignal.getInAppMessages()` (in Java) and provide access to in app messages-scoped functionality.
+The In App Messages namespace is accessible via `OneSignal.InAppMessages` (in Kotlin) or `OneSignal.getInAppMessages()` (in Java) and provide access to in app messages-scoped functionality.
 
 | **Kotlin**                                                                     | **Java**                                                                       | **Description**                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
 | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -296,7 +296,7 @@ The In App Messages namespace is accessible via `OneSignal.inAppMessages` (in Ko
 
 
 **Debug Namespace**
-The debug namespace is accessible via `OneSignal.debug` (in Kotlin) or `OneSignal.getDebug()` (in Java) and provide access to debug-scoped functionality.
+The debug namespace is accessible via `OneSignal.Debug` (in Kotlin) or `OneSignal.getDebug()` (in Java) and provide access to debug-scoped functionality.
 
 | **Kotlin**                 | **Java**                                                           | **Description**                                                                                      |
 | -------------------------- | ------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------- |

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/IOneSignal.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/IOneSignal.kt
@@ -28,25 +28,25 @@ interface IOneSignal {
     /**
      * The session manager for accessing session-scoped management.
      */
-    val session: ISessionManager
+    val Session: ISessionManager
 
     /**
      * The notification manager for accessing device-scoped
      * notification management.
      */
-    val notifications: INotificationsManager
+    val Notifications: INotificationsManager
 
     /**
      * The location manager for accessing device-scoped
      * location management.
      */
-    val location: ILocationManager
+    val Location: ILocationManager
 
     /**
      * The In App Messaging manager for accessing device-scoped
      * IAP management.
      */
-    val inAppMessages: IInAppMessagesManager
+    val InAppMessages: IInAppMessagesManager
 
     /**
      * Access to debug the SDK in the event additional information is required to diagnose any
@@ -54,7 +54,7 @@ interface IOneSignal {
      *
      * WARNING: This should not be used in a production setting.
      */
-    val debug: IDebugManager
+    val Debug: IDebugManager
 
     /**
      * Determines whether a user must consent to privacy prior

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/OneSignal.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/OneSignal.kt
@@ -50,32 +50,32 @@ object OneSignal {
      * has been called.
      */
     @JvmStatic
-    val session: ISessionManager
-        get() = oneSignal.session
+    val Session: ISessionManager
+        get() = oneSignal.Session
 
     /**
      * The notification manager for accessing device-scoped notification management. Initialized
      * only after [initWithContext] has been called.
      */
     @JvmStatic
-    val notifications: INotificationsManager
-        get() = oneSignal.notifications
+    val Notifications: INotificationsManager
+        get() = oneSignal.Notifications
 
     /**
      * The location manager for accessing device-scoped location management. Initialized
      * only after [initWithContext] has been called.
      */
     @JvmStatic
-    val location: ILocationManager
-        get() = oneSignal.location
+    val Location: ILocationManager
+        get() = oneSignal.Location
 
     /**
      * The In App Messaging manager for accessing device-scoped IAP management. Initialized
      * only after [initWithContext] has been called.
      */
     @JvmStatic
-    val inAppMessages: IInAppMessagesManager
-        get() = oneSignal.inAppMessages
+    val InAppMessages: IInAppMessagesManager
+        get() = oneSignal.InAppMessages
 
     /**
      * Access to debug the SDK in the additional information is required to diagnose any
@@ -84,8 +84,8 @@ object OneSignal {
      * WARNING: This should not be used in a production setting.
      */
     @JvmStatic
-    val debug: IDebugManager
-        get() = oneSignal.debug
+    val Debug: IDebugManager
+        get() = oneSignal.Debug
 
     /**
      * Determines whether a user must consent to privacy prior

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
@@ -75,11 +75,11 @@ internal class OneSignalImp : IOneSignal, IServiceProvider {
         }
 
     // we hardcode the DebugManager implementation so it can be used prior to calling `initWithContext`
-    override val debug: IDebugManager = DebugManager()
-    override val session: ISessionManager get() = if (isInitialized) _session!! else throw Exception("Must call 'initWithContext' before use")
-    override val notifications: INotificationsManager get() = if (isInitialized) _notifications!! else throw Exception("Must call 'initWithContext' before use")
-    override val location: ILocationManager get() = if (isInitialized) _location!! else throw Exception("Must call 'initWithContext' before use")
-    override val inAppMessages: IInAppMessagesManager get() = if (isInitialized) _iam!! else throw Exception("Must call 'initWithContext' before use")
+    override val Debug: IDebugManager = DebugManager()
+    override val Session: ISessionManager get() = if (isInitialized) _session!! else throw Exception("Must call 'initWithContext' before use")
+    override val Notifications: INotificationsManager get() = if (isInitialized) _notifications!! else throw Exception("Must call 'initWithContext' before use")
+    override val Location: ILocationManager get() = if (isInitialized) _location!! else throw Exception("Must call 'initWithContext' before use")
+    override val InAppMessages: IInAppMessagesManager get() = if (isInitialized) _iam!! else throw Exception("Must call 'initWithContext' before use")
     override val User: IUserManager get() = if (isInitialized) _user!! else throw Exception("Must call 'initWithContext' before use")
 
     // Services required by this class


### PR DESCRIPTION
# Description
## One Line Summary
Update high level components to be accessed via pascal casing.

## Details

### Motivation
To keep consistent, make all high level components accessible via a property that is in pascal case (i.e. `OneSignal.Notifications`, `OneSignal.InAppMessages`, etc).  This is in contradiction to Kotlin best practices, but is favored to keep access patterns consistent across the SDK.

### Scope
This is name change only, no functional changes.

# Testing

## Manual testing
No testing was performed.  The codebase compiles, and existing unit tests pass.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [ ] I have filled out all **REQUIRED** sections above
   - [ ] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [ ] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [ ] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.
