### PR TITLE
[Player model] Handle DeadSystemException

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/ApplicationInfoHelper.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/ApplicationInfoHelper.kt
@@ -1,0 +1,41 @@
+package com.onesignal
+
+import android.annotation.TargetApi
+import android.content.Context
+import android.content.pm.ApplicationInfo
+import android.content.pm.PackageManager
+import android.os.DeadSystemException
+import android.util.AndroidException
+
+class ApplicationInfoHelper {
+    companion object {
+        // Safe to cache as nothing can change the app while it is running.
+        private var cachedInfo: ApplicationInfo? = null
+
+        @TargetApi(24)
+        fun getInfo(context: Context): ApplicationInfo? {
+            if (cachedInfo != null) {
+                return cachedInfo
+            }
+
+            val packageManager = context.packageManager
+            return try {
+                // Using this instead of context.applicationInfo as it's metaData is always null
+                cachedInfo = packageManager.getApplicationInfo(
+                    context.packageName,
+                    PackageManager.GET_META_DATA,
+                )
+                cachedInfo
+            } catch (e: AndroidException) {
+                // Suppressing DeadSystemException as the app is already dying for
+                // another reason and allowing this exception to bubble up would
+                // create a red herring for app developers. We still re-throw
+                // others, as we don't want to silently hide other issues.
+                if (e !is DeadSystemException) {
+                    throw e
+                }
+                null
+            }
+        }
+    }
+}

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/BadgeCountUpdater.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/BadgeCountUpdater.java
@@ -29,7 +29,6 @@ package com.onesignal;
 
 import android.content.Context;
 import android.content.pm.ApplicationInfo;
-import android.content.pm.PackageManager;
 import android.database.Cursor;
 import android.os.Build;
 import android.os.Bundle;
