### PR TITLE
Update work-runtime dependency version

### DIFF
--- a/OneSignalSDK/onesignal/notifications/build.gradle
+++ b/OneSignalSDK/onesignal/notifications/build.gradle
@@ -95,8 +95,8 @@ dependencies {
 
     api('androidx.work:work-runtime') {
         version {
-            require '[2.1.0, 2.7.99]'
-            prefer '2.7.1'
+            require '[2.1.0, 2.8.99]'
+            prefer '2.8.1'
         }
     }
 


### PR DESCRIPTION
# Description
## One Line Summary
Update work-runtime dependency version to 2.8.1

## Details
Prevents gradle crash with latest version of WorkManager

### Motivation
Reported in #1889

### Scope
androidx.work:work-runtime dependency

# Testing
## Unit testing
Built app on Android 12 and 13 emulators and ran unit tests with updated dependency version to ensure no issues.

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/1890)
<!-- Reviewable:end -->
