### PR TITLE
[Abandoned][Tests] Allow JSONObject Kotlin extension functions to work in tests

### DIFF
--- a/OneSignalSDK/onesignal/core/build.gradle
+++ b/OneSignalSDK/onesignal/core/build.gradle
@@ -88,8 +88,12 @@ dependencies {
     testImplementation("androidx.test:core-ktx:1.4.0")
     testImplementation("androidx.test:core:1.4.0")
     testImplementation("io.mockk:mockk:1.13.2")
-    testImplementation("org.json:json:20180813")
     testImplementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
+
+    // org.json:json is needed for non-Robolectric tests.
+    // On the flip side this can break tests using Robolectric so
+    // ContainedRobolectricRunner.kt contains a workaround.
+    testImplementation("org.json:json:20240205")
 }
 
 ktlint {

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/selftest/JSONObjectExtensionMethodsAllowedInTestsTest.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/selftest/JSONObjectExtensionMethodsAllowedInTestsTest.kt
@@ -1,0 +1,20 @@
+package com.onesignal.selftest
+
+import com.onesignal.common.toMap
+import com.onesignal.testhelpers.extensions.RobolectricTest
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.runner.junit4.KotestTestRunner
+import org.json.JSONObject
+import org.junit.runner.RunWith
+
+@RobolectricTest
+@RunWith(KotestTestRunner::class)
+class JSONObjectExtensionMethodsAllowedInTestsTest : FunSpec({
+    // This is testing logic in ContainedRobolectricRunner.keepExistingOrgJson() works
+    test("ensure we can use a Kotlin extension method defined in src in our tests") {
+        val test = JSONObject()
+        test.put("test", "test")
+        // Ensuring this doesn't throw
+        test.toMap()
+    }
+})

--- a/OneSignalSDK/onesignal/in-app-messages/build.gradle
+++ b/OneSignalSDK/onesignal/in-app-messages/build.gradle
@@ -88,8 +88,12 @@ dependencies {
     testImplementation("androidx.test:core-ktx:1.4.0")
     testImplementation("androidx.test:core:1.4.0")
     testImplementation("io.mockk:mockk:1.13.2")
-    testImplementation("org.json:json:20180813")
     testImplementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
+
+    // org.json:json is needed for non-Robolectric tests.
+    // On the flip side this can break tests using Robolectric so
+    // ContainedRobolectricRunner.kt contains a workaround.
+    testImplementation("org.json:json:20240205")
 }
 
 ktlint {

--- a/OneSignalSDK/onesignal/location/build.gradle
+++ b/OneSignalSDK/onesignal/location/build.gradle
@@ -87,9 +87,13 @@ dependencies {
     testImplementation("androidx.test:core-ktx:1.4.0")
     testImplementation("androidx.test:core:1.4.0")
     testImplementation("io.mockk:mockk:1.13.2")
-    testImplementation("org.json:json:20180813")
     testImplementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
     testImplementation("com.google.android.gms:play-services-location:18.0.0")
+
+    // org.json:json is needed for non-Robolectric tests.
+    // On the flip side this can break tests using Robolectric so
+    // ContainedRobolectricRunner.kt contains a workaround.
+    testImplementation("org.json:json:20240205")
 }
 
 ktlint {

--- a/OneSignalSDK/onesignal/notifications/build.gradle
+++ b/OneSignalSDK/onesignal/notifications/build.gradle
@@ -100,8 +100,12 @@ dependencies {
     testImplementation("androidx.test:core-ktx:1.4.0")
     testImplementation("androidx.test:core:1.4.0")
     testImplementation("io.mockk:mockk:1.13.2")
-    testImplementation("org.json:json:20180813")
     testImplementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
+
+    // org.json:json is needed for non-Robolectric tests.
+    // On the flip side this can break tests using Robolectric so
+    // ContainedRobolectricRunner.kt contains a workaround.
+    testImplementation("org.json:json:20240205")
 }
 
 ktlint {

--- a/OneSignalSDK/onesignal/testhelpers/src/main/java/com/onesignal/testhelpers/extensions/ContainedRobolectricRunner.kt
+++ b/OneSignalSDK/onesignal/testhelpers/src/main/java/com/onesignal/testhelpers/extensions/ContainedRobolectricRunner.kt
@@ -5,6 +5,7 @@
  */
 package com.onesignal.testhelpers.extensions
 
+import org.json.JSONObject
 import org.junit.runners.model.FrameworkMethod
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
@@ -37,9 +38,32 @@ class ContainedRobolectricRunner(
     }
 
     override fun createClassLoaderConfig(method: FrameworkMethod?): InstrumentationConfiguration {
-        return InstrumentationConfiguration.Builder(super.createClassLoaderConfig(method))
-            .doNotAcquirePackage("io.kotest")
-            .build()
+        val builder =
+            InstrumentationConfiguration.Builder(super.createClassLoaderConfig(method))
+                .doNotAcquirePackage("io.kotest")
+
+        if (keepExistingOrgJson()) builder.doNotAcquirePackage("org.json")
+
+        return builder.build()
+    }
+
+    // Don't let Robolectric replace "org.json" if it's something other than
+    // Google's non-working stub.
+    // It's common for developers to include the "org.json:json" package
+    // in their build.gradle and we shouldn't unexpectedly replace it.
+    // One known issue is if a tests attempts to utilize a Kotlin extension
+    // method that is defined in the "src" (AKA production) it won't be found
+    // at runtime.
+    private fun keepExistingOrgJson(): Boolean {
+        return try {
+            // This throws if we have Google's non-working stub
+            JSONObject().put("test", "test")
+            true
+        } catch (_: ClassNotFoundException) {
+            false
+        } catch (_: RuntimeException) {
+            false
+        }
     }
 
     override fun getConfig(method: Method?): Config {


### PR DESCRIPTION
# Description
## One Line Summary
Allow tests to utilize JSONObject Kotlin extension functions defined in our `JSONObjectExtensions.kt`.

## Details

### Motivation
We have a number of useful Kotlin extension functions `JSONObjectExtensions.kt` and it would be helpful to use them in tests.

### Scope
Only fixes issue with JSONObject in tests.

# Testing
## Unit testing
Added unit test to ensure our `JSONObject` extension functions will work in other tests.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2003)
<!-- Reviewable:end -->
