### PR TITLE
CI - Switch to android-actions/setup-android@v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,10 @@ jobs:
         with:
           gradle-version: 7.3.1
       - name: "[Setup] Android"
-        uses: maxim-lobanov/setup-android-tools@v1
+        uses: android-actions/setup-android@v3
         with:
-          packages: |
-            platforms;android-31
-            build-tools;31.0.0
-          cache: true
+          cmdline-tools-version: 10406996
+          log-accepted-android-sdk-licenses: false
       - name: "[Test] Linting"
         working-directory: OneSignalSDK
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,8 @@ jobs:
       - name: "[Setup] Java"
         uses: actions/setup-java@v3
         with:
+          java-version: '17'
           distribution: 'temurin'
-          java-version: 11
-      - name: "[Setup] Gradle"
-        uses: gradle/gradle-build-action@v2
-        with:
-          gradle-version: 7.3.1
       - name: "[Setup] Android"
         uses: android-actions/setup-android@v3
         with:


### PR DESCRIPTION
# Description
## One Line Summary
`maxim-lobanov/setup-android-tools` is no longer working with github CI, replacing it with `android-actions/setup-android@v3`.

## Details
Setup `android-actions/setup-android@v3` to use the latest Android command line tools it currently supports 10406996. Disabled printing Android licenses via `log-accepted-android-sdk-licenses: false` to keep our logs small.
Also update CI from Java 11 -> 17, as the new Android SDK tools require it.

Thanks to the work @nan-li did in PR #1958 which this PR is based on.

### Motivation
`maxim-lobanov/setup-android-tools` is no longer working with github CI and it hasn't been updated in 4 years.

### Scope
Only updating Android SDK dependencies to get the CI past the setup failing.
* Linting, unit test failures, and other step fixes will be addressed in follow up PRs.

# Testing
## Unit testing
Ensured CI test now gets past the Android setup phase. (linting is still failing but, will be addressed in a follow up PR)

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
      - Out of scope of this PR to fix lint errors.
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/1992)
<!-- Reviewable:end -->
