### PR TITLE
Release 5.1.0

### DIFF
--- a/Examples/OneSignalDemo/app/build.gradle
+++ b/Examples/OneSignalDemo/app/build.gradle
@@ -84,12 +84,12 @@ dependencies {
     implementation 'com.github.bumptech.glide:glide:4.12.0'
 
     /** START - Google Play Builds **/
-    gmsImplementation('com.onesignal:OneSignal:5.0.5')
+    gmsImplementation('com.onesignal:OneSignal:5.1.0')
     /** END - Google Play Builds **/
 
     /** START - Huawei Builds **/
     // Omit Google / Firebase libraries for Huawei builds.
-    huaweiImplementation('com.onesignal:OneSignal:5.0.5') {
+    huaweiImplementation('com.onesignal:OneSignal:5.1.0') {
         exclude group: 'com.google.android.gms', module: 'play-services-gcm'
         exclude group: 'com.google.android.gms', module: 'play-services-analytics'
         exclude group: 'com.google.android.gms', module: 'play-services-location'

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/OneSignalUtils.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/OneSignalUtils.kt
@@ -6,7 +6,7 @@ object OneSignalUtils {
     /**
      * The version of this SDK.
      */
-    const val SDK_VERSION: String = "050005"
+    const val SDK_VERSION: String = "050100"
 
     fun isValidEmail(email: String): Boolean {
         if (email.isEmpty()) {

--- a/OneSignalSDK/settings.gradle
+++ b/OneSignalSDK/settings.gradle
@@ -3,7 +3,7 @@
 gradle.rootProject {
     allprojects {
         group = 'com.onesignal'
-        version = '5.0.5'
+        version = '5.1.0'
         configurations.all {
             resolutionStrategy.dependencySubstitution {
                 substitute(module('com.onesignal:OneSignal')).using(project(':OneSignal'))


### PR DESCRIPTION
## What's Changed
Update trigger model to always drive a change event https://github.com/OneSignal/OneSignal-Android-SDK/pull/1925
Wait for activity to be set rather than immediately return in waitUntilSystemConditionsAvailable https://github.com/OneSignal/OneSignal-Android-SDK/pull/1926
Notification click not fired without iam module https://github.com/OneSignal/OneSignal-Android-SDK/pull/1931
Crash on bindService with broadcast receiver context https://github.com/OneSignal/OneSignal-Android-SDK/pull/1935
Fix: Catch IllegalStateException on call to Google's location library https://github.com/OneSignal/OneSignal-Android-SDK/pull/1940
Fix: Update startGetLocation to only run if location is shared https://github.com/OneSignal/OneSignal-Android-SDK/pull/1942
Add getter for onesignalId and UserStateObserver https://github.com/OneSignal/OneSignal-Android-SDK/pull/1909
Remove ACCESS_COARSE_LOCATION permission https://github.com/OneSignal/OneSignal-Android-SDK/pull/1949

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/1952)
<!-- Reviewable:end -->
