### PR TITLE
Fix set_response_time.yml

### DIFF
--- a/.github/workflows/set_response_time.yml
+++ b/.github/workflows/set_response_time.yml
@@ -17,8 +17,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-      - run: npm install @octokit/action
-      - uses: actions/github-script@v6.0.7
+      - run: npm install @octokit/action@6.0.6
+      - uses: actions/github-script@v6
         id: set-time 
         with:
           result-encoding: string


### PR DESCRIPTION
Fix set response time script to match the other repos by specifying an octokit action version number

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2022)
<!-- Reviewable:end -->
