### PR TITLE
Update push subscription model properties between sessions

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
@@ -1,7 +1,10 @@
 package com.onesignal.internal
 
 import android.content.Context
+import android.os.Build
 import com.onesignal.IOneSignal
+import com.onesignal.common.AndroidUtils
+import com.onesignal.common.DeviceUtils
 import com.onesignal.common.IDManager
 import com.onesignal.common.OneSignalUtils
 import com.onesignal.common.modeling.ModelChangeTags
@@ -285,6 +288,12 @@ internal class OneSignalImp : IOneSignal, IServiceProvider {
                             legacyUserSyncJSON.safeString("identifier") ?: ""
                         pushSubscriptionModel.status = SubscriptionStatus.fromInt(notificationTypes)
                             ?: SubscriptionStatus.NO_PERMISSION
+
+                        pushSubscriptionModel.sdk = OneSignalUtils.SDK_VERSION
+                        pushSubscriptionModel.deviceOS = Build.VERSION.RELEASE
+                        pushSubscriptionModel.carrier = DeviceUtils.getCarrierName(services.getService<IApplicationService>().appContext) ?: ""
+                        pushSubscriptionModel.appVersion = AndroidUtils.getAppVersion(services.getService<IApplicationService>().appContext) ?: ""
+
                         configModel!!.pushSubscriptionId = legacyPlayerId
                         subscriptionModelStore!!.add(
                             pushSubscriptionModel,
@@ -466,6 +475,10 @@ internal class OneSignalImp : IOneSignal, IServiceProvider {
         newPushSubscription.optedIn = currentPushSubscription?.optedIn ?: true
         newPushSubscription.address = currentPushSubscription?.address ?: ""
         newPushSubscription.status = currentPushSubscription?.status ?: SubscriptionStatus.NO_PERMISSION
+        newPushSubscription.sdk = OneSignalUtils.SDK_VERSION
+        newPushSubscription.deviceOS = Build.VERSION.RELEASE
+        newPushSubscription.carrier = DeviceUtils.getCarrierName(services.getService<IApplicationService>().appContext) ?: ""
+        newPushSubscription.appVersion = AndroidUtils.getAppVersion(services.getService<IApplicationService>().appContext) ?: ""
 
         // ensure we always know this devices push subscription ID
         configModel!!.pushSubscriptionId = newPushSubscription.id

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/RefreshUserOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/RefreshUserOperationExecutor.kt
@@ -106,6 +106,10 @@ internal class RefreshUserOperationExecutor(
                         }
                     }
                 subscriptionModel.optedIn = subscriptionModel.status != SubscriptionStatus.UNSUBSCRIBE
+                subscriptionModel.sdk = subscription.sdk ?: ""
+                subscriptionModel.deviceOS = subscription.deviceOS ?: ""
+                subscriptionModel.carrier = subscription.carrier ?: ""
+                subscriptionModel.appVersion = subscription.appVersion ?: ""
 
                 // We only add a push subscription if it is this device's push subscription.
                 if (subscriptionModel.type != SubscriptionType.PUSH || subscriptionModel.id == _configModelStore.model.pushSubscriptionId) {

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/subscriptions/ISubscriptionManager.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/subscriptions/ISubscriptionManager.kt
@@ -11,7 +11,7 @@ interface ISubscriptionManager : IEventNotifier<ISubscriptionChangedHandler> {
 
     fun addEmailSubscription(email: String)
 
-    fun addOrUpdatePushSubscription(
+    fun addOrUpdatePushSubscriptionToken(
         pushToken: String?,
         pushTokenStatus: SubscriptionStatus,
     )

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/subscriptions/SubscriptionModel.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/subscriptions/SubscriptionModel.kt
@@ -108,4 +108,30 @@ class SubscriptionModel : Model() {
         set(value) {
             setEnumProperty(::status.name, value)
         }
+
+    // Prior to v5.0.5, we did not save the following properties, so we must default get() to ""
+    
+    var sdk: String
+        get() = getStringProperty(::sdk.name) { "" }
+        set(value) {
+            setStringProperty(::sdk.name, value)
+        }
+
+    var deviceOS: String
+        get() = getStringProperty(::deviceOS.name) { "" }
+        set(value) {
+            setStringProperty(::deviceOS.name, value)
+        }
+
+    var carrier: String
+        get() = getStringProperty(::carrier.name) { "" }
+        set(value) {
+            setStringProperty(::carrier.name, value)
+        }
+
+    var appVersion: String
+        get() = getStringProperty(::appVersion.name) { "" }
+        set(value) {
+            setStringProperty(::appVersion.name, value)
+        }
 }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/subscriptions/SubscriptionModel.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/subscriptions/SubscriptionModel.kt
@@ -110,7 +110,6 @@ class SubscriptionModel : Model() {
         }
 
     // Prior to v5.0.5, we did not save the following properties, so we must default get() to ""
-    
     var sdk: String
         get() = getStringProperty(::sdk.name) { "" }
         set(value) {

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/subscriptions/SubscriptionModelStore.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/subscriptions/SubscriptionModelStore.kt
@@ -1,8 +1,34 @@
 package com.onesignal.user.internal.subscriptions
 
+import com.onesignal.common.modeling.ModelChangeTags
 import com.onesignal.common.modeling.SimpleModelStore
 import com.onesignal.core.internal.preferences.IPreferencesService
 
 open class SubscriptionModelStore(prefs: IPreferencesService) : SimpleModelStore<SubscriptionModel>({
     SubscriptionModel()
-}, "subscriptions", prefs)
+}, "subscriptions", prefs) {
+    override fun replaceAll(
+        models: List<SubscriptionModel>,
+        tag: String,
+    ) {
+        if (tag != ModelChangeTags.HYDRATE) {
+            return super.replaceAll(models, tag)
+        }
+        // When hydrating an existing push subscription model, use existing device properties
+        synchronized(models) {
+            for (model in models) {
+                if (model.type == SubscriptionType.PUSH) {
+                    val existingPushModel = get(model.id)
+                    if (existingPushModel != null) {
+                        model.sdk = existingPushModel.sdk
+                        model.deviceOS = existingPushModel.deviceOS
+                        model.carrier = existingPushModel.carrier
+                        model.appVersion = existingPushModel.appVersion
+                    }
+                    break
+                }
+            }
+            super.replaceAll(models, tag)
+        }
+    }
+}

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/subscriptions/impl/SubscriptionManager.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/subscriptions/impl/SubscriptionManager.kt
@@ -55,7 +55,7 @@ internal class SubscriptionManager(
         addSubscriptionToModels(SubscriptionType.SMS, sms)
     }
 
-    override fun addOrUpdatePushSubscription(
+    override fun addOrUpdatePushSubscriptionToken(
         pushToken: String?,
         pushTokenStatus: SubscriptionStatus,
     ) {

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/subscriptions/impl/SubscriptionManager.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/subscriptions/impl/SubscriptionManager.kt
@@ -1,11 +1,18 @@
 package com.onesignal.user.internal.subscriptions.impl
 
+import android.os.Build
+import com.onesignal.common.AndroidUtils
+import com.onesignal.common.DeviceUtils
 import com.onesignal.common.IDManager
+import com.onesignal.common.OneSignalUtils
 import com.onesignal.common.events.EventProducer
 import com.onesignal.common.modeling.IModelStoreChangeHandler
 import com.onesignal.common.modeling.ModelChangedArgs
+import com.onesignal.core.internal.application.IApplicationService
 import com.onesignal.debug.LogLevel
 import com.onesignal.debug.internal.logging.Logging
+import com.onesignal.session.internal.session.ISessionLifecycleHandler
+import com.onesignal.session.internal.session.ISessionService
 import com.onesignal.user.internal.EmailSubscription
 import com.onesignal.user.internal.PushSubscription
 import com.onesignal.user.internal.SmsSubscription
@@ -32,8 +39,10 @@ import com.onesignal.user.subscriptions.PushSubscriptionChangedState
  * subscription model.
  */
 internal class SubscriptionManager(
+    private val _applicationService: IApplicationService,
+    private val _sessionService: ISessionService,
     private val _subscriptionModelStore: SubscriptionModelStore,
-) : ISubscriptionManager, IModelStoreChangeHandler<SubscriptionModel> {
+) : ISubscriptionManager, IModelStoreChangeHandler<SubscriptionModel>, ISessionLifecycleHandler {
     private val events = EventProducer<ISubscriptionChangedHandler>()
     override var subscriptions: SubscriptionList = SubscriptionList(listOf(), UninitializedPushSubscription())
     override val pushSubscriptionModel: SubscriptionModel
@@ -45,7 +54,16 @@ internal class SubscriptionManager(
         }
 
         _subscriptionModelStore.subscribe(this)
+        _sessionService.subscribe(this)
     }
+
+    override fun onSessionStarted() {
+        refreshPushSubscriptionState()
+    }
+
+    override fun onSessionActive() { }
+
+    override fun onSessionEnded(duration: Long) { }
 
     override fun addEmailSubscription(email: String) {
         addSubscriptionToModels(SubscriptionType.EMAIL, email)
@@ -213,6 +231,31 @@ internal class SubscriptionManager(
             SubscriptionType.PUSH -> {
                 PushSubscription(subscriptionModel)
             }
+        }
+    }
+
+    /**
+     * Called when app has gained focus and the subscription state should be refreshed.
+     */
+    private fun refreshPushSubscriptionState() {
+        val pushSub = subscriptions.push
+
+        if (pushSub is UninitializedPushSubscription) {
+            return
+        }
+        val pushSubModel = (pushSub as Subscription).model
+
+        pushSubModel.sdk = OneSignalUtils.SDK_VERSION
+        pushSubModel.deviceOS = Build.VERSION.RELEASE
+
+        val carrier = DeviceUtils.getCarrierName(_applicationService.appContext)
+        carrier?.let {
+            pushSubModel.carrier = carrier
+        }
+
+        val appVersion = AndroidUtils.getAppVersion(_applicationService.appContext)
+        appVersion?.let {
+            pushSubModel.appVersion = appVersion
         }
     }
 }

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/subscriptions/SubscriptionManagerTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/subscriptions/SubscriptionManagerTests.kt
@@ -134,7 +134,7 @@ class SubscriptionManagerTests : FunSpec({
         val subscriptionManager = SubscriptionManager(mockSubscriptionModelStore)
 
         // When
-        subscriptionManager.addOrUpdatePushSubscription("pushToken", SubscriptionStatus.SUBSCRIBED)
+        subscriptionManager.addOrUpdatePushSubscriptionToken("pushToken", SubscriptionStatus.SUBSCRIBED)
 
         // Then
         verify {
@@ -170,7 +170,7 @@ class SubscriptionManagerTests : FunSpec({
         val subscriptionManager = SubscriptionManager(mockSubscriptionModelStore)
 
         // When
-        subscriptionManager.addOrUpdatePushSubscription("pushToken2", SubscriptionStatus.FIREBASE_FCM_ERROR_IOEXCEPTION_OTHER)
+        subscriptionManager.addOrUpdatePushSubscriptionToken("pushToken2", SubscriptionStatus.FIREBASE_FCM_ERROR_IOEXCEPTION_OTHER)
 
         // Then
         pushSubscription.address shouldBe "pushToken2"

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/subscriptions/SubscriptionManagerTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/subscriptions/SubscriptionManagerTests.kt
@@ -2,6 +2,8 @@ package com.onesignal.user.internal.subscriptions
 
 import com.onesignal.common.modeling.ModelChangeTags
 import com.onesignal.common.modeling.ModelChangedArgs
+import com.onesignal.core.internal.application.IApplicationService
+import com.onesignal.session.internal.session.ISessionService
 import com.onesignal.user.internal.subscriptions.impl.SubscriptionManager
 import com.onesignal.user.subscriptions.ISmsSubscription
 import io.kotest.core.spec.style.FunSpec
@@ -24,6 +26,8 @@ class SubscriptionManagerTests : FunSpec({
     test("initializes subscriptions from model store") {
         // Given
         val mockSubscriptionModelStore = mockk<SubscriptionModelStore>()
+        val mockApplicationService = mockk<IApplicationService>()
+        val mockSessionService = mockk<ISessionService>(relaxed = true)
         val pushSubscription = SubscriptionModel()
         pushSubscription.id = "subscription1"
         pushSubscription.type = SubscriptionType.PUSH
@@ -49,7 +53,7 @@ class SubscriptionManagerTests : FunSpec({
         every { mockSubscriptionModelStore.subscribe(any()) } just runs
         every { mockSubscriptionModelStore.list() } returns listOfSubscriptions
 
-        val subscriptionManager = SubscriptionManager(mockSubscriptionModelStore)
+        val subscriptionManager = SubscriptionManager(mockApplicationService, mockSessionService, mockSubscriptionModelStore)
 
         // When
         val subscriptions = subscriptionManager.subscriptions
@@ -71,13 +75,15 @@ class SubscriptionManagerTests : FunSpec({
     test("add email subscription adds to model store") {
         // Given
         val mockSubscriptionModelStore = mockk<SubscriptionModelStore>()
+        val mockApplicationService = mockk<IApplicationService>()
+        val mockSessionService = mockk<ISessionService>(relaxed = true)
 
         val listOfSubscriptions = listOf<SubscriptionModel>()
         every { mockSubscriptionModelStore.subscribe(any()) } just runs
         every { mockSubscriptionModelStore.add(any()) } just runs
         every { mockSubscriptionModelStore.list() } returns listOfSubscriptions
 
-        val subscriptionManager = SubscriptionManager(mockSubscriptionModelStore)
+        val subscriptionManager = SubscriptionManager(mockApplicationService, mockSessionService, mockSubscriptionModelStore)
 
         // When
         subscriptionManager.addEmailSubscription("name@company.com")
@@ -98,13 +104,15 @@ class SubscriptionManagerTests : FunSpec({
     test("add sms subscription adds to model store") {
         // Given
         val mockSubscriptionModelStore = mockk<SubscriptionModelStore>()
+        val mockApplicationService = mockk<IApplicationService>()
+        val mockSessionService = mockk<ISessionService>(relaxed = true)
 
         val listOfSubscriptions = listOf<SubscriptionModel>()
         every { mockSubscriptionModelStore.subscribe(any()) } just runs
         every { mockSubscriptionModelStore.add(any()) } just runs
         every { mockSubscriptionModelStore.list() } returns listOfSubscriptions
 
-        val subscriptionManager = SubscriptionManager(mockSubscriptionModelStore)
+        val subscriptionManager = SubscriptionManager(mockApplicationService, mockSessionService, mockSubscriptionModelStore)
 
         // When
         subscriptionManager.addSmsSubscription("+15558675309")
@@ -125,13 +133,15 @@ class SubscriptionManagerTests : FunSpec({
     test("add push subscription adds to model store") {
         // Given
         val mockSubscriptionModelStore = mockk<SubscriptionModelStore>()
+        val mockApplicationService = mockk<IApplicationService>()
+        val mockSessionService = mockk<ISessionService>(relaxed = true)
 
         val listOfSubscriptions = listOf<SubscriptionModel>()
         every { mockSubscriptionModelStore.subscribe(any()) } just runs
         every { mockSubscriptionModelStore.add(any()) } just runs
         every { mockSubscriptionModelStore.list() } returns listOfSubscriptions
 
-        val subscriptionManager = SubscriptionManager(mockSubscriptionModelStore)
+        val subscriptionManager = SubscriptionManager(mockApplicationService, mockSessionService, mockSubscriptionModelStore)
 
         // When
         subscriptionManager.addOrUpdatePushSubscriptionToken("pushToken", SubscriptionStatus.SUBSCRIBED)
@@ -152,6 +162,8 @@ class SubscriptionManagerTests : FunSpec({
     test("update push subscription updates model store") {
         // Given
         val mockSubscriptionModelStore = mockk<SubscriptionModelStore>()
+        val mockApplicationService = mockk<IApplicationService>()
+        val mockSessionService = mockk<ISessionService>(relaxed = true)
 
         val pushSubscription = SubscriptionModel()
         pushSubscription.id = "subscription1"
@@ -167,7 +179,7 @@ class SubscriptionManagerTests : FunSpec({
         every { mockSubscriptionModelStore.list() } returns listOfSubscriptions
         every { mockSubscriptionModelStore.get("subscription1") } returns pushSubscription
 
-        val subscriptionManager = SubscriptionManager(mockSubscriptionModelStore)
+        val subscriptionManager = SubscriptionManager(mockApplicationService, mockSessionService, mockSubscriptionModelStore)
 
         // When
         subscriptionManager.addOrUpdatePushSubscriptionToken("pushToken2", SubscriptionStatus.FIREBASE_FCM_ERROR_IOEXCEPTION_OTHER)
@@ -180,6 +192,8 @@ class SubscriptionManagerTests : FunSpec({
     test("remove email subscription removes from model store") {
         // Given
         val mockSubscriptionModelStore = mockk<SubscriptionModelStore>()
+        val mockApplicationService = mockk<IApplicationService>()
+        val mockSessionService = mockk<ISessionService>(relaxed = true)
 
         val emailSubscription = SubscriptionModel()
         emailSubscription.id = "subscription1"
@@ -195,7 +209,7 @@ class SubscriptionManagerTests : FunSpec({
         every { mockSubscriptionModelStore.list() } returns listOfSubscriptions
         every { mockSubscriptionModelStore.remove("subscription1") } just runs
 
-        val subscriptionManager = SubscriptionManager(mockSubscriptionModelStore)
+        val subscriptionManager = SubscriptionManager(mockApplicationService, mockSessionService, mockSubscriptionModelStore)
 
         // When
         subscriptionManager.removeEmailSubscription("name@company.com")
@@ -207,6 +221,8 @@ class SubscriptionManagerTests : FunSpec({
     test("remove sms subscription removes from model store") {
         // Given
         val mockSubscriptionModelStore = mockk<SubscriptionModelStore>()
+        val mockApplicationService = mockk<IApplicationService>()
+        val mockSessionService = mockk<ISessionService>(relaxed = true)
 
         val emailSubscription = SubscriptionModel()
         emailSubscription.id = "subscription1"
@@ -222,7 +238,7 @@ class SubscriptionManagerTests : FunSpec({
         every { mockSubscriptionModelStore.list() } returns listOfSubscriptions
         every { mockSubscriptionModelStore.remove("subscription1") } just runs
 
-        val subscriptionManager = SubscriptionManager(mockSubscriptionModelStore)
+        val subscriptionManager = SubscriptionManager(mockApplicationService, mockSessionService, mockSubscriptionModelStore)
 
         // When
         subscriptionManager.removeSmsSubscription("+18458675309")
@@ -241,6 +257,8 @@ class SubscriptionManagerTests : FunSpec({
         smsSubscription.address = "+18458675309"
 
         val mockSubscriptionModelStore = mockk<SubscriptionModelStore>()
+        val mockApplicationService = mockk<IApplicationService>()
+        val mockSessionService = mockk<ISessionService>(relaxed = true)
         val listOfSubscriptions = listOf<SubscriptionModel>()
 
         every { mockSubscriptionModelStore.subscribe(any()) } just runs
@@ -248,7 +266,7 @@ class SubscriptionManagerTests : FunSpec({
 
         val spySubscriptionChangedHandler = spyk<ISubscriptionChangedHandler>()
 
-        val subscriptionManager = SubscriptionManager(mockSubscriptionModelStore)
+        val subscriptionManager = SubscriptionManager(mockApplicationService, mockSessionService, mockSubscriptionModelStore)
         subscriptionManager.subscribe(spySubscriptionChangedHandler)
 
         // When
@@ -280,6 +298,8 @@ class SubscriptionManagerTests : FunSpec({
         emailSubscription.address = "+18458675309"
 
         val mockSubscriptionModelStore = mockk<SubscriptionModelStore>()
+        val mockApplicationService = mockk<IApplicationService>()
+        val mockSessionService = mockk<ISessionService>(relaxed = true)
         val listOfSubscriptions = listOf(emailSubscription)
 
         every { mockSubscriptionModelStore.subscribe(any()) } just runs
@@ -287,7 +307,7 @@ class SubscriptionManagerTests : FunSpec({
 
         val spySubscriptionChangedHandler = spyk<ISubscriptionChangedHandler>()
 
-        val subscriptionManager = SubscriptionManager(mockSubscriptionModelStore)
+        val subscriptionManager = SubscriptionManager(mockApplicationService, mockSessionService, mockSubscriptionModelStore)
         subscriptionManager.subscribe(spySubscriptionChangedHandler)
 
         // When
@@ -321,6 +341,8 @@ class SubscriptionManagerTests : FunSpec({
         smsSubscription.address = "+18458675309"
 
         val mockSubscriptionModelStore = mockk<SubscriptionModelStore>()
+        val mockApplicationService = mockk<IApplicationService>()
+        val mockSessionService = mockk<ISessionService>(relaxed = true)
         val listOfSubscriptions = listOf(smsSubscription)
 
         every { mockSubscriptionModelStore.subscribe(any()) } just runs
@@ -328,7 +350,7 @@ class SubscriptionManagerTests : FunSpec({
 
         val spySubscriptionChangedHandler = spyk<ISubscriptionChangedHandler>()
 
-        val subscriptionManager = SubscriptionManager(mockSubscriptionModelStore)
+        val subscriptionManager = SubscriptionManager(mockApplicationService, mockSessionService, mockSubscriptionModelStore)
         subscriptionManager.subscribe(spySubscriptionChangedHandler)
 
         // When

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/listeners/DeviceRegistrationListener.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/listeners/DeviceRegistrationListener.kt
@@ -71,7 +71,7 @@ internal class DeviceRegistrationListener(
 
         if (pushSubscription.token.isNotEmpty()) {
             val permission = _notificationsManager.permission
-            _subscriptionManager.addOrUpdatePushSubscription(
+            _subscriptionManager.addOrUpdatePushSubscriptionToken(
                 null,
                 if (permission) SubscriptionStatus.SUBSCRIBED else SubscriptionStatus.NO_PERMISSION,
             )
@@ -79,7 +79,7 @@ internal class DeviceRegistrationListener(
             suspendifyOnThread {
                 val pushTokenAndStatus = _pushTokenManager.retrievePushToken()
                 val permission = _notificationsManager.permission
-                _subscriptionManager.addOrUpdatePushSubscription(
+                _subscriptionManager.addOrUpdatePushSubscriptionToken(
                     pushTokenAndStatus.token,
                     if (permission) pushTokenAndStatus.status else SubscriptionStatus.NO_PERMISSION,
                 )


### PR DESCRIPTION
# Description
## One Line Summary
On new sessions, we will update the server with changes to app version, sdk version, carrier, and device OS.

## Details

### Motivation
If app version or sdk version is updated, these updates should be sent to the server.

### Scope
**1. Add these properties to Subscription Model**
First, these properties should exist on Subscription Model. It now has `sdk`, `deviceOS`, `carrier`, and `appVersion` as properties so that they can persist. When push subscription models are initialized, these properties are now also set on the model.

**2. On new sessions, check for subscription property updates**
Let the SubscriptionManager refresh the push subscription model on new sessions.

**3. Don't hydrate this info for a push subscription model**
When hydrating an existing push subscription model, use existing local data for these properties.
This information should always come from the local device. The reason for this change is that on a new session, we may detect a change to one of these properties and we do not want to overwrite it with old remote data from the get_user response.

There are other ways to implement this PR, and open to discussing another approach.

# Testing
## Unit testing
None, should consider adding a test that can test this.

## Manual testing
Android 33 Emulator
- Tested new app installs
- Tested with logging in
- Tested an existing app installation that does not have this data saved, and then running a new session with the changes in this PR. It will enqueue extraneous update subscription operations because it had no previous data to compare, but this is acceptable as the SDK is on a new version anyway. Eventually, there will be a single update request sent with a snapshot of the push subscription model.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/1922)
<!-- Reviewable:end -->
