### PR TITLE
Fix: Update startGetLocation to only run if location is shared

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/preferences/IPreferencesService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/preferences/IPreferencesService.kt
@@ -194,6 +194,11 @@ object PreferenceOneSignalKeys {
      */
     const val PREFS_OS_LAST_LOCATION_TIME = "OS_LAST_LOCATION_TIME"
 
+    /**
+     * (Boolean) Whether location should be shared with OneSignal.
+     */
+    const val PREFS_OS_LOCATION_SHARED = "OS_LOCATION_SHARED"
+
     // Permissions
 
     /**

--- a/OneSignalSDK/onesignal/location/src/main/java/com/onesignal/location/internal/LocationManager.kt
+++ b/OneSignalSDK/onesignal/location/src/main/java/com/onesignal/location/internal/LocationManager.kt
@@ -4,6 +4,7 @@ import android.os.Build
 import com.onesignal.common.AndroidUtils
 import com.onesignal.common.threading.suspendifyOnThread
 import com.onesignal.core.internal.application.IApplicationService
+import com.onesignal.core.internal.preferences.IPreferencesService
 import com.onesignal.core.internal.startup.IStartableService
 import com.onesignal.debug.LogLevel
 import com.onesignal.debug.internal.logging.Logging
@@ -22,12 +23,14 @@ internal class LocationManager(
     private val _capturer: ILocationCapturer,
     private val _locationController: ILocationController,
     private val _locationPermissionController: LocationPermissionController,
+    private val _prefs: IPreferencesService,
 ) : ILocationManager, IStartableService, ILocationPermissionChangedHandler {
-    private var _isShared: Boolean = false
+    private var _isShared: Boolean = _prefs.getBool("OneSignal", "PREFS_OS_LOCATION_SHARED", false)!!
     override var isShared
         get() = _isShared
         set(value) {
             Logging.debug("LocationManager.setIsShared(value: $value)")
+            _prefs.saveBool("OneSignal", "PREFS_OS_LOCATION_SHARED", value)
             _isShared = value
         }
 

--- a/OneSignalSDK/onesignal/location/src/main/java/com/onesignal/location/internal/LocationManager.kt
+++ b/OneSignalSDK/onesignal/location/src/main/java/com/onesignal/location/internal/LocationManager.kt
@@ -179,13 +179,18 @@ internal class LocationManager(
 
     // Started from this class or PermissionActivity
     private suspend fun startGetLocation() {
-        Logging.debug("LocationManager.startGetLocation()") // with lastLocation: " + lastLocation)
-        try {
-            if (!_locationController.start()) {
-                Logging.warn("LocationManager.startGetLocation: not possible, no location dependency found")
+        if (isShared) {
+            Logging.debug("LocationManager.startGetLocation()") // with lastLocation: " + lastLocation)
+            try {
+                if (!_locationController.start()) {
+                    Logging.warn("LocationManager.startGetLocation: not possible, no location dependency found")
+                }
+            } catch (t: Throwable) {
+                Logging.warn(
+                    "LocationManager.startGetLocation: Location permission exists but there was an error initializing: ",
+                    t
+                )
             }
-        } catch (t: Throwable) {
-            Logging.warn("LocationManager.startGetLocation: Location permission exists but there was an error initializing: ", t)
         }
     }
 }

--- a/OneSignalSDK/onesignal/location/src/main/java/com/onesignal/location/internal/LocationManager.kt
+++ b/OneSignalSDK/onesignal/location/src/main/java/com/onesignal/location/internal/LocationManager.kt
@@ -76,7 +76,7 @@ internal class LocationManager(
         var result = false
         withContext(Dispatchers.Main) {
             if (!isShared) {
-                return@withContext false
+                Logging.error("Location permissions must be granted by setting isShared to true")
             }
 
             val hasFinePermissionGranted =

--- a/OneSignalSDK/onesignal/location/src/main/java/com/onesignal/location/internal/LocationManager.kt
+++ b/OneSignalSDK/onesignal/location/src/main/java/com/onesignal/location/internal/LocationManager.kt
@@ -32,6 +32,8 @@ internal class LocationManager(
             Logging.debug("LocationManager.setIsShared(value: $value)")
             _prefs.saveBool("OneSignal", "PREFS_OS_LOCATION_SHARED", value)
             _isShared = value
+
+            onLocationPermissionChanged(value)
         }
 
     override fun start() {

--- a/OneSignalSDK/onesignal/location/src/main/java/com/onesignal/location/internal/LocationManager.kt
+++ b/OneSignalSDK/onesignal/location/src/main/java/com/onesignal/location/internal/LocationManager.kt
@@ -188,7 +188,7 @@ internal class LocationManager(
             } catch (t: Throwable) {
                 Logging.warn(
                     "LocationManager.startGetLocation: Location permission exists but there was an error initializing: ",
-                    t
+                    t,
                 )
             }
         }

--- a/OneSignalSDK/onesignal/location/src/main/java/com/onesignal/location/internal/LocationManager.kt
+++ b/OneSignalSDK/onesignal/location/src/main/java/com/onesignal/location/internal/LocationManager.kt
@@ -179,18 +179,20 @@ internal class LocationManager(
 
     // Started from this class or PermissionActivity
     private suspend fun startGetLocation() {
-        if (isShared) {
-            Logging.debug("LocationManager.startGetLocation()") // with lastLocation: " + lastLocation)
-            try {
-                if (!_locationController.start()) {
-                    Logging.warn("LocationManager.startGetLocation: not possible, no location dependency found")
-                }
-            } catch (t: Throwable) {
-                Logging.warn(
-                    "LocationManager.startGetLocation: Location permission exists but there was an error initializing: ",
-                    t,
-                )
+        if (!isShared) {
+            return
+        }
+
+        Logging.debug("LocationManager.startGetLocation()") // with lastLocation: " + lastLocation)
+        try {
+            if (!_locationController.start()) {
+                Logging.warn("LocationManager.startGetLocation: not possible, no location dependency found")
             }
+        } catch (t: Throwable) {
+            Logging.warn(
+                "LocationManager.startGetLocation: Location permission exists but there was an error initializing: ",
+                t,
+            )
         }
     }
 }

--- a/OneSignalSDK/onesignal/location/src/main/java/com/onesignal/location/internal/LocationManager.kt
+++ b/OneSignalSDK/onesignal/location/src/main/java/com/onesignal/location/internal/LocationManager.kt
@@ -5,6 +5,8 @@ import com.onesignal.common.AndroidUtils
 import com.onesignal.common.threading.suspendifyOnThread
 import com.onesignal.core.internal.application.IApplicationService
 import com.onesignal.core.internal.preferences.IPreferencesService
+import com.onesignal.core.internal.preferences.PreferenceOneSignalKeys
+import com.onesignal.core.internal.preferences.PreferenceStores
 import com.onesignal.core.internal.startup.IStartableService
 import com.onesignal.debug.LogLevel
 import com.onesignal.debug.internal.logging.Logging
@@ -25,12 +27,12 @@ internal class LocationManager(
     private val _locationPermissionController: LocationPermissionController,
     private val _prefs: IPreferencesService,
 ) : ILocationManager, IStartableService, ILocationPermissionChangedHandler {
-    private var _isShared: Boolean = _prefs.getBool("OneSignal", "PREFS_OS_LOCATION_SHARED", false)!!
+    private var _isShared: Boolean = _prefs.getBool(PreferenceStores.ONESIGNAL, PreferenceOneSignalKeys.PREFS_OS_LOCATION_SHARED, false)!!
     override var isShared
         get() = _isShared
         set(value) {
             Logging.debug("LocationManager.setIsShared(value: $value)")
-            _prefs.saveBool("OneSignal", "PREFS_OS_LOCATION_SHARED", value)
+            _prefs.saveBool(PreferenceStores.ONESIGNAL, PreferenceOneSignalKeys.PREFS_OS_LOCATION_SHARED, value)
             _isShared = value
 
             onLocationPermissionChanged(value)
@@ -76,7 +78,7 @@ internal class LocationManager(
         var result = false
         withContext(Dispatchers.Main) {
             if (!isShared) {
-                Logging.error("Location permissions must be granted by setting isShared to true")
+                Logging.warn("Requesting location permission, but location sharing must also be enabled by setting isShared to true")
             }
 
             val hasFinePermissionGranted =


### PR DESCRIPTION
# Description
## One Line Summary
Update startGetLocation to only run if location is shared

## Details

### Motivation
In #1910 it was reported that when `OneSignal.Location.setShared(false)` but location permission is granted through a custom UI, OneSignal is still accessing and recording the device's location. Adding a conditional before `startGetLocation` to check whether `isShared` is true will prevent OneSignal from accessing the device's location when `setShared` is false.

# Testing
## Manual testing
The following steps were followed on and Android 14 emulator to recreate and test the fix:

1. Add [native code](https://developer.android.com/develop/sensors-and-location/location/permissions#java) to request/grant location permission.
2. Set `OneSignal.Location.setShared(false)`
3. Restart app and observe that location is shared in OneSignal dashboard
4. Add conditional to `startGetLocation`
5. On a new device, request location permission natively
6. Restart app and observe that location is not shared in OneSignal dashboard

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [X] Location
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/1942)
<!-- Reviewable:end -->
