### PR TITLE
Make ServiceBuilder.getService thread safe

### DIFF
--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/common/ServiceProviderTest.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/common/ServiceProviderTest.kt
@@ -1,0 +1,44 @@
+package com.onesignal.common
+
+import com.onesignal.common.services.ServiceBuilder
+import com.onesignal.common.services.ServiceProvider
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.types.shouldBeSameInstanceAs
+import java.util.concurrent.LinkedBlockingQueue
+
+internal interface IMyTestInterface
+
+internal class MySlowConstructorClass : IMyTestInterface {
+    init {
+        // NOTE: Keep these println calls, otherwise Kotlin optimizes
+        //   something which cases the test not fail when it should.
+        println("MySlowConstructorClass BEFORE")
+        Thread.sleep(10)
+        println("MySlowConstructorClass AFTER")
+    }
+}
+
+class ServiceProviderTest : FunSpec({
+
+    fun setupServiceProviderWithSlowInitClass(): ServiceProvider {
+        val serviceBuilder = ServiceBuilder()
+        serviceBuilder.register<MySlowConstructorClass>().provides<IMyTestInterface>()
+        return serviceBuilder.build()
+    }
+
+    test("getService is thread safe") {
+        val services = setupServiceProviderWithSlowInitClass()
+
+        val queue = LinkedBlockingQueue<IMyTestInterface>()
+        Thread {
+            queue.add(services.getService<IMyTestInterface>())
+        }.start()
+        Thread {
+            queue.add(services.getService<IMyTestInterface>())
+        }.start()
+
+        val firstReference = queue.take()
+        val secondReference = queue.take()
+        firstReference shouldBeSameInstanceAs secondReference
+    }
+})


### PR DESCRIPTION
# Description
## One Line Summary
Make `ServiceBuilder` thread safe, to avoid cases where it can unexpectedly return different instances for the same interface.

## Details
### Motivation
We are getting a number of crash reports with `appContext` being `null` and I believe `ServiceBuilder.getService` not being thread safe is cause. (but unknown if the only one)
### Scope
Only thread safely changes to `ServiceBuilder.kt`.

