### PR TITLE
Fix proguard rules

### DIFF
--- a/OneSignalSDK/onesignal/core/consumer-rules.pro
+++ b/OneSignalSDK/onesignal/core/consumer-rules.pro
@@ -1,3 +1,17 @@
 -dontwarn com.onesignal.**
 
 -dontwarn com.amazon.**
+
+-keepclassmembers class com.onesignal.core.** { *; }
+
+-keepclassmembers class com.onesignal.session.** { *; }
+
+-keepclassmembers class com.onesignal.user.** { *; }
+
+-keepclassmembers class com.onesignal.internal.** { *; }
+
+-keepclassmembers class com.onesignal.debug.** { *; }
+
+-keepclassmembers class com.onesignal.common.** { *; }
+
+-keep class ** implements com.onesignal.common.modules.IModule { *; }

--- a/OneSignalSDK/onesignal/in-app-messages/consumer-rules.pro
+++ b/OneSignalSDK/onesignal/in-app-messages/consumer-rules.pro
@@ -1,1 +1,3 @@
 -dontwarn com.onesignal.iam.**
+
+-keepclassmembers class com.onesignal.inAppMessages.** { *; }

--- a/OneSignalSDK/onesignal/location/consumer-rules.pro
+++ b/OneSignalSDK/onesignal/location/consumer-rules.pro
@@ -1,1 +1,3 @@
 -dontwarn com.onesignal.location.**
+
+-keepclassmembers class com.onesignal.location.** { *; }

--- a/OneSignalSDK/onesignal/notifications/consumer-rules.pro
+++ b/OneSignalSDK/onesignal/notifications/consumer-rules.pro
@@ -12,6 +12,18 @@
     java.lang.String getToken(java.lang.String, java.lang.String);
 }
 
+-keep class ** implements com.onesignal.notifications.IPermissionObserver{
+    void onNotificationPermissionChange(java.lang.Boolean);
+}
+
+-keep class ** implements com.onesignal.user.subscriptions.IPushSubscriptionObserver {
+    void onPushSubscriptionChange(com.onesignal.user.subscriptions.PushSubscriptionChangedState);
+}
+
+-keep class ** implements com.onesignal.notifications.INotificationServiceExtension{
+   void onNotificationReceived(com.onesignal.notifications.INotificationReceivedEvent);
+}
+
 -keep class com.onesignal.notifications.internal.badges.impl.shortcutbadger.impl.AdwHomeBadger { <init>(...); }
 -keep class com.onesignal.notifications.internal.badges.impl.shortcutbadger.impl.ApexHomeBadger { <init>(...); }
 -keep class com.onesignal.notifications.internal.badges.impl.shortcutbadger.impl.AsusHomeBadger { <init>(...); }

--- a/OneSignalSDK/onesignal/notifications/consumer-rules.pro
+++ b/OneSignalSDK/onesignal/notifications/consumer-rules.pro
@@ -49,3 +49,5 @@
 -keep public class com.onesignal.notifications.services.ADMMessageHandlerJob {*;}
 
 -keep class com.onesignal.JobIntentService$* {*;}
+
+-keepclassmembers class com.onesignal.notifications.** { *; }


### PR DESCRIPTION
# Description
## One Line Summary
Fix our proguard rules to prevent crashes when running with minify enabled.

## Details
Due to how we have implemented dependency injection when minify  is enabled the system is removing OneSignal code that is required. This PR implements a catch all solution that should resolve the issue, but does not optimally reduce the size of the SDK. Long term we should look at changing our dependency injection implementation or explciitly removing what can safely be removed.

### Motivation
Fix crash

### Scope
Entire SDK

# Testing
## Unit testing
N/A

## Manual testing
Tested by adding the same rules to a separate app after adding OneSignal as a customer would.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/1828)
<!-- Reviewable:end -->
