### PR TITLE
Fix Amazon purchase tracking setup

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/purchases/impl/TrackAmazonPurchase.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/purchases/impl/TrackAmazonPurchase.kt
@@ -69,18 +69,18 @@ internal class TrackAmazonPurchase(
         try {
             // 2.0.1
             val listenerHandlerClass = Class.forName("com.amazon.device.iap.internal.d")
-            listenerHandlerObject = try {
+            try {
                 // iap v2.x
-                listenerHandlerClass.getMethod("d").invoke(null)
+                listenerHandlerObject = listenerHandlerClass.getMethod("d").invoke(null)
             } catch (e: NullPointerException) {
                 // appstore v3.x
-                listenerHandlerClass.getMethod("e").invoke(null)
+                listenerHandlerObject = listenerHandlerClass.getMethod("e").invoke(null)
                 registerListenerOnMainThread = true
             }
             val locListenerHandlerField = listenerHandlerClass.getDeclaredField("f")
             locListenerHandlerField.isAccessible = true
             osPurchasingListener = OSPurchasingListener(_operationRepo, _configModelStore, _identityModelStore)
-            osPurchasingListener!!.orgPurchasingListener = locListenerHandlerField.get(listenerHandlerObject) as PurchasingListener
+            osPurchasingListener!!.orgPurchasingListener = locListenerHandlerField.get(listenerHandlerObject) as PurchasingListener?
 
             listenerHandlerField = locListenerHandlerField
             canTrack = true

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/purchases/impl/TrackAmazonPurchase.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/purchases/impl/TrackAmazonPurchase.kt
@@ -73,9 +73,16 @@ internal class TrackAmazonPurchase(
                 // iap v2.x
                 listenerHandlerObject = listenerHandlerClass.getMethod("d").invoke(null)
             } catch (e: NullPointerException) {
-                // appstore v3.x
-                listenerHandlerObject = listenerHandlerClass.getMethod("e").invoke(null)
-                registerListenerOnMainThread = true
+                // iap v3.x
+                try {
+                    // appstore v3.0.1 - v3.0.3
+                    listenerHandlerObject = listenerHandlerClass.getMethod("e").invoke(null)
+                    registerListenerOnMainThread = true
+                } catch (err: NullPointerException) {
+                    // appstore v3.0.4
+                    listenerHandlerObject = listenerHandlerClass.getMethod("g").invoke(null)
+                    registerListenerOnMainThread = true
+                }
             }
             val locListenerHandlerField = listenerHandlerClass.getDeclaredField("f")
             locListenerHandlerField.isAccessible = true


### PR DESCRIPTION
# Description
## One Line Summary
Fixes crash `"java.lang.IllegalArgumentException: Expected receiver of type com.amazon.device.iap.internal.d, but got kotlin.Unit"` and update to allow using appstore `v3.0.4`.

## Details

### Motivation
We have many reports of this crash and I was able to reproduce after adding `v3.0.3` of the Amazon AppStore SDK.

Additionally,`v3.0.4` of the Amazon AppStore SDK released in March 2023 changed the name of an internal method we rely on, so update to handle this version. We had no reports of this crashing so no one seems to be using this version so far.


### Scope

1. We did not correctly set a `listenerHandlerObject` in the startup code for tracking Amazon purchases, and this is the object that got a type of `kotlin.Unit`. The reason is because of the way we were setting it via shorthand. However, let's not use this shorthand since it is easy to make this mistake if we add code in the future.

```kotlin
// Incorrect, listenerHandlerObject equals the last line of the block, registerListenerOnMainThread = true
listenerHandlerObject = try {
    listenerHandlerClass.getMethod("d").invoke(null)
} catch (e: NullPointerException) {
    listenerHandlerClass.getMethod("e").invoke(null)
    registerListenerOnMainThread = true
}

// Correct, listenerHandlerObject equals the last line of the block, listenerHandlerClass.getMethod("e").invoke(null)
listenerHandlerObject = try {
    listenerHandlerClass.getMethod("d").invoke(null)
} catch (e: NullPointerException) {
    registerListenerOnMainThread = true
    listenerHandlerClass.getMethod("e").invoke(null)
}
```

2. Second, we make a cast to `PurchasingListener` when it can be optional, so cast to `PurchasingListener?` instead or else we will receive a different NPE crash.

I tested on player model, and see it can be nullable. The casting worked differently with Java so we did not encounter this crash.

3. There is no change to apps not using Amazon AppStore, as we return early and don't go down these lines of code.

4. An internal method of the appstore SDK was renamed in v3.0.4, and we are now compatible with this version.
```java
package com.amazon.device.iap.internal;

// 3.0.3
public static d e() {
    return c;
}

// 3.0.4
public static d g() {
    return c;
}
```

# Testing
## Unit testing
None

## Manual testing
Tested on Android emulator API 33
1. Add dependency `'com.amazon.device:amazon-appstore-sdk:3.0.3'` to Demo App
2. Reproduced the "Expected receiver of type com.amazon.device.iap.internal.d, but got kotlin.Unit" crash
4. Then test everything is working after this fix
5. Add dependency `'com.amazon.device:amazon-appstore-sdk:3.0.4'` to Demo App and see there is a crash
6. Make v3.0.4 fix and everything works.
7. Then confirm both 3.0.3 and 3.0.4 work with the code changes.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/1860)
<!-- Reviewable:end -->
