### PR TITLE
[5.0.0] Make subscribers in EventProducer synchronized

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/events/EventProducer.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/events/EventProducer.kt
@@ -3,6 +3,7 @@ package com.onesignal.common.events
 import com.onesignal.common.threading.suspendifyOnMain
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import java.util.*
 
 /**
  * A standard implementation that implements [IEventNotifier] and additional functionality to make
@@ -13,7 +14,7 @@ open class EventProducer<THandler> : IEventNotifier<THandler> {
     override val hasSubscribers: Boolean
         get() = _subscribers.any()
 
-    private val _subscribers: MutableList<THandler> = mutableListOf()
+    private val _subscribers: MutableList<THandler> = Collections.synchronizedList(mutableListOf())
 
     override fun subscribe(handler: THandler) {
         _subscribers.add(handler)


### PR DESCRIPTION
# Description
## One Line Summary
Address ConcurrentModificationException crash by making subscribers in EventProducer synchronized

## Details

### Motivation
Customer issue of ConcurrentModificationException reported by Firebase Crashlytics while registering for push notifications.

### Scope
Crash occurs while iterating over subscribers list in EventProducer.

# Testing
## Unit testing
No unit testing used for this fix. Future unit test could be written to create a multithreading environment.

## Manual testing
Unable to reproduce original crash. Tested branch builds and push notifications registration is successful.


# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/1796)
<!-- Reviewable:end -->
