### PR TITLE
Release 5.0.4

### DIFF
--- a/Examples/OneSignalDemo/app/build.gradle
+++ b/Examples/OneSignalDemo/app/build.gradle
@@ -84,12 +84,12 @@ dependencies {
     implementation 'com.github.bumptech.glide:glide:4.12.0'
 
     /** START - Google Play Builds **/
-    gmsImplementation('com.onesignal:OneSignal:5.0.3')
+    gmsImplementation('com.onesignal:OneSignal:5.0.4')
     /** END - Google Play Builds **/
 
     /** START - Huawei Builds **/
     // Omit Google / Firebase libraries for Huawei builds.
-    huaweiImplementation('com.onesignal:OneSignal:5.0.3') {
+    huaweiImplementation('com.onesignal:OneSignal:5.0.4') {
         exclude group: 'com.google.android.gms', module: 'play-services-gcm'
         exclude group: 'com.google.android.gms', module: 'play-services-analytics'
         exclude group: 'com.google.android.gms', module: 'play-services-location'

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/OneSignalUtils.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/OneSignalUtils.kt
@@ -6,7 +6,7 @@ object OneSignalUtils {
     /**
      * The version of this SDK.
      */
-    const val SDK_VERSION: String = "050003"
+    const val SDK_VERSION: String = "050004"
 
     fun isValidEmail(email: String): Boolean {
         if (email.isEmpty()) {

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/threading/ThreadUtils.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/threading/ThreadUtils.kt
@@ -48,8 +48,7 @@ fun suspendifyOnMain(block: suspend () -> Unit) {
                     block()
                 }
             }
-        }
-        catch (e: Exception) {
+        } catch (e: Exception) {
             Logging.error("Exception on thread with switch to main", e)
         }
     }
@@ -70,8 +69,7 @@ fun suspendifyOnThread(
             runBlocking {
                 block()
             }
-        }
-        catch (e: Exception) {
+        } catch (e: Exception) {
             Logging.error("Exception on thread", e)
         }
     }
@@ -93,9 +91,8 @@ fun suspendifyOnThread(
             runBlocking {
                 block()
             }
-        }
-        catch (e: Exception) {
-            Logging.error("Exception on thread '${name}'", e)
+        } catch (e: Exception) {
+            Logging.error("Exception on thread '$name'", e)
         }
     }
 }

--- a/OneSignalSDK/settings.gradle
+++ b/OneSignalSDK/settings.gradle
@@ -3,7 +3,7 @@
 gradle.rootProject {
     allprojects {
         group = 'com.onesignal'
-        version = '5.0.3'
+        version = '5.0.4'
         configurations.all {
             resolutionStrategy.dependencySubstitution {
                 substitute(module('com.onesignal:OneSignal')).using(project(':OneSignal'))


### PR DESCRIPTION
## What's Changed
* Remove detekt by @shepherd-l in https://github.com/OneSignal/OneSignal-Android-SDK/pull/1881
* Update PropertiesModel's deserialization of tags to not use `Model.initializeFromJson` by @brismithers in https://github.com/OneSignal/OneSignal-Android-SDK/pull/1884
* Retrieve current ADM PurchasingListener assuming it returns a nullable. by @brismithers in https://github.com/OneSignal/OneSignal-Android-SDK/pull/1888
* Fix: Add synchronized blocks to prevent ConcurrentModificationException by @jennantilla in https://github.com/OneSignal/OneSignal-Android-SDK/pull/1876
* Update work-runtime dependency version by @jennantilla in https://github.com/OneSignal/OneSignal-Android-SDK/pull/1890
* Update comment linting errors on PropertiesModelTests by @jennantilla in https://github.com/OneSignal/OneSignal-Android-SDK/pull/1891
* General protection against exceptions that occur on a thread. by @brismithers in https://github.com/OneSignal/OneSignal-Android-SDK/pull/1887


**Full Changelog**: https://github.com/OneSignal/OneSignal-Android-SDK/compare/5.0.3...5.0.4

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/1899)
<!-- Reviewable:end -->
