### PR TITLE
User Model - Update privacy consent property names

### DIFF
--- a/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/activity/MainActivity.java
+++ b/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/activity/MainActivity.java
@@ -41,7 +41,7 @@ public class MainActivity extends AppCompatActivity {
     protected void onResume() {
         super.onResume();
 
-        boolean hasConsent = OneSignal.getRequiresPrivacyConsent();
+        boolean hasConsent = OneSignal.getConsentGiven();
         if (hasConsent)
             viewModel.setupLayout();
     }

--- a/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/model/MainActivityViewModel.java
+++ b/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/model/MainActivityViewModel.java
@@ -884,7 +884,7 @@ public class MainActivityViewModel implements ActivityViewModel, IPushSubscripti
     }
 
     private void togglePrivacyConsent(boolean hasConsent) {
-        OneSignal.setPrivacyConsent(hasConsent);
+        OneSignal.setConsentGiven(hasConsent);
         SharedPreferenceUtil.cacheUserPrivacyConsent(context, hasConsent);
 
         shouldScrollTop = hasConsent;

--- a/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/model/SplashActivityViewModel.java
+++ b/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/model/SplashActivityViewModel.java
@@ -63,7 +63,7 @@ public class SplashActivityViewModel implements ActivityViewModel {
     private void setupOneSignalSDK() {
         boolean privacyConsent = true;
 
-        OneSignal.setRequiresPrivacyConsent(privacyConsent);
+        OneSignal.setConsentRequired(privacyConsent);
 
         boolean isLocationShared = SharedPreferenceUtil.getCachedLocationSharedStatus(context);
         OneSignal.getLocation().setShared(isLocationShared);

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/IOneSignal.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/IOneSignal.kt
@@ -62,13 +62,13 @@ interface IOneSignal {
      * should be set to `true` prior to the invocation of
      * [initWithContext] to ensure compliance.
      */
-    var requiresPrivacyConsent: Boolean
+    var consentRequired: Boolean
 
     /**
      * Indicates whether privacy consent has been granted. This field is only relevant when
-     * the application has opted into data privacy protections. See [requiresPrivacyConsent].
+     * the application has opted into data privacy protections. See [consentRequired].
      */
-    var privacyConsent: Boolean
+    var consentGiven: Boolean
 
     /**
      * Whether to disable the "GMS is missing" prompt to the user.

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/OneSignal.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/OneSignal.kt
@@ -94,18 +94,18 @@ object OneSignal {
      * [initWithContext] to ensure compliance.
      */
     @JvmStatic
-    var requiresPrivacyConsent: Boolean
-        get() = oneSignal.requiresPrivacyConsent
-        set(value) { oneSignal.requiresPrivacyConsent = value }
+    var consentRequired: Boolean
+        get() = oneSignal.consentRequired
+        set(value) { oneSignal.consentRequired = value }
 
     /**
      * Indicates whether privacy consent has been granted. This field is only relevant when
      * the application has opted into data privacy protections. See [requiresPrivacyConsent].
      */
     @JvmStatic
-    var privacyConsent: Boolean
-        get() = oneSignal.privacyConsent
-        set(value) { oneSignal.privacyConsent = value }
+    var consentGiven: Boolean
+        get() = oneSignal.consentGiven
+        set(value) { oneSignal.consentGiven = value }
 
     /**
      * Whether to disable the "GMS is missing" prompt to the user.

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/config/ConfigModel.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/config/ConfigModel.kt
@@ -36,16 +36,16 @@ class ConfigModel : Model() {
     /**
      * Whether the SDK requires privacy consent to send data to backend.
      */
-    var requiresPrivacyConsent: Boolean?
-        get() = getOptBooleanProperty(::requiresPrivacyConsent.name)
-        set(value) { setOptBooleanProperty(::requiresPrivacyConsent.name, value) }
+    var consentRequired: Boolean?
+        get() = getOptBooleanProperty(::consentRequired.name)
+        set(value) { setOptBooleanProperty(::consentRequired.name, value) }
 
     /**
      * Whether the SDK has been given consent to privacy.
      */
-    var givenPrivacyConsent: Boolean?
-        get() = getOptBooleanProperty(::givenPrivacyConsent.name)
-        set(value) { setOptBooleanProperty(::givenPrivacyConsent.name, value) }
+    var consentGiven: Boolean?
+        get() = getOptBooleanProperty(::consentGiven.name)
+        set(value) { setOptBooleanProperty(::consentGiven.name, value) }
 
     /**
      * Whether location is shared.

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/config/impl/ConfigModelStoreListener.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/config/impl/ConfigModelStoreListener.kt
@@ -88,7 +88,7 @@ internal class ConfigModelStoreListener(
                     params.disableGMSMissingPrompt?.let { config.disableGMSMissingPrompt = it }
                     params.unsubscribeWhenNotificationsDisabled?.let { config.unsubscribeWhenNotificationsDisabled = it }
                     params.locationShared?.let { config.locationShared = it }
-                    params.requiresUserPrivacyConsent?.let { config.requiresPrivacyConsent = it }
+                    params.requiresUserPrivacyConsent?.let { config.consentRequired = it }
                     params.opRepoExecutionInterval?.let { config.opRepoExecutionInterval = it }
                     params.influenceParams.notificationLimit?.let { config.influenceParams.notificationLimit = it }
                     params.influenceParams.indirectNotificationAttributionWindow?.let { config.influenceParams.indirectNotificationAttributionWindow = it }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/http/impl/HttpClient.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/http/impl/HttpClient.kt
@@ -58,7 +58,7 @@ internal class HttpClient(
         cacheKey: String?,
     ): HttpResponse {
         // If privacy consent is required but not yet given, any non-GET request should be blocked.
-        if (method != null && _configModelStore.model.requiresPrivacyConsent == true && _configModelStore.model.givenPrivacyConsent != true) {
+        if (method != null && _configModelStore.model.consentRequired == true && _configModelStore.model.consentGiven != true) {
             Logging.warn("$method `$url` was called before the user provided privacy consent. Your application is set to require the user's privacy consent before the OneSignal SDK can be initialized. Please ensure the user has provided consent before calling this method. You can check the latest OneSignal consent status by calling OneSignal.privacyConsent")
             return HttpResponse(0, null, null)
         }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
@@ -53,18 +53,18 @@ internal class OneSignalImp : IOneSignal, IServiceProvider {
     override val sdkVersion: String = OneSignalUtils.sdkVersion
     override var isInitialized: Boolean = false
 
-    override var requiresPrivacyConsent: Boolean
-        get() = _configModel?.requiresPrivacyConsent ?: (_requiresPrivacyConsent == true)
+    override var consentRequired: Boolean
+        get() = _configModel?.consentRequired ?: (_consentRequired == true)
         set(value) {
-            _requiresPrivacyConsent = value
-            _configModel?.requiresPrivacyConsent = value
+            _consentRequired = value
+            _configModel?.consentRequired = value
         }
 
-    override var privacyConsent: Boolean
-        get() = _configModel?.givenPrivacyConsent ?: (_givenPrivacyConsent == true)
+    override var consentGiven: Boolean
+        get() = _configModel?.consentGiven ?: (_consentGiven == true)
         set(value) {
-            _givenPrivacyConsent = value
-            _configModel?.givenPrivacyConsent = value
+            _consentGiven = value
+            _configModel?.consentGiven = value
         }
 
     override var disableGMSMissingPrompt: Boolean
@@ -99,8 +99,8 @@ internal class OneSignalImp : IOneSignal, IServiceProvider {
     private val _services: ServiceProvider
     private var _configModel: ConfigModel? = null
     private var _sessionModel: SessionModel? = null
-    private var _requiresPrivacyConsent: Boolean? = null
-    private var _givenPrivacyConsent: Boolean? = null
+    private var _consentRequired: Boolean? = null
+    private var _consentGiven: Boolean? = null
     private var _disableGMSMissingPrompt: Boolean? = null
     private val _loginLock: Any = Any()
 
@@ -174,13 +174,13 @@ internal class OneSignalImp : IOneSignal, IServiceProvider {
         }
 
         // if requires privacy consent was set prior to init, set it in the model now
-        if (_requiresPrivacyConsent != null) {
-            _configModel!!.requiresPrivacyConsent = _requiresPrivacyConsent!!
+        if (_consentRequired != null) {
+            _configModel!!.consentRequired = _consentRequired!!
         }
 
         // if privacy consent was set prior to init, set it in the model now
-        if (_givenPrivacyConsent != null) {
-            _configModel!!.givenPrivacyConsent = _givenPrivacyConsent!!
+        if (_consentGiven != null) {
+            _configModel!!.consentGiven = _consentGiven!!
         }
 
         if (_disableGMSMissingPrompt != null) {

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/session/internal/outcomes/OutcomeEventsControllerTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/session/internal/outcomes/OutcomeEventsControllerTests.kt
@@ -43,6 +43,14 @@ class OutcomeEventsControllerTests : FunSpec({
         Logging.logLevel = LogLevel.NONE
     }
 
+    fun createTestSubscriptionModel(): SubscriptionModel {
+        val subModel = SubscriptionModel()
+        subModel.id = "subscriptionId"
+        subModel.address = "subscriptionAddress"
+        subModel.optedIn = true
+        return subModel
+    }
+
     test("send outcome with disabled influences") {
         /* Given */
         val now = 111L
@@ -86,8 +94,7 @@ class OutcomeEventsControllerTests : FunSpec({
         val mockInfluenceManager = mockk<IInfluenceManager>()
         every { mockInfluenceManager.influences } returns listOf(Influence(InfluenceChannel.NOTIFICATION, InfluenceType.UNATTRIBUTED, null))
 
-        val subscriptionModel = SubscriptionModel()
-        subscriptionModel.id = "subscriptionId"
+        val subscriptionModel = createTestSubscriptionModel()
 
         val mockSubscriptionManager = mockk<ISubscriptionManager>()
         every { mockSubscriptionManager.subscriptions.push } returns PushSubscription(subscriptionModel)
@@ -132,8 +139,8 @@ class OutcomeEventsControllerTests : FunSpec({
         val mockInfluenceManager = mockk<IInfluenceManager>()
         every { mockInfluenceManager.influences } returns listOf(Influence(InfluenceChannel.NOTIFICATION, InfluenceType.INDIRECT, JSONArray(notificationIds)))
 
-        val subscriptionModel = SubscriptionModel()
-        subscriptionModel.id = "subscriptionId"
+        val subscriptionModel = createTestSubscriptionModel()
+
         val mockSubscriptionManager = mockk<ISubscriptionManager>()
         every { mockSubscriptionManager.subscriptions.push } returns PushSubscription(subscriptionModel)
 
@@ -178,8 +185,8 @@ class OutcomeEventsControllerTests : FunSpec({
         val mockInfluenceManager = mockk<IInfluenceManager>()
         every { mockInfluenceManager.influences } returns listOf(Influence(InfluenceChannel.NOTIFICATION, InfluenceType.DIRECT, JSONArray(notificationIds)))
 
-        val subscriptionModel = SubscriptionModel()
-        subscriptionModel.id = "subscriptionId"
+        val subscriptionModel = createTestSubscriptionModel()
+
         val mockSubscriptionManager = mockk<ISubscriptionManager>()
         every { mockSubscriptionManager.subscriptions.push } returns PushSubscription(subscriptionModel)
 
@@ -224,8 +231,8 @@ class OutcomeEventsControllerTests : FunSpec({
         val mockInfluenceManager = mockk<IInfluenceManager>()
         every { mockInfluenceManager.influences } returns listOf(Influence(InfluenceChannel.NOTIFICATION, InfluenceType.UNATTRIBUTED, null))
 
-        val subscriptionModel = SubscriptionModel()
-        subscriptionModel.id = "subscriptionId"
+        val subscriptionModel = createTestSubscriptionModel()
+
         val mockSubscriptionManager = mockk<ISubscriptionManager>()
         every { mockSubscriptionManager.subscriptions.push } returns PushSubscription(subscriptionModel)
 
@@ -268,8 +275,8 @@ class OutcomeEventsControllerTests : FunSpec({
         val mockInfluenceManager = mockk<IInfluenceManager>()
         every { mockInfluenceManager.influences } returns listOf(Influence(InfluenceChannel.NOTIFICATION, InfluenceType.UNATTRIBUTED, null))
 
-        val subscriptionModel = SubscriptionModel()
-        subscriptionModel.id = "subscriptionId"
+        val subscriptionModel = createTestSubscriptionModel()
+
         val mockSubscriptionManager = mockk<ISubscriptionManager>()
         every { mockSubscriptionManager.subscriptions.push } returns PushSubscription(subscriptionModel)
 
@@ -322,8 +329,8 @@ class OutcomeEventsControllerTests : FunSpec({
         coEvery { mockOutcomeEventsRepository.getNotCachedUniqueInfluencesForOutcome("OUTCOME_1", any()) } returns listOf(notificationInfluence) andThen listOf()
         coEvery { mockOutcomeEventsRepository.saveUniqueOutcomeEventParams(any()) } answers { waiter.wake() }
 
-        val subscriptionModel = SubscriptionModel()
-        subscriptionModel.id = "subscriptionId"
+        val subscriptionModel = createTestSubscriptionModel()
+
         val mockSubscriptionManager = mockk<ISubscriptionManager>()
         every { mockSubscriptionManager.subscriptions.push } returns PushSubscription(subscriptionModel)
 
@@ -376,8 +383,8 @@ class OutcomeEventsControllerTests : FunSpec({
         val notificationInfluence2 = Influence(InfluenceChannel.NOTIFICATION, InfluenceType.DIRECT, JSONArray(notificationIds2))
         every { mockInfluenceManager.influences } returns listOf(notificationInfluence1) andThen listOf(notificationInfluence2)
 
-        val subscriptionModel = SubscriptionModel()
-        subscriptionModel.id = "subscriptionId"
+        val subscriptionModel = createTestSubscriptionModel()
+
         val mockSubscriptionManager = mockk<ISubscriptionManager>()
         every { mockSubscriptionManager.subscriptions.push } returns PushSubscription(subscriptionModel)
 
@@ -438,8 +445,8 @@ class OutcomeEventsControllerTests : FunSpec({
         val mockInfluenceManager = mockk<IInfluenceManager>()
         every { mockInfluenceManager.influences } returns listOf(Influence(InfluenceChannel.NOTIFICATION, InfluenceType.UNATTRIBUTED, null))
 
-        val subscriptionModel = SubscriptionModel()
-        subscriptionModel.id = "subscriptionId"
+        val subscriptionModel = createTestSubscriptionModel()
+
         val mockSubscriptionManager = mockk<ISubscriptionManager>()
         every { mockSubscriptionManager.subscriptions.push } returns PushSubscription(subscriptionModel)
 
@@ -483,8 +490,8 @@ class OutcomeEventsControllerTests : FunSpec({
         val mockSessionService = mockk<ISessionService>()
         every { mockSessionService.subscribe(any()) } just Runs
 
-        val subscriptionModel = SubscriptionModel()
-        subscriptionModel.id = "subscriptionId"
+        val subscriptionModel = createTestSubscriptionModel()
+
         val mockSubscriptionManager = mockk<ISubscriptionManager>()
         every { mockSubscriptionManager.subscriptions.push } returns PushSubscription(subscriptionModel)
 
@@ -571,8 +578,8 @@ class OutcomeEventsControllerTests : FunSpec({
         val mockSessionService = mockk<ISessionService>()
         every { mockSessionService.subscribe(any()) } just Runs
 
-        val subscriptionModel = SubscriptionModel()
-        subscriptionModel.id = "subscriptionId"
+        val subscriptionModel = createTestSubscriptionModel()
+
         val mockSubscriptionManager = mockk<ISubscriptionManager>()
         every { mockSubscriptionManager.subscriptions.push } returns PushSubscription(subscriptionModel)
 


### PR DESCRIPTION
# Description
## One Line Summary
Update the privacy consent property names

## Details
requiresPrivacyConsent has become consentRequired()
privacyConsent has become consentGiven()

Also fixes outcomes unit tests so unit tests now pass

### Motivation
simplify api

### Scope
privacy consent

# Testing
## Unit testing
Fix outcomes unit tests

## Manual testing
Test privacy consent on an emulator

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.
