### PR TITLE
[5.0.0] Fix canRequestPermission always returning true

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/activities/PermissionsActivity.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/activities/PermissionsActivity.kt
@@ -104,6 +104,11 @@ class PermissionsActivity : Activity() {
                     ?: throw RuntimeException("Missing handler for permissionRequestType: $permissionRequestType")
                 if (granted) {
                     callback.onAccept()
+                    _preferenceService!!.saveBool(
+                        PreferenceStores.ONESIGNAL,
+                        "${PreferenceOneSignalKeys.PREFS_OS_USER_RESOLVED_PERMISSION_PREFIX}$androidPermissionString",
+                        true,
+                    )
                 } else {
                     callback.onReject(shouldShowSettings())
                 }
@@ -132,7 +137,7 @@ class PermissionsActivity : Activity() {
             ) {
                 _preferenceService!!.saveBool(
                     PreferenceStores.ONESIGNAL,
-                    "${PreferenceOneSignalKeys.PREFS_OS_USER_REJECTED_PERMISSION_PREFIX}$androidPermissionString",
+                    "${PreferenceOneSignalKeys.PREFS_OS_USER_RESOLVED_PERMISSION_PREFIX}$androidPermissionString",
                     true,
                 )
                 return false
@@ -141,7 +146,7 @@ class PermissionsActivity : Activity() {
 
         return _preferenceService!!.getBool(
             PreferenceStores.ONESIGNAL,
-            "${PreferenceOneSignalKeys.PREFS_OS_USER_REJECTED_PERMISSION_PREFIX}$androidPermissionString",
+            "${PreferenceOneSignalKeys.PREFS_OS_USER_RESOLVED_PERMISSION_PREFIX}$androidPermissionString",
             false,
         )!!
     }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/preferences/IPreferencesService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/preferences/IPreferencesService.kt
@@ -156,7 +156,7 @@ object PreferenceOneSignalKeys {
      * (Boolean) A prefix key for the permission state. When true, the user has rejected this
      * permission too many times and will not be prompted again.
      */
-    const val PREFS_OS_USER_REJECTED_PERMISSION_PREFIX = "USER_REJECTED_PERMISSION_"
+    const val PREFS_OS_USER_RESOLVED_PERMISSION_PREFIX = "USER_RESOLVED_PERMISSION_"
 
     // HTTP
     /**

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/permissions/impl/NotificationPermissionController.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/permissions/impl/NotificationPermissionController.kt
@@ -58,7 +58,7 @@ internal class NotificationPermissionController(
     override val canRequestPermission: Boolean
         get() = !_preferenceService.getBool(
             PreferenceStores.ONESIGNAL,
-            "${PreferenceOneSignalKeys.PREFS_OS_USER_REJECTED_PERMISSION_PREFIX}$ANDROID_PERMISSION_STRING",
+            "${PreferenceOneSignalKeys.PREFS_OS_USER_RESOLVED_PERMISSION_PREFIX}$ANDROID_PERMISSION_STRING",
             false,
         )!!
 


### PR DESCRIPTION
# Description
## One Line Summary
Fix canRequestPermission always returning true.

## Details

### Motivation
Addresses https://github.com/OneSignal/OneSignal-Android-SDK/issues/1792 where canRequestPermission always returns true, even if user has already accepted the push prompt.

### Scope
PreferenceStores updated when a user grants push permission. Key renamed to PREFS_OS_USER_RESOLVED_PERMISSION_PREFIX for increased clarity.

# Testing
## Manual testing
Tested that new value is updated in PreferenceStores and `canRequestPermission` successfully returns the correct boolean, depending on user behavior.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/1798)
<!-- Reviewable:end -->
