### PR TITLE
Retrieve current ADM PurchasingListener assuming it returns a nullable.

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/purchases/impl/TrackAmazonPurchase.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/purchases/impl/TrackAmazonPurchase.kt
@@ -121,7 +121,7 @@ internal class TrackAmazonPurchase(
         if (!canTrack) return
         try {
             val curPurchasingListener =
-                listenerHandlerField!![listenerHandlerObject] as PurchasingListener
+                listenerHandlerField!!.get(listenerHandlerObject) as PurchasingListener?
             if (curPurchasingListener !== osPurchasingListener) {
                 osPurchasingListener!!.orgPurchasingListener = curPurchasingListener
                 setListener()


### PR DESCRIPTION
# Description
## One Line Summary
Update `TrackAmazonPurchase.onUnfocused` to retrieve the `PurchasingListener` assuming it can be null.

## Details
This builds on top of #1860, the same logic applies. However if a user unfocuses the application early enough during initialization, the `TrackAmazonPurchase.onUnfocused` will be called.  This also retrieves the current `PurchasingListener`, which can be null.

The statement was also switched from index notation to use `.get`, similar to the initialization logic, to keep things consistent.

### Motivation
#1812 

# Testing
## Unit testing
No unit tests were added

## Manual testing
Tested on Android emulator API 33

1. Add dependency 'com.amazon.device:amazon-appstore-sdk:3.0.3' to Demo App
2. Reproduced the crash by unfocusing the app when the splash screen shows
3. Then test everything is working after this fix

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/1888)
<!-- Reviewable:end -->
