### PR TITLE
[Tests] Upgrade to Junit5

### DIFF
--- a/OneSignalSDK/build.gradle
+++ b/OneSignalSDK/build.gradle
@@ -17,7 +17,6 @@ buildscript {
         kotestVersion = '5.8.0'
         ktlintPluginVersion = '11.6.1'
         ktlintVersion = '1.0.1'
-        junitVersion = '4.13.2'
         // DO NOT upgrade for tests, using an old version so it matches AOSP
         tdunningJsonForTest = '1.0'
     }

--- a/OneSignalSDK/build.gradle
+++ b/OneSignalSDK/build.gradle
@@ -14,7 +14,7 @@ buildscript {
         huaweiHMSPushVersion = '6.3.0.304'
         huaweiHMSLocationVersion = '4.0.0.300'
         kotlinVersion = '1.7.10'
-        kotestVersion = '5.5.0'
+        kotestVersion = '5.8.0'
         ktlintPluginVersion = '11.6.1'
         ktlintVersion = '1.0.1'
         junitVersion = '4.13.2'

--- a/OneSignalSDK/onesignal/core/build.gradle
+++ b/OneSignalSDK/onesignal/core/build.gradle
@@ -32,6 +32,9 @@ android {
         unitTests {
             includeAndroidResources = true
         }
+        unitTests.all {
+            it.useJUnitPlatform()
+        }
     }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -79,9 +82,9 @@ dependencies {
     }
 
     testImplementation(project(':OneSignal:testhelpers'))
-    testImplementation("junit:junit:$junitVersion")
-    testImplementation("io.kotest:kotest-runner-junit4:$kotestVersion")
-    testImplementation("io.kotest:kotest-runner-junit4-jvm:$kotestVersion")
+
+    testImplementation("io.kotest:kotest-runner-junit5:$kotestVersion")
+    testImplementation("io.kotest:kotest-runner-junit5-jvm:$kotestVersion")
     testImplementation("io.kotest:kotest-assertions-core:$kotestVersion")
     testImplementation("io.kotest:kotest-property:$kotestVersion")
     testImplementation("org.robolectric:robolectric:4.8.1")

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/common/JSONObjectExtensionsTest.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/common/JSONObjectExtensionsTest.kt
@@ -2,14 +2,11 @@ package com.onesignal.common
 
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
-import io.kotest.runner.junit4.KotestTestRunner
 import io.mockk.mockkStatic
 import io.mockk.verify
 import org.json.JSONArray
 import org.json.JSONObject
-import org.junit.runner.RunWith
 
-@RunWith(KotestTestRunner::class)
 class JSONObjectExtensionsTest : DescribeSpec({
     describe("toMap") {
         // Some org.json JVM libraries define their own toMap. We want to

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/common/ModelingTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/common/ModelingTests.kt
@@ -10,11 +10,7 @@ import com.onesignal.user.internal.subscriptions.SubscriptionModel
 import com.onesignal.user.internal.subscriptions.SubscriptionModelStore
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import io.kotest.runner.junit4.KotestTestRunner
-import junit.framework.TestCase
-import org.junit.runner.RunWith
 
-@RunWith(KotestTestRunner::class)
 class ModelingTests : FunSpec({
 
     test("Deadlock related to Model.setOptAnyProperty") {
@@ -55,7 +51,7 @@ class ModelingTests : FunSpec({
         t2.join(1000)
 
         // verify if the thread has been successfully terminated
-        TestCase.assertEquals(Thread.State.TERMINATED, t2.state)
+        t2.state shouldBe Thread.State.TERMINATED
     }
 
     test("Deadlock related to ModelSstore add() or remove()") {
@@ -113,7 +109,7 @@ class ModelingTests : FunSpec({
         t2.join(1000)
 
         // verify if the thread has been successfully terminated
-        TestCase.assertEquals(Thread.State.TERMINATED, t2.state)
+        t2.state shouldBe Thread.State.TERMINATED
     }
 
     test("Unsubscribing handler in change event may cause the concurrent modification exception") {

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/application/ApplicationServiceTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/application/ApplicationServiceTests.kt
@@ -11,15 +11,12 @@ import com.onesignal.debug.internal.logging.Logging
 import com.onesignal.testhelpers.extensions.RobolectricTest
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import io.kotest.runner.junit4.KotestTestRunner
 import io.mockk.spyk
 import io.mockk.verify
 import kotlinx.coroutines.delay
-import org.junit.runner.RunWith
 import org.robolectric.Robolectric
 
 @RobolectricTest
-@RunWith(KotestTestRunner::class)
 class ApplicationServiceTests : FunSpec({
 
     beforeAny {

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/database/OSDatabaseTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/database/OSDatabaseTests.kt
@@ -10,12 +10,9 @@ import com.onesignal.session.internal.outcomes.impl.OutcomeTableProvider
 import com.onesignal.testhelpers.extensions.RobolectricTest
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import io.kotest.runner.junit4.KotestTestRunner
 import io.mockk.mockk
-import org.junit.runner.RunWith
 
 @RobolectricTest
-@RunWith(KotestTestRunner::class)
 class OSDatabaseTests : FunSpec({
 
     beforeAny {

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/http/HttpClientTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/http/HttpClientTests.kt
@@ -11,12 +11,9 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.beInstanceOf
-import io.kotest.runner.junit4.KotestTestRunner
 import kotlinx.coroutines.TimeoutCancellationException
 import org.json.JSONObject
-import org.junit.runner.RunWith
 
-@RunWith(KotestTestRunner::class)
 class HttpClientTests : FunSpec({
 
     beforeAny {

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/operations/OperationRepoTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/operations/OperationRepoTests.kt
@@ -8,7 +8,6 @@ import com.onesignal.debug.internal.logging.Logging
 import com.onesignal.mocks.MockHelper
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import io.kotest.runner.junit4.KotestTestRunner
 import io.mockk.CapturingSlot
 import io.mockk.coEvery
 import io.mockk.coVerifyOrder
@@ -17,9 +16,7 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.slot
-import org.junit.runner.RunWith
 
-@RunWith(KotestTestRunner::class)
 class OperationRepoTests : FunSpec({
 
     beforeAny {

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/preferences/PreferencesServiceTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/preferences/PreferencesServiceTests.kt
@@ -11,12 +11,9 @@ import com.onesignal.testhelpers.extensions.RobolectricTest
 import io.kotest.assertions.throwables.shouldThrowUnit
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import io.kotest.runner.junit4.KotestTestRunner
 import kotlinx.coroutines.delay
-import org.junit.runner.RunWith
 
 @RobolectricTest
-@RunWith(KotestTestRunner::class)
 class PreferencesServiceTests : FunSpec({
     val mockPrefStoreName = PreferenceStores.ONESIGNAL
     val mockBoolPrefStoreKey = "mock-bool"

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/startup/StartupServiceTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/startup/StartupServiceTests.kt
@@ -5,14 +5,11 @@ import com.onesignal.debug.internal.logging.Logging
 import io.kotest.assertions.throwables.shouldThrowUnit
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import io.kotest.runner.junit4.KotestTestRunner
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.verify
-import org.junit.runner.RunWith
 
-@RunWith(KotestTestRunner::class)
 class StartupServiceTests : FunSpec({
 
     beforeAny {

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/internal/OneSignalImpTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/internal/OneSignalImpTests.kt
@@ -5,10 +5,7 @@ import com.onesignal.debug.internal.logging.Logging
 import io.kotest.assertions.throwables.shouldThrowUnit
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import io.kotest.runner.junit4.KotestTestRunner
-import org.junit.runner.RunWith
 
-@RunWith(KotestTestRunner::class)
 class OneSignalImpTests : FunSpec({
     beforeAny {
         Logging.logLevel = LogLevel.NONE

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/selftest/JSONObjectEnvTest.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/selftest/JSONObjectEnvTest.kt
@@ -5,9 +5,7 @@ import com.onesignal.testhelpers.extensions.RobolectricTest
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.core.spec.style.funSpec
 import io.kotest.matchers.shouldBe
-import io.kotest.runner.junit4.KotestTestRunner
 import org.json.JSONObject
-import org.junit.runner.RunWith
 
 /**
  * This purpose of this file is to ensure org.json classes being used in
@@ -29,7 +27,6 @@ val keyAOSPBehavior =
     }
 
 @RobolectricTest
-@RunWith(KotestTestRunner::class)
 class JSONObjectRobolectricEnvTest : FunSpec({
     test("ensure our src JSON Kotlin extension methods work with @RobolectricTest") {
         val test = JSONObject()
@@ -41,7 +38,6 @@ class JSONObjectRobolectricEnvTest : FunSpec({
     include(keyAOSPBehavior)
 })
 
-@RunWith(KotestTestRunner::class)
 class JSONObjectJVMEnvTest : FunSpec({
     include(keyAOSPBehavior)
 })

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/session/internal/influence/InfluenceManagerTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/session/internal/influence/InfluenceManagerTests.kt
@@ -9,14 +9,11 @@ import com.onesignal.session.internal.session.ISessionService
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
-import io.kotest.runner.junit4.KotestTestRunner
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
-import org.junit.runner.RunWith
 
-@RunWith(KotestTestRunner::class)
 class InfluenceManagerTests : FunSpec({
 
     test("default are disabled influences") {

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/session/internal/outcomes/OutcomeEventsBackendServiceTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/session/internal/outcomes/OutcomeEventsBackendServiceTests.kt
@@ -11,13 +11,10 @@ import com.onesignal.session.internal.outcomes.impl.OutcomeEventsBackendService
 import io.kotest.assertions.throwables.shouldThrowUnit
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import io.kotest.runner.junit4.KotestTestRunner
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
-import org.junit.runner.RunWith
 
-@RunWith(KotestTestRunner::class)
 class OutcomeEventsBackendServiceTests : FunSpec({
     beforeAny {
         Logging.logLevel = LogLevel.NONE

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/session/internal/outcomes/OutcomeEventsControllerTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/session/internal/outcomes/OutcomeEventsControllerTests.kt
@@ -23,7 +23,6 @@ import com.onesignal.user.internal.subscriptions.SubscriptionModel
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
-import io.kotest.runner.junit4.KotestTestRunner
 import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -35,9 +34,7 @@ import io.mockk.runs
 import io.mockk.spyk
 import kotlinx.coroutines.delay
 import org.json.JSONArray
-import org.junit.runner.RunWith
 
-@RunWith(KotestTestRunner::class)
 class OutcomeEventsControllerTests : FunSpec({
     beforeAny {
         Logging.logLevel = LogLevel.NONE

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/session/internal/outcomes/OutcomeEventsRepositoryTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/session/internal/outcomes/OutcomeEventsRepositoryTests.kt
@@ -16,15 +16,12 @@ import com.onesignal.testhelpers.extensions.RobolectricTest
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
-import io.kotest.runner.junit4.KotestTestRunner
 import io.mockk.verify
 import io.mockk.verifyAll
 import io.mockk.verifySequence
 import org.json.JSONArray
-import org.junit.runner.RunWith
 
 @RobolectricTest
-@RunWith(KotestTestRunner::class)
 class OutcomeEventsRepositoryTests : FunSpec({
     beforeAny {
         Logging.logLevel = LogLevel.NONE

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/session/internal/session/SessionServiceTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/session/internal/session/SessionServiceTests.kt
@@ -4,12 +4,9 @@ import com.onesignal.mocks.MockHelper
 import com.onesignal.session.internal.session.impl.SessionService
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import io.kotest.runner.junit4.KotestTestRunner
 import io.mockk.spyk
 import io.mockk.verify
-import org.junit.runner.RunWith
 
-@RunWith(KotestTestRunner::class)
 class SessionServiceTests : FunSpec({
 
     test("session created on focus when current session invalid") {

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/UserManagerTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/UserManagerTests.kt
@@ -7,16 +7,13 @@ import com.onesignal.user.internal.subscriptions.SubscriptionList
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
-import io.kotest.runner.junit4.KotestTestRunner
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.slot
 import io.mockk.verify
-import org.junit.runner.RunWith
 
-@RunWith(KotestTestRunner::class)
 class UserManagerTests : FunSpec({
 
     test("language is backed by the language context") {

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/backend/IdentityBackendServiceTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/backend/IdentityBackendServiceTests.kt
@@ -7,13 +7,10 @@ import com.onesignal.debug.internal.logging.Logging
 import com.onesignal.user.internal.backend.impl.IdentityBackendService
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import io.kotest.runner.junit4.KotestTestRunner
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
-import org.junit.runner.RunWith
 
-@RunWith(KotestTestRunner::class)
 class IdentityBackendServiceTests : FunSpec({
     beforeAny {
         Logging.logLevel = LogLevel.NONE

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/backend/SubscriptionBackendServiceTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/backend/SubscriptionBackendServiceTests.kt
@@ -10,15 +10,12 @@ import com.onesignal.user.internal.subscriptions.SubscriptionStatus
 import io.kotest.assertions.throwables.shouldThrowUnit
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import io.kotest.runner.junit4.KotestTestRunner
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
-import org.junit.runner.RunWith
 
 // WARNING: Adding @RobolectricTest will cause JSONObject.map() to stop working
 // at runtime.
-@RunWith(KotestTestRunner::class)
 class SubscriptionBackendServiceTests : FunSpec({
     beforeAny {
         Logging.logLevel = LogLevel.NONE

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/backend/UserBackendServiceTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/backend/UserBackendServiceTests.kt
@@ -9,14 +9,11 @@ import com.onesignal.user.internal.backend.impl.UserBackendService
 import io.kotest.assertions.throwables.shouldThrowUnit
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import io.kotest.runner.junit4.KotestTestRunner
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
-import org.junit.runner.RunWith
 import java.math.BigDecimal
 
-@RunWith(KotestTestRunner::class)
 class UserBackendServiceTests : FunSpec({
     beforeAny {
         Logging.logLevel = LogLevel.NONE

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/IdentityOperationExecutorTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/IdentityOperationExecutorTests.kt
@@ -13,7 +13,6 @@ import com.onesignal.user.internal.identity.IdentityModelStore
 import com.onesignal.user.internal.operations.impl.executors.IdentityOperationExecutor
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import io.kotest.runner.junit4.KotestTestRunner
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -21,9 +20,7 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.verify
-import org.junit.runner.RunWith
 
-@RunWith(KotestTestRunner::class)
 class IdentityOperationExecutorTests : FunSpec({
 
     test("execution of set alias operation") {

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/LoginUserOperationExecutorTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/LoginUserOperationExecutorTests.kt
@@ -25,15 +25,12 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldBeOneOf
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
-import io.kotest.runner.junit4.KotestTestRunner
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
-import org.junit.runner.RunWith
 
 @RobolectricTest
-@RunWith(KotestTestRunner::class)
 class LoginUserOperationExecutorTests : FunSpec({
     val appId = "appId"
     val localOneSignalId = "local-onesignalId"

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/RefreshUserOperationExecutorTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/RefreshUserOperationExecutorTests.kt
@@ -19,16 +19,13 @@ import com.onesignal.user.internal.subscriptions.SubscriptionModelStore
 import com.onesignal.user.internal.subscriptions.SubscriptionType
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import io.kotest.runner.junit4.KotestTestRunner
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
-import org.junit.runner.RunWith
 
-@RunWith(KotestTestRunner::class)
 class RefreshUserOperationExecutorTests : FunSpec({
     val appId = "appId"
     val existingSubscriptionId1 = "existing-subscriptionId1"

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/SubscriptionOperationExecutorTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/SubscriptionOperationExecutorTests.kt
@@ -17,7 +17,6 @@ import com.onesignal.user.internal.subscriptions.SubscriptionStatus
 import com.onesignal.user.internal.subscriptions.SubscriptionType
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import io.kotest.runner.junit4.KotestTestRunner
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -25,10 +24,8 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.verify
-import org.junit.runner.RunWith
 
 @RobolectricTest
-@RunWith(KotestTestRunner::class)
 class SubscriptionOperationExecutorTests : FunSpec({
     val appId = "appId"
     val remoteOneSignalId = "remote-onesignalId"

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/UpdateUserOperationExecutorTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/UpdateUserOperationExecutorTests.kt
@@ -11,16 +11,13 @@ import com.onesignal.user.internal.properties.PropertiesModel
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
-import io.kotest.runner.junit4.KotestTestRunner
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
-import org.junit.runner.RunWith
 import java.math.BigDecimal
 
-@RunWith(KotestTestRunner::class)
 class UpdateUserOperationExecutorTests : FunSpec({
     val appId = "appId"
     val localOneSignalId = "local-onesignalId"

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/properties/PropertiesModelTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/properties/PropertiesModelTests.kt
@@ -3,11 +3,8 @@ package com.onesignal.user.internal.properties
 import com.onesignal.common.putJSONObject
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import io.kotest.runner.junit4.KotestTestRunner
 import org.json.JSONObject
-import org.junit.runner.RunWith
 
-@RunWith(KotestTestRunner::class)
 class PropertiesModelTests : FunSpec({
 
     test("successfully initializes varying tag names") {

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/subscriptions/SubscriptionManagerTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/subscriptions/SubscriptionManagerTests.kt
@@ -11,16 +11,13 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.beInstanceOf
-import io.kotest.runner.junit4.KotestTestRunner
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.spyk
 import io.mockk.verify
-import org.junit.runner.RunWith
 
-@RunWith(KotestTestRunner::class)
 class SubscriptionManagerTests : FunSpec({
 
     test("initializes subscriptions from model store") {

--- a/OneSignalSDK/onesignal/in-app-messages/build.gradle
+++ b/OneSignalSDK/onesignal/in-app-messages/build.gradle
@@ -32,6 +32,9 @@ android {
         unitTests {
             includeAndroidResources = true
         }
+        unitTests.all {
+            it.useJUnitPlatform()
+        }
     }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -79,9 +82,9 @@ dependencies {
     }
 
     testImplementation(project(':OneSignal:testhelpers'))
-    testImplementation("junit:junit:$junitVersion")
-    testImplementation("io.kotest:kotest-runner-junit4:$kotestVersion")
-    testImplementation("io.kotest:kotest-runner-junit4-jvm:$kotestVersion")
+
+    testImplementation("io.kotest:kotest-runner-junit5:$kotestVersion")
+    testImplementation("io.kotest:kotest-runner-junit5-jvm:$kotestVersion")
     testImplementation("io.kotest:kotest-assertions-core:$kotestVersion")
     testImplementation("io.kotest:kotest-property:$kotestVersion")
     testImplementation("org.robolectric:robolectric:4.8.1")

--- a/OneSignalSDK/onesignal/in-app-messages/src/test/java/com/onesignal/inAppMessages/internal/InAppMessagesManagerTests.kt
+++ b/OneSignalSDK/onesignal/in-app-messages/src/test/java/com/onesignal/inAppMessages/internal/InAppMessagesManagerTests.kt
@@ -16,15 +16,12 @@ import com.onesignal.user.IUserManager
 import com.onesignal.user.internal.subscriptions.ISubscriptionManager
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import io.kotest.runner.junit4.KotestTestRunner
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.verify
-import org.junit.runner.RunWith
 
-@RunWith(KotestTestRunner::class)
 class InAppMessagesManagerTests : FunSpec({
 
     test("triggers are backed by the trigger model store") {

--- a/OneSignalSDK/onesignal/in-app-messages/src/test/java/com/onesignal/inAppMessages/internal/backend/InAppBackendServiceTests.kt
+++ b/OneSignalSDK/onesignal/in-app-messages/src/test/java/com/onesignal/inAppMessages/internal/backend/InAppBackendServiceTests.kt
@@ -18,13 +18,10 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldStartWith
-import io.kotest.runner.junit4.KotestTestRunner
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
-import org.junit.runner.RunWith
 
-@RunWith(KotestTestRunner::class)
 class InAppBackendServiceTests : FunSpec({
     beforeAny {
         Logging.logLevel = LogLevel.NONE

--- a/OneSignalSDK/onesignal/in-app-messages/src/test/java/com/onesignal/inAppMessages/internal/preview/InAppMessagePreviewHandlerTests.kt
+++ b/OneSignalSDK/onesignal/in-app-messages/src/test/java/com/onesignal/inAppMessages/internal/preview/InAppMessagePreviewHandlerTests.kt
@@ -12,7 +12,6 @@ import com.onesignal.notifications.internal.lifecycle.INotificationLifecycleServ
 import com.onesignal.testhelpers.extensions.RobolectricTest
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import io.kotest.runner.junit4.KotestTestRunner
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -20,7 +19,6 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import org.json.JSONObject
-import org.junit.runner.RunWith
 import org.robolectric.Robolectric
 import org.robolectric.annotation.Config
 
@@ -29,7 +27,6 @@ import org.robolectric.annotation.Config
     sdk = [26],
 )
 @RobolectricTest
-@RunWith(KotestTestRunner::class)
 class InAppMessagePreviewHandlerTests : FunSpec({
     beforeAny {
         Logging.logLevel = LogLevel.NONE

--- a/OneSignalSDK/onesignal/in-app-messages/src/test/java/com/onesignal/inAppMessages/internal/repositories/InAppRepositoryTests.kt
+++ b/OneSignalSDK/onesignal/in-app-messages/src/test/java/com/onesignal/inAppMessages/internal/repositories/InAppRepositoryTests.kt
@@ -9,15 +9,12 @@ import com.onesignal.mocks.DatabaseMockHelper
 import com.onesignal.mocks.MockHelper
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import io.kotest.runner.junit4.KotestTestRunner
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.verify
-import org.junit.runner.RunWith
 
-@RunWith(KotestTestRunner::class)
 class InAppRepositoryTests : FunSpec({
     beforeAny {
         Logging.logLevel = LogLevel.NONE

--- a/OneSignalSDK/onesignal/location/build.gradle
+++ b/OneSignalSDK/onesignal/location/build.gradle
@@ -32,6 +32,9 @@ android {
         unitTests {
             includeAndroidResources = true
         }
+        unitTests.all {
+            it.useJUnitPlatform()
+        }
     }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -78,9 +81,9 @@ dependencies {
     compileOnly "com.huawei.hms:location:$huaweiHMSLocationVersion"
 
     testImplementation(project(':OneSignal:testhelpers'))
-    testImplementation("junit:junit:$junitVersion")
-    testImplementation("io.kotest:kotest-runner-junit4:$kotestVersion")
-    testImplementation("io.kotest:kotest-runner-junit4-jvm:$kotestVersion")
+
+    testImplementation("io.kotest:kotest-runner-junit5:$kotestVersion")
+    testImplementation("io.kotest:kotest-runner-junit5-jvm:$kotestVersion")
     testImplementation("io.kotest:kotest-assertions-core:$kotestVersion")
     testImplementation("io.kotest:kotest-property:$kotestVersion")
     testImplementation("org.robolectric:robolectric:4.8.1")

--- a/OneSignalSDK/onesignal/location/src/test/java/com/onesignal/location/internal/background/LocationBackgroundServiceTests.kt
+++ b/OneSignalSDK/onesignal/location/src/test/java/com/onesignal/location/internal/background/LocationBackgroundServiceTests.kt
@@ -14,17 +14,14 @@ import com.onesignal.mocks.MockHelper
 import com.onesignal.testhelpers.extensions.RobolectricTest
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import io.kotest.runner.junit4.KotestTestRunner
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.verify
-import org.junit.runner.RunWith
 import org.robolectric.Shadows
 
 @RobolectricTest
-@RunWith(KotestTestRunner::class)
 class LocationBackgroundServiceTests : FunSpec({
     beforeAny {
         Logging.logLevel = LogLevel.NONE

--- a/OneSignalSDK/onesignal/location/src/test/java/com/onesignal/location/internal/capture/LocationCapturerTests.kt
+++ b/OneSignalSDK/onesignal/location/src/test/java/com/onesignal/location/internal/capture/LocationCapturerTests.kt
@@ -9,15 +9,12 @@ import com.onesignal.location.internal.preferences.ILocationPreferencesService
 import com.onesignal.mocks.MockHelper
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import io.kotest.runner.junit4.KotestTestRunner
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.slot
-import org.junit.runner.RunWith
 
-@RunWith(KotestTestRunner::class)
 class LocationCapturerTests : FunSpec({
     beforeAny {
         Logging.logLevel = LogLevel.NONE

--- a/OneSignalSDK/onesignal/location/src/test/java/com/onesignal/location/internal/controller/GmsLocationControllerTests.kt
+++ b/OneSignalSDK/onesignal/location/src/test/java/com/onesignal/location/internal/controller/GmsLocationControllerTests.kt
@@ -12,12 +12,10 @@ import com.onesignal.testhelpers.extensions.RobolectricTest
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
-import io.kotest.runner.junit4.KotestTestRunner
 import io.mockk.every
 import io.mockk.spyk
 import io.mockk.verify
 import io.mockk.verifySequence
-import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 
 @Config(
@@ -26,7 +24,6 @@ import org.robolectric.annotation.Config
     sdk = [26],
 )
 @RobolectricTest
-@RunWith(KotestTestRunner::class)
 class GmsLocationControllerTests : FunSpec({
     beforeAny {
         Logging.logLevel = LogLevel.NONE

--- a/OneSignalSDK/onesignal/location/src/test/java/com/onesignal/location/internal/permissions/LocationPermissionControllerTests.kt
+++ b/OneSignalSDK/onesignal/location/src/test/java/com/onesignal/location/internal/permissions/LocationPermissionControllerTests.kt
@@ -8,16 +8,13 @@ import com.onesignal.testhelpers.extensions.RobolectricTest
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.longs.shouldBeGreaterThan
 import io.kotest.matchers.shouldBe
-import io.kotest.runner.junit4.KotestTestRunner
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.verify
 import kotlinx.coroutines.delay
-import org.junit.runner.RunWith
 
 @RobolectricTest
-@RunWith(KotestTestRunner::class)
 class LocationPermissionControllerTests : FunSpec({
     beforeAny {
         Logging.logLevel = LogLevel.NONE

--- a/OneSignalSDK/onesignal/notifications/build.gradle
+++ b/OneSignalSDK/onesignal/notifications/build.gradle
@@ -32,6 +32,9 @@ android {
         unitTests {
             includeAndroidResources = true
         }
+        unitTests.all {
+            it.useJUnitPlatform()
+        }
     }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -91,9 +94,9 @@ dependencies {
     }
 
     testImplementation(project(':OneSignal:testhelpers'))
-    testImplementation("junit:junit:$junitVersion")
-    testImplementation("io.kotest:kotest-runner-junit4:$kotestVersion")
-    testImplementation("io.kotest:kotest-runner-junit4-jvm:$kotestVersion")
+
+    testImplementation("io.kotest:kotest-runner-junit5:$kotestVersion")
+    testImplementation("io.kotest:kotest-runner-junit5-jvm:$kotestVersion")
     testImplementation("io.kotest:kotest-assertions-core:$kotestVersion")
     testImplementation("io.kotest:kotest-property:$kotestVersion")
     testImplementation("org.robolectric:robolectric:4.8.1")

--- a/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/backend/NotificationBackendServiceTests.kt
+++ b/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/backend/NotificationBackendServiceTests.kt
@@ -10,13 +10,10 @@ import com.onesignal.notifications.internal.backend.impl.NotificationBackendServ
 import io.kotest.assertions.throwables.shouldThrowUnit
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import io.kotest.runner.junit4.KotestTestRunner
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
-import org.junit.runner.RunWith
 
-@RunWith(KotestTestRunner::class)
 class NotificationBackendServiceTests : FunSpec({
     beforeAny {
         Logging.logLevel = LogLevel.NONE

--- a/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/channels/NotificationChannelManagerTests.kt
+++ b/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/channels/NotificationChannelManagerTests.kt
@@ -16,10 +16,8 @@ import com.onesignal.testhelpers.extensions.RobolectricTest
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
-import io.kotest.runner.junit4.KotestTestRunner
 import org.json.JSONArray
 import org.json.JSONObject
-import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 import java.math.BigInteger
 
@@ -29,7 +27,6 @@ import java.math.BigInteger
     sdk = [26],
 )
 @RobolectricTest
-@RunWith(KotestTestRunner::class)
 class NotificationChannelManagerTests : FunSpec({
     beforeAny {
         Logging.logLevel = LogLevel.NONE

--- a/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/generation/NotificationGenerationProcessorTests.kt
+++ b/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/generation/NotificationGenerationProcessorTests.kt
@@ -16,7 +16,6 @@ import com.onesignal.notifications.internal.summary.INotificationSummaryManager
 import com.onesignal.testhelpers.extensions.RobolectricTest
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import io.kotest.runner.junit4.KotestTestRunner
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -25,7 +24,6 @@ import io.mockk.mockk
 import io.mockk.runs
 import kotlinx.coroutines.delay
 import org.json.JSONObject
-import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 
 @Config(
@@ -33,7 +31,6 @@ import org.robolectric.annotation.Config
     sdk = [26],
 )
 @RobolectricTest
-@RunWith(KotestTestRunner::class)
 class NotificationGenerationProcessorTests : FunSpec({
     beforeAny {
         Logging.logLevel = LogLevel.NONE

--- a/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/limiting/NotificationLimitManagerTests.kt
+++ b/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/limiting/NotificationLimitManagerTests.kt
@@ -12,12 +12,10 @@ import com.onesignal.notifications.internal.limiting.impl.NotificationLimitManag
 import com.onesignal.notifications.internal.summary.INotificationSummaryManager
 import com.onesignal.testhelpers.extensions.RobolectricTest
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.runner.junit4.KotestTestRunner
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 import io.mockk.spyk
-import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.Implements
 
@@ -27,7 +25,6 @@ import org.robolectric.annotation.Implements
     sdk = [26],
 )
 @RobolectricTest
-@RunWith(KotestTestRunner::class)
 class NotificationLimitManagerTests : FunSpec({
     beforeAny {
         Logging.logLevel = LogLevel.NONE

--- a/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/pushtoken/PushTokenManagerTests.kt
+++ b/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/pushtoken/PushTokenManagerTests.kt
@@ -9,14 +9,11 @@ import com.onesignal.notifications.shadows.ShadowRoboNotificationManager
 import com.onesignal.user.internal.subscriptions.SubscriptionStatus
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import io.kotest.runner.junit4.KotestTestRunner
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
-import org.junit.runner.RunWith
 
-@RunWith(KotestTestRunner::class)
 class PushTokenManagerTests : FunSpec({
     beforeAny {
         Logging.logLevel = LogLevel.NONE

--- a/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/summary/NotificationSummaryManagerTests.kt
+++ b/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/summary/NotificationSummaryManagerTests.kt
@@ -12,13 +12,11 @@ import com.onesignal.notifications.shadows.ShadowRoboNotificationManager
 import com.onesignal.testhelpers.extensions.RobolectricTest
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import io.kotest.runner.junit4.KotestTestRunner
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
-import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 
 @Config(
@@ -27,7 +25,6 @@ import org.robolectric.annotation.Config
     sdk = [26],
 )
 @RobolectricTest
-@RunWith(KotestTestRunner::class)
 class NotificationSummaryManagerTests : FunSpec({
     beforeAny {
         Logging.logLevel = LogLevel.NONE

--- a/OneSignalSDK/onesignal/testhelpers/build.gradle
+++ b/OneSignalSDK/onesignal/testhelpers/build.gradle
@@ -38,8 +38,12 @@ android {
 dependencies {
     implementation(project(':OneSignal:core'))
 
-    implementation("junit:junit:$junitVersion")
-    implementation("io.kotest:kotest-runner-junit4:$kotestVersion")
+    // Only use for RobolectricExtension.kt,
+    // to bridge Robolectric's JUnit4 usage to Kotest's Junit 5
+    implementation("junit:junit:4.13.2")
+
+    implementation("io.kotest:kotest-runner-junit5:$kotestVersion")
+    implementation("io.kotest:kotest-runner-junit5-jvm:$kotestVersion")
     implementation("org.robolectric:robolectric:4.8.1")
     implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
     implementation("io.mockk:mockk:1.13.2")


### PR DESCRIPTION
# Description
## One Line Summary
JUnit 5 supports better test result output with Kotest and a number of other features.

### Motivation
* Make nested test easier to read in the report output.
* JUnit 4 is not get any new features, and at this point probably only gets security fixes.

### Scope
Only unit tests, only upgrading JUnit 4 -> 5.

# Testing
## Unit testing
Unit tests pass locally and on CI

## Manual testing
No production source was changed.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2006)
<!-- Reviewable:end -->
