### PR TITLE
Fix issue with migration from v4 to v5 when obfuscation is used by the app

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/preferences/PreferenceStoreFix.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/preferences/PreferenceStoreFix.kt
@@ -1,0 +1,49 @@
+package com.onesignal.core.internal.preferences
+
+import android.content.Context
+import android.os.Build
+import com.onesignal.debug.LogLevel
+import com.onesignal.debug.internal.logging.Logging
+import java.io.File
+
+object PreferenceStoreFix {
+
+    /**
+     * Ensure the OneSignal preference store is not using the v4 obfuscated version, if one
+     * exists.
+     */
+    fun ensureNoObfuscatedPrefStore(context: Context) {
+        try {
+            // In the v4 version the OneSignal shared preference name was based on the OneSignal
+            // class name, which might be minimized/obfuscated if the app is using ProGuard or
+            // similar.  In order for a device to successfully migrate from v4 to v5 picking
+            // up the subscription, we need to copy the shared preferences from the obfuscated
+            // version to the static "OneSignal" preference name.  We only do this
+            // if there isn't already a "OneSignal" preference store.
+            val sharedPrefsDir = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                File(context.dataDir, "shared_prefs")
+            } else {
+                File(context.filesDir.parentFile, "shared_prefs")
+            }
+            val osPrefsFile = File(sharedPrefsDir, "OneSignal.xml")
+
+            if (!sharedPrefsDir.exists() || !sharedPrefsDir.isDirectory || osPrefsFile.exists())
+                return
+
+            val prefsFileList = sharedPrefsDir.listFiles() ?: return
+
+            // Go through every preference file, looking for the OneSignal preference store.
+            for (prefsFile in prefsFileList) {
+                val prefsStore =
+                    context.getSharedPreferences(prefsFile.nameWithoutExtension, Context.MODE_PRIVATE)
+
+                if (prefsStore.contains(PreferenceOneSignalKeys.PREFS_LEGACY_PLAYER_ID)) {
+                    prefsFile.renameTo(osPrefsFile)
+                    return
+                }
+            }
+        } catch (e: Throwable) {
+            Logging.log(LogLevel.ERROR, "error attempting to fix obfuscated preference store", e)
+        }
+    }
+}

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/preferences/PreferenceStoreFix.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/preferences/PreferenceStoreFix.kt
@@ -7,7 +7,6 @@ import com.onesignal.debug.internal.logging.Logging
 import java.io.File
 
 object PreferenceStoreFix {
-
     /**
      * Ensure the OneSignal preference store is not using the v4 obfuscated version, if one
      * exists.
@@ -20,15 +19,18 @@ object PreferenceStoreFix {
             // up the subscription, we need to copy the shared preferences from the obfuscated
             // version to the static "OneSignal" preference name.  We only do this
             // if there isn't already a "OneSignal" preference store.
-            val sharedPrefsDir = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-                File(context.dataDir, "shared_prefs")
-            } else {
-                File(context.filesDir.parentFile, "shared_prefs")
-            }
+            val sharedPrefsDir =
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                    File(context.dataDir, "shared_prefs")
+                } else {
+                    File(context.filesDir.parentFile, "shared_prefs")
+                }
+
             val osPrefsFile = File(sharedPrefsDir, "OneSignal.xml")
 
-            if (!sharedPrefsDir.exists() || !sharedPrefsDir.isDirectory || osPrefsFile.exists())
+            if (!sharedPrefsDir.exists() || !sharedPrefsDir.isDirectory || osPrefsFile.exists()) {
                 return
+            }
 
             val prefsFileList = sharedPrefsDir.listFiles() ?: return
 

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
@@ -1,6 +1,7 @@
 package com.onesignal.internal
 
 import android.content.Context
+import android.os.Build
 import com.onesignal.IOneSignal
 import com.onesignal.common.IDManager
 import com.onesignal.common.OneSignalUtils
@@ -19,6 +20,7 @@ import com.onesignal.core.internal.config.ConfigModelStore
 import com.onesignal.core.internal.operations.IOperationRepo
 import com.onesignal.core.internal.preferences.IPreferencesService
 import com.onesignal.core.internal.preferences.PreferenceOneSignalKeys
+import com.onesignal.core.internal.preferences.PreferenceStoreFix
 import com.onesignal.core.internal.preferences.PreferenceStores
 import com.onesignal.core.internal.startup.StartupService
 import com.onesignal.debug.IDebugManager
@@ -174,6 +176,8 @@ internal class OneSignalImp : IOneSignal, IServiceProvider {
         if (isInitialized) {
             return true
         }
+
+        PreferenceStoreFix.ensureNoObfuscatedPrefStore(context)
 
         // start the application service. This is called explicitly first because we want
         // to make sure it has the context provided on input, for all other startable services

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
@@ -1,7 +1,6 @@
 package com.onesignal.internal
 
 import android.content.Context
-import android.os.Build
 import com.onesignal.IOneSignal
 import com.onesignal.common.IDManager
 import com.onesignal.common.OneSignalUtils


### PR DESCRIPTION
# Description
## One Line Summary
Fix issue with migration from v4 to v5 when obfuscation is used by the app

## Details
The v5 SDK will read/write to a preference store called "OneSignal", it is [defined as a string ](https://github.com/OneSignal/OneSignal-Android-SDK/blob/user-model/main/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/preferences/IPreferencesService.kt#L155) so it is always expected a file at /data/data/<app_id>/shared_prefs/OneSignal.xml .  The v4 SDK however will read/write to a preference store defined as OneSignal.class.getSimpleName(); (see [here](https://github.com/OneSignal/OneSignal-Android-SDK/blob/main/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalPrefs.java#L59)).

When an app is using ProGuard (or similar) the OneSignal class name can be renamed, as a result the underlying preference store for v4 can be named anything.  So when going from v4 -> v5 (or even different builds of v4 to v4),  on startup the SDK does not find the preference store and believes it is starting "fresh", resulting in a new subscription for the device.

Since we don't know what name was used, the underlying fix is to scan the existing preference stores to find the correct one and rename it to "OneSignal.xml", which is the static name as of v5.

### Motivation
Desire to only have 1 subscription per device across app builds.

### Scope
This fix is a startup/initialization fix targeting devices that have a new app install migrating from SDK v4 to SDK v5.

# Testing

## Manual testing
1. On an emulator, run as a fresh install the OneSignal Example app on v4, but modifying the [PREFS_ONESIGNAL](https://github.com/OneSignal/OneSignal-Android-SDK/blob/main/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalPrefs.java#L59) value to a static string like "g3" (pick any string).  A new subscriber should be created when started.
2. On the same emulator and without uninstalling the v4 version, run the OneSignal example app on this version of the SDK.
3. When `OneSignal.initWithContext` is called the preference file should be appropriately renamed, and the subscriber created from the v4 SDK version is used by the v5 SDK.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/1901)
<!-- Reviewable:end -->