@@ -51,19 +50,20 @@ class BadgeCountUpdater {
       if (badgesEnabled != -1)
          return (badgesEnabled == 1);
 
-      try {
-         ApplicationInfo ai = context.getPackageManager().getApplicationInfo(context.getPackageName(), PackageManager.GET_META_DATA);
-         Bundle bundle = ai.metaData;
-         if (bundle != null) {
-            String defaultStr = bundle.getString("com.onesignal.BadgeCount");
-            badgesEnabled = "DISABLE".equals(defaultStr) ? 0 : 1;
-         }
-         else
-            badgesEnabled = 1;
-      } catch (PackageManager.NameNotFoundException e) {
+      ApplicationInfo ai = ApplicationInfoHelper.Companion.getInfo(context);
+      if (ai == null) {
          badgesEnabled = 0;
-         OneSignal.Log(OneSignal.LOG_LEVEL.ERROR, "Error reading meta-data tag 'com.onesignal.BadgeCount'. Disabling badge setting.", e);
+         OneSignal.Log(OneSignal.LOG_LEVEL.ERROR, "Error reading meta-data tag 'com.onesignal.BadgeCount'. Disabling badge setting.");
+         return false;
       }
+
+      Bundle bundle = ai.metaData;
+      if (bundle != null) {
+         String defaultStr = bundle.getString("com.onesignal.BadgeCount");
+         badgesEnabled = "DISABLE".equals(defaultStr) ? 0 : 1;
+      }
+      else
+         badgesEnabled = 1;
 
       return (badgesEnabled == 1);
    }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotification.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotification.java
@@ -33,6 +33,7 @@ import android.app.PendingIntent;
 import android.content.ContentValues;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.ApplicationInfo;
 import android.content.res.Resources;
 import android.database.Cursor;
 import android.graphics.Bitmap;
@@ -133,6 +134,15 @@ class GenerateNotification {
       if (OSUtils.isRunningOnMainThread())
          throw new OSThrowable.OSMainThreadException("Process for showing a notification should never been done on Main Thread!");
    }
+
+   private static CharSequence getApplicationLabel() {
+      ApplicationInfo applicationInfo = ApplicationInfoHelper.Companion.getInfo(currentContext);
+      if (applicationInfo == null) {
+         return "";
+      }
+
+      return currentContext.getPackageManager().getApplicationLabel(applicationInfo);
+   }
    
    private static CharSequence getTitle(JSONObject fcmJson) {
       CharSequence title = fcmJson.optString("title", null);
@@ -140,7 +150,7 @@ class GenerateNotification {
       if (title != null)
          return title;
 
-      return currentContext.getPackageManager().getApplicationLabel(currentContext.getApplicationInfo());
+      return getApplicationLabel();
    }
 
    private static PendingIntent getNewDismissActionPendingIntent(int requestCode, Intent intent) {
@@ -615,7 +625,7 @@ class GenerateNotification {
          //   Default small and large icons are used instead of the payload options to enforce this.
          summaryBuilder.setContentIntent(summaryContentIntent)
               .setDeleteIntent(summaryDeleteIntent)
-              .setContentTitle(currentContext.getPackageManager().getApplicationLabel(currentContext.getApplicationInfo()))
+              .setContentTitle(getApplicationLabel())
               .setContentText(summaryMessage)
               .setNumber(notificationCount)
               .setSmallIcon(getDefaultSmallIconId())
@@ -735,7 +745,7 @@ class GenerateNotification {
       //   Default small and large icons are used instead of the payload options to enforce this.
       summaryBuilder.setContentIntent(summaryContentIntent)
             .setDeleteIntent(summaryDeleteIntent)
-            .setContentTitle(currentContext.getPackageManager().getApplicationLabel(currentContext.getApplicationInfo()))
+            .setContentTitle(getApplicationLabel())
             .setContentText(summaryMessage)
             .setNumber(grouplessNotifCount)
             .setSmallIcon(getDefaultSmallIconId())

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/GooglePlayServicesUpgradePrompt.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/GooglePlayServicesUpgradePrompt.java
@@ -4,7 +4,6 @@ import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.PendingIntent;
 import android.content.DialogInterface;
-import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 
 import com.google.android.gms.common.GoogleApiAvailability;
@@ -13,18 +12,23 @@ import static com.onesignal.OSUtils.getResourceString;
 
 class GooglePlayServicesUpgradePrompt {
    private static final int PLAY_SERVICES_RESOLUTION_REQUEST = 9_000;
-
    private static boolean isGooglePlayStoreInstalled() {
-      try {
-         PackageManager pm = OneSignal.appContext.getPackageManager();
-         PackageInfo info = pm.getPackageInfo(GoogleApiAvailability.GOOGLE_PLAY_SERVICES_PACKAGE, PackageManager.GET_META_DATA);
-         String label = (String) info.applicationInfo.loadLabel(pm);
-         return (!label.equals("Market"));
-      } catch (PackageManager.NameNotFoundException e) {
-         // Google Play Store might not be installed, ignore exception if so
+      GetPackageInfoResult result =
+          PackageInfoHelper.Companion.getInfo(
+              OneSignal.appContext,
+              GoogleApiAvailability.GOOGLE_PLAY_SERVICES_PACKAGE,
+              PackageManager.GET_META_DATA
+          );
+      if (!result.getSuccessful()) {
+         return false;
+      }
+      if (result.getPackageInfo() == null) {
+         return false;
       }
 
-      return false;
+      PackageManager pm = OneSignal.appContext.getPackageManager();
+      String label = (String) result.getPackageInfo().applicationInfo.loadLabel(pm);
+      return !label.equals("Market");
    }
 
    static void showUpdateGPSDialog() {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NavigateToAndroidSettingsForNotifications.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NavigateToAndroidSettingsForNotifications.kt
@@ -38,7 +38,10 @@ object NavigateToAndroidSettingsForNotifications {
 
         // for Android 5-7
         intent.putExtra("app_package", context.getPackageName())
-        intent.putExtra("app_uid", context.getApplicationInfo().uid)
+        val applicationInfo = ApplicationInfoHelper.getInfo(context)
+        if (applicationInfo != null) {
+            intent.putExtra("app_uid", applicationInfo.uid)
+        }
 
         // for Android 8 and above
         intent.putExtra("android.provider.extra.APP_PACKAGE", context.getPackageName())

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSUtils.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSUtils.java
@@ -271,13 +271,22 @@ class OSUtils {
    }
 
    private static boolean packageInstalledAndEnabled(@NonNull String packageName) {
-      try {
-         PackageManager pm = OneSignal.appContext.getPackageManager();
-         PackageInfo info = pm.getPackageInfo(packageName, PackageManager.GET_META_DATA);
-         return info.applicationInfo.enabled;
-      } catch (PackageManager.NameNotFoundException e) {
+      GetPackageInfoResult result =
+           PackageInfoHelper.Companion.getInfo(
+                OneSignal.appContext,
+                packageName,
+                PackageManager.GET_META_DATA
+           );
+      if (!result.getSuccessful()) {
          return false;
       }
+
+      PackageInfo info = result.getPackageInfo();
+      if (info == null) {
+         return false;
+      }
+
+      return info.applicationInfo.enabled;
    }
 
    // TODO: Maybe able to switch to GoogleApiAvailability.isGooglePlayServicesAvailable to simplify

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSUtils.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSUtils.java
@@ -416,15 +416,11 @@ class OSUtils {
    }
 
    static Bundle getManifestMetaBundle(Context context) {
-      ApplicationInfo ai;
-      try {
-         ai = context.getPackageManager().getApplicationInfo(context.getPackageName(), PackageManager.GET_META_DATA);
-         return ai.metaData;
-      } catch (PackageManager.NameNotFoundException e) {
-         Log(OneSignal.LOG_LEVEL.ERROR, "Manifest application info not found", e);
+      ApplicationInfo ai = ApplicationInfoHelper.Companion.getInfo(context);
+      if (ai == null) {
+         return null;
       }
-
-      return null;
+      return ai.metaData;
    }
 
    static boolean getManifestMetaBoolean(Context context, String metaName) {
@@ -496,16 +492,11 @@ class OSUtils {
    }
 
    static int getTargetSdkVersion(Context context) {
-      String packageName = context.getPackageName();
-      PackageManager packageManager = context.getPackageManager();
-      try {
-         ApplicationInfo applicationInfo = packageManager.getApplicationInfo(packageName, 0);
-         return applicationInfo.targetSdkVersion;
-      } catch (PackageManager.NameNotFoundException e) {
-         e.printStackTrace();
+      ApplicationInfo applicationInfo = ApplicationInfoHelper.Companion.getInfo(context);
+      if (applicationInfo == null) {
+         return Build.VERSION_CODES.ICE_CREAM_SANDWICH_MR1;
       }
-
-      return Build.VERSION_CODES.ICE_CREAM_SANDWICH_MR1;
+      return applicationInfo.targetSdkVersion;
    }
 
    static boolean isValidResourceName(String name) {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -1502,7 +1502,6 @@ public class OneSignal {
 
    private static void registerUserTask() throws JSONException {
       String packageName = appContext.getPackageName();
-      PackageManager packageManager = appContext.getPackageManager();
 
       JSONObject deviceInfo = new JSONObject();
 
@@ -1516,11 +1515,10 @@ public class OneSignal {
       deviceInfo.put("sdk_type", sdkType);
       deviceInfo.put("android_package", packageName);
       deviceInfo.put("device_model", Build.MODEL);
-
-      try {
-         deviceInfo.put("game_version", packageManager.getPackageInfo(packageName, 0).versionCode);
-      } catch (PackageManager.NameNotFoundException e) {}
-
+      Integer appVersion = getAppVersion();
+      if (appVersion != null) {
+         deviceInfo.put("game_version", appVersion);
+      }
       deviceInfo.put("net_type", osUtils.getNetType());
       deviceInfo.put("carrier", osUtils.getCarrierName());
       deviceInfo.put("rooted", RootToolsInternalMethods.isRooted());
@@ -1541,6 +1539,21 @@ public class OneSignal {
       OneSignalStateSynchronizer.readyToUpdate(true);
 
       waitingToPostStateSync = false;
+   }
+
+   private static Integer getAppVersion() {
+      String packageName = appContext.getPackageName();
+      GetPackageInfoResult result =
+           PackageInfoHelper.Companion.getInfo(
+                OneSignal.appContext,
+                packageName,
+                0
+           );
+      if (!result.getSuccessful() || result.getPackageInfo() == null) {
+         return null;
+      }
+
+      return result.getPackageInfo().versionCode;
    }
 
    public static void setSMSNumber(@NonNull final String smsNumber, OSSMSUpdateHandler callback) {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -921,17 +921,16 @@ public class OneSignal {
    }
 
    private static void setupPrivacyConsent(Context context) {
-      try {
-         ApplicationInfo ai = context.getPackageManager().getApplicationInfo(context.getPackageName(), PackageManager.GET_META_DATA);
-         Bundle bundle = ai.metaData;
-
-         // Read the current privacy consent setting from AndroidManifest.xml
-         String requireSetting = bundle.getString("com.onesignal.PrivacyConsent");
-         if (requireSetting != null)
-            setRequiresUserPrivacyConsent("ENABLE".equalsIgnoreCase(requireSetting));
-      } catch (Throwable t) {
-         t.printStackTrace();
+      ApplicationInfo ai = ApplicationInfoHelper.Companion.getInfo(context);
+      if (ai == null) {
+         return;
       }
+      Bundle bundle = ai.metaData;
+
+      // Read the current privacy consent setting from AndroidManifest.xml
+      String requireSetting = bundle.getString("com.onesignal.PrivacyConsent");
+      if (requireSetting != null)
+         setRequiresUserPrivacyConsent("ENABLE".equalsIgnoreCase(requireSetting));
    }
 
    private static void handleAppIdChange() {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/PackageInfoHelper.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/PackageInfoHelper.kt
@@ -1,0 +1,50 @@
+package com.onesignal
+
+import android.annotation.TargetApi
+import android.content.Context
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
+import android.os.DeadSystemException
+import android.util.AndroidException
+
+data class GetPackageInfoResult(
+    // Check this value first, if false ignore other properties
+    //   - If false this means Android throw an error, so it's not possible
+    //     to know if the app we are checking is even installed.
+    val successful: Boolean,
+
+    // Raw PackageInfo from Android API
+    // NOTE: Ignore this value if successful == false
+    // Will be null if package is not installed.
+    val packageInfo: PackageInfo?,
+)
+
+class PackageInfoHelper {
+    companion object {
+        @TargetApi(24)
+        fun getInfo(appContext: Context, packageName: String, flags: Int): GetPackageInfoResult {
+            val packageManager = appContext.packageManager
+            return try {
+                GetPackageInfoResult(
+                    true,
+                    packageManager.getPackageInfo(
+                        packageName,
+                        flags,
+                    ),
+                )
+            } catch (e: PackageManager.NameNotFoundException) {
+                // Expected if package is not installed on the device.
+                GetPackageInfoResult(true, null)
+            } catch (e: AndroidException) {
+                // Suppressing DeadSystemException as the app is already dying for
+                // another reason and allowing this exception to bubble up would
+                // create a red herring for app developers. We still re-throw
+                // others, as we don't want to silently hide other issues.
+                if (e !is DeadSystemException) {
+                    throw e
+                }
+                GetPackageInfoResult(false, null)
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Description
## One Line Summary
Catch `DeadSystemException` to prevent red herring crash reports.

## Details

### Motivation
`DeadSystemException` happens after a the app is in a bad state, not the root cause. Suppressing these as they are a red herring.

### Scope
Wrap known Android API that throw `DeadSystemException` in helper functions to handle this exception. This includes; `getApplicationInfo`, `getPackageInfo`, and `isHuaweiMobileServicesAvailable` (seems to use `getPackageInfo` under its hood).

### What is a DeadSystemException
From [Android's docs](https://developer.android.com/reference/android/os/DeadSystemException):
> The core Android system has died and is going through a runtime restart. All running apps will be promptly killed.

Since this exception is not the fault of the app (or SDK) there isn't anything the app (or SDK) can do to recover from such a state. Catching and ignoring these won't improve the end-user experience since the app is already being killed, however doing so will clean up the noise from crash statistics, hopefully allowing the developer to discover the root cause.

# Testing
## Unit testing

## Manual testing
Tested with an Android 14 emulator, device subscribes and receives notifications. Also ensured disabling badges works. Also on a Android 6.0 emulator, ensuring the notification title defaults to the app label correctly.

# Affected code checklist
   - [X] Notifications
      - [X] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
       - Some tests are failing on main already.
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/1937)
<!-- Reviewable:end -->
