### PR TITLE
Fix timezone_id not being set

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/TimeUtils.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/TimeUtils.kt
@@ -17,7 +17,7 @@ object TimeUtils {
         return offset / 1000
     }
 
-    fun getTimeZoneId(): String? {
+    fun getTimeZoneId(): String {
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             ZoneId.systemDefault().id
         } else {

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/backend/IUserBackendService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/backend/IUserBackendService.kt
@@ -14,10 +14,11 @@ interface IUserBackendService {
      * the application.
      * @param subscriptions The subscriptions that should also be created and associated with the user. If subscriptions are already owned by a different user
      * they will be transferred to this user.
+     * @param properties The properties for this user. For new users this should include the timezone_id property.
      *
      * @return The backend response
      */
-    suspend fun createUser(appId: String, identities: Map<String, String>, subscriptions: List<SubscriptionObject>): CreateUserResponse
+    suspend fun createUser(appId: String, identities: Map<String, String>, subscriptions: List<SubscriptionObject>, properties: Map<String, String>): CreateUserResponse
     // TODO: Change to send only the push subscription, optimally
 
     /**

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/backend/impl/UserBackendService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/backend/impl/UserBackendService.kt
@@ -14,7 +14,7 @@ internal class UserBackendService(
     private val _httpClient: IHttpClient,
 ) : IUserBackendService {
 
-    override suspend fun createUser(appId: String, identities: Map<String, String>, subscriptions: List<SubscriptionObject>): CreateUserResponse {
+    override suspend fun createUser(appId: String, identities: Map<String, String>, subscriptions: List<SubscriptionObject>, properties: Map<String, String>): CreateUserResponse {
         val requestJSON = JSONObject()
 
         if (identities.isNotEmpty()) {
@@ -24,6 +24,10 @@ internal class UserBackendService(
         if (subscriptions.isNotEmpty()) {
             requestJSON
                 .put("subscriptions", JSONConverter.convertToJSON(subscriptions))
+        }
+
+        if (properties.isNotEmpty()) {
+            requestJSON.put("properties", JSONObject().putMap(properties))
         }
 
         val response = _httpClient.post("apps/$appId/users", requestJSON)

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/LoginUserOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/LoginUserOperationExecutor.kt
@@ -1,11 +1,7 @@
 package com.onesignal.user.internal.operations.impl.executors
 
 import android.os.Build
-import com.onesignal.common.AndroidUtils
-import com.onesignal.common.DeviceUtils
-import com.onesignal.common.NetworkUtils
-import com.onesignal.common.OneSignalUtils
-import com.onesignal.common.RootToolsInternalMethods
+import com.onesignal.common.*
 import com.onesignal.common.exceptions.BackendException
 import com.onesignal.common.modeling.ModelChangeTags
 import com.onesignal.core.internal.application.IApplicationService
@@ -16,10 +12,8 @@ import com.onesignal.core.internal.operations.ExecutionResult
 import com.onesignal.core.internal.operations.IOperationExecutor
 import com.onesignal.core.internal.operations.Operation
 import com.onesignal.debug.internal.logging.Logging
-import com.onesignal.user.internal.backend.IUserBackendService
+import com.onesignal.user.internal.backend.*
 import com.onesignal.user.internal.backend.IdentityConstants
-import com.onesignal.user.internal.backend.SubscriptionObject
-import com.onesignal.user.internal.backend.SubscriptionObjectType
 import com.onesignal.user.internal.identity.IdentityModelStore
 import com.onesignal.user.internal.operations.CreateSubscriptionOperation
 import com.onesignal.user.internal.operations.DeleteSubscriptionOperation
@@ -99,6 +93,8 @@ internal class LoginUserOperationExecutor(
     private suspend fun createUser(createUserOperation: LoginUserOperation, operations: List<Operation>): ExecutionResponse {
         var identities = mapOf<String, String>()
         var subscriptions = mapOf<String, SubscriptionObject>()
+        val properties = mutableMapOf<String, String>()
+        properties["timezone_id"] = TimeUtils.getTimeZoneId()!!
 
         if (createUserOperation.externalId != null) {
             val mutableIdentities = identities.toMutableMap()
@@ -118,7 +114,7 @@ internal class LoginUserOperationExecutor(
 
         try {
             val subscriptionList = subscriptions.toList()
-            val response = _userBackend.createUser(createUserOperation.appId, identities, subscriptionList.map { it.second })
+            val response = _userBackend.createUser(createUserOperation.appId, identities, subscriptionList.map { it.second }, properties)
             val idTranslations = mutableMapOf<String, String>()
             // Add the "local-to-backend" ID translation to the IdentifierTranslator for any operations that were
             // *not* executed but still reference the locally-generated IDs.

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/LoginUserOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/LoginUserOperationExecutor.kt
@@ -94,7 +94,7 @@ internal class LoginUserOperationExecutor(
         var identities = mapOf<String, String>()
         var subscriptions = mapOf<String, SubscriptionObject>()
         val properties = mutableMapOf<String, String>()
-        properties["timezone_id"] = TimeUtils.getTimeZoneId()!!
+        properties["timezone_id"] = TimeUtils.getTimeZoneId()
 
         if (createUserOperation.externalId != null) {
             val mutableIdentities = identities.toMutableMap()

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/LoginUserOperationExecutorTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/LoginUserOperationExecutorTests.kt
@@ -46,7 +46,7 @@ class LoginUserOperationExecutorTests : FunSpec({
     test("login anonymous user successfully creates user") {
         /* Given */
         val mockUserBackendService = mockk<IUserBackendService>()
-        coEvery { mockUserBackendService.createUser(any(), any(), any()) } returns
+        coEvery { mockUserBackendService.createUser(any(), any(), any(), any()) } returns
             CreateUserResponse(
                 mapOf(IdentityConstants.ONESIGNAL_ID to remoteOneSignalId),
                 PropertiesObject(),
@@ -80,6 +80,7 @@ class LoginUserOperationExecutorTests : FunSpec({
                 appId,
                 mapOf(),
                 any(),
+                any(),
             )
         }
     }
@@ -87,7 +88,7 @@ class LoginUserOperationExecutorTests : FunSpec({
     test("login anonymous user fails with retry when network condition exists") {
         /* Given */
         val mockUserBackendService = mockk<IUserBackendService>()
-        coEvery { mockUserBackendService.createUser(any(), any(), any()) } throws BackendException(408, "TIMEOUT")
+        coEvery { mockUserBackendService.createUser(any(), any(), any(), any()) } throws BackendException(408, "TIMEOUT")
 
         val mockIdentityOperationExecutor = mockk<IdentityOperationExecutor>()
 
@@ -103,13 +104,13 @@ class LoginUserOperationExecutorTests : FunSpec({
 
         /* Then */
         response.result shouldBe ExecutionResult.FAIL_RETRY
-        coVerify(exactly = 1) { mockUserBackendService.createUser(appId, mapOf(), any()) }
+        coVerify(exactly = 1) { mockUserBackendService.createUser(appId, mapOf(), any(), any()) }
     }
 
     test("login anonymous user fails with no retry when backend error condition exists") {
         /* Given */
         val mockUserBackendService = mockk<IUserBackendService>()
-        coEvery { mockUserBackendService.createUser(any(), any(), any()) } throws BackendException(404, "NOT FOUND")
+        coEvery { mockUserBackendService.createUser(any(), any(), any(), any()) } throws BackendException(404, "NOT FOUND")
 
         val mockIdentityOperationExecutor = mockk<IdentityOperationExecutor>()
 
@@ -125,13 +126,13 @@ class LoginUserOperationExecutorTests : FunSpec({
 
         /* Then */
         response.result shouldBe ExecutionResult.FAIL_NORETRY
-        coVerify(exactly = 1) { mockUserBackendService.createUser(appId, mapOf(), any()) }
+        coVerify(exactly = 1) { mockUserBackendService.createUser(appId, mapOf(), any(), any()) }
     }
 
     test("login identified user without association successfully creates user") {
         /* Given */
         val mockUserBackendService = mockk<IUserBackendService>()
-        coEvery { mockUserBackendService.createUser(any(), any(), any()) } returns
+        coEvery { mockUserBackendService.createUser(any(), any(), any(), any()) } returns
             CreateUserResponse(mapOf(IdentityConstants.ONESIGNAL_ID to remoteOneSignalId), PropertiesObject(), listOf())
 
         val mockIdentityOperationExecutor = mockk<IdentityOperationExecutor>()
@@ -148,7 +149,7 @@ class LoginUserOperationExecutorTests : FunSpec({
 
         /* Then */
         response.result shouldBe ExecutionResult.SUCCESS
-        coVerify(exactly = 1) { mockUserBackendService.createUser(appId, mapOf(IdentityConstants.EXTERNAL_ID to "externalId"), any()) }
+        coVerify(exactly = 1) { mockUserBackendService.createUser(appId, mapOf(IdentityConstants.EXTERNAL_ID to "externalId"), any(), any()) }
     }
 
     test("login identified user with association succeeds when association is successful") {
@@ -187,7 +188,7 @@ class LoginUserOperationExecutorTests : FunSpec({
     test("login identified user with association fails with retry when association fails with retry") {
         /* Given */
         val mockUserBackendService = mockk<IUserBackendService>()
-        coEvery { mockUserBackendService.createUser(any(), any(), any()) } returns
+        coEvery { mockUserBackendService.createUser(any(), any(), any(), any()) } returns
             CreateUserResponse(mapOf(IdentityConstants.ONESIGNAL_ID to remoteOneSignalId), PropertiesObject(), listOf())
 
         val mockIdentityOperationExecutor = mockk<IdentityOperationExecutor>()
@@ -222,7 +223,7 @@ class LoginUserOperationExecutorTests : FunSpec({
     test("login identified user with association successfully creates user when association fails with no retry") {
         /* Given */
         val mockUserBackendService = mockk<IUserBackendService>()
-        coEvery { mockUserBackendService.createUser(any(), any(), any()) } returns
+        coEvery { mockUserBackendService.createUser(any(), any(), any(), any()) } returns
             CreateUserResponse(mapOf(IdentityConstants.ONESIGNAL_ID to remoteOneSignalId), PropertiesObject(), listOf())
 
         val mockIdentityOperationExecutor = mockk<IdentityOperationExecutor>()
@@ -252,13 +253,13 @@ class LoginUserOperationExecutorTests : FunSpec({
                 },
             )
         }
-        coVerify(exactly = 1) { mockUserBackendService.createUser(appId, mapOf(IdentityConstants.EXTERNAL_ID to "externalId"), any()) }
+        coVerify(exactly = 1) { mockUserBackendService.createUser(appId, mapOf(IdentityConstants.EXTERNAL_ID to "externalId"), any(), any()) }
     }
 
     test("login identified user with association fails with retry when association fails with no retry and network condition exists") {
         /* Given */
         val mockUserBackendService = mockk<IUserBackendService>()
-        coEvery { mockUserBackendService.createUser(any(), any(), any()) } throws BackendException(408, "TIMEOUT")
+        coEvery { mockUserBackendService.createUser(any(), any(), any(), any()) } throws BackendException(408, "TIMEOUT")
 
         val mockIdentityOperationExecutor = mockk<IdentityOperationExecutor>()
         coEvery { mockIdentityOperationExecutor.execute(any()) } returns ExecutionResponse(ExecutionResult.FAIL_NORETRY)
@@ -287,13 +288,13 @@ class LoginUserOperationExecutorTests : FunSpec({
                 },
             )
         }
-        coVerify(exactly = 1) { mockUserBackendService.createUser(appId, mapOf(IdentityConstants.EXTERNAL_ID to "externalId"), any()) }
+        coVerify(exactly = 1) { mockUserBackendService.createUser(appId, mapOf(IdentityConstants.EXTERNAL_ID to "externalId"), any(), any()) }
     }
 
     test("creating user will merge operations into one backend call") {
         /* Given */
         val mockUserBackendService = mockk<IUserBackendService>()
-        coEvery { mockUserBackendService.createUser(any(), any(), any()) } returns
+        coEvery { mockUserBackendService.createUser(any(), any(), any(), any()) } returns
             CreateUserResponse(
                 mapOf(IdentityConstants.ONESIGNAL_ID to remoteOneSignalId),
                 PropertiesObject(),
@@ -357,6 +358,7 @@ class LoginUserOperationExecutorTests : FunSpec({
                     it[0].token shouldBe "pushToken2"
                     it[0].notificationTypes shouldBe SubscriptionStatus.SUBSCRIBED
                 },
+                any(),
             )
         }
     }
@@ -364,7 +366,7 @@ class LoginUserOperationExecutorTests : FunSpec({
     test("creating user will hydrate when the user hasn't changed") {
         /* Given */
         val mockUserBackendService = mockk<IUserBackendService>()
-        coEvery { mockUserBackendService.createUser(any(), any(), any()) } returns
+        coEvery { mockUserBackendService.createUser(any(), any(), any(), any()) } returns
             CreateUserResponse(
                 mapOf(IdentityConstants.ONESIGNAL_ID to remoteOneSignalId),
                 PropertiesObject(),
@@ -423,6 +425,7 @@ class LoginUserOperationExecutorTests : FunSpec({
                 appId,
                 mapOf(),
                 any(),
+                any(),
             )
         }
     }
@@ -430,7 +433,7 @@ class LoginUserOperationExecutorTests : FunSpec({
     test("creating user will not hydrate when the user has changed") {
         /* Given */
         val mockUserBackendService = mockk<IUserBackendService>()
-        coEvery { mockUserBackendService.createUser(any(), any(), any()) } returns
+        coEvery { mockUserBackendService.createUser(any(), any(), any(), any()) } returns
             CreateUserResponse(
                 mapOf(IdentityConstants.ONESIGNAL_ID to remoteOneSignalId),
                 PropertiesObject(),
@@ -489,6 +492,7 @@ class LoginUserOperationExecutorTests : FunSpec({
                 appId,
                 mapOf(),
                 any(),
+                any(),
             )
         }
     }
@@ -496,7 +500,7 @@ class LoginUserOperationExecutorTests : FunSpec({
     test("creating user will provide local to remote translations") {
         /* Given */
         val mockUserBackendService = mockk<IUserBackendService>()
-        coEvery { mockUserBackendService.createUser(any(), any(), any()) } returns
+        coEvery { mockUserBackendService.createUser(any(), any(), any(), any()) } returns
             CreateUserResponse(
                 mapOf(IdentityConstants.ONESIGNAL_ID to remoteOneSignalId),
                 PropertiesObject(),
@@ -535,6 +539,7 @@ class LoginUserOperationExecutorTests : FunSpec({
             mockUserBackendService.createUser(
                 appId,
                 mapOf(),
+                any(),
                 any(),
             )
         }


### PR DESCRIPTION
# Description
## One Line Summary
This fixes an issue where timezone_id was not being set as a property on users.

## Details
This issue resulted in scheduled notifications being received at the wrong time.
In order to send the `timezone_id` we are adding a properties map in the `createUser` call. The properties set there (only `timezone_id`) will be hydrated to the properties model when the response is received.
fixes #1829 

### Motivation
Fix scheduled notifications

### Scope
user properties during createUser

# Testing
## Unit testing
Added properties object to existing unit tests

## Manual testing
Tested scheduled notifications on a physical device.

# Affected code checklist
   - [x] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/1842)
<!-- Reviewable:end -->
