### PR TITLE
Concurrent modification in event producer

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/events/EventProducer.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/events/EventProducer.kt
@@ -60,7 +60,8 @@ open class EventProducer<THandler> : IEventNotifier<THandler> {
      */
     fun fireOnMain(callback: (THandler) -> Unit) {
         suspendifyOnMain {
-            for (s in subscribers) {
+            val localList = subscribers.toList()
+            for (s in localList) {
                 callback(s)
             }
         }
@@ -73,7 +74,8 @@ open class EventProducer<THandler> : IEventNotifier<THandler> {
      * @param callback The callback will be invoked for each subscribed handler, allowing you to call the handler.
      */
     suspend fun suspendingFire(callback: suspend (THandler) -> Unit) {
-        for (s in subscribers) {
+        val localList = subscribers.toList()
+        for (s in localList) {
             callback(s)
         }
     }
@@ -86,7 +88,8 @@ open class EventProducer<THandler> : IEventNotifier<THandler> {
      */
     suspend fun suspendingFireOnMain(callback: suspend (THandler) -> Unit) {
         withContext(Dispatchers.Main) {
-            for (s in subscribers) {
+            val localList = subscribers.toList()
+            for (s in localList) {
                 callback(s)
             }
         }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/events/EventProducer.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/events/EventProducer.kt
@@ -45,10 +45,9 @@ open class EventProducer<THandler> : IEventNotifier<THandler> {
      * @param callback The callback will be invoked for each subscribed handler, allowing you to call the handler.
      */
     fun fire(callback: (THandler) -> Unit) {
-        synchronized(subscribers) {
-            for (s in subscribers) {
-                callback(s)
-            }
+        val localList = subscribers.toList()
+        for (s in localList) {
+            callback(s)
         }
     }
 


### PR DESCRIPTION
# Description
Instead of iterating the subscribers list when an event.fire() is called, iterate through a copy of the list to avoid concurrent modification.

## Details

### Motivation
Fixes a bug that causes concurrent modification when calling EventProducer.fire()

# Testing
I am unable to reproduce the exception consistently.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [ ] I have filled out all **REQUIRED** sections above
   - [ ] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/1970)
<!-- Reviewable:end -->
