### PR TITLE
Fix JSON Kotlin Extension Functions

### DIFF
--- a/OneSignalSDK/build.gradle
+++ b/OneSignalSDK/build.gradle
@@ -18,6 +18,8 @@ buildscript {
         ktlintPluginVersion = '11.6.1'
         ktlintVersion = '1.0.1'
         junitVersion = '4.13.2'
+        // DO NOT upgrade for tests, using an old version so it matches AOSP
+        tdunningJsonForTest = '1.0'
     }
 
     repositories {

--- a/OneSignalSDK/onesignal/core/build.gradle
+++ b/OneSignalSDK/onesignal/core/build.gradle
@@ -88,8 +88,10 @@ dependencies {
     testImplementation("androidx.test:core-ktx:1.4.0")
     testImplementation("androidx.test:core:1.4.0")
     testImplementation("io.mockk:mockk:1.13.2")
-    testImplementation("org.json:json:20180813")
     testImplementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
+
+    // com.tdunning:json is needed for non-Robolectric tests.
+    testImplementation("com.tdunning:json:$tdunningJsonForTest")
 }
 
 ktlint {

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/common/JSONObjectExtensionsTest.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/common/JSONObjectExtensionsTest.kt
@@ -42,14 +42,17 @@ class JSONObjectExtensionsTest : DescribeSpec({
                 )
         }
 
-        it("supports JSONArray") {
-            val test =
-                JSONObject()
-                    .put("MyArray", JSONArray().put("String"))
-            test.toMap() shouldBe
-                mapOf(
-                    "MyArray" to listOf("String"),
-                )
+        describe("JSONArray") {
+            it("supports empty") {
+                val test = JSONObject().put("MyArray", JSONArray())
+                test.toMap() shouldBe
+                    mapOf("MyArray" to emptyList<Any>())
+            }
+            it("supports one item") {
+                val test = JSONObject().put("MyArray", JSONArray().put("String"))
+                test.toMap() shouldBe
+                    mapOf("MyArray" to listOf("String"))
+            }
         }
 
         it("supports JSONObject") {

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/common/JSONObjectExtensionsTest.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/common/JSONObjectExtensionsTest.kt
@@ -1,0 +1,65 @@
+package com.onesignal.common
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.runner.junit4.KotestTestRunner
+import io.mockk.mockkStatic
+import io.mockk.verify
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.runner.RunWith
+
+@RunWith(KotestTestRunner::class)
+class JSONObjectExtensionsTest : DescribeSpec({
+    describe("toMap") {
+        // Some org.json JVM libraries define their own toMap. We want to
+        // ensure we are testing ours, not theirs.
+        it("is using our extension function") {
+            mockkStatic(JSONObject::toMap) {
+                JSONObject().toMap()
+                verify { any<JSONObject>().toMap() }
+            }
+        }
+
+        it("supports primitives") {
+            val test =
+                JSONObject()
+                    .put("String", "String")
+                    .put("Boolean", true)
+                    .put("Integer", 1)
+                    .put("Long", 2L)
+                    .put("Float", 3.3f)
+                    .put("Double", Double.MAX_VALUE)
+
+            test.toMap() shouldBe
+                mapOf(
+                    "String" to "String",
+                    "Boolean" to true,
+                    "Integer" to 1,
+                    "Long" to 2L,
+                    "Float" to 3.3f,
+                    "Double" to Double.MAX_VALUE,
+                )
+        }
+
+        it("supports JSONArray") {
+            val test =
+                JSONObject()
+                    .put("MyArray", JSONArray().put("String"))
+            test.toMap() shouldBe
+                mapOf(
+                    "MyArray" to listOf("String"),
+                )
+        }
+
+        it("supports JSONObject") {
+            val test =
+                JSONObject()
+                    .put("MyNestedJSONObject", JSONObject().put("String", "String"))
+            test.toMap() shouldBe
+                mapOf(
+                    "MyNestedJSONObject" to mapOf("String" to "String"),
+                )
+        }
+    }
+})

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/selftest/JSONObjectEnvTest.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/selftest/JSONObjectEnvTest.kt
@@ -1,0 +1,47 @@
+package com.onesignal.selftest
+
+import com.onesignal.common.toMap
+import com.onesignal.testhelpers.extensions.RobolectricTest
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.funSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.runner.junit4.KotestTestRunner
+import org.json.JSONObject
+import org.junit.runner.RunWith
+
+/**
+ * This purpose of this file is to ensure org.json classes being used in
+ * other tests matches real Android devices.
+*/
+
+val keyAOSPBehavior =
+    funSpec {
+        // This is a key oddity only AOSP seems to do
+        test("JSONObject.getString stringifies JSON object") {
+            val json =
+                JSONObject()
+                    .put(
+                        "obj",
+                        JSONObject().put("nested", "value"),
+                    )
+            json.getString("obj") shouldBe "{\"nested\":\"value\"}"
+        }
+    }
+
+@RobolectricTest
+@RunWith(KotestTestRunner::class)
+class JSONObjectRobolectricEnvTest : FunSpec({
+    test("ensure our src JSON Kotlin extension methods work with @RobolectricTest") {
+        val test = JSONObject()
+        test.put("test", "test")
+        // Ensuring this doesn't throw
+        test.toMap()
+    }
+
+    include(keyAOSPBehavior)
+})
+
+@RunWith(KotestTestRunner::class)
+class JSONObjectJVMEnvTest : FunSpec({
+    include(keyAOSPBehavior)
+})

--- a/OneSignalSDK/onesignal/in-app-messages/build.gradle
+++ b/OneSignalSDK/onesignal/in-app-messages/build.gradle
@@ -88,8 +88,10 @@ dependencies {
     testImplementation("androidx.test:core-ktx:1.4.0")
     testImplementation("androidx.test:core:1.4.0")
     testImplementation("io.mockk:mockk:1.13.2")
-    testImplementation("org.json:json:20180813")
     testImplementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
+
+    // com.tdunning:json is needed for non-Robolectric tests.
+    testImplementation("com.tdunning:json:$tdunningJsonForTest")
 }
 
 ktlint {

--- a/OneSignalSDK/onesignal/location/build.gradle
+++ b/OneSignalSDK/onesignal/location/build.gradle
@@ -87,9 +87,11 @@ dependencies {
     testImplementation("androidx.test:core-ktx:1.4.0")
     testImplementation("androidx.test:core:1.4.0")
     testImplementation("io.mockk:mockk:1.13.2")
-    testImplementation("org.json:json:20180813")
     testImplementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
     testImplementation("com.google.android.gms:play-services-location:18.0.0")
+
+    // com.tdunning:json is needed for non-Robolectric tests.
+    testImplementation("com.tdunning:json:$tdunningJsonForTest")
 }
 
 ktlint {

--- a/OneSignalSDK/onesignal/notifications/build.gradle
+++ b/OneSignalSDK/onesignal/notifications/build.gradle
@@ -100,8 +100,10 @@ dependencies {
     testImplementation("androidx.test:core-ktx:1.4.0")
     testImplementation("androidx.test:core:1.4.0")
     testImplementation("io.mockk:mockk:1.13.2")
-    testImplementation("org.json:json:20180813")
     testImplementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
+
+    // com.tdunning:json is needed for non-Robolectric tests.
+    testImplementation("com.tdunning:json:$tdunningJsonForTest")
 }
 
 ktlint {


### PR DESCRIPTION
# Description
## One Line Summary
Fixes our JSON Kotlin extension functions and added tests to ensure our JSON implementation in tests stay accurate.

## Details
This PR sloves 3 issues with JSONArray / JSONArray:
1. Tests were running with a different implementation than Android's
   * Swapping out `org.json:json` for `com.tdunning:json` fixed this.
      - Yes this is confusing, but `org.json:json` is NOT the same library as Android's `org.json` namespace!
2. Our `JSONObject.toMap()` Kotlin extension function didn't support nested JSON.
   * It isn't clear if anything in our SDK was affected by this today, but can bite us in the future.
3. Could not use JSONObject Kotlin extension functions defined in src in tests using Robolectric
   * Was only an issue with `org.json:json` for some reason, so swapping `com.tdunning:json` also fixed this issue.


This PR is based on some of the attempted work from PR #2003.

### Motivation
`JSONObject` and `JSONArray` are two APIs we use a lot in this SDK. It is important they are working fully and we are testing with the same implementation in tests.

### Scope
Effects code that uses `JSONObject.toMap()`. And tests that used `org.json:json`.

### History 
Fun fact, Google rolled [their own org.json](https://cs.android.com/android/platform/superproject/main/+/main:libcore/json/src/main/java/org/json/JSONObject.java;l=34?q=jsonobject) for Android. They probably did this due to the silly "The Software shall be used for Good, not Evil." line in [the orignal org.json licence](https://www.json.org/license.html).
* The original [org.json](https://github.com/stleary/JSON-java/issues/756) is now public domain.

# Testing
## Unit testing
New [JSONObjectEnvTest.kt](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2004/files#diff-5e066b1919d5f409aca7a1d25c687ac65a15972f75c62e871c978f49bd73d045) and [JSONObjectExtensionsTest.kt ](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2004/files#diff-b81646a50d3df8a1625e919a0c46d32ce5cbc6610e319ad1a0037f1016792efd) test files were added to cover the behavior changes and ensure test env does not regress.

## Manual testing
Tested on an Android 14 emulator ensuring the device tag updates are sent.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2004)
<!-- Reviewable:end -->
