### PR TITLE
Remove detekt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,6 @@ jobs:
         working-directory: OneSignalSDK
         run: |
           ./gradlew ktlintCheck --console=plain
-      - name: "[Test] Analyzing"
-        working-directory: OneSignalSDK
-        continue-on-error: true
-        run: |
-          ./gradlew detekt --console=plain
       - name: "[Test] SDK Unit Tests"
         working-directory: OneSignalSDK
         run: |

--- a/OneSignalSDK/build.gradle
+++ b/OneSignalSDK/build.gradle
@@ -17,7 +17,6 @@ buildscript {
         kotestVersion = '5.5.0'
         ktlintPluginVersion = '11.3.1'
         ktlintVersion = '0.48.2'
-        detektVersion = '1.21.0'
         junitVersion = '4.13.2'
     }
 
@@ -34,7 +33,6 @@ buildscript {
         classpath "com.huawei.agconnect:agcp:$huaweiAgconnectVersion"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath "org.jlleitschuh.gradle:ktlint-gradle:$ktlintPluginVersion"
-        classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:$detektVersion"
     }
 }
 

--- a/OneSignalSDK/onesignal/core/build.gradle
+++ b/OneSignalSDK/onesignal/core/build.gradle
@@ -2,7 +2,6 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'org.jlleitschuh.gradle.ktlint'
-    id 'io.gitlab.arturbosch.detekt'
 }
 
 android {

--- a/OneSignalSDK/onesignal/in-app-messages/build.gradle
+++ b/OneSignalSDK/onesignal/in-app-messages/build.gradle
@@ -2,7 +2,6 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'org.jlleitschuh.gradle.ktlint'
-    id 'io.gitlab.arturbosch.detekt'
 }
 
 android {

--- a/OneSignalSDK/onesignal/location/build.gradle
+++ b/OneSignalSDK/onesignal/location/build.gradle
@@ -2,7 +2,6 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'org.jlleitschuh.gradle.ktlint'
-    id 'io.gitlab.arturbosch.detekt'
 }
 
 android {

--- a/OneSignalSDK/onesignal/notifications/build.gradle
+++ b/OneSignalSDK/onesignal/notifications/build.gradle
@@ -2,7 +2,6 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'org.jlleitschuh.gradle.ktlint'
-    id 'io.gitlab.arturbosch.detekt'
 }
 
 android {


### PR DESCRIPTION
# Description
## One Line Summary
Removes detekt from our ci.

## Details

### Motivation
We are using detekt for static analysis but detekt comes with a linter by default. detekt uses ktLint which we already use in our ci. The [latest release of detekt](https://github.com/detekt/detekt/releases/tag/v1.23.1) uses ktLint 0.50.0, which is quite old - the latest release of ktLint is 1.0.1. We decided to remove detekt for now and plan to add static analysis at a later time.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/1881)
<!-- Reviewable:end -->
