### PR TITLE
Upgrade play-services-basement to 18.1.0

### DIFF
--- a/OneSignalSDK/onesignal/notifications/build.gradle
+++ b/OneSignalSDK/onesignal/notifications/build.gradle
@@ -69,23 +69,13 @@ dependencies {
 
     compileOnly('com.amazon.device:amazon-appstore-sdk:[3.0.1, 3.0.99]')
 
-    // play-services-base:16.1.0 is the last version before going to AndroidX
-    // play-services-base:17.0.0 is the first version using AndroidX
-    // Required for GoogleApiAvailability
-    implementation('com.google.android.gms:play-services-base') {
-        version {
-            require '[17.0.0, 17.6.99]'
-            prefer '17.6.0'
-        }
-    }
-
     // firebase-messaging:18.0.0 is the last version before going to AndroidX
     // firebase-messaging:19.0.0 is the first version using AndroidX
     // firebase-messaging:23.0.0 incoporates fix for SecurityException: Not allowed to bind to service
     api('com.google.firebase:firebase-messaging') {
         version {
             require '[19.0.0, 23.0.99]'
-            prefer '23.0.0'
+            prefer '23.0.8'
         }
     }
 

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorAbstractGoogle.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorAbstractGoogle.kt
@@ -34,6 +34,7 @@ import com.onesignal.notifications.internal.registration.IPushRegistrator
 import com.onesignal.user.internal.subscriptions.SubscriptionStatus
 import kotlinx.coroutines.delay
 import java.io.IOException
+import java.util.concurrent.ExecutionException
 
 /**
  * The abstract google push registration service.  It is expected [PushRegistratorFCM] will extend
@@ -47,7 +48,7 @@ internal abstract class PushRegistratorAbstractGoogle(
     IPushRegistrator, IPushRegistratorCallback {
     abstract val providerName: String
 
-    @Throws(Throwable::class)
+    @Throws(ExecutionException::class, InterruptedException::class, IOException::class)
     abstract suspend fun getToken(senderId: String): String
 
     override suspend fun registerForPush(): IPushRegistrator.RegisterResult {

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorFCM.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorFCM.kt
@@ -128,7 +128,7 @@ internal class PushRegistratorFCM(
                 try {
                     token = Tasks.await(tokenTask)
                 } catch (e: ExecutionException) {
-                    throw tokenTask.exception
+                    throw tokenTask.exception ?: e
                 }
             }
 


### PR DESCRIPTION
# Description
## One Line Summary
Google recommends updating to `play-services-basement:18.1.0`.

## Details
Bumped `firebase-messaging` from `23.0.0` to `23.0.8`. It has a dependency on `play-services-basement:18.1.0` which gives us the recommended version. Also removed our direct dependency on ` play-services-base` as this can easily get out of sync with other Google libraries when when we update them, such as `firebase-messaging` we updated in this PR. See commit message for even more details.

### Motivation
Google recommends updating to `play-services-basement:18.1.0`.

### Scope
Only upgrade `play-services-basement`  firebase-messaging

# Testing
## Unit testing

## Manual testing
Tested a new installed on an Android 14 emulator, ensuring we still get a FCM push token.

# Affected code checklist
   - [X] Notifications
      - [ ] Display
      - [ ] Open
      - [X] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
      - Test are currently failing on main
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/1982)
<!-- Reviewable:end -->
