### PR TITLE
Update trigger model to always drive a change event

### DIFF
--- a/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/triggers/TriggerModel.kt
+++ b/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/triggers/TriggerModel.kt
@@ -18,6 +18,6 @@ class TriggerModel : Model() {
     var value: Any
         get() = getAnyProperty(::value.name) { "" }
         set(value) {
-            setAnyProperty(::value.name, value)
+            setAnyProperty(::value.name, value, forceChange = true)
         }
 }


### PR DESCRIPTION
# Description
## One Line Summary
Update trigger model to always drive a change event when changing the value. This allows IAMs to be re-evaluated even when setting a trigger to the same value.

## Details
When calling `OneSignal.getInAppMessages().addTrigger(...)` the expectation is it will drive the evaluation of whether to display an IAM regardless of the trigger key/value.  For v5 triggers are built on top of the model infrastructure, and evaluation is triggered when a model is changed.  This means if a trigger key/value already exists, setting it to the same value would not drive IAM evaluation.  This fix updates this specific case to drive IAM evaluation regardless of whether the value has changed.

### Motivation
v5 add trigger functionality to be identical to previous SDK behaviors.

### Scope
This fix is limited to when IAMs are evaluated, specifically through calling `addTrigger` when the trigger key already exists.

# Testing

## Manual testing
Ran the example app in an emulator, setting the same trigger key/value pair multiple times ensuring an IAM based on that trigger is displayed each time.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [x] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/1925)
<!-- Reviewable:end -->
