### PR TITLE
Fix crash from missing operationExecutor in OperationModelStore create

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/modeling/IModelStore.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/modeling/IModelStore.kt
@@ -16,7 +16,7 @@ interface IModelStore<TModel> :
      *
      * @param jsonObject The optional [JSONObject] to initialize the new model with.
      */
-    fun create(jsonObject: JSONObject? = null): TModel
+    fun create(jsonObject: JSONObject? = null): TModel?
 
     /**
      * List the models that are owned by this model store.

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/modeling/ModelStore.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/modeling/ModelStore.kt
@@ -126,7 +126,7 @@ abstract class ModelStore<TModel>(
             val str = _prefs.getString(PreferenceStores.ONESIGNAL, PreferenceOneSignalKeys.MODEL_STORE_PREFIX + name, "[]")
             val jsonArray = JSONArray(str)
             for (index in 0 until jsonArray.length()) {
-                val newModel = create(jsonArray.getJSONObject(index))
+                val newModel = create(jsonArray.getJSONObject(index)) ?: continue
                 _models.add(newModel)
                 // listen for changes to this model
                 newModel.subscribe(this)

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/modeling/SingletonModelStore.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/modeling/SingletonModelStore.kt
@@ -24,7 +24,7 @@ open class SingletonModelStore<TModel>(
                 return model
             }
 
-            val createdModel = store.create()
+            val createdModel = store.create() ?: throw Exception("Unable to initialize model from store $store")
             createdModel.id = _singletonId
             store.add(createdModel)
             return createdModel

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/impl/OperationModelStore.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/impl/OperationModelStore.kt
@@ -3,11 +3,13 @@ package com.onesignal.core.internal.operations.impl
 import com.onesignal.common.modeling.ModelStore
 import com.onesignal.core.internal.operations.Operation
 import com.onesignal.core.internal.preferences.IPreferencesService
+import com.onesignal.debug.internal.logging.Logging
 import com.onesignal.user.internal.operations.CreateSubscriptionOperation
 import com.onesignal.user.internal.operations.DeleteAliasOperation
 import com.onesignal.user.internal.operations.DeleteSubscriptionOperation
 import com.onesignal.user.internal.operations.DeleteTagOperation
 import com.onesignal.user.internal.operations.LoginUserOperation
+import com.onesignal.user.internal.operations.LoginUserFromSubscriptionOperation
 import com.onesignal.user.internal.operations.RefreshUserOperation
 import com.onesignal.user.internal.operations.SetAliasOperation
 import com.onesignal.user.internal.operations.SetPropertyOperation
@@ -18,6 +20,7 @@ import com.onesignal.user.internal.operations.TrackSessionStartOperation
 import com.onesignal.user.internal.operations.TransferSubscriptionOperation
 import com.onesignal.user.internal.operations.UpdateSubscriptionOperation
 import com.onesignal.user.internal.operations.impl.executors.IdentityOperationExecutor
+import com.onesignal.user.internal.operations.impl.executors.LoginUserFromSubscriptionOperationExecutor
 import com.onesignal.user.internal.operations.impl.executors.LoginUserOperationExecutor
 import com.onesignal.user.internal.operations.impl.executors.RefreshUserOperationExecutor
 import com.onesignal.user.internal.operations.impl.executors.SubscriptionOperationExecutor
@@ -30,13 +33,15 @@ internal class OperationModelStore(prefs: IPreferencesService) : ModelStore<Oper
         load()
     }
 
-    override fun create(jsonObject: JSONObject?): Operation {
+    override fun create(jsonObject: JSONObject?): Operation? {
         if (jsonObject == null) {
-            throw NullPointerException("jsonObject")
+            Logging.error("null jsonObject sent to OperationModelStore.create")
+            return null
         }
 
         if (!jsonObject.has(Operation::name.name)) {
-            throw IllegalArgumentException("jsonObject must have '${Operation::name.name}' attribute")
+            Logging.error("jsonObject must have '${Operation::name.name}' attribute")
+            return null
         }
 
         // Determine the type of operation based on the name property in the json
@@ -48,6 +53,7 @@ internal class OperationModelStore(prefs: IPreferencesService) : ModelStore<Oper
             SubscriptionOperationExecutor.DELETE_SUBSCRIPTION -> DeleteSubscriptionOperation()
             SubscriptionOperationExecutor.TRANSFER_SUBSCRIPTION -> TransferSubscriptionOperation()
             LoginUserOperationExecutor.LOGIN_USER -> LoginUserOperation()
+            LoginUserFromSubscriptionOperationExecutor.LOGIN_USER_FROM_SUBSCRIPTION_USER -> LoginUserFromSubscriptionOperation()
             RefreshUserOperationExecutor.REFRESH_USER -> RefreshUserOperation()
             UpdateUserOperationExecutor.SET_TAG -> SetTagOperation()
             UpdateUserOperationExecutor.DELETE_TAG -> DeleteTagOperation()


### PR DESCRIPTION
I removed throwing from create for non-singleton model stores. I kept throw if a singleton model store is unable to create its model.

# Description
## One Line Summary
Fix a crash when the login user from subscription operation is being read from the cache.

## Details
fixes #1814 
The OperationModelStore did not account for the `LoginUserFromSubscriptionOperation` operation when creating operations from JSON and would throw an exception.

This create method can no longer throw an exception even if it doesn't find the operation.

### Motivation
Fix crash

### Scope
cached login operation

# Testing
## Unit testing
**OPTIONAL -**  Explain unit tests added, if not clear in the code.

## Manual testing
Tested on a physical device.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/1845)
<!-- Reviewable:end -->
