### PR TITLE
DON't MERGE: creates Concurrent Modification Exception

### DIFF
--- a/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/model/MainActivityViewModel.java
+++ b/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/model/MainActivityViewModel.java
@@ -563,7 +563,8 @@ public class MainActivityViewModel implements ActivityViewModel, IPushSubscripti
 
     private void setupTagsLayout() {
         setupTagRecyclerView();
-
+        System.out.println("❌ calling requestPermission within setupTagsLayout");
+        OneSignal.getNotifications().requestPermission(false, Continue.with(r -> {}));
         addTagButton.setOnClickListener(v -> dialog.createAddPairAlertDialog("Add Tag", ProfileUtil.FieldType.TAG, new AddPairAlertDialogCallback() {
             @Override
             public void onSuccess(Pair<String, Object> pair) {

--- a/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/InAppMessagesManager.kt
+++ b/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/InAppMessagesManager.kt
@@ -1,6 +1,7 @@
 package com.onesignal.inAppMessages.internal
 
 import android.app.AlertDialog
+import com.onesignal.OneSignal
 import com.onesignal.common.AndroidUtils
 import com.onesignal.common.IDManager
 import com.onesignal.common.JSONUtils
@@ -338,6 +339,8 @@ internal class InAppMessagesManager(
     }
 
     private suspend fun attemptToShowInAppMessage() {
+        println("❌ calling requestPermission within attemptToShowInAppMessage")
+        var resp = OneSignal.Notifications.requestPermission(false);
         // We need to wait for system conditions to be the correct ones
         if (!_applicationService.waitUntilSystemConditionsAvailable()) {
             Logging.warn("InAppMessagesManager.attemptToShowInAppMessage: In app message not showing due to system condition not correct")


### PR DESCRIPTION
- permission has to be off
- crashes most of the time when app is starting up

Stacktrace:
```
2023-12-19 11:59:59.103  7373-7373  AndroidRuntime          com.onesignal.sdktest                E  FATAL EXCEPTION: main
                                                                                                    Process: com.onesignal.sdktest, PID: 7373
                                                                                                    java.util.ConcurrentModificationException
                                                                                                    	at java.util.ArrayList$Itr.next(ArrayList.java:860)
                                                                                                    	at com.onesignal.common.events.EventProducer.fire(EventProducer.kt:49)
                                                                                                    	at com.onesignal.core.internal.application.impl.ApplicationService.setCurrent(ApplicationService.kt:51)
                                                                                                    	at com.onesignal.core.internal.application.impl.ApplicationService.onActivityStarted(ApplicationService.kt:151)
                                                                                                    	at android.app.Application.dispatchActivityStarted(Application.java:401)
                                                                                                    	at android.app.Activity.dispatchActivityStarted(Activity.java:1404)
                                                                                                    	at android.app.Activity.onStart(Activity.java:1922)
                                                                                                    	at android.app.Instrumentation.callActivityOnStart(Instrumentation.java:1543)
                                                                                                    	at android.app.Activity.performStart(Activity.java:8330)
                                                                                                    	at android.app.ActivityThread.handleStartActivity(ActivityThread.java:3670)
                                                                                                    	at android.app.servertransaction.TransactionExecutor.performLifecycleSequence(TransactionExecutor.java:221)
                                                                                                    	at android.app.servertransaction.TransactionExecutor.cycleToPath(TransactionExecutor.java:201)
                                                                                                    	at android.app.servertransaction.TransactionExecutor.executeLifecycleState(TransactionExecutor.java:173)
                                                                                                    	at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:97)
                                                                                                    	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2307)
                                                                                                    	at android.os.Handler.dispatchMessage(Handler.java:106)
                                                                                                    	at android.os.Looper.loopOnce(Looper.java:201)
                                                                                                    	at android.os.Looper.loop(Looper.java:288)
                                                                                                    	at android.app.ActivityThread.main(ActivityThread.java:7872)
                                                                                                    	at java.lang.reflect.Method.invoke(Native Method)
                                                                                                    	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
                                                                                                    	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:936)
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/1948)
<!-- Reviewable:end -->
