### PR TITLE
[Player Model] Fix notification permission compile error

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationPermissionController.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationPermissionController.kt
@@ -41,7 +41,7 @@ object NotificationPermissionController : PermissionsActivity.PermissionCallback
         PermissionsActivity.registerAsCallback(PERMISSION_TYPE, this)
     }
 
-    val supportsNativePrompt: Boolean by lazy {
+    private val supportsNativePrompt: Boolean by lazy {
         Build.VERSION.SDK_INT > 32 &&
             OSUtils.getTargetSdkVersion(OneSignal.appContext) > 32
     }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationPermissionController.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationPermissionController.kt
@@ -28,7 +28,6 @@
 package com.onesignal
 
 import android.os.Build
-import androidx.annotation.ChecksSdkIntAtLeast
 
 object NotificationPermissionController : PermissionsActivity.PermissionCallback {
     private const val PERMISSION_TYPE = "NOTIFICATION"
@@ -42,7 +41,6 @@ object NotificationPermissionController : PermissionsActivity.PermissionCallback
         PermissionsActivity.registerAsCallback(PERMISSION_TYPE, this)
     }
 
-    @ChecksSdkIntAtLeast(api = 33)
     val supportsNativePrompt: Boolean by lazy {
         Build.VERSION.SDK_INT > 32 &&
             OSUtils.getTargetSdkVersion(OneSignal.appContext) > 32

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationPermissionController.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationPermissionController.kt
@@ -43,7 +43,7 @@ object NotificationPermissionController : PermissionsActivity.PermissionCallback
     }
 
     @ChecksSdkIntAtLeast(api = 33)
-    val supportsNativePrompt: Boolean by lazy = {
+    val supportsNativePrompt: Boolean by lazy {
         Build.VERSION.SDK_INT > 32 &&
             OSUtils.getTargetSdkVersion(OneSignal.appContext) > 32
     }


### PR DESCRIPTION
# Description
## One Line Summary
Fix a compile error due to a syntax error introduced in PR #1848.

## Details
Also cleaned up some warnings related to an unneeded annotation and scoping to private.

### Motivation
Fix compile error so we can release the fix from PR #1848 and so future release can be made.

### Scope
Only fixing issues related to `NotificationPermissionController.supportsNativePrompt`.
Fixes #1930

# Testing
## Unit testing

## Manual testing
Tested on Android 14 emulator, ensure it prompts for notifications.

# Affected code checklist
   - [X] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
      - pre-existing test failure "uses-sdk:minSdkVersion 17 cannot be smaller than version 19 declared in library [com.google.firebase:firebase-messaging:23.0.0]"
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/1933)
<!-- Reviewable:end -->
