### PR TITLE
Update comment linting errors on PropertiesModelTests

### DIFF
--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/properties/PropertiesModelTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/properties/PropertiesModelTests.kt
@@ -11,23 +11,24 @@ import org.junit.runner.RunWith
 class PropertiesModelTests : FunSpec({
 
     test("successfully initializes varying tag names") {
-        /* Given */
-        val varyingTags = JSONObject()
-            .putJSONObject(PropertiesModel::tags.name) {
-                it.put("value", "data1")
-                    .put("isEmpty", "data2")
-                    .put("object", "data3")
-                    .put("1", "data4")
-                    .put("false", "data5")
-                    .put("15.7", "data6")
-            }
+        // Given
+        val varyingTags =
+            JSONObject()
+                .putJSONObject(PropertiesModel::tags.name) {
+                    it.put("value", "data1")
+                        .put("isEmpty", "data2")
+                        .put("object", "data3")
+                        .put("1", "data4")
+                        .put("false", "data5")
+                        .put("15.7", "data6")
+                }
         val propertiesModel = PropertiesModel()
 
-        /* When */
+        // When
         propertiesModel.initializeFromJson(varyingTags)
         val tagsModel = propertiesModel.tags
 
-        /* Then */
+        // Then
         tagsModel["value"] shouldBe "data1"
         tagsModel["isEmpty"] shouldBe "data2"
         tagsModel["object"] shouldBe "data3"


### PR DESCRIPTION
# Description
## One Line Summary
Update comment linting errors on `PropertiesModelTests`.

## Details
#1884 included a new unit test that was merged before #1882, which accounts for linting errors. This update will allow lint checks on future PRs to pass.

Errors:
- Replace the block comment with an EOL comment
- A multiline expression should start on a new line

### Motivation
Ensure that GitHub Action checking for linting errors pass in future PRs.

### Scope
Only comment formatting in PropertiesModelTests were changed to adhere to Kotlin conventions.

# Testing
## Unit testing
Reran `PropertiesModelTests` to ensure unit test still passes. 
Reran `./gradlew ktlintCheck` to ensure lint check passes.

## Manual testing
Built/ran on Android 13 emulator to ensure no issue with example app.

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/1891)
<!-- Reviewable:end -->
