### PR TITLE
[5.0.0] Fix new notifications were replacing old ones

### DIFF
--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/common/NotificationGenerationJob.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/common/NotificationGenerationJob.kt
@@ -7,25 +7,17 @@ import org.json.JSONObject
 import java.security.SecureRandom
 
 class NotificationGenerationJob(
-    private var _notification: Notification,
+    inNotification: Notification,
     var jsonPayload: JSONObject,
 ) {
-    var notification: Notification
-        get() = _notification
-        private set(value) {
-            // If there is no android ID on the notification coming in, create one either
-            // copying from the previous one or generating a new one.
-            if (value != null && !value!!.hasNotificationId()) {
-                val curNotification = _notification
-                if (curNotification != null && curNotification.hasNotificationId()) {
-                    value.androidNotificationId = curNotification.androidNotificationId
-                } else {
-                    value.androidNotificationId = SecureRandom().nextInt()
-                }
-            }
+    val notification: Notification = inNotification.setAndroidNotificationId()
 
-            _notification = value
+    private fun Notification.setAndroidNotificationId() = this.also {
+        // If there is no android ID on the notification coming in, generate a new one.
+        if (it != null && !it.hasNotificationId()) {
+            it.androidNotificationId = SecureRandom().nextInt()
         }
+    }
 
     var isRestoring = false
     var isNotificationToDisplay = false


### PR DESCRIPTION
# Description
## One Line Summary
Fixes bug where each new notification was replacing the previous one regardless of collapse_id being set.

## Details

### Motivation
Fixes bug

### Scope
**Fix bug for generating notification's android notification ID**

* Bug: In the `NotificationGenerationJob`, the setter for its notification was generating a random android notification ID. However, this private setter is never actually called. Setters are not triggered in initialization. This resulted in the android notification ID always being zero for every notification on a `NotificationGenerationJob`.
* The fix: Now we set the random ID in initialization of a `NotificationGenerationJob`, and make the notification property immutable (a `val` instead of `var`) as it is never re-set anyway.

# Testing
## Unit testing
None

## Manual testing
Android 33 emulator
- Tested sending multiple notifications and they all stay
- Tested collapse IDs do replace only the appropriate notification

# Affected code checklist
   - [x] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [ ] I have filled out all **REQUIRED** sections above
   - [ ] PR does one thing
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [ ] Code is as readable as possible.
   - [ ] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/1840)
<!-- Reviewable:end -->
