### PR TITLE
Remove ACCESS_COARSE_LOCATION permission

### DIFF
--- a/OneSignalSDK/onesignal/location/src/main/AndroidManifest.xml
+++ b/OneSignalSDK/onesignal/location/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest>
 
-    <!-- At a minimum the location module requires course permission, the app has the option
-         to also include ACCESS_FINE_LOCATION and/or ACCESS_BACKGROUND_LOCATION -->
+    <!-- At a minimum the location module requires the app to include ACCESS_COARSE_LOCATION,
+         with the option to also include ACCESS_FINE_LOCATION and/or ACCESS_BACKGROUND_LOCATION -->
 </manifest>

--- a/OneSignalSDK/onesignal/location/src/main/AndroidManifest.xml
+++ b/OneSignalSDK/onesignal/location/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest>
 
     <!-- At a minimum the location module requires course permission, the app has the option
          to also include ACCESS_FINE_LOCATION and/or ACCESS_BACKGROUND_LOCATION -->
-    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
 </manifest>


### PR DESCRIPTION
# Description
## One Line Summary
Removes ACCESS_COARSE_LOCATION from the location module

## Details

### Motivation
Fixes
- https://github.com/OneSignal/OneSignal-Unity-SDK/issues/670
- https://github.com/OneSignal/OneSignal-Flutter-SDK/issues/803
- and the same in other wrappers

This change was made to avoid the location permission requirement for those who use the com.onesignal:OneSignal package like our wrapper SDKs and do not use location with OneSignal.

### Scope
[Requires developers to add ACCESS_COARSE_LOCATION to their AndroidManifest themselves if they would like to use OneSignal location](https://documentation.onesignal.com/docs/mobile-sdk#configuring-location-on-android). This change reverts back to the player model behaviour.

# Testing
## Manual testing
Tested calling location request permission with location sharing on, app build with Android Studio 2022.1.1 of the OneSignal example app on an emulated Pixel 4 with Android 12.

Calling OneSignal.Location.requestPermission() without ACCESS_COARSE_LOCATION(or other location permissions) logs and does not crash the app.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/1949)
<!-- Reviewable:end -->
