### PR TITLE
[5.0.0] Fix IAM display & dismiss bugs

### DIFF
--- a/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/InAppMessagesManager.kt
+++ b/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/InAppMessagesManager.kt
@@ -393,11 +393,9 @@ internal class InAppMessagesManager(
         }
 
         // fire the external callback
-        if (!_lifecycleCallback.hasSubscribers) {
-            Logging.verbose("InAppMessagesManager.messageWasDismissed: inAppMessageLifecycleHandler is null")
-            return
+        if (_lifecycleCallback.hasSubscribers) {
+            _lifecycleCallback.fireOnMain { it.onDidDismiss(InAppMessageLifecycleEvent(message)) }
         }
-        _lifecycleCallback.fireOnMain { it.onDidDismiss(InAppMessageLifecycleEvent(message)) }
 
         _state.inAppMessageIdShowing = null
 


### PR DESCRIPTION
# Description
## One Line Summary
This PR addresses two In App Message bugs:

1. IAM with a custom trigger not displaying after dismissing previous IAM.
`InAppMessagesManager.attemptToShowInAppMessage: There is an IAM currently showing!`
2. `messageWasDismissed` returning early if `!_lifecycleCallback.hasSubscribers`

## Details

### Motivation
**Issue 1** 
Issue is reproducible following these steps:

1. Create IAM_1 that is triggered On App Open
2. Create IAM_2 that has a custom trigger
3. Run app
4. IAM_1 displays
5. Dismiss IAM_1
6. Trigger IAM_2 with `addTrigger` method
7. IAM_2 does not display, console logs `InAppMessagesManager.attemptToShowInAppMessage: There is an IAM currently showing!`

setting `inAppMessageIdShowing` back to `null` in `attemptToShowInAppMessage` allows IAM_2 to successfully display.

**Issue 2**
This issue was caught during a pair programming session where the early return would interfere with `_lifecycleCallback.fireOnMain` being called.

### Scope
Changes affect displaying and dismissing IAMs, specifically `attemptToShowInAppMessage` & `messageWasDismissed` in InAppMessagesManager.

### OPTIONAL - Other
**OPTIONAL -** Feel free to add any other sections or sub-sections that can explain your PR better.

# Testing
## Manual testing
Tested Issue 1 to ensure that second IAM  successfully displays.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [X] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [ ] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/1799)
<!-- Reviewable:end -->
