### PR TITLE
Add public class CallbackThreadManager

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/CallbackThreadManager.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/CallbackThreadManager.kt
@@ -1,0 +1,59 @@
+/**
+ * Modified MIT License
+ * <p>
+ * Copyright 2023 OneSignal
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * <p>
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * <p>
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ * <p>
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.onesignal
+
+import kotlin.concurrent.thread
+
+/**
+ * Provides a public API to allow changing which thread callbacks and observers
+ * should fire on.
+ *
+ * Initial motivation for this is to allow the OneSignal-Unity-SDK to config
+ * the SDK to fire off the main thread. This is to avoid cases where Unity may
+ * cause the main UI thread to wait on a background thread when calling back
+ * into Unity.
+ *
+ * Usage: CallbackThreadManager.preference = UseThread.Background
+ */
+class CallbackThreadManager {
+    enum class UseThread {
+        MainUI,
+        Background
+    }
+
+    companion object {
+        var preference = UseThread.MainUI
+
+        fun runOnPreferred(runnable: Runnable) {
+            when (preference) {
+                UseThread.MainUI -> OSUtils.runOnMainUIThread(runnable)
+                UseThread.Background -> thread { runnable.run() }
+            }
+        }
+    }
+}

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageController.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSInAppMessageController.java
@@ -479,7 +479,7 @@ class OSInAppMessageController extends OSBackgroundManager implements OSDynamicT
         if (OneSignal.inAppMessageClickHandler == null)
             return;
 
-        OSUtils.runOnMainUIThread(new Runnable() {
+        CallbackThreadManager.Companion.runOnPreferred(new Runnable() {
             @Override
             public void run() {
                 // Send public outcome from handler

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSObservable.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSObservable.java
@@ -79,7 +79,7 @@ class OSObservable<ObserverType, StateType> {
                final Method method = clazz.getDeclaredMethod(methodName, state.getClass());
                method.setAccessible(true);
                if (fireOnMainThread) {
-                  OSUtils.runOnMainUIThread(
+                  CallbackThreadManager.Companion.runOnPreferred(
                       new Runnable() {
                           @Override
                           public void run() {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -2332,7 +2332,7 @@ public class OneSignal {
 
       // TODO: Once the NotificationOpenedHandler gets a Worker, we should make sure we add a catch
       //    like we have implemented for the OSRemoteNotificationReceivedHandler and NotificationWillShowInForegroundHandlers
-      OSUtils.runOnMainUIThread(new Runnable() {
+      CallbackThreadManager.Companion.runOnPreferred(new Runnable() {
          @Override
          public void run() {
             notificationOpenedHandler.notificationOpened(openedResult);

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalStateSynchronizer.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalStateSynchronizer.java
@@ -306,8 +306,7 @@ class OneSignalStateSynchronizer {
                }
             }
 
-            // Need to call completion handler on main thread since the request response came from an async PUT
-            OSUtils.runOnMainUIThread(new Runnable() {
+            CallbackThreadManager.Companion.runOnPreferred(new Runnable() {
                @Override
                public void run() {
                   if (completionHandler != null)


### PR DESCRIPTION
# Description
## One Line Summary
New public API allows changing the default thread used to fire async events, observers, and callbacks for the rest of the OneSignal public API.

## Details

### Motivation
This is intended for advanced use-cased, motivated mostly by a need from the OneSignal Unity wrapper SDK. Specifically to avoid cases where Unity may cause the main UI thread to wait on a background thread when calling back into Unity. Given how the binding between C# and Java works here, there is no way for the C# code to switch threads itself, so this API has to be available to do so.

### Scope
By default, this PR has no effect, however if `CallbackThreadManager.preference = UseThread.Background` is called this will fire click events (IAMs and Notifications), Observers, and the special case `setExternalUserId` callback (was special cased before this PR) to fire a on a new background thread.

### OneSignal-Unity-SDK
There will be a follow up PR to also utilize this in the `OneSignal-Unity-SDK`.

# Testing
## Unit testing
None

## Manual testing
Ensured setExternalUserId continued firing on the main UI thread, and also it fires on the background thread after chaing the preference.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [X] Public API changes
      - New `CallbackThreadManager` class

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/1776)
<!-- Reviewable:end -->
