### PR TITLE
[v5] Pause operation repo and retry failed user create

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/IOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/IOperationExecutor.kt
@@ -71,4 +71,11 @@ enum class ExecutionResult {
      * The operation failed due to a conflict and can be handled.
      */
     FAIL_CONFLICT,
+
+    /**
+     * Used in special create user case.
+     * The operation failed due to a non-retryable error. Pause the operation repo
+     * and retry on a new session, giving the SDK a chance to recover from the failed user create.
+     */
+    FAIL_PAUSE_OPREPO,
 }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/LoginUserOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/LoginUserOperationExecutor.kt
@@ -205,7 +205,7 @@ internal class LoginUserOperationExecutor(
                 NetworkUtils.ResponseStatusType.UNAUTHORIZED ->
                     ExecutionResponse(ExecutionResult.FAIL_UNAUTHORIZED)
                 else ->
-                    ExecutionResponse(ExecutionResult.FAIL_NORETRY)
+                    ExecutionResponse(ExecutionResult.FAIL_PAUSE_OPREPO)
             }
         }
     }


### PR DESCRIPTION
# Description
## One Line Summary
Give the SDK a future chance to recover from failed user creation, similar to the behavior of the iOS SDK.

## Details
Successful user creation is vital to the functioning of the SDK.

**Problem:**
If the create user request fails with an un-retryable error such as a 400 response, the SDK would not retry and stay in an unrecoverable error state with no onesignal_id, and no subscription_id (potentially). Therefore, it would never register, send data, or receive notifications. The only way out was to uninstall the app.

**Solution:**
Let's give the SDK a chance to recover from failed user creation, similar to the behavior of the iOS SDK. When met with this error, we will pause the operation repo from executing any more operations as it is impossible to do anything without a onesignal_id.

Then, on new sessions or new cold starts, we will retry the still-cached operation, in the hopes that perhaps it can succeed at this later date.

### Motivation
If the create user request fails with an un-retryable error such as a 400 response, the SDK would not retry and stay in an unrecoverable error state with no onesignal_id, and no subscription_id (potentially). 

### Scope
Only affects user create requests that receive a 400-range error.

# Testing
## Unit testing
None, but can consider adding in the future to mimic the behavior

## Manual testing
Android emulator API 33
1. New app install with an unsupported device language (`sl` at time of testing)
2. Create User fails with 400 error
3. See the operation repo is paused
4. Call login to an existing EUID
5. Kill app and change device language to `en`
6. Re-open app a while later
7. Create User succeeds
8. Login also succeeds
9. The SDK is now logged into the appropriate EUID/user from the Login call.
10. Send and receive a push notification on the device

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/1900)
<!-- Reviewable:end -->
