### PR TITLE
fix: null pointer on get app context

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/application/impl/ApplicationService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/application/impl/ApplicationService.kt
@@ -344,3 +344,25 @@ class ApplicationService() : IApplicationService, ActivityLifecycleCallbacks, On
         }
     }
 }
+
+object ApplicationServiceUtil {
+    fun isValidInstance(_applicationService: IApplicationService?): Boolean {
+        return try {
+            if (_applicationService == null) {
+                println("Error: _applicationService is null")
+                false
+            } else if (_applicationService.appContext == null) {
+                println("Error: _applicationService.appContext is null")
+                false
+            } else {
+                true
+            }
+        } catch (e: NullPointerException) {
+            println("ApplicationService's AppContext not initialized: ${e.message}")
+            false
+        } catch (e: Exception) {
+            println("Exception thrown while checking ApplicationService's App Context: ${e.message}")
+            false
+        }
+    }
+}

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/device/impl/DeviceService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/device/impl/DeviceService.kt
@@ -5,8 +5,9 @@ import android.os.Build
 import com.onesignal.common.AndroidUtils
 import com.onesignal.core.internal.application.IApplicationService
 import com.onesignal.core.internal.device.IDeviceService
+import com.onesignal.core.internal.application.impl.ApplicationServiceUtil
 
