### PR TITLE
[5.0.0] Combine less operations with the create user operation

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/backend/IUserBackendService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/backend/IUserBackendService.kt
@@ -12,13 +12,13 @@ interface IUserBackendService {
      * @param appId The ID of the OneSignal application this user will be created under.
      * @param identities The identities to retrieve/modify this user in subsequent requests.  Each identity key/value pair must be unique within
      * the application.
-     * @param properties The properties for this user.
      * @param subscriptions The subscriptions that should also be created and associated with the user. If subscriptions are already owned by a different user
      * they will be transferred to this user.
      *
      * @return The backend response
      */
-    suspend fun createUser(appId: String, identities: Map<String, String>, properties: PropertiesObject, subscriptions: List<SubscriptionObject>): CreateUserResponse
+    suspend fun createUser(appId: String, identities: Map<String, String>, subscriptions: List<SubscriptionObject>): CreateUserResponse
+    // TODO: Change to send only the push subscription, optimally
 
     /**
      * Update the user identified by the [appId]/[aliasId]/[aliasLabel] on the backend.

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/backend/impl/UserBackendService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/backend/impl/UserBackendService.kt
@@ -14,15 +14,11 @@ internal class UserBackendService(
     private val _httpClient: IHttpClient,
 ) : IUserBackendService {
 
-    override suspend fun createUser(appId: String, identities: Map<String, String>, properties: PropertiesObject, subscriptions: List<SubscriptionObject>): CreateUserResponse {
+    override suspend fun createUser(appId: String, identities: Map<String, String>, subscriptions: List<SubscriptionObject>): CreateUserResponse {
         val requestJSON = JSONObject()
 
         if (identities.isNotEmpty()) {
             requestJSON.put("identity", JSONObject().putMap(identities))
-        }
-
-        if (properties.hasAtLeastOnePropertySet) {
-            requestJSON.put("properties", JSONConverter.convertToJSON(properties))
         }
 
         if (subscriptions.isNotEmpty()) {

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/DeleteAliasOperation.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/DeleteAliasOperation.kt
@@ -31,7 +31,7 @@ class DeleteAliasOperation() : Operation(IdentityOperationExecutor.DELETE_ALIAS)
         get() = getStringProperty(::label.name)
         private set(value) { setStringProperty(::label.name, value) }
 
-    override val createComparisonKey: String get() = "$appId.User.$onesignalId"
+    override val createComparisonKey: String get() = ""
     override val modifyComparisonKey: String get() = "$appId.User.$onesignalId.Alias.$label"
     override val groupComparisonType: GroupComparisonType = GroupComparisonType.NONE
     override val canStartExecute: Boolean get() = !IDManager.isLocalId(onesignalId)

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/DeleteTagOperation.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/DeleteTagOperation.kt
@@ -32,7 +32,7 @@ class DeleteTagOperation() : Operation(UpdateUserOperationExecutor.DELETE_TAG) {
         get() = getStringProperty(::key.name)
         private set(value) { setStringProperty(::key.name, value) }
 
-    override val createComparisonKey: String get() = "$appId.User.$onesignalId"
+    override val createComparisonKey: String get() = ""
     override val modifyComparisonKey: String get() = createComparisonKey
     override val groupComparisonType: GroupComparisonType = GroupComparisonType.ALTER
     override val canStartExecute: Boolean get() = !IDManager.isLocalId(onesignalId)

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/SetAliasOperation.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/SetAliasOperation.kt
@@ -39,7 +39,7 @@ class SetAliasOperation() : Operation(IdentityOperationExecutor.SET_ALIAS) {
         get() = getStringProperty(::value.name)
         private set(value) { setStringProperty(::value.name, value) }
 
-    override val createComparisonKey: String get() = "$appId.User.$onesignalId"
+    override val createComparisonKey: String get() = ""
     override val modifyComparisonKey: String get() = "$appId.User.$onesignalId.Identity.$label"
     override val groupComparisonType: GroupComparisonType = GroupComparisonType.ALTER
     override val canStartExecute: Boolean get() = !IDManager.isLocalId(onesignalId)

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/SetPropertyOperation.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/SetPropertyOperation.kt
@@ -38,7 +38,7 @@ class SetPropertyOperation() : Operation(UpdateUserOperationExecutor.SET_PROPERT
         get() = getOptAnyProperty(::value.name)
         private set(value) { setOptAnyProperty(::value.name, value) }
 
-    override val createComparisonKey: String get() = "$appId.User.$onesignalId"
+    override val createComparisonKey: String get() = ""
     override val modifyComparisonKey: String get() = createComparisonKey
     override val groupComparisonType: GroupComparisonType = GroupComparisonType.ALTER
     override val canStartExecute: Boolean get() = !IDManager.isLocalId(onesignalId)

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/SetTagOperation.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/SetTagOperation.kt
@@ -39,7 +39,7 @@ class SetTagOperation() : Operation(UpdateUserOperationExecutor.SET_TAG) {
         get() = getStringProperty(::value.name)
         private set(value) { setStringProperty(::value.name, value) }
 
-    override val createComparisonKey: String get() = "$appId.User.$onesignalId"
+    override val createComparisonKey: String get() = ""
     override val modifyComparisonKey: String get() = createComparisonKey
     override val groupComparisonType: GroupComparisonType = GroupComparisonType.ALTER
     override val canStartExecute: Boolean get() = !IDManager.isLocalId(onesignalId)

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/LoginUserOperationExecutorTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/LoginUserOperationExecutorTests.kt
@@ -46,7 +46,7 @@ class LoginUserOperationExecutorTests : FunSpec({
     test("login anonymous user successfully creates user") {
         /* Given */
         val mockUserBackendService = mockk<IUserBackendService>()
-        coEvery { mockUserBackendService.createUser(any(), any(), any(), any()) } returns
+        coEvery { mockUserBackendService.createUser(any(), any(), any()) } returns
             CreateUserResponse(
                 mapOf(IdentityConstants.ONESIGNAL_ID to remoteOneSignalId),
                 PropertiesObject(),
@@ -80,7 +80,6 @@ class LoginUserOperationExecutorTests : FunSpec({
                 appId,
                 mapOf(),
                 any(),
-                any(),
             )
         }
     }
@@ -88,7 +87,7 @@ class LoginUserOperationExecutorTests : FunSpec({
     test("login anonymous user fails with retry when network condition exists") {
         /* Given */
         val mockUserBackendService = mockk<IUserBackendService>()
-        coEvery { mockUserBackendService.createUser(any(), any(), any(), any()) } throws BackendException(408, "TIMEOUT")
+        coEvery { mockUserBackendService.createUser(any(), any(), any()) } throws BackendException(408, "TIMEOUT")
 
         val mockIdentityOperationExecutor = mockk<IdentityOperationExecutor>()
 
@@ -104,13 +103,13 @@ class LoginUserOperationExecutorTests : FunSpec({
 
         /* Then */
         response.result shouldBe ExecutionResult.FAIL_RETRY
-        coVerify(exactly = 1) { mockUserBackendService.createUser(appId, mapOf(), any(), any()) }
+        coVerify(exactly = 1) { mockUserBackendService.createUser(appId, mapOf(), any()) }
     }
 
     test("login anonymous user fails with no retry when backend error condition exists") {
         /* Given */
         val mockUserBackendService = mockk<IUserBackendService>()
-        coEvery { mockUserBackendService.createUser(any(), any(), any(), any()) } throws BackendException(404, "NOT FOUND")
+        coEvery { mockUserBackendService.createUser(any(), any(), any()) } throws BackendException(404, "NOT FOUND")
 
         val mockIdentityOperationExecutor = mockk<IdentityOperationExecutor>()
 
@@ -126,13 +125,13 @@ class LoginUserOperationExecutorTests : FunSpec({
 
         /* Then */
         response.result shouldBe ExecutionResult.FAIL_NORETRY
-        coVerify(exactly = 1) { mockUserBackendService.createUser(appId, mapOf(), any(), any()) }
+        coVerify(exactly = 1) { mockUserBackendService.createUser(appId, mapOf(), any()) }
     }
 
     test("login identified user without association successfully creates user") {
         /* Given */
         val mockUserBackendService = mockk<IUserBackendService>()
-        coEvery { mockUserBackendService.createUser(any(), any(), any(), any()) } returns
+        coEvery { mockUserBackendService.createUser(any(), any(), any()) } returns
             CreateUserResponse(mapOf(IdentityConstants.ONESIGNAL_ID to remoteOneSignalId), PropertiesObject(), listOf())
 
         val mockIdentityOperationExecutor = mockk<IdentityOperationExecutor>()
@@ -149,7 +148,7 @@ class LoginUserOperationExecutorTests : FunSpec({
 
         /* Then */
         response.result shouldBe ExecutionResult.SUCCESS
-        coVerify(exactly = 1) { mockUserBackendService.createUser(appId, mapOf(IdentityConstants.EXTERNAL_ID to "externalId"), any(), any()) }
+        coVerify(exactly = 1) { mockUserBackendService.createUser(appId, mapOf(IdentityConstants.EXTERNAL_ID to "externalId"), any()) }
     }
 
     test("login identified user with association succeeds when association is successful") {
@@ -188,7 +187,7 @@ class LoginUserOperationExecutorTests : FunSpec({
     test("login identified user with association fails with retry when association fails with retry") {
         /* Given */
         val mockUserBackendService = mockk<IUserBackendService>()
-        coEvery { mockUserBackendService.createUser(any(), any(), any(), any()) } returns
+        coEvery { mockUserBackendService.createUser(any(), any(), any()) } returns
             CreateUserResponse(mapOf(IdentityConstants.ONESIGNAL_ID to remoteOneSignalId), PropertiesObject(), listOf())
 
         val mockIdentityOperationExecutor = mockk<IdentityOperationExecutor>()
@@ -223,7 +222,7 @@ class LoginUserOperationExecutorTests : FunSpec({
     test("login identified user with association successfully creates user when association fails with no retry") {
         /* Given */
         val mockUserBackendService = mockk<IUserBackendService>()
-        coEvery { mockUserBackendService.createUser(any(), any(), any(), any()) } returns
+        coEvery { mockUserBackendService.createUser(any(), any(), any()) } returns
             CreateUserResponse(mapOf(IdentityConstants.ONESIGNAL_ID to remoteOneSignalId), PropertiesObject(), listOf())
 
         val mockIdentityOperationExecutor = mockk<IdentityOperationExecutor>()
@@ -253,13 +252,13 @@ class LoginUserOperationExecutorTests : FunSpec({
                 },
             )
         }
-        coVerify(exactly = 1) { mockUserBackendService.createUser(appId, mapOf(IdentityConstants.EXTERNAL_ID to "externalId"), any(), any()) }
+        coVerify(exactly = 1) { mockUserBackendService.createUser(appId, mapOf(IdentityConstants.EXTERNAL_ID to "externalId"), any()) }
     }
 
     test("login identified user with association fails with retry when association fails with no retry and network condition exists") {
         /* Given */
         val mockUserBackendService = mockk<IUserBackendService>()
-        coEvery { mockUserBackendService.createUser(any(), any(), any(), any()) } throws BackendException(408, "TIMEOUT")
+        coEvery { mockUserBackendService.createUser(any(), any(), any()) } throws BackendException(408, "TIMEOUT")
 
         val mockIdentityOperationExecutor = mockk<IdentityOperationExecutor>()
         coEvery { mockIdentityOperationExecutor.execute(any()) } returns ExecutionResponse(ExecutionResult.FAIL_NORETRY)
@@ -288,13 +287,13 @@ class LoginUserOperationExecutorTests : FunSpec({
                 },
             )
         }
-        coVerify(exactly = 1) { mockUserBackendService.createUser(appId, mapOf(IdentityConstants.EXTERNAL_ID to "externalId"), any(), any()) }
+        coVerify(exactly = 1) { mockUserBackendService.createUser(appId, mapOf(IdentityConstants.EXTERNAL_ID to "externalId"), any()) }
     }
 
     test("creating user will merge operations into one backend call") {
         /* Given */
         val mockUserBackendService = mockk<IUserBackendService>()
-        coEvery { mockUserBackendService.createUser(any(), any(), any(), any()) } returns
+        coEvery { mockUserBackendService.createUser(any(), any(), any()) } returns
             CreateUserResponse(
                 mapOf(IdentityConstants.ONESIGNAL_ID to remoteOneSignalId),
                 PropertiesObject(),
@@ -352,14 +351,6 @@ class LoginUserOperationExecutorTests : FunSpec({
                 appId,
                 mapOf("aliasLabel1" to "aliasValue1-2"),
                 withArg {
-                    it.country shouldBe "country"
-                    it.language shouldBe "lang2"
-                    it.timezoneId shouldBe "timezone"
-                    it.latitude shouldBe 123.45
-                    it.longitude shouldBe 678.90
-                    it.tags shouldBe mapOf("tagKey1" to "tagValue1-2")
-                },
-                withArg {
                     it.count() shouldBe 1
                     it[0].type shouldBe SubscriptionObjectType.ANDROID_PUSH
                     it[0].enabled shouldBe true
@@ -373,7 +364,7 @@ class LoginUserOperationExecutorTests : FunSpec({
     test("creating user will hydrate when the user hasn't changed") {
         /* Given */
         val mockUserBackendService = mockk<IUserBackendService>()
-        coEvery { mockUserBackendService.createUser(any(), any(), any(), any()) } returns
+        coEvery { mockUserBackendService.createUser(any(), any(), any()) } returns
             CreateUserResponse(
                 mapOf(IdentityConstants.ONESIGNAL_ID to remoteOneSignalId),
                 PropertiesObject(),
@@ -432,7 +423,6 @@ class LoginUserOperationExecutorTests : FunSpec({
                 appId,
                 mapOf(),
                 any(),
-                any(),
             )
         }
     }
@@ -440,7 +430,7 @@ class LoginUserOperationExecutorTests : FunSpec({
     test("creating user will not hydrate when the user has changed") {
         /* Given */
         val mockUserBackendService = mockk<IUserBackendService>()
-        coEvery { mockUserBackendService.createUser(any(), any(), any(), any()) } returns
+        coEvery { mockUserBackendService.createUser(any(), any(), any()) } returns
             CreateUserResponse(
                 mapOf(IdentityConstants.ONESIGNAL_ID to remoteOneSignalId),
                 PropertiesObject(),
@@ -499,7 +489,6 @@ class LoginUserOperationExecutorTests : FunSpec({
                 appId,
                 mapOf(),
                 any(),
-                any(),
             )
         }
     }
@@ -507,7 +496,7 @@ class LoginUserOperationExecutorTests : FunSpec({
     test("creating user will provide local to remote translations") {
         /* Given */
         val mockUserBackendService = mockk<IUserBackendService>()
-        coEvery { mockUserBackendService.createUser(any(), any(), any(), any()) } returns
+        coEvery { mockUserBackendService.createUser(any(), any(), any()) } returns
             CreateUserResponse(
                 mapOf(IdentityConstants.ONESIGNAL_ID to remoteOneSignalId),
                 PropertiesObject(),
@@ -546,7 +535,6 @@ class LoginUserOperationExecutorTests : FunSpec({
             mockUserBackendService.createUser(
                 appId,
                 mapOf(),
-                any(),
                 any(),
             )
         }


### PR DESCRIPTION
# Description
## One Line Summary
Only send enqueued subscription operations with the CreateUser operation, and not tags, aliases, and properties operations.

## Details

### Motivation
Modify the create user operation to send less associated info. Let's send less data into a create user request to minimize chances that other information in the request payload causes the create user request to fail.

* At time of writing, known failure cases are subscriptions over limit or tags over limit.
* We won't combine alias, tags, and properties operations to the create user operation.
* Ideally we only want to combine the **push subscription** operations and not any sms or email operations to the create user operation, but that will require more changes to the SDK, as currently all subscriptions are treated the same by the model / model store / operation repo infrastructure.
* For now, we will send any subscription operations with the create user operation, but no tags, aliases, or properties. It is unlikely that many email or sms subscription operations will be enqueued before the create user request happens.

### Scope
* The create user request will now only have subscription related updates in the payload.
* Tag, alias, and properties operations will stay in the operation repo and be sent separately.

# Testing
## Unit testing
* No new unit tests are added but existing test are updated after these changes.
* Should consider testing the changes in this PR

## Manual testing
Tested on Pixel emulator on API 30.
* Both of the below scenarios led to a bad SDK user state prior to this PR

**New app install creating a guest user**
1. New app install without wifi
2. Add many tags
3. Turn on wifi
4. Create user request is sent with the push subscription, and succeeds
5. The SDK has a user with a `onesignal_id` and a push subscription with an `id`
6. Then the tags are sent and fails
7. Note that tags still exist on the properties model even though they are not updated to the server but they will be refreshed on a new session.

**When the SDK has an identified user, login to another user**
1. The SDK has a user with an `external_id`
2. Turn off wifi
3. Call login to to different `external_id` and then add many tags
4. Turn on wifi
5. The create user request is sent with the push subscription, and succeeds
6. Then the tags are sent and fails

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [x] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/1794)
<!-- Reviewable:end -->
