### PR TITLE
[Fix] Rename kotlin modules

### DIFF
--- a/OneSignalSDK/onesignal/core/build.gradle
+++ b/OneSignalSDK/onesignal/core/build.gradle
@@ -42,6 +42,8 @@ android {
         jvmTarget = '1.8'
     }
     namespace 'com.onesignal.core'
+
+    kotlinOptions.freeCompilerArgs += ['-module-name', namespace]
 }
 
 tasks.withType(Test) {

--- a/OneSignalSDK/onesignal/in-app-messages/build.gradle
+++ b/OneSignalSDK/onesignal/in-app-messages/build.gradle
@@ -42,6 +42,8 @@ android {
         jvmTarget = '1.8'
     }
     namespace 'com.onesignal.inAppMessages'
+
+    kotlinOptions.freeCompilerArgs += ['-module-name', namespace]
 }
 
 tasks.withType(Test) {

--- a/OneSignalSDK/onesignal/location/build.gradle
+++ b/OneSignalSDK/onesignal/location/build.gradle
@@ -42,6 +42,8 @@ android {
         jvmTarget = '1.8'
     }
     namespace 'com.onesignal.location'
+
+    kotlinOptions.freeCompilerArgs += ['-module-name', namespace]
 }
 
 tasks.withType(Test) {

--- a/OneSignalSDK/onesignal/notifications/build.gradle
+++ b/OneSignalSDK/onesignal/notifications/build.gradle
@@ -42,6 +42,8 @@ android {
         jvmTarget = '1.8'
     }
     namespace 'com.onesignal.notifications'
+
+    kotlinOptions.freeCompilerArgs += ['-module-name', namespace]
 }
 
 tasks.withType(Test) {

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/generation/impl/NotificationGenerationProcessor.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/generation/impl/NotificationGenerationProcessor.kt
@@ -116,7 +116,7 @@ internal class NotificationGenerationProcessor(
                         }.join()
                     }
                 } catch (to: TimeoutCancellationException) {
-                    Logging.error("notificationWillShowInForegroundHandler timed out, continuing with wantsToDisplay=$wantsToDisplay.", to)
+                    Logging.info("notificationWillShowInForegroundHandler timed out, continuing with wantsToDisplay=$wantsToDisplay.", to)
                 } catch (t: Throwable) {
                     Logging.error("notificationWillShowInForegroundHandler threw an exception. Displaying normal OneSignal notification.", t)
                 }


### PR DESCRIPTION
# Description
## One Line Summary

- Renamed Kotlin modules to include OneSignal namespace to prevent build errors with other SDKs.
- Changed Notifications time out log level from error to info because the time out can be intentional when calling preventDefault

## Details

### Motivation
Fixes https://github.com/OneSignal/OneSignal-Unity-SDK/issues/632 build error with ironSource where `More than one file was found with OS independent path 'META-INF/core_release.kotlin_module'.`


# Testing
## Manual testing
Tested building for Android on Unity 2021.3.24 of blank project with ironSource 7.5.0, UnityAds 4.3.3.36.2(from ironSource Integration Manager), and OneSignal core-release.aar with Kotlin module rename.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/1844)
<!-- Reviewable:end -->
