### PR TITLE
Fix: Method `optIn()` not working after `optOut()` has been called

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/RefreshUserOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/RefreshUserOperationExecutor.kt
@@ -105,7 +105,7 @@ internal class RefreshUserOperationExecutor(
                             SubscriptionType.PUSH
                         }
                     }
-                subscriptionModel.optedIn = subscriptionModel.status != SubscriptionStatus.UNSUBSCRIBE
+                subscriptionModel.optedIn = subscriptionModel.status != SubscriptionStatus.UNSUBSCRIBE && subscriptionModel.status != SubscriptionStatus.DISABLED_FROM_REST_API_DEFAULT_REASON
                 subscriptionModel.sdk = subscription.sdk ?: ""
                 subscriptionModel.deviceOS = subscription.deviceOS ?: ""
                 subscriptionModel.carrier = subscription.carrier ?: ""

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/subscriptions/SubscriptionModel.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/subscriptions/SubscriptionModel.kt
@@ -67,6 +67,9 @@ enum class SubscriptionStatus(val value: Int) {
     /** The subscription is not enabled due to an FCM authentication failed IOException */
     FIREBASE_FCM_ERROR_IOEXCEPTION_AUTHENTICATION_FAILED(-29),
 
+    /** The subscription is not enabled because the app has disabled the subscription via API */
+    DISABLED_FROM_REST_API_DEFAULT_REASON(-30),
+
     /** The subscription is not enabled due to some other (unknown locally) error */
     ERROR(9999),
     ;
@@ -79,6 +82,10 @@ enum class SubscriptionStatus(val value: Int) {
 }
 
 class SubscriptionModel : Model() {
+    /**
+     * Reflects user preference only, defaults true.
+     * The public API for [IPushSubscription.optedIn] considers this value AND permission.
+     */
     var optedIn: Boolean
         get() = getBooleanProperty(::optedIn.name)
         set(value) {
@@ -97,6 +104,13 @@ class SubscriptionModel : Model() {
             setStringProperty(::address.name, value)
         }
 
+    /**
+     * This reflects the "device-level" subscription status.
+     *
+     * For example, if [IPushSubscription.optOut] is called, the SDK sends UNSUBSCRIBE(-2) to the server.
+     * However, locally on the model, we still keep the existing status.
+     * It is necessary when [IPushSubscription.optIn] is called again to know the true device status.
+     */
     var status: SubscriptionStatus
         get() {
             if (!hasProperty(::status.name)) {

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/subscriptions/SubscriptionModelStore.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/subscriptions/SubscriptionModelStore.kt
@@ -24,6 +24,7 @@ open class SubscriptionModelStore(prefs: IPreferencesService) : SimpleModelStore
                         model.deviceOS = existingPushModel.deviceOS
                         model.carrier = existingPushModel.carrier
                         model.appVersion = existingPushModel.appVersion
+                        model.status = existingPushModel.status
                     }
                     break
                 }


### PR DESCRIPTION
# Description
## One Line Summary
Fix method `optIn()` not working after `optOut()` has been called, by maintaining the local push subscription status.

## Details

### Motivation

- Fixes https://github.com/OneSignal/react-native-onesignal/issues/1590
- Fixes https://github.com/OneSignal/OneSignal-Android-SDK/issues/1824
- Fixes https://github.com/OneSignal/OneSignal-Flutter-SDK/issues/729
- Fixes https://github.com/OneSignal/OneSignal-Android-SDK/issues/1837
- Fixes https://github.com/OneSignal/OneSignal-Flutter-SDK/issues/811

**Existing Problem:**
- If on a previous session, `optOut()` was called, that means we sent notification_types of `UNSUBSCRIBE(-2)` to the server.
- We will hydrate the push subscription with the status of `UNSUBSCRIBE(-2)` in the response on the next session.
- However, we lose the true device-level subscription status in doing so.
- Then, when `optIn()` is called, we were using `UNSUBSCRIBE(-2)` along with `optedIn` to calculate the data to send in the Update Subscription request.
- This resulted in incorrect values being sent and reports of `optIn()` method not working.

**Solution:**
- We can still hydrate the push subscription model's `optedIn` property if we see either `UNSUBSCRIBE(-2)` or `DISABLED_FROM_REST_API_DEFAULT_REASON(-30)` in the response.
- However, we will not hydrate the `model.status` from the server. When the subscription model store is replacing all of the subscriptions in the refresh user operation, keep the existing push subscription `status`.
- This way, when `optIn()` is called again, we can use this _device-level status_ with the `optedIn` boolean to calculate values to send to the server.

### Scope
- Also added parsing of `DISABLED_FROM_REST_API_DEFAULT_REASON(-30)` from the server to update local `optedIn` state
- The subscription values we send to the server are calculated by the helper method `getSubscriptionEnabledAndStatus` ([here](https://github.com/OneSignal/OneSignal-Android-SDK/blob/52987ab505816e3f42fe837f195a53ef817f94e7/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/listeners/SubscriptionModelStoreListener.kt#L58)) so the model's own properties aren't directly sent.

# Testing
## Unit testing
No unit test added, can consider adding.

## Manual testing
Android emulator API 33
- tested scenarios of `optIn()` and `optOut()` with different permissions, new session, cold starts, and logging into different users

Android emulator API 30
- tested scenarios of `optIn()` and `optOut()` with new session, cold starts, and logging into different users

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [ ] I have filled out all **REQUIRED** sections above
   - [ ] PR does one thing
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [ ] Code is as readable as possible.
   - [ ] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/1957)
<!-- Reviewable:end -->