-internal class DeviceService(private val _applicationService: IApplicationService) :
+internal class DeviceService(private val _applicationService: IApplicationService?) :
     IDeviceService {
     companion object {
         private const val HMS_CORE_SERVICES_PACKAGE = "com.huawei.hwid" // = HuaweiApiAvailability.SERVICES_PACKAGE
@@ -67,11 +68,13 @@ internal class DeviceService(private val _applicationService: IApplicationServic
 
             // If running on Android O and targeting O we need version 26.0.0 for
             //   the new compat NotificationCompat.Builder constructor.
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O &&
-                AndroidUtils.getTargetSdkVersion(_applicationService.appContext) >= Build.VERSION_CODES.O
-            ) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                if (!ApplicationServiceUtil.isValidInstance(_applicationService)) {
+                    return IDeviceService.AndroidSupportLibraryStatus.MISSING
+                }
+    
                 // Class was added in 26.0.0-beta2
-                if (!AndroidUtils.hasJobIntentService()) {
+                if (!AndroidUtils.hasJobIntentService() && AndroidUtils.getTargetSdkVersion(_applicationService!!.appContext) >= Build.VERSION_CODES.O) {
                     return IDeviceService.AndroidSupportLibraryStatus.OUTDATED
                 }
             }
@@ -103,7 +106,11 @@ internal class DeviceService(private val _applicationService: IApplicationServic
 
     private fun packageInstalledAndEnabled(packageName: String): Boolean {
         return try {
-            val pm = _applicationService.appContext.packageManager
+            if (!ApplicationServiceUtil.isValidInstance(_applicationService)) {
+                return false;
+            }
+    
+            val pm = _applicationService!!.appContext.packageManager
             val info = pm.getPackageInfo(packageName, PackageManager.GET_META_DATA)
             info.applicationInfo.enabled
         } catch (e: PackageManager.NameNotFoundException) {
@@ -137,7 +144,11 @@ internal class DeviceService(private val _applicationService: IApplicationServic
             val isHuaweiMobileServicesAvailableMethod = clazz.getMethod("isHuaweiMobileServicesAvailable", android.content.Context::class.java)
             val availabilityInstance = newInstanceMethod.invoke(null)
 
-            val result = isHuaweiMobileServicesAvailableMethod.invoke(availabilityInstance, _applicationService.appContext) as Int
+            if (!ApplicationServiceUtil.isValidInstance(_applicationService)) {
+                return false;
+            }
+
+            val result = isHuaweiMobileServicesAvailableMethod.invoke(availabilityInstance, _applicationService!!.appContext) as Int
 
             return result == HMS_AVAILABLE_SUCCESSFUL
         } catch (e: ClassNotFoundException) {

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/preferences/impl/PreferencesService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/preferences/impl/PreferencesService.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.SharedPreferences
 import com.onesignal.common.threading.Waiter
 import com.onesignal.core.internal.application.IApplicationService
+import com.onesignal.core.internal.application.impl.ApplicationServiceUtil
 import com.onesignal.core.internal.preferences.IPreferencesService
 import com.onesignal.core.internal.preferences.PreferenceStores
 import com.onesignal.core.internal.startup.IStartableService
@@ -17,7 +18,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 
 internal class PreferencesService(
-    private val _applicationService: IApplicationService,
+    private val _applicationService: IApplicationService?,
     private val _time: ITime,
 ) : IPreferencesService, IStartableService {
     private val _prefsToApply: Map<String, MutableMap<String, Any?>> = mapOf(
@@ -154,7 +155,12 @@ internal class PreferencesService(
 
     @Synchronized
     private fun getSharedPrefsByName(store: String): SharedPreferences? {
-        return _applicationService.appContext.getSharedPreferences(store, Context.MODE_PRIVATE)
+
+        if (!ApplicationServiceUtil.isValidInstance(_applicationService)) {
+            return null
+        }
+
+        return _applicationService!!.appContext.getSharedPreferences(store, Context.MODE_PRIVATE)
     }
 
     companion object {

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
@@ -15,6 +15,7 @@ import com.onesignal.common.threading.suspendifyOnThread
 import com.onesignal.core.CoreModule
 import com.onesignal.core.internal.application.IApplicationService
 import com.onesignal.core.internal.application.impl.ApplicationService
+import com.onesignal.core.internal.application.impl.ApplicationServiceUtil
 import com.onesignal.core.internal.config.ConfigModel
 import com.onesignal.core.internal.config.ConfigModelStore
 import com.onesignal.core.internal.operations.IOperationRepo
@@ -150,6 +151,9 @@ internal class OneSignalImp : IOneSignal, IServiceProvider {
         val applicationService = _services.getService<IApplicationService>()
         (applicationService as ApplicationService).start(context)
 
+        if (!ApplicationServiceUtil.isValidInstance(applicationService)) {
+            return false
+        }
         // Give the logging singleton access to the application service to support visual logging.
         Logging.applicationService = applicationService
 

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/application/ApplicationServiceUtilsTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/application/ApplicationServiceUtilsTests.kt
@@ -1,0 +1,82 @@
+package com.onesignal.core.internal.application
+
+import android.app.Activity
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.onesignal.core.internal.application.impl.ApplicationService
+import com.onesignal.debug.LogLevel
+import com.onesignal.debug.internal.logging.Logging
+import com.onesignal.extensions.RobolectricTest
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.runner.junit4.KotestTestRunner
+import org.junit.runner.RunWith
+import com.onesignal.core.internal.application.impl.ApplicationServiceUtil
+
+@RobolectricTest
+@RunWith(KotestTestRunner::class)
+class ApplicationServiceUtilsTests : FunSpec({
+
+    beforeAny {
+        Logging.logLevel = LogLevel.NONE
+    }
+
+    test("returns true if application service is not null and app context is not null") {
+        /* Given */
+         val context = ApplicationProvider.getApplicationContext<Context>()
+        val applicationService = ApplicationService()
+        applicationService.start(context)
+
+        /* When */
+        val result = ApplicationServiceUtil.isValidInstance(applicationService)
+
+        /* Then */
+        result shouldBe true
+    }
+
+    test("returns false if application service is null") {
+        /* Given */
+        val applicationService: IApplicationService? = null
+
+
+        /* When */
+        val result = ApplicationServiceUtil.isValidInstance(applicationService)
+
+        /* Then */
+        result shouldBe false
+    }
+
+     test("returns false if app context is null and or exception is thrown") {
+         /* Given */
+         val applicationService = ApplicationService()
+
+         /* When */
+         val result = ApplicationServiceUtil.isValidInstance(applicationService)
+
+         /* Then */
+         result shouldBe false
+     }
+
+}) {
+    companion object {
+        fun pushActivity(applicationService: ApplicationService, currActivity: Activity, newActivity: Activity, destoryCurrent: Boolean = false) {
+            applicationService.onActivityPaused(currActivity)
+            applicationService.onActivityCreated(newActivity, null)
+            applicationService.onActivityStarted(newActivity)
+            applicationService.onActivityResumed(newActivity)
+            applicationService.onActivityStopped(currActivity)
+
+            if (destoryCurrent) {
+                applicationService.onActivityDestroyed(currActivity)
+            }
+        }
+
+        fun popActivity(applicationService: ApplicationService, currActivity: Activity, oldActivity: Activity) {
+            applicationService.onActivityPaused(currActivity)
+            applicationService.onActivityStarted(oldActivity)
+            applicationService.onActivityResumed(oldActivity)
+            applicationService.onActivityStopped(currActivity)
+            applicationService.onActivityDestroyed(currActivity)
+        }
+    }
+}


### PR DESCRIPTION
# Description
## One Line Summary
Created ApplicationServiceUtil object, which checks if `applicationService` and `appContext` are valid references. Added Null checks to both ApplicationService and DeviceService, which were sources of null pointer Exceptions.
It also checks if the app service has initialized correctly right after the initialization.
## Details

### Motivation
https://github.com/OneSignal/react-native-onesignal/issues/1587
Stack Trace:
```
Exception java.lang.RuntimeException: Unable to start receiver com.onesignal.notifications.receivers.FCMBroadcastReceiver: java.lang.reflect.InvocationTargetException
  at android.app.ActivityThread.handleReceiver (ActivityThread.java:4600)
  at android.app.ActivityThread.-$$Nest$mhandleReceiver
  at android.app.ActivityThread$H.handleMessage (ActivityThread.java:2261)
  at android.os.Handler.dispatchMessage (Handler.java:106)
  at android.os.Looper.loopOnce (Looper.java:211)
  at android.os.Looper.loop (Looper.java:300)
  at android.app.ActivityThread.main (ActivityThread.java:8410)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:559)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:954)
Caused by java.lang.reflect.InvocationTargetException:
  at java.lang.reflect.Constructor.newInstance0
  at java.lang.reflect.Constructor.newInstance (Constructor.java:343)
  at com.onesignal.common.services.ServiceRegistrationReflection.resolve (ServiceRegistration.kt:238)
  at com.onesignal.common.services.ServiceProvider.getServiceOrNull (ServiceProvider.kt:51)
  at com.onesignal.common.services.ServiceProvider.getService (ServiceProvider.kt:6)
  at com.onesignal.internal.OneSignalImp.initWithContext (OneSignalImp.kt:76)
  at com.onesignal.OneSignal.initWithContext (OneSignal.kt:2)
  at com.onesignal.notifications.receivers.FCMBroadcastReceiver.onReceive (FCMBroadcastReceiver.kt:32)
  at android.app.ActivityThread.handleReceiver (ActivityThread.java:4588)
Caused by java.lang.NullPointerException:
  at com.onesignal.core.internal.application.impl.ApplicationService.getAppContext (ApplicationService.kt:3)
  at com.onesignal.core.internal.preferences.impl.PreferencesService.getSharedPrefsByName (PreferencesService.kt:4)
  at com.onesignal.core.internal.preferences.impl.PreferencesService.get (PreferencesService.kt:38)
  at com.onesignal.core.internal.preferences.impl.PreferencesService.getString (PreferencesService.kt:13)
  at com.onesignal.common.modeling.ModelStore.load (ModelStore.kt:29)
  at com.onesignal.common.modeling.SimpleModelStore.<init> (SimpleModelStore.kt:4)
  at com.onesignal.core.internal.config.ConfigModelStore.<init> (ConfigModelStore.kt:12)
```

2nd StackTrace:
```
Exception java.lang.RuntimeException: Unable to start receiver com.onesignal.notifications.receivers.NotificationDismissReceiver: java.lang.NullPointerException
  at android.app.ActivityThread.handleReceiver (ActivityThread.java:4895)
  at android.app.ActivityThread.-$$Nest$mhandleReceiver
  at android.app.ActivityThread$H.handleMessage (ActivityThread.java:2422)
  at android.os.Handler.dispatchMessage (Handler.java:106)
  at android.os.Looper.loopOnce (Looper.java:226)
  at android.os.Looper.loop (Looper.java:313)
  at android.app.ActivityThread.main (ActivityThread.java:8775)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:571)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1067)
Caused by java.lang.NullPointerException:
  at com.onesignal.core.internal.application.impl.ApplicationService.getAppContext (ApplicationService.kt:3)
  at com.onesignal.core.internal.device.impl.DeviceService.packageInstalledAndEnabled (DeviceService.kt:3)
  at com.onesignal.core.internal.device.impl.DeviceService.isGMSInstalledAndEnabled (DeviceService.kt:3)
  at com.onesignal.core.internal.device.impl.DeviceService.supportsGooglePush (DeviceService.kt:9)
  at com.onesignal.core.internal.device.impl.DeviceService.getDeviceType (DeviceService.kt:10)
  at com.onesignal.core.internal.device.impl.DeviceService.isAndroidDeviceType (DeviceService.kt:1)
  at com.onesignal.location.LocationModule$register$1.invoke (LocationModule.kt:3)
  at com.onesignal.location.LocationModule$register$1.invoke (LocationModule.kt:1)
  at com.onesignal.common.services.ServiceRegistrationLambda.resolve (ServiceRegistration.kt:13)
  at com.onesignal.common.services.ServiceProvider.getServiceOrNull (ServiceProvider.kt:51)
  at com.onesignal.common.services.ServiceProvider.getService (ServiceProvider.kt:6)
  at com.onesignal.common.services.ServiceRegistrationReflection.resolve (ServiceRegistration.kt:208)
  at com.onesignal.common.services.ServiceProvider.getServiceOrNull (ServiceProvider.kt:51)
  at com.onesignal.common.services.ServiceProvider.getService (ServiceProvider.kt:6)
  at com.onesignal.common.services.ServiceRegistrationReflection.resolve (ServiceRegistration.kt:208)
  at com.onesignal.common.services.ServiceProvider.getServiceOrNull (ServiceProvider.kt:51)
  at com.onesignal.common.services.ServiceProvider.getService (ServiceProvider.kt:6)
  at com.onesignal.internal.OneSignalImp.initWithContext (OneSignalImp.kt:233)
  at com.onesignal.OneSignal.initWithContext (OneSignal.kt:2)
  at com.onesignal.notifications.receivers.NotificationDismissReceiver.onReceive (NotificationDismissReceiver.kt:20)
  at android.app.ActivityThread.handleReceiver (ActivityThread.java:4886)
```
### Scope


### OPTIONAL - Other

# Testing
## Unit testing

## Manual testing

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [x] Core
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - Fix NullPointer exception in DeviceService.kt and PreferencesService.kt
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/1878)
<!-- Reviewable:end -->
