### PR TITLE
Crash on bindService with broadcast receiver context

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/purchases/impl/TrackGooglePurchase.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/purchases/impl/TrackGooglePurchase.kt
@@ -132,7 +132,8 @@ internal class TrackGooglePurchase(
             mServiceConn = serviceConn
             val serviceIntent = Intent("com.android.vending.billing.InAppBillingService.BIND")
             serviceIntent.setPackage("com.android.vending")
-            _applicationService.appContext.bindService(serviceIntent, serviceConn, Context.BIND_AUTO_CREATE)
+            // Invoke 'applicationContext' to avoid exceptions caused by 'ReceiverRestrictedContext' when using 'bindService'.
+            _applicationService.appContext.applicationContext.bindService(serviceIntent, serviceConn, Context.BIND_AUTO_CREATE)
         } else if (mIInAppBillingService != null) {
             queryBoughtItems()
         }

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/receivers/BootUpReceiver.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/receivers/BootUpReceiver.kt
@@ -37,7 +37,7 @@ class BootUpReceiver : BroadcastReceiver() {
         context: Context,
         intent: Intent,
     ) {
-        if (!OneSignal.initWithContext(context)) {
+        if (!OneSignal.initWithContext(context.applicationContext)) {
             return
         }
 

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/receivers/FCMBroadcastReceiver.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/receivers/FCMBroadcastReceiver.kt
@@ -23,7 +23,7 @@ class FCMBroadcastReceiver : BroadcastReceiver() {
             return
         }
 
-        if (!OneSignal.initWithContext(context)) {
+        if (!OneSignal.initWithContext(context.applicationContext)) {
             return
         }
 

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/receivers/UpgradeReceiver.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/receivers/UpgradeReceiver.kt
@@ -46,7 +46,7 @@ class UpgradeReceiver : BroadcastReceiver() {
             return
         }
 
-        if (!OneSignal.initWithContext(context)) {
+        if (!OneSignal.initWithContext(context.applicationContext)) {
             return
         }
 


### PR DESCRIPTION
# Description
## One Line Summary
Change broadcast receivers that calls initWithContext with the context from onReceive. 

## Details
The context carried by BroadcastReceiver.onReceive on certain older Android devices may be ReceiverRestrictedContext, disallowed from invoking bindService. However, this context type no longer exists in newer Android API levels, in which the method now carries the application context. Therefore, it explained why the observed crash affects some, but not all, devices. Accessing context.applicationContext retrieves the actual application context that registered the receiver and is permitted to call bindService.

### Motivation
Fixing a critical bug that causes the client app to crash.

### Scope
Customers that were not affected will continue remain unaffected because context.applicationContext is the same as context in devices with newer Android versions

# Testing
## Unit testing
Unable to reproduce the issue, since ReceiverRestrictedContext is no longer accessible

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/1935)
<!-- Reviewable:end -->