### SDK Internal Details
When investigating we found a case where two instances of `IApplicationService` could be created. Specifically if an instance of [`ReceiveReceiptWorker`](https://github.com/OneSignal/OneSignal-Android-SDK/blob/5.1.5/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/receivereceipt/impl/ReceiveReceiptWorkManager.kt#L75) is created by the Android Operating System when `OneSignal.initWithContext` is called (by the app developer or internally by the SDK). This can result in two thread calling `ServiceBuilder.getService()`, creating the two instances of a class unexpectedly.

### What This May Fix
While this fix addresses a single known cause of `OneSignal.initWithContext` throwing on a `null` `Context` error, it is unclear if this is the only source of this, or by how much this fix will help lower these crashes.

## Reproducing the Crash in an app
While I could not reproduce the issue in a real world scenario there is a unit test in this PR [ServiceProviderTest](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2012/files#diff-6f664477893312bd5d54d22fb9277dc7117f59322377a776ce87d6c41aaeaf15R21). Also a integration style test can be done by running the example app in the [crash-with-null-context-on-initWithContext](https://github.com/OneSignal/OneSignal-Android-SDK/commits/repo/crash-with-null-context-on-initWithContext/) branch, see aa32927443821ab725a8ce6e1e5ad45d2edf749f through for more details.

##  Crashes
This PR may address NullPointerException from `initWithContext` like this one:
https://github.com/OneSignal/OneSignal-Android-SDK/issues/1995
```
Caused by java.lang.NullPointerException
null cannot be cast to non-null type kotlin.String
com.onesignal.common.modeling.Model.getStringProperty (Model.kt:491)
com.onesignal.common.modeling.Model.getStringProperty$default (Model.kt:488)
com.onesignal.user.internal.identity.IdentityModel.getOnesignalId (IdentityModel.kt:19)
com.onesignal.user.internal.operations.impl.listeners.SubscriptionModelStoreListener.getUpdateOperation (SubscriptionModelStoreListener.kt:48)
com.onesignal.user.internal.operations.impl.listeners.SubscriptionModelStoreListener.getUpdateOperation (SubscriptionModelStoreListener.kt:15)
com.onesignal.core.internal.operations.listeners.ModelStoreListener.onModelUpdated (ModelStoreListener.kt:52)
com.onesignal.common.modeling.ModelStore$onChanged$1.invoke (ModelStore.kt:91)
com.onesignal.common.modeling.ModelStore$onChanged$1.invoke (ModelStore.kt:91)
com.onesignal.common.events.EventProducer.fire (EventProducer.kt:50)
com.onesignal.common.modeling.ModelStore.onChanged (ModelStore.kt:91)
com.onesignal.common.modeling.Model$notifyChanged$1.invoke (Model.kt:666)
com.onesignal.common.modeling.Model$notifyChanged$1.invoke (Model.kt:666)
com.onesignal.common.events.EventProducer.fire (EventProducer.kt:50)
com.onesignal.common.modeling.Model.notifyChanged (Model.kt:666)
com.onesignal.common.modeling.Model.setOptAnyProperty (Model.kt:460)
com.onesignal.common.modeling.Model.setOptEnumProperty$default (Model.kt:327)
com.onesignal.user.internal.subscriptions.SubscriptionModel.getStatus (SubscriptionModel.kt:117)
com.onesignal.user.internal.PushSubscription.getOptedIn (PushSubscription.kt:22)
com.onesignal.user.internal.PushSubscription.fetchState (PushSubscription.kt:44)
com.onesignal.user.internal.PushSubscription.<init> (PushSubscription.kt:15)
com.onesignal.user.internal.subscriptions.impl.SubscriptionManager.createSubscriptionFromModel (SubscriptionManager.kt:232)
com.onesignal.user.internal.subscriptions.impl.SubscriptionManager.createSubscriptionAndAddToSubscriptionList (SubscriptionManager.kt)
com.onesignal.user.internal.subscriptions.impl.SubscriptionManager.onModelAdded (SubscriptionManager.kt:149)
com.onesignal.user.internal.subscriptions.impl.SubscriptionManager.onModelRemoved (SubscriptionManager.kt:41)
com.onesignal.user.internal.subscriptions.impl.SubscriptionManager.onModelAdded (SubscriptionManager.kt:41)
com.onesignal.common.modeling.ModelStore$addItem$2.invoke (ModelStore.kt:138)
com.onesignal.common.modeling.ModelStore$addItem$2.invoke (ModelStore.kt:138)
com.onesignal.common.events.EventProducer.fire (EventProducer.kt:50)
com.onesignal.common.modeling.ModelStore.addItem (ModelStore.kt:138)
com.onesignal.common.modeling.ModelStore.addItem$default (ModelStore.kt:121)
com.onesignal.common.modeling.ModelStore.add (ModelStore.kt:49)
com.onesignal.internal.OneSignalImp.initWithContext (OneSignalImp.kt:299)
com.onesignal.OneSignal.initWithContext (OneSignal.kt:135)
xxx.onCreate (CustomApplication.kt:40)
android.app.Instrumentation.callApplicationOnCreate (Instrumentation.java:1154)
```

# Testing
## Unit testing
### Added a new test
Created a new [ServiceProviderTest](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2012/files#diff-6f664477893312bd5d54d22fb9277dc7117f59322377a776ce87d6c41aaeaf15R21) test confirm that `ServiceBuilder.getService()` should return the same instance, even when accessed from two threads. To ensure the test is consistent we made the constructor slow so both threads end up on the same line of the production code we want to test.

* [First commit](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2012/commits/893381b05fbd55eef74dbfc663dd27cceb098901), only new test added, [confirmation of CI failure](https://github.com/OneSignal/OneSignal-Android-SDK/actions/runs/8106094806/job/22155472101?pr=2012#step:6:676)
* [Second commit](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2012/commits/0e613e39b2be921c1453f5145c9b13635df3427e), fix added, [confirmation of CI passing](https://github.com/OneSignal/OneSignal-Android-SDK/actions/runs/8106284501/job/22155946861?pr=2012#step:6:680)

## Manual testing
Tested on an Android 6 and Android 14 emulator, ensuring notifications display.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [X] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2012)
<!-- Reviewable:end -->
