### PR TITLE
CRASH - When the launch url is invalide

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -31,6 +31,7 @@ import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.Application;
 import android.app.NotificationManager;
+import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ApplicationInfo;
@@ -182,6 +183,13 @@ public class OneSignal {
        */
       void notificationOpened(OSNotificationOpenedResult result);
    }
+
+    /**
+     * Fires delegate when starting destination Activity fail.
+     */
+    public interface OSNotificationOpenedError {
+        void onOpenDestinationActivityNotFoundError(ActivityNotFoundException exception);
+    }
 
    /**
     * An interface used to process a OneSignal In-App Message the user just tapped on.
@@ -404,6 +412,7 @@ public class OneSignal {
    static OSRemoteNotificationReceivedHandler remoteNotificationReceivedHandler;
    static OSNotificationWillShowInForegroundHandler notificationWillShowInForegroundHandler;
    static OSNotificationOpenedHandler notificationOpenedHandler;
+   static OSNotificationOpenedError notificationOpenedError;
    static OSInAppMessageClickHandler inAppMessageClickHandler;
 
    // Is the init() of OneSignal SDK finished yet
@@ -2459,8 +2468,14 @@ public class OneSignal {
          }
       } catch (JSONException e) {
          e.printStackTrace();
+      } catch (ActivityNotFoundException e) {
+         if (notificationOpenedError != null) {
+             notificationOpenedError.onOpenDestinationActivityNotFoundError(e);
+         } else {
+            e.printStackTrace();
+         }
       }
-   }
+}
 
    private static boolean shouldInitDirectSessionFromNotificationOpen(Activity context, final JSONArray data) {
       if (inForeground) {


### PR DESCRIPTION
# Description
Catch an crash when the url is invalide and add an callback in case of this error happen 

## Details

### Motivation
FIX this [issue](https://github.com/OneSignal/OneSignal-Android-SDK/issues/1827#issue-1875268837)

### Scope
When we start the destination activity more than `JSONException` we catch `ActivityNotFoundException` and we call the listener 

## Manual testing
Tested opening a notification with an invalide url , app build with Android Studio 2023.1.1 with our app (Omada) on a Pixel 5 with Android 13.

# Affected code checklist
   - [x] Notifications
      - [ ] Display
      - [x] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.