### PR TITLE
fix: remove annotation ChecksSdkIntAtLeast

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationPermissionController.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationPermissionController.kt
@@ -28,7 +28,6 @@
 package com.onesignal
 
 import android.os.Build
-import androidx.annotation.ChecksSdkIntAtLeast
 
 object NotificationPermissionController : PermissionsActivity.PermissionCallback {
     private const val PERMISSION_TYPE = "NOTIFICATION"
@@ -42,7 +41,6 @@ object NotificationPermissionController : PermissionsActivity.PermissionCallback
         PermissionsActivity.registerAsCallback(PERMISSION_TYPE, this)
     }
 
-    @ChecksSdkIntAtLeast(api = 33)
     val supportsNativePrompt: Boolean by lazy = {
         Build.VERSION.SDK_INT > 32 &&
             OSUtils.getTargetSdkVersion(OneSignal.appContext) > 32


### PR DESCRIPTION
when change var supportsNativePrompt to lazy init
# Description
## One Line Summary
Fix the annotation when this https://github.com/OneSignal/OneSignal-Android-SDK/pull/1848 request was merged. Just remove it because I don't know the better way to fix it

## Details

### Motivation
Fix build problem

### Scope
**RECOMMEND - OPTIONAL -** What is intended to be effected. What is known not to change. Example: Notifications are grouped when parameter X is set, not enabled by default.

### OPTIONAL - Other
**OPTIONAL -** Feel free to add any other sections or sub-sections that can explain your PR better.

# Testing
## Unit testing
**OPTIONAL -**  Explain unit tests added, if not clear in the code.

## Manual testing
**RECOMMEND - OPTIONAL -** Explain what scenarios were tested and the environment.
Example: Tested opening a notification while the app was foregrounded, app build with Android Studio 2020.3 with a fresh install of the OneSignal example app on a Pixel 6 with Android 12.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/1866)
<!-- Reviewable:end -->
