### PR TITLE
[Docs] Update supported android versions in readme to include Android 14

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,4 +28,4 @@ For account issues and support please contact OneSignal support from the [OneSig
 To make things easier, we have published demo projects in the `/Examples` folder of this repository.
 
 #### Supports:
-* Tested from Android 4.1.0 (API level 16) to Android 12 (31)
+* Tested from Android 5.0 (API level 21) to Android 14 (34)


### PR DESCRIPTION
# Description
## One Line Summary
Updated tested / supported Android versions in repos readme.

## Details

### Motivation
Developer use the readme to evaluate libraries before using, it is import Android versions are up to date so they know what is supported.

### Scope
Only update Android versions in the Readme.

### History
We support Android 14 (API 34) for a while but this readme was never updated. Also since OneSignal-Android-SDK 5.0.0 we only support Android 5.0 (API 21).

# Testing
## Unit testing
N/A

## Manual testing
N/A

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2024)
<!-- Reviewable:end -->
