### PR TITLE
fix: NullPointerException getTargetSdkVersion

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationPermissionController.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationPermissionController.kt
@@ -43,9 +43,10 @@ object NotificationPermissionController : PermissionsActivity.PermissionCallback
     }
 
     @ChecksSdkIntAtLeast(api = 33)
-    val supportsNativePrompt =
+    val supportsNativePrompt: Boolean by lazy = {
         Build.VERSION.SDK_INT > 32 &&
             OSUtils.getTargetSdkVersion(OneSignal.appContext) > 32
+    }
 
     fun prompt(
         fallbackToSettings: Boolean,


### PR DESCRIPTION
<!-- START -->
# Description
Sometime, the application starts but the context was not initialized in OneSignal module soon enough and it will be null. This happens sometime with React Native application. And the block of above code will be executed when NotificationPermissionController is initialized --> Context is null. So it should be moved to block of code of the function prompt below. So when we call from JS promptForPushNotificationsWithUserResponse later, the context should be initialized.

## Details

### Motivation
Fix the crash https://github.com/OneSignal/react-native-onesignal/issues/1516




# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/1848)
<!-- Reviewable:end -->
