### PR TITLE
Update PropertiesModel's deserialization of tags to not use `Model.initializeFromJson`

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/modeling/Model.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/modeling/Model.kt
@@ -105,6 +105,7 @@ open class Model(
                         Float::class.java, java.lang.Float::class.java -> data[property] = jsonObject.getDouble(property).toFloat()
                         Int::class.java, java.lang.Integer::class.java -> data[property] = jsonObject.getInt(property)
                         Boolean::class.java, java.lang.Boolean::class.java -> data[property] = jsonObject.getBoolean(property)
+                        String::class.java, java.lang.String::class.java -> data[property] = jsonObject.getString(property)
                         else -> data[property] = jsonObject.get(property)
                     }
                 }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/properties/PropertiesModel.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/properties/PropertiesModel.kt
@@ -91,7 +91,9 @@ class PropertiesModel : Model() {
     override fun createModelForProperty(property: String, jsonObject: JSONObject): Model? {
         if (property == ::tags.name) {
             val model = MapModel<String>(this, ::tags.name)
-            model.initializeFromJson(jsonObject)
+            for (key in jsonObject.keys()) {
+                model.setStringProperty(key, jsonObject.getString(key))
+            }
             return model
         }
 

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/properties/PropertiesModelTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/properties/PropertiesModelTests.kt
@@ -1,0 +1,38 @@
+package com.onesignal.user.internal.properties
+
+import com.onesignal.common.putJSONObject
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.runner.junit4.KotestTestRunner
+import org.json.JSONObject
+import org.junit.runner.RunWith
+
+@RunWith(KotestTestRunner::class)
+class PropertiesModelTests : FunSpec({
+
+    test("successfully initializes varying tag names") {
+        /* Given */
+        val varyingTags = JSONObject()
+            .putJSONObject(PropertiesModel::tags.name) {
+                it.put("value", "data1")
+                    .put("isEmpty", "data2")
+                    .put("object", "data3")
+                    .put("1", "data4")
+                    .put("false", "data5")
+                    .put("15.7", "data6")
+            }
+        val propertiesModel = PropertiesModel()
+
+        /* When */
+        propertiesModel.initializeFromJson(varyingTags)
+        val tagsModel = propertiesModel.tags
+
+        /* Then */
+        tagsModel["value"] shouldBe "data1"
+        tagsModel["isEmpty"] shouldBe "data2"
+        tagsModel["object"] shouldBe "data3"
+        tagsModel["1"] shouldBe "data4"
+        tagsModel["false"] shouldBe "data5"
+        tagsModel["15.7"] shouldBe "data6"
+    }
+})


### PR DESCRIPTION
# Description
## One Line Summary
This updates the tag deserialization logic in `PropertyModel.createModelForProperty` to no longer use `Model.initializeFromJson`, which relies on [reflection](https://github.com/OneSignal/OneSignal-Android-SDK/blob/user-model/main/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/modeling/Model.kt#L97) to determine the expected data type.  Using reflection is useful when the data model being deserialized is represented by a statically defined class.

The problem with using reflections for tags is tag names are dynamic and might be the same as `MapModel` (the statically defined class that holds the tags).  Examples: `value`, `isEmpty`, `size`. 

Since tags must be flat, I updated `PropertyModel.createModelForProperty` to iterate through the `JSONObject` key value pairs directly.

Additionally, I noticed the reflection logic does not check for a String return value.  For completeness, I added that additional case to ensure string properties get string values from the JSON object.

## Details

### Motivation
https://github.com/OneSignal/OneSignal-Android-SDK/issues/1874

### Scope
The intent of this fix is to allow the model deserialization code, which is primarily used during initialization, to successfully deserialize user state.

# Testing
## Unit testing
Added a new `PropertiesModelTests` to drive and verify deserialization of a `PropertiesModel` works as expected regarding tags.

## Manual testing
Replicated the problem described in [this issue](https://github.com/OneSignal/OneSignal-Android-SDK/issues/1874) by adding a tag named `value` with a non-boolean value.  Once added, restart the app and verify proper deserialization.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/1884)
<!-- Reviewable:end -->
