### PR TITLE
Fix language not being set

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/LoginUserOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/LoginUserOperationExecutor.kt
@@ -26,6 +26,7 @@ import com.onesignal.user.internal.properties.PropertiesModelStore
 import com.onesignal.user.internal.subscriptions.SubscriptionModel
 import com.onesignal.user.internal.subscriptions.SubscriptionModelStore
 import com.onesignal.user.internal.subscriptions.SubscriptionType
+import java.util.Locale
 
 internal class LoginUserOperationExecutor(
     private val _identityOperationExecutor: IdentityOperationExecutor,
@@ -95,6 +96,7 @@ internal class LoginUserOperationExecutor(
         var subscriptions = mapOf<String, SubscriptionObject>()
         val properties = mutableMapOf<String, String>()
         properties["timezone_id"] = TimeUtils.getTimeZoneId()!!
+        properties["language"] = Locale.getDefault().getLanguage()
 
         if (createUserOperation.externalId != null) {
             val mutableIdentities = identities.toMutableMap()

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/LoginUserOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/LoginUserOperationExecutor.kt
@@ -7,6 +7,7 @@ import com.onesignal.common.modeling.ModelChangeTags
 import com.onesignal.core.internal.application.IApplicationService
 import com.onesignal.core.internal.config.ConfigModelStore
 import com.onesignal.core.internal.device.IDeviceService
+import com.onesignal.core.internal.language.ILanguageContext
 import com.onesignal.core.internal.operations.ExecutionResponse
 import com.onesignal.core.internal.operations.ExecutionResult
 import com.onesignal.core.internal.operations.IOperationExecutor
@@ -26,7 +27,6 @@ import com.onesignal.user.internal.properties.PropertiesModelStore
 import com.onesignal.user.internal.subscriptions.SubscriptionModel
 import com.onesignal.user.internal.subscriptions.SubscriptionModelStore
 import com.onesignal.user.internal.subscriptions.SubscriptionType
-import java.util.Locale
 
 internal class LoginUserOperationExecutor(
     private val _identityOperationExecutor: IdentityOperationExecutor,
@@ -37,6 +37,7 @@ internal class LoginUserOperationExecutor(
     private val _propertiesModelStore: PropertiesModelStore,
     private val _subscriptionsModelStore: SubscriptionModelStore,
     private val _configModelStore: ConfigModelStore,
+    private val _languageContext: ILanguageContext
 ) : IOperationExecutor {
 
     override val operations: List<String>
@@ -96,7 +97,7 @@ internal class LoginUserOperationExecutor(
         var subscriptions = mapOf<String, SubscriptionObject>()
         val properties = mutableMapOf<String, String>()
         properties["timezone_id"] = TimeUtils.getTimeZoneId()!!
-        properties["language"] = Locale.getDefault().getLanguage()
+        properties["language"] = _languageContext.language
 
         if (createUserOperation.externalId != null) {
             val mutableIdentities = identities.toMutableMap()

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/backend/UserBackendServiceTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/backend/UserBackendServiceTests.kt
@@ -45,10 +45,10 @@ class UserBackendServiceTests : FunSpec({
         /* Given */
         val osId = "11111111-1111-1111-1111-111111111111"
         val spyHttpClient = mockk<IHttpClient>()
-        coEvery { spyHttpClient.post(any(), any()) } returns HttpResponse(202, "{identity:{onesignal_id: \"$osId\", aliasLabel1: \"aliasValue1\"}, properties:{timezone_id: \"testTimeZone\"}}")
+        coEvery { spyHttpClient.post(any(), any()) } returns HttpResponse(202, "{identity:{onesignal_id: \"$osId\", aliasLabel1: \"aliasValue1\"}, properties:{timezone_id: \"testTimeZone\", language: \"testLanguage\"}}")
         val userBackendService = UserBackendService(spyHttpClient)
         val identities = mapOf("aliasLabel1" to "aliasValue1")
-        val properties = mapOf("timzone_id" to "testTimeZone")
+        val properties = mapOf("timezone_id" to "testTimeZone", "language" to "testLanguage")
         val subscriptions = listOf<SubscriptionObject>()
 
         /* When */
@@ -58,6 +58,7 @@ class UserBackendServiceTests : FunSpec({
         response.identities["onesignal_id"] shouldBe osId
         response.identities["aliasLabel1"] shouldBe "aliasValue1"
         response.properties.timezoneId shouldBe "testTimeZone"
+        response.properties.language shouldBe "testLanguage"
         response.subscriptions.count() shouldBe 0
         coVerify {
             spyHttpClient.post(
@@ -77,11 +78,11 @@ class UserBackendServiceTests : FunSpec({
         /* Given */
         val osId = "11111111-1111-1111-1111-111111111111"
         val spyHttpClient = mockk<IHttpClient>()
-        coEvery { spyHttpClient.post(any(), any()) } returns HttpResponse(202, "{identity:{onesignal_id: \"$osId\"}, subscriptions:[{id:\"subscriptionId1\", type:\"AndroidPush\"}], properties:{timezone_id: \"testTimeZone\"}}")
+        coEvery { spyHttpClient.post(any(), any()) } returns HttpResponse(202, "{identity:{onesignal_id: \"$osId\"}, subscriptions:[{id:\"subscriptionId1\", type:\"AndroidPush\"}], properties:{timezone_id: \"testTimeZone\", language: \"testLanguage\"}}")
         val userBackendService = UserBackendService(spyHttpClient)
         val identities = mapOf<String, String>()
         val subscriptions = mutableListOf<SubscriptionObject>()
-        val properties = mapOf("timzone_id" to "testTimeZone")
+        val properties = mapOf("timezone_id" to "testTimeZone", "language" to "testLanguage")
         subscriptions.add(SubscriptionObject("SHOULDNOTUSE", SubscriptionObjectType.ANDROID_PUSH))
 
         /* When */
@@ -90,6 +91,7 @@ class UserBackendServiceTests : FunSpec({
         /* Then */
         response.identities["onesignal_id"] shouldBe osId
         response.properties.timezoneId shouldBe "testTimeZone"
+        response.properties.language shouldBe "testLanguage"
         response.subscriptions.count() shouldBe 1
         response.subscriptions[0].id shouldBe "subscriptionId1"
         response.subscriptions[0].type shouldBe SubscriptionObjectType.ANDROID_PUSH

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/LoginUserOperationExecutorTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/LoginUserOperationExecutorTests.kt
@@ -67,6 +67,7 @@ class LoginUserOperationExecutorTests : FunSpec({
             mockPropertiesModelStore,
             mockSubscriptionsModelStore,
             MockHelper.configModelStore(),
+            MockHelper.languageContext()
         )
         val operations = listOf<Operation>(LoginUserOperation(appId, localOneSignalId, null, null))
 
@@ -96,7 +97,7 @@ class LoginUserOperationExecutorTests : FunSpec({
         val mockPropertiesModelStore = MockHelper.propertiesModelStore()
         val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
 
-        val loginUserOperationExecutor = LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore())
+        val loginUserOperationExecutor = LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext())
         val operations = listOf<Operation>(LoginUserOperation(appId, localOneSignalId, null, null))
 
         /* When */
@@ -118,7 +119,7 @@ class LoginUserOperationExecutorTests : FunSpec({
         val mockPropertiesModelStore = MockHelper.propertiesModelStore()
         val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
 
-        val loginUserOperationExecutor = LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore())
+        val loginUserOperationExecutor = LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext())
         val operations = listOf<Operation>(LoginUserOperation(appId, localOneSignalId, null, null))
 
         /* When */
@@ -141,7 +142,7 @@ class LoginUserOperationExecutorTests : FunSpec({
         val mockPropertiesModelStore = MockHelper.propertiesModelStore()
         val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
 
-        val loginUserOperationExecutor = LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore())
+        val loginUserOperationExecutor = LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext())
         val operations = listOf<Operation>(LoginUserOperation(appId, localOneSignalId, "externalId", null))
 
         /* When */
@@ -163,7 +164,7 @@ class LoginUserOperationExecutorTests : FunSpec({
         val mockPropertiesModelStore = MockHelper.propertiesModelStore()
         val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
 
-        val loginUserOperationExecutor = LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore())
+        val loginUserOperationExecutor = LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext())
         val operations = listOf<Operation>(LoginUserOperation(appId, localOneSignalId, "externalId", "existingOneSignalId"))
 
         /* When */
@@ -198,7 +199,7 @@ class LoginUserOperationExecutorTests : FunSpec({
         val mockPropertiesModelStore = MockHelper.propertiesModelStore()
         val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
 
-        val loginUserOperationExecutor = LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore())
+        val loginUserOperationExecutor = LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext())
         val operations = listOf<Operation>(LoginUserOperation(appId, localOneSignalId, "externalId", "existingOneSignalId"))
 
         /* When */
@@ -233,7 +234,7 @@ class LoginUserOperationExecutorTests : FunSpec({
         val mockPropertiesModelStore = MockHelper.propertiesModelStore()
         val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
 
-        val loginUserOperationExecutor = LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore())
+        val loginUserOperationExecutor = LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext())
         val operations = listOf<Operation>(LoginUserOperation(appId, localOneSignalId, "externalId", "existingOneSignalId"))
 
         /* When */
@@ -268,7 +269,7 @@ class LoginUserOperationExecutorTests : FunSpec({
         val mockPropertiesModelStore = MockHelper.propertiesModelStore()
         val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
 
-        val loginUserOperationExecutor = LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore())
+        val loginUserOperationExecutor = LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext())
         val operations = listOf<Operation>(LoginUserOperation(appId, localOneSignalId, "externalId", "existingOneSignalId"))
 
         /* When */
@@ -315,6 +316,7 @@ class LoginUserOperationExecutorTests : FunSpec({
             mockPropertiesModelStore,
             mockSubscriptionsModelStore,
             MockHelper.configModelStore(),
+            MockHelper.languageContext()
         )
         val operations = listOf<Operation>(
             LoginUserOperation(appId, localOneSignalId, null, null),
@@ -402,6 +404,7 @@ class LoginUserOperationExecutorTests : FunSpec({
             mockPropertiesModelStore,
             mockSubscriptionsModelStore,
             MockHelper.configModelStore(),
+            MockHelper.languageContext()
         )
         val operations = listOf<Operation>(
             LoginUserOperation(appId, localOneSignalId, null, null),
@@ -469,6 +472,7 @@ class LoginUserOperationExecutorTests : FunSpec({
             mockPropertiesModelStore,
             mockSubscriptionsModelStore,
             MockHelper.configModelStore(),
+            MockHelper.languageContext()
         )
         val operations = listOf<Operation>(
             LoginUserOperation(appId, localOneSignalId, null, null),
@@ -522,6 +526,7 @@ class LoginUserOperationExecutorTests : FunSpec({
             mockPropertiesModelStore,
             mockSubscriptionsModelStore,
             MockHelper.configModelStore(),
+            MockHelper.languageContext()
         )
         val operations = listOf<Operation>(
             LoginUserOperation(appId, localOneSignalId, null, null),


### PR DESCRIPTION
# Description
## One Line Summary
This fixes an issue where language was not being set as a user property when a new user is created.

## Details
This issue resulted in language being set as "en" by default despite device settings.
In order to send the language we are building upon the properties map added in #1842. An additional property set there (language) will be hydrated to the properties model when the response is received.

This fixes https://github.com/OneSignal/OneSignal-Android-SDK/issues/1843

### Motivation
Ensure language matches device.

### Scope
user properties during createUser

# Testing
## Unit testing
Added language to properties object in unit tests. Ran/passed unit tests. 

## Manual testing
Tested a fresh install with a Pixel 7 emulator running Android 13 with device language set to French. User is created with language code 'fr' and reflected in dashboard.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/1847)
<!-- Reviewable:end -->
