### PR TITLE
[Player Model] Fix project errors

### DIFF
--- a/OneSignalSDK/build.gradle
+++ b/OneSignalSDK/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         huaweiAgconnectVersion = '1.6.2.300'
         huaweiHMSPushVersion = '6.3.0.304'
         huaweiHMSLocationVersion = '4.0.0.300'
-        kotlinVersion = '1.4.32'
+        kotlinVersion = '1.5.32'
         ktlintVersion = '11.0.0'
         detektVersion = '1.21.0'
     }

--- a/OneSignalSDK/unittest/build.gradle
+++ b/OneSignalSDK/unittest/build.gradle
@@ -1,6 +1,6 @@
 ext {
     buildVersions = [
-            minSdkVersion: 17,
+            minSdkVersion: 19,
             versionCode: 1,
             versionName: '1.0'
     ]


### PR DESCRIPTION
# Description
## One Line Summary
Fix build errors the prevent building with Android Studio 2022.3.1 and running the tests at all.

## Details
* Fixed Android Studio 2022.3.1 build issue - Upgraded to Kotlin 1.5
* Fixed unit tests - set `minSdkVersion: 19` in tests (from 17).

### Motivation
We want to allow building with modern Android Studio versions and we want to test to run again to prevent silently missing bugs.

### Scope
Only fixing project building and test building issues in Player Model (v4).

# Testing
## Unit testing
## Manual testing
I am able to build and run on Android Studio 2022.3.1 on Windows 11 23H2 with an Android 14 emulator after these fixes.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/1934)
<!-- Reviewable:end -->
