### PR TITLE
[Feat] Add backoff to OperationRepo when retrying network calls

### DIFF
--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/operations/OperationRepoTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/operations/OperationRepoTests.kt
@@ -16,6 +16,7 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.slot
+import io.mockk.spyk
 
 class OperationRepoTests : FunSpec({
 
@@ -73,7 +74,15 @@ class OperationRepoTests : FunSpec({
         every { mockOperationModelStore.remove(any()) } just runs
 
         val operationRepo =
-            OperationRepo(listOf(mockExecutor), mockOperationModelStore, MockHelper.configModelStore(), MockHelper.time(1000))
+            spyk(
+                OperationRepo(
+                    listOf(mockExecutor),
+                    mockOperationModelStore,
+                    MockHelper.configModelStore(),
+                    MockHelper.time(1000),
+                ),
+            )
+        coEvery { operationRepo.delayBeforeRetry(any()) } just runs
 
         val operationIdSlot = slot<String>()
         val operation = mockOperation(operationIdSlot = operationIdSlot)
@@ -93,6 +102,7 @@ class OperationRepoTests : FunSpec({
                     it[0] shouldBe operation
                 },
             )
+            operationRepo.delayBeforeRetry(1)
             mockExecutor.execute(
                 withArg {
                     it.count() shouldBe 1


### PR DESCRIPTION
# Description
## One Line Summary
Add a delay to retries with a backoff to slow down network calls from `OperationRepo`.

## Details

### Motivation
Retrying too quickly:
* puts unnecessary load on the device and OneSignal's backend.
* may cause multiple OneSignal Users being created
    - some of them being in a bad state with the same `external_id` but different `onesignal_id` values due to this fast retrying.
    - Mostly only an issue when `OperationRepo.force` is true, which causes the 5 second batching to delay to be skipped, which normally get set when calling `OneSignal.login`

### Scope
Only affects adding a delay to retries on `OperationRepo`.


# Testing
## Unit testing
To ensure this works as expected we [updated the retrying test to confirm the delay is called](https://github.com/OneSignal/OneSignal-Android-SDK/compare/feat/add_backoff_to_operation_retries?expand=1#diff-7fa744405d396861944bf74935126dad924f9dfd24d3dda580a8d8a6461687d9R105).

## Manual testing
Also to ensure this commit works as intended I ran this on an Android 14 emu and ensured it waits the right amount of time when there is `500` response. Also after we stop getting a `500` error the queue successfully resumes and all pending tags are even added too. While it's waiting for the next retry I ensured it didn't lock main thread as well.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [X] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2017)
<!-- Reviewable:end -->
