### PR TITLE
[5.0.0] Differentiate login errors and add logs

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/IOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/IOperationExecutor.kt
@@ -68,4 +68,10 @@ enum class ExecutionResult {
      * retried if authorization can be achieved.
      */
     FAIL_UNAUTHORIZED,
+
+    /**
+     * Used in special login case.
+     * The operation failed due to a conflict and can be handled.
+     */
+    FAIL_CONFLICT,
 }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/impl/OperationRepo.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/impl/OperationRepo.kt
@@ -167,6 +167,7 @@ internal class OperationRepo(
                 }
                 ExecutionResult.FAIL_UNAUTHORIZED, // TODO: Need to provide callback for app to reset JWT. For now, fail with no retry.
                 ExecutionResult.FAIL_NORETRY,
+                ExecutionResult.FAIL_CONFLICT,
                 -> {
                     Logging.error("Operation execution failed without retry: $operations")
                     // on failure we remove the operation from the store and wake any waiters

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/IdentityOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/IdentityOperationExecutor.kt
@@ -51,10 +51,10 @@ internal class IdentityOperationExecutor(
                 return when (responseType) {
                     NetworkUtils.ResponseStatusType.RETRYABLE ->
                         ExecutionResponse(ExecutionResult.FAIL_RETRY)
-                    NetworkUtils.ResponseStatusType.INVALID,
-                    NetworkUtils.ResponseStatusType.CONFLICT,
-                    ->
+                    NetworkUtils.ResponseStatusType.INVALID ->
                         ExecutionResponse(ExecutionResult.FAIL_NORETRY)
+                    NetworkUtils.ResponseStatusType.CONFLICT ->
+                        ExecutionResponse(ExecutionResult.FAIL_CONFLICT)
                     NetworkUtils.ResponseStatusType.UNAUTHORIZED ->
                         ExecutionResponse(ExecutionResult.FAIL_UNAUTHORIZED)
                     NetworkUtils.ResponseStatusType.MISSING -> {

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/LoginUserOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/LoginUserOperationExecutor.kt
@@ -86,9 +86,16 @@ internal class LoginUserOperationExecutor(
 
                     ExecutionResponse(ExecutionResult.SUCCESS_STARTING_ONLY, mapOf(loginUserOp.onesignalId to backendOneSignalId))
                 }
+                ExecutionResult.FAIL_CONFLICT -> {
+                    // When the SetAliasOperation fails with conflict that *most likely* means the externalId provided
+                    // is already associated to a user.  This *expected* condition means we must create a user.
+                    // We hardcode the response of "user-2" in the log to provide information to the SDK consumer
+                    Logging.debug("LoginUserOperationExecutor now handling 409 response with \"code\": \"user-2\" by switching to user with \"external_id\": \"${loginUserOp.externalId}\"")
+                    createUser(loginUserOp, operations)
+                }
                 ExecutionResult.FAIL_NORETRY -> {
-                    // When the SetAliasOperation fails without retry that *most likely* means the externalId provided
-                    // is already associated to a user.  This expected condition means we must create a user.
+                    // Some other failure occurred, still try to recover by creating the user
+                    Logging.error("LoginUserOperationExecutor encountered error. Attempt to recover by switching to user with \"external_id\": \"${loginUserOp.externalId}\"")
                     createUser(loginUserOp, operations)
                 }
                 else -> ExecutionResponse(result.result)


### PR DESCRIPTION
# Description
## One Line Summary
Differentiate login failure cases for (1) conflict response and (2) other general 400-based errors, and add a log clarifying expected conflict error.

## Details

### Motivation
We have had reports that developers are troubled to receive a 409 error response for login

**1. Differentiate login failure cases**
* The implementation of login with external_id has not changed in this PR. We still try to create the user on both failures (as before)
* We add new `ExecutionResult` type of `FAIL_CONFLICT` to differentiate this case from general failure case of `FAIL_NORETRY`

**2. Add logs to login failures**
* Seeing a 409 error response can be worrisome for developers, when this response is fine and expected.
* We cannot remove the 409 error logged so let them know we are handling the response

Example of logs:
```
D/OneSignal: [OpRepo] LoginUserOperationExecutor(operation: [{"name":"login-user","appId":"APP_ID","onesignalId":"local-xxx","externalId":"abcd","existingOnesignalId":"xxx","id":"1cacee4c-9ecb-45ed-aa6c-a8c0eb47c5b1"}, {"name":"transfer-subscription","appId":"APP_ID","subscriptionId":"yyy","onesignalId":"local-xxx","id":"31216d16-70cd-4194-af7d-539415dc7fdb"}])
D/OneSignal: [OpRepo] IdentityOperationExecutor(operations: [{"name":"set-alias","appId":"APP_ID","onesignalId":"ONESIGNAL_ID","label":"external_id","value":"abcd"}])
D/OneSignal: [DefaultDispatcher-worker-2] HttpClient: PATCH apps/APP_ID/users/by/onesignal_id/xxx/identity - {"identity":{"external_id":"abcd"}}
D/OneSignal: [DefaultDispatcher-worker-2] HttpClient: PATCH apps/APP_ID/users/by/onesignal_id/xxx/identity - FAILED STATUS: 409
W/OneSignal: [DefaultDispatcher-worker-2] HttpClient: PATCH RECEIVED JSON: {"errors":[{"code":"user-2","title":"One or more Aliases claimed by another User","meta":{"external_id":"abcd"}}]}
D/OneSignal: [OpRepo] LoginUserOperationExecutor now handling 409 response with "code": "user-2" by switching to user with "external_id": "abcd"
```
### Scope
There is no implementation detail changes to `login`. We still handle login failures the same way but log differently when it fails due to a 409 conflict (which is a correct expected response) and another unexpected error response.

# Testing
## Unit testing
None, we should add tests though.

## Manual testing
Android emulator on API 33
* Tested login to existing external_id, receive a 409, see the log explaining we are handling the case, and see we successfully switch to that user
* Also tested a login flow that results in a 400 response and see the other error log.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [x] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [ ] I have filled out all **REQUIRED** sections above
   - [ ] PR does one thing
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [ ] Code is as readable as possible.
   - [ ] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/1841)
<!-- Reviewable:end -->
