### PR TITLE
Migration: Missing onesignalId during initWithContext 

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
@@ -289,6 +289,8 @@ internal class OneSignalImp : IOneSignal, IServiceProvider {
                             legacyUserSyncJSON.safeString("identifier") ?: ""
                         if (notificationTypes != null) {
                             pushSubscriptionModel.status = SubscriptionStatus.fromInt(notificationTypes) ?: SubscriptionStatus.NO_PERMISSION
+                        } else {
+                            pushSubscriptionModel.status = SubscriptionStatus.SUBSCRIBED
                         }
 
                         pushSubscriptionModel.sdk = OneSignalUtils.SDK_VERSION


### PR DESCRIPTION
# Description
## One Line Summary
Add default subscription status if legacy user info was previously saved on the device.

## Details

### Motivation
We've received crash reports from this thread https://github.com/OneSignal/OneSignal-Android-SDK/issues/1995, indicating a crash caused by a null pointer exception when calling onesignal_id during the initWithText process. After some research, I discovered that this only occurs when the push subscription status is missing during a migration from v4 to v5. The getter of the subscription status will attempt to make a change to the model, which will then be queued in the model update operation. This operation requires onesignal_id to be completed, but the id is null at the early stage. To prevent the access of onesignal_id when it is null in the early init process, this fix will add a default subscription status in case of its absence under the NO_PROPOGATE tag.

# Testing
## Manual testing
Step to reproduce:
  1. Perform a fresh install of v4 on an Android device. (I am using Pixel 3a API 34)
  2. Make sure the player is created and shown on the OneSignal dashboard.
  3. Check out main and comment out the code that adds push subscription status when notification_types is null.
  4. Build and run the app on the same device. Notice that a null pointer exception is reported due to onesignal Id being null.

After the fix, the crash no longer exists. Some normal OneSignal operations such as logging in, logging out, sending and receiving push notifications are all working properly.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2009)
<!-- Reviewable:end -->
