### PR TITLE
[Fix] Duplicate GET /user call on cold start when calling login with the same external_id

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
@@ -359,15 +359,6 @@ internal class OneSignalImp : IOneSignal, IServiceProvider {
             currentIdentityOneSignalId = identityModelStore!!.model.onesignalId
 
             if (currentIdentityExternalId == externalId) {
-                // login is for same user that is already logged in, fetch (refresh)
-                // the current user.
-                operationRepo!!.enqueue(
-                    RefreshUserOperation(
-                        configModel!!.appId,
-                        identityModelStore!!.model.onesignalId,
-                    ),
-                    true,
-                )
                 return
             }
 


### PR DESCRIPTION
# Description
## One Line Summary
Omit making a GET /user call on cold start when calling login on the same external_id.

## Details
We already refresh when the app is cold started, so this results in two GET calls back-to-back for apps that call login every time the app is opened the by the user. We are still refreshing the user if switch user happens.

### Motivation
Optimize network calls is beneficial to the device and OneSignal's backend.

### Scope
Only effects `OneSignal.login`, only omitting an extra get User call.

# Testing
## Unit testing
Adding a test is out of scope for this PR, since there is no existing test infrastructure to test code in `OneSignalImp`. Also such code should be refactored out into a different class to make it more testable anyway.

## Manual testing
Test on an Android 14 emulator.
### Before
![Screenshot 2024-03-04 Before remove extra Get User call on login](https://github.com/OneSignal/OneSignal-Android-SDK/assets/645861/db45560e-ab9c-4afb-ae9d-c6a99a96e49e)

### After
![Screenshot 2024-03-04 194601 After remove extra Get User call on login](https://github.com/OneSignal/OneSignal-Android-SDK/assets/645861/b09adc9c-f0a4-4941-bcf3-bff4fd8b99a1)

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2015)
<!-- Reviewable:end -->
