### PR TITLE
initWithContext synchronization fix

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
@@ -250,10 +250,11 @@ internal class OneSignalImp : IOneSignal, IServiceProvider {
             startupService!!.bootstrap()
 
             if (forceCreateUser || !identityModelStore!!.model.hasProperty(IdentityConstants.ONESIGNAL_ID)) {
-                val legacyPlayerId = preferencesService!!.getString(
-                    PreferenceStores.ONESIGNAL,
-                    PreferenceOneSignalKeys.PREFS_LEGACY_PLAYER_ID
-                )
+                val legacyPlayerId =
+                    preferencesService!!.getString(
+                        PreferenceStores.ONESIGNAL,
+                        PreferenceOneSignalKeys.PREFS_LEGACY_PLAYER_ID,
+                    )
                 if (legacyPlayerId == null) {
                     Logging.debug("initWithContext: creating new device-scoped user")
                     createAndSwitchToNewUser()
@@ -293,7 +294,7 @@ internal class OneSignalImp : IOneSignal, IServiceProvider {
                         configModel!!.pushSubscriptionId = legacyPlayerId
                         subscriptionModelStore!!.add(
                             pushSubscriptionModel,
-                            ModelChangeTags.NO_PROPOGATE
+                            ModelChangeTags.NO_PROPOGATE,
                         )
                         suppressBackendOperation = true
                     }
@@ -304,13 +305,13 @@ internal class OneSignalImp : IOneSignal, IServiceProvider {
                         LoginUserFromSubscriptionOperation(
                             configModel!!.appId,
                             identityModelStore!!.model.onesignalId,
-                            legacyPlayerId
+                            legacyPlayerId,
                         ),
                     )
                     preferencesService!!.saveString(
                         PreferenceStores.ONESIGNAL,
                         PreferenceOneSignalKeys.PREFS_LEGACY_PLAYER_ID,
-                        null
+                        null,
                     )
                 }
             } else {
@@ -318,8 +319,8 @@ internal class OneSignalImp : IOneSignal, IServiceProvider {
                 operationRepo!!.enqueue(
                     RefreshUserOperation(
                         configModel!!.appId,
-                        identityModelStore!!.model.onesignalId
-                    )
+                        identityModelStore!!.model.onesignalId,
+                    ),
                 )
             }
 

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
@@ -172,14 +172,8 @@ internal class OneSignalImp : IOneSignal, IServiceProvider {
     ): Boolean {
         Logging.log(LogLevel.DEBUG, "initWithContext(context: $context, appId: $appId)")
 
-        // do not do this again if already initialized
-        if (isInitialized) {
-            Logging.log(LogLevel.DEBUG, "initWithContext: SDK already initialized")
-            return true
-        }
-
         synchronized(initLock) {
-            // check whether we've been initialized again, now that we have the lock
+            // do not do this again if already initialized
             if (isInitialized) {
                 Logging.log(LogLevel.DEBUG, "initWithContext: SDK already initialized")
                 return true

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
@@ -131,6 +131,7 @@ internal class OneSignalImp : IOneSignal, IServiceProvider {
     private var _consentRequired: Boolean? = null
     private var _consentGiven: Boolean? = null
     private var _disableGMSMissingPrompt: Boolean? = null
+    private val initLock: Any = Any()
     private val loginLock: Any = Any()
 
     private val listOfModules =
@@ -173,128 +174,161 @@ internal class OneSignalImp : IOneSignal, IServiceProvider {
 
         // do not do this again if already initialized
         if (isInitialized) {
+            Logging.log(LogLevel.DEBUG, "initWithContext: SDK already initialized")
             return true
         }
 
-        PreferenceStoreFix.ensureNoObfuscatedPrefStore(context)
-
-        // start the application service. This is called explicitly first because we want
-        // to make sure it has the context provided on input, for all other startable services
-        // to depend on if needed.
-        val applicationService = services.getService<IApplicationService>()
-        (applicationService as ApplicationService).start(context)
-
-        // Give the logging singleton access to the application service to support visual logging.
-        Logging.applicationService = applicationService
-
-        // get the current config model, if there is one
-        configModel = services.getService<ConfigModelStore>().model
-        sessionModel = services.getService<SessionModelStore>().model
-
-        // initWithContext is called by our internal services/receivers/activites but they do not provide
-        // an appId (they don't know it).  If the app has never called the external initWithContext
-        // prior to our services/receivers/activities we will blow up, as no appId has been established.
-        if (appId == null && !configModel!!.hasProperty(ConfigModel::appId.name)) {
-            Logging.warn("initWithContext called without providing appId, and no appId has been established!")
-            return false
-        }
-
-        var forceCreateUser = false
-        // if the app id was specified as input, update the config model with it
-        if (appId != null) {
-            if (!configModel!!.hasProperty(ConfigModel::appId.name) || configModel!!.appId != appId) {
-                forceCreateUser = true
+        synchronized(initLock) {
+            // check whether we've been initialized again, now that we have the lock
+            if (isInitialized) {
+                Logging.log(LogLevel.DEBUG, "initWithContext: SDK already initialized")
+                return true
             }
-            configModel!!.appId = appId
-        }
 
-        // if requires privacy consent was set prior to init, set it in the model now
-        if (_consentRequired != null) {
-            configModel!!.consentRequired = _consentRequired!!
-        }
+            Logging.log(LogLevel.DEBUG, "initWithContext: SDK initializing")
 
-        // if privacy consent was set prior to init, set it in the model now
-        if (_consentGiven != null) {
-            configModel!!.consentGiven = _consentGiven!!
-        }
+            PreferenceStoreFix.ensureNoObfuscatedPrefStore(context)
 
-        if (_disableGMSMissingPrompt != null) {
-            configModel!!.disableGMSMissingPrompt = _disableGMSMissingPrompt!!
-        }
+            // start the application service. This is called explicitly first because we want
+            // to make sure it has the context provided on input, for all other startable services
+            // to depend on if needed.
+            val applicationService = services.getService<IApplicationService>()
+            (applicationService as ApplicationService).start(context)
 
-        // "Inject" the services required by this main class
-        _location = services.getService()
-        _user = services.getService()
-        _session = services.getService()
-        iam = services.getService()
-        _notifications = services.getService()
-        operationRepo = services.getService()
-        propertiesModelStore = services.getService()
-        identityModelStore = services.getService()
-        subscriptionModelStore = services.getService()
-        preferencesService = services.getService()
+            // Give the logging singleton access to the application service to support visual logging.
+            Logging.applicationService = applicationService
 
-        // Instantiate and call the IStartableServices
-        startupService = services.getService()
-        startupService!!.bootstrap()
+            // get the current config model, if there is one
+            configModel = services.getService<ConfigModelStore>().model
+            sessionModel = services.getService<SessionModelStore>().model
 
-        if (forceCreateUser || !identityModelStore!!.model.hasProperty(IdentityConstants.ONESIGNAL_ID)) {
-            val legacyPlayerId = preferencesService!!.getString(PreferenceStores.ONESIGNAL, PreferenceOneSignalKeys.PREFS_LEGACY_PLAYER_ID)
-            if (legacyPlayerId == null) {
-                Logging.debug("initWithContext: creating new device-scoped user")
-                createAndSwitchToNewUser()
-                operationRepo!!.enqueue(
-                    LoginUserOperation(
-                        configModel!!.appId,
-                        identityModelStore!!.model.onesignalId,
-                        identityModelStore!!.model.externalId,
-                    ),
-                )
-            } else {
-                Logging.debug("initWithContext: creating user linked to subscription $legacyPlayerId")
+            // initWithContext is called by our internal services/receivers/activites but they do not provide
+            // an appId (they don't know it).  If the app has never called the external initWithContext
+            // prior to our services/receivers/activities we will blow up, as no appId has been established.
+            if (appId == null && !configModel!!.hasProperty(ConfigModel::appId.name)) {
+                Logging.warn("initWithContext called without providing appId, and no appId has been established!")
+                return false
+            }
 
-                // Converting a 4.x SDK to the 5.x SDK.  We pull the legacy user sync values to create the subscription model, then enqueue
-                // a specialized `LoginUserFromSubscriptionOperation`, which will drive fetching/refreshing of the local user
-                // based on the subscription ID we do have.
-                val legacyUserSyncString =
-                    preferencesService!!.getString(
-                        PreferenceStores.ONESIGNAL,
-                        PreferenceOneSignalKeys.PREFS_LEGACY_USER_SYNCVALUES,
-                    )
-                var suppressBackendOperation = false
-
-                if (legacyUserSyncString != null) {
-                    val legacyUserSyncJSON = JSONObject(legacyUserSyncString)
-                    val notificationTypes = legacyUserSyncJSON.getInt("notification_types")
-
-                    val pushSubscriptionModel = SubscriptionModel()
-                    pushSubscriptionModel.id = legacyPlayerId
-                    pushSubscriptionModel.type = SubscriptionType.PUSH
-                    pushSubscriptionModel.optedIn = notificationTypes != SubscriptionStatus.NO_PERMISSION.value && notificationTypes != SubscriptionStatus.UNSUBSCRIBE.value
-                    pushSubscriptionModel.address = legacyUserSyncJSON.safeString("identifier") ?: ""
-                    pushSubscriptionModel.status = SubscriptionStatus.fromInt(notificationTypes) ?: SubscriptionStatus.NO_PERMISSION
-                    configModel!!.pushSubscriptionId = legacyPlayerId
-                    subscriptionModelStore!!.add(pushSubscriptionModel, ModelChangeTags.NO_PROPOGATE)
-                    suppressBackendOperation = true
+            var forceCreateUser = false
+            // if the app id was specified as input, update the config model with it
+            if (appId != null) {
+                if (!configModel!!.hasProperty(ConfigModel::appId.name) || configModel!!.appId != appId) {
+                    forceCreateUser = true
                 }
-
-                createAndSwitchToNewUser(suppressBackendOperation = suppressBackendOperation)
-
-                operationRepo!!.enqueue(
-                    LoginUserFromSubscriptionOperation(configModel!!.appId, identityModelStore!!.model.onesignalId, legacyPlayerId),
-                )
-                preferencesService!!.saveString(PreferenceStores.ONESIGNAL, PreferenceOneSignalKeys.PREFS_LEGACY_PLAYER_ID, null)
+                configModel!!.appId = appId
             }
-        } else {
-            Logging.debug("initWithContext: using cached user ${identityModelStore!!.model.onesignalId}")
-            operationRepo!!.enqueue(RefreshUserOperation(configModel!!.appId, identityModelStore!!.model.onesignalId))
+
+            // if requires privacy consent was set prior to init, set it in the model now
+            if (_consentRequired != null) {
+                configModel!!.consentRequired = _consentRequired!!
+            }
+
+            // if privacy consent was set prior to init, set it in the model now
+            if (_consentGiven != null) {
+                configModel!!.consentGiven = _consentGiven!!
+            }
+
+            if (_disableGMSMissingPrompt != null) {
+                configModel!!.disableGMSMissingPrompt = _disableGMSMissingPrompt!!
+            }
+
+            // "Inject" the services required by this main class
+            _location = services.getService()
+            _user = services.getService()
+            _session = services.getService()
+            iam = services.getService()
+            _notifications = services.getService()
+            operationRepo = services.getService()
+            propertiesModelStore = services.getService()
+            identityModelStore = services.getService()
+            subscriptionModelStore = services.getService()
+            preferencesService = services.getService()
+
+            // Instantiate and call the IStartableServices
+            startupService = services.getService()
+            startupService!!.bootstrap()
+
+            if (forceCreateUser || !identityModelStore!!.model.hasProperty(IdentityConstants.ONESIGNAL_ID)) {
+                val legacyPlayerId = preferencesService!!.getString(
+                    PreferenceStores.ONESIGNAL,
+                    PreferenceOneSignalKeys.PREFS_LEGACY_PLAYER_ID
+                )
+                if (legacyPlayerId == null) {
+                    Logging.debug("initWithContext: creating new device-scoped user")
+                    createAndSwitchToNewUser()
+                    operationRepo!!.enqueue(
+                        LoginUserOperation(
+                            configModel!!.appId,
+                            identityModelStore!!.model.onesignalId,
+                            identityModelStore!!.model.externalId,
+                        ),
+                    )
+                } else {
+                    Logging.debug("initWithContext: creating user linked to subscription $legacyPlayerId")
+
+                    // Converting a 4.x SDK to the 5.x SDK.  We pull the legacy user sync values to create the subscription model, then enqueue
+                    // a specialized `LoginUserFromSubscriptionOperation`, which will drive fetching/refreshing of the local user
+                    // based on the subscription ID we do have.
+                    val legacyUserSyncString =
+                        preferencesService!!.getString(
+                            PreferenceStores.ONESIGNAL,
+                            PreferenceOneSignalKeys.PREFS_LEGACY_USER_SYNCVALUES,
+                        )
+                    var suppressBackendOperation = false
+
+                    if (legacyUserSyncString != null) {
+                        val legacyUserSyncJSON = JSONObject(legacyUserSyncString)
+                        val notificationTypes = legacyUserSyncJSON.getInt("notification_types")
+
+                        val pushSubscriptionModel = SubscriptionModel()
+                        pushSubscriptionModel.id = legacyPlayerId
+                        pushSubscriptionModel.type = SubscriptionType.PUSH
+                        pushSubscriptionModel.optedIn =
+                            notificationTypes != SubscriptionStatus.NO_PERMISSION.value && notificationTypes != SubscriptionStatus.UNSUBSCRIBE.value
+                        pushSubscriptionModel.address =
+                            legacyUserSyncJSON.safeString("identifier") ?: ""
+                        pushSubscriptionModel.status = SubscriptionStatus.fromInt(notificationTypes)
+                            ?: SubscriptionStatus.NO_PERMISSION
+                        configModel!!.pushSubscriptionId = legacyPlayerId
+                        subscriptionModelStore!!.add(
+                            pushSubscriptionModel,
+                            ModelChangeTags.NO_PROPOGATE
+                        )
+                        suppressBackendOperation = true
+                    }
+
+                    createAndSwitchToNewUser(suppressBackendOperation = suppressBackendOperation)
+
+                    operationRepo!!.enqueue(
+                        LoginUserFromSubscriptionOperation(
+                            configModel!!.appId,
+                            identityModelStore!!.model.onesignalId,
+                            legacyPlayerId
+                        ),
+                    )
+                    preferencesService!!.saveString(
+                        PreferenceStores.ONESIGNAL,
+                        PreferenceOneSignalKeys.PREFS_LEGACY_PLAYER_ID,
+                        null
+                    )
+                }
+            } else {
+                Logging.debug("initWithContext: using cached user ${identityModelStore!!.model.onesignalId}")
+                operationRepo!!.enqueue(
+                    RefreshUserOperation(
+                        configModel!!.appId,
+                        identityModelStore!!.model.onesignalId
+                    )
+                )
+            }
+
+            startupService!!.start()
+
+            isInitialized = true
+
+            return true
         }
-
-        startupService!!.start()
-
-        isInitialized = true
-
-        return true
     }
 
     override fun login(
@@ -304,7 +338,7 @@ internal class OneSignalImp : IOneSignal, IServiceProvider {
         Logging.log(LogLevel.DEBUG, "login(externalId: $externalId, jwtBearerToken: $jwtBearerToken)")
 
         if (!isInitialized) {
-            Logging.log(LogLevel.ERROR, "Must call 'initWithContext' before using Login")
+            throw Exception("Must call 'initWithContext' before 'login'")
         }
 
         var currentIdentityExternalId: String? = null
@@ -378,8 +412,7 @@ internal class OneSignalImp : IOneSignal, IServiceProvider {
         Logging.log(LogLevel.DEBUG, "logout()")
 
         if (!isInitialized) {
-            Logging.log(LogLevel.ERROR, "Must call 'initWithContext' before using Login")
-            return
+            throw Exception("Must call 'initWithContext' before 'logout'")
         }
 
         // only allow one login/logout at a time

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/internal/OneSignalImpTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/internal/OneSignalImpTests.kt
@@ -9,7 +9,7 @@ import io.kotest.runner.junit4.KotestTestRunner
 import org.junit.runner.RunWith
 
 @RunWith(KotestTestRunner::class)
-class OneSignalImplTests : FunSpec({
+class OneSignalImpTests : FunSpec({
     beforeAny {
         Logging.logLevel = LogLevel.NONE
     }
@@ -19,9 +19,10 @@ class OneSignalImplTests : FunSpec({
         val os = OneSignalImp()
 
         // When
-        val exception = shouldThrowUnit<Exception> {
-            os.login("login-id")
-        }
+        val exception =
+            shouldThrowUnit<Exception> {
+                os.login("login-id")
+            }
 
         // Then
         exception.message shouldBe "Must call 'initWithContext' before 'login'"
@@ -32,9 +33,10 @@ class OneSignalImplTests : FunSpec({
         val os = OneSignalImp()
 
         // When
-        val exception = shouldThrowUnit<Exception> {
-            os.logout()
-        }
+        val exception =
+            shouldThrowUnit<Exception> {
+                os.logout()
+            }
 
         // Then
         exception.message shouldBe "Must call 'initWithContext' before 'logout'"

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/internal/OneSignalImplTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/internal/OneSignalImplTests.kt
@@ -1,0 +1,42 @@
+package com.onesignal.internal
+
+import com.onesignal.debug.LogLevel
+import com.onesignal.debug.internal.logging.Logging
+import io.kotest.assertions.throwables.shouldThrowUnit
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.runner.junit4.KotestTestRunner
+import org.junit.runner.RunWith
+
+@RunWith(KotestTestRunner::class)
+class OneSignalImplTests : FunSpec({
+    beforeAny {
+        Logging.logLevel = LogLevel.NONE
+    }
+
+    test("attempting login before initWithContext throws exception") {
+        // Given
+        val os = OneSignalImp()
+
+        // When
+        val exception = shouldThrowUnit<Exception> {
+            os.login("login-id")
+        }
+
+        // Then
+        exception.message shouldBe "Must call 'initWithContext' before 'login'"
+    }
+
+    test("attempting logout before initWithContext throws exception") {
+        // Given
+        val os = OneSignalImp()
+
+        // When
+        val exception = shouldThrowUnit<Exception> {
+            os.logout()
+        }
+
+        // Then
+        exception.message shouldBe "Must call 'initWithContext' before 'logout'"
+    }
+})


### PR DESCRIPTION
# Description
## One Line Summary
Synchronize initWithContext so initialization occurs once, and prevent login/logout from being called before `initWithContext`.

## Details
It is possible for an app to call `initWithContext` on different threads at the same time, causing the initialization logic to run more than once.  If this were to happen, the internal state of the SDK will not be correct.  For example, the initialization code drives calling `registerActivityLifecycleCallbacks`, we don't want to have 2 of those!

This change synchronizes the initialization logic so the SDK can only go through `initWithContext` once.  Additionally, the `login` and `logout` functions now throw exceptions rather than log an error, if called before `initWithContext`.  This is done to raise programming errors to the caller, rather than swallow them in the logs.

### Motivation
No specific issues to point to, although the belief is this is a concurrency issue that needs to be resolved.

### Scope
This change is limited to initialization and login/logout flows.

# Testing
## Unit testing
2 additional unit tests were added to demonstrate the expected behavior of calling login/logout before calling `initWithContext`.

## Manual testing
Run the OneSignal Example App on an emulator to ensure initialization of the SDK continues to operate successfully.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/1903)
<!-- Reviewable:end -->
