### PR TITLE
[Fix] Call initWithContext on all entry points

### DIFF
--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/generation/impl/NotificationGenerationWorkManager.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/generation/impl/NotificationGenerationWorkManager.kt
@@ -63,8 +63,8 @@ internal class NotificationGenerationWorkManager : INotificationGenerationWorkMa
 
     class NotificationGenerationWorker(context: Context, workerParams: WorkerParameters) : CoroutineWorker(context, workerParams) {
         override suspend fun doWork(): Result {
-            if (!OneSignal.isInitialized) {
-                return Result.failure()
+            if (!OneSignal.initWithContext(applicationContext)) {
+                return Result.success()
             }
 
             val notificationProcessor: INotificationGenerationProcessor = OneSignal.getService()

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/receivereceipt/impl/ReceiveReceiptWorkManager.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/receivereceipt/impl/ReceiveReceiptWorkManager.kt
@@ -72,13 +72,16 @@ internal class ReceiveReceiptWorkManager(
     }
 
     class ReceiveReceiptWorker(context: Context, workerParams: WorkerParameters) : CoroutineWorker(context, workerParams) {
-        private var receiveReceiptProcessor: IReceiveReceiptProcessor = OneSignal.getService()
-
         override suspend fun doWork(): Result {
-            val inputData = inputData
+            if (!OneSignal.initWithContext(applicationContext)) {
+                return Result.success()
+            }
+
             val notificationId = inputData.getString(OS_NOTIFICATION_ID)!!
             val appId = inputData.getString(OS_APP_ID)!!
             val subscriptionId = inputData.getString(OS_SUBSCRIPTION_ID)!!
+
+            val receiveReceiptProcessor = OneSignal.getService<IReceiveReceiptProcessor>()
             receiveReceiptProcessor.sendReceiveReceipt(appId, subscriptionId, notificationId)
             return Result.success()
         }

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/services/ADMMessageHandler.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/services/ADMMessageHandler.kt
@@ -13,6 +13,10 @@ import com.onesignal.notifications.internal.registration.impl.IPushRegistratorCa
 class ADMMessageHandler : ADMMessageHandlerBase("ADMMessageHandler") {
     override fun onMessage(intent: Intent) {
         val context = applicationContext
+        if (!OneSignal.initWithContext(context)) {
+            return
+        }
+
         val bundle = intent.extras
 
         val bundleProcessor = OneSignal.getService<INotificationBundleProcessor>()

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/services/ADMMessageHandlerJob.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/services/ADMMessageHandlerJob.kt
@@ -14,9 +14,15 @@ class ADMMessageHandlerJob : ADMMessageHandlerJobBase() {
         context: Context?,
         intent: Intent?,
     ) {
-        val bundle = intent?.extras
-
+        if (context == null) {
+            return
+        }
+        if (!OneSignal.initWithContext(context.applicationContext)) {
+            return
+        }
         val bundleProcessor = OneSignal.getService<INotificationBundleProcessor>()
+
+        val bundle = intent?.extras
 
         bundleProcessor.processBundleFromReceiver(context!!, bundle!!)
     }


### PR DESCRIPTION
# Description
## One Line Summary
Call `initWithContext` on all entry points where the app process can start, fixing the inconsistencies in initialization which addresses some rare edge cases.

## Details
We call `OneSignal.initWithContext` on most entry points but some were missed. Consistency is important as differences can lead to edge case bugs that are hard to reproduce and debug.

One recent example of this was with `ReceiveReceiptWorker`, its inconsistency lead to a hard to debug issue that was uncovered by PR #2012

In this PR an issue was discovered in `NotificationGenerationWorker`. It almost always runs after receiving a push, but not guaranteed. It was checking for `OneSignal.isInitialized` but instead should always call `initWithContext` as it can be an entry point to the app process.

The `ADMMessageHandlerJob` may or may not have had an issue, but we matched up the `initWithContext` behavior to be safe.

### Motivation
Initialization consistency is important as differences can lead to edge case bugs that are hard to reproduce and debug.

### Scope
Only effects initialization on internal entry points for OneSignal events.

# Testing
## Unit testing
No unit test coverage exists on these entry points, to test such code these would have to be abstracted out which is out of scope of this PR.

## Manual testing
Ensure notifications are displayed on an Android 6 emulator, both when the app process is in the background when it it was stopped.

# Affected code checklist
   - [X] Notifications
      - [ ] Display
      - [ ] Open
      - [X] Push Processing
      - [X] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2018)
<!-- Reviewable:end -->
