### PR TITLE
[Fix] Bump work-runtime dependency version implementation

### DIFF
--- a/OneSignalSDK/onesignal/notifications/build.gradle
+++ b/OneSignalSDK/onesignal/notifications/build.gradle
@@ -65,7 +65,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4"
-    implementation 'androidx.work:work-runtime-ktx:2.7.1'
+    implementation 'androidx.work:work-runtime-ktx:2.8.1'
 
     compileOnly('com.amazon.device:amazon-appstore-sdk:[3.0.1, 3.0.99]')
 


### PR DESCRIPTION
# Description
## One Line Summary
Bump work-runtime dependency version implementation

## Details

### Motivation
In #1890 we updated work-runtime dependency to the latest version (2.8.1) to prevent gradle crash with latest version of WorkManager. However, as #1915 points out, the implementation of this dependency still uses an older version. This PR will align versions.

# Testing
## Manual testing
Built app on Android 12 and 13 emulators and ran unit tests with updated dependency version to ensure no issues.

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/1960)
<!-- Reviewable:end -->
