### PR TITLE
[PlayerModel] [Fix] Retry starting new threads

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSBackgroundSync.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSBackgroundSync.java
@@ -27,6 +27,8 @@
 
 package com.onesignal;
 
+import static com.onesignal.OSUtils.startThreadWithRetry;
+
 import android.app.AlarmManager;
 import android.app.PendingIntent;
 import android.app.job.JobInfo;
@@ -63,7 +65,7 @@ abstract class OSBackgroundSync {
         OneSignal.onesignalLog(OneSignal.LOG_LEVEL.DEBUG, "OSBackground sync, calling initWithContext");
         OneSignal.initWithContext(context);
         syncBgThread = new Thread(runnable, getSyncTaskThreadId());
-        syncBgThread.start();
+        startThreadWithRetry(syncBgThread);
     }
 
     boolean stopSyncBgThread() {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSUtils.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSUtils.java
@@ -691,4 +691,18 @@ class OSUtils {
    static String getRootCauseMessage(@NonNull Throwable throwable) {
       return getRootCauseThrowable(throwable).getMessage();
    }
+
+   static void startThreadWithRetry(@NonNull Thread thread) {
+      boolean started = false;
+      while (!started) {
+         try {
+            thread.start();
+            started = true;
+         } catch (OutOfMemoryError ignored) {
+            try {
+               Thread.sleep(250);
+            } catch (InterruptedException ignoreInterrupted) {}
+         }
+      }
+   }
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -75,6 +75,7 @@ import java.util.TimeZone;
 import static com.onesignal.GenerateNotification.BUNDLE_KEY_ACTION_ID;
 import static com.onesignal.GenerateNotification.BUNDLE_KEY_ANDROID_NOTIFICATION_ID;
 import static com.onesignal.NotificationBundleProcessor.newJsonArray;
+import static com.onesignal.OSUtils.startThreadWithRetry;
 
 /**
  * The main OneSignal class - this is where you will interface with the OneSignal SDK
@@ -1488,7 +1489,7 @@ public class OneSignal {
          return;
       }
 
-      new Thread(new Runnable() {
+      Thread thread = new Thread(new Runnable() {
          public void run() {
             try {
                registerUserTask();
@@ -1496,7 +1497,8 @@ public class OneSignal {
                Log(LOG_LEVEL.FATAL, "FATAL Error registering device!", t);
             }
          }
-      }, "OS_REG_USER").start();
+      }, "OS_REG_USER");
+      startThreadWithRetry(thread);
    }
 
    private static void registerUserTask() throws JSONException {


### PR DESCRIPTION
# Description
## One Line Summary
Handle `Thread.start()` throwing `OutOfMemoryError` errors by retrying.

## Details

### Motivation
App developers can handle `onTrimMemory` and might be cleaning up memory. While the SDK can't know if this is being done it's better to retry then to crash the app.

### Scope
This commit doesn't cover all new threads, just some of the most common ones.
Also in v5 most new threads have been migrated to Kotlin coroutines so this PR should not be used outside of this player model branch.

### Crash Examples
#### Crash 1
```
java.lang.OutOfMemoryError: pthread_create (1040KB stack) failed: Try again
  at java.lang.Thread.nativeCreate(Thread.java:-2)
  at java.lang.Thread.start(Thread.java:883)
  at com.onesignal.OneSignalRestClient.callResponseHandlerOnFailure(OneSignalRestClient.java:296)
  at com.onesignal.OneSignalRestClient.getThreadTimeout(OneSignalRestClient.java:260)
  at com.onesignal.OneSignalRestClient.startHTTPConnection(OneSignalRestClient.java:260)
  at com.onesignal.OneSignalRestClient.access$100(OneSignalRestClient.java:46)
  at com.onesignal.OneSignalRestClient$4.run(OneSignalRestClient.java:114)
  at java.lang.Thread.run(Thread.java:919)
```

#### Crash 2
```
java.lang.OutOfMemoryError: pthread_create (1040KB stack) failed: Try again
  at java.lang.Thread.nativeCreate(Thread.java:-2)
  at java.lang.Thread.start(Thread.java:733)
  at com.onesignal.OneSignal.registerUser(OneSignal.java:1499)
  at com.onesignal.OneSignal.access$400(OneSignal.java:86)
  at com.onesignal.OneSignal$6.complete(OneSignal.java:1099)
  at com.onesignal.PushRegistratorAbstractGoogle.internalRegisterForPush(PushRegistratorAbstractGoogle.java:71)
  at com.onesignal.PushRegistratorAbstractGoogle.registerForPush(PushRegistratorAbstractGoogle.java:51)
  at com.onesignal.OneSignal.registerForPushToken(OneSignal.java:1079)
  at com.onesignal.OneSignal.startRegistrationOrOnSession(OneSignal.java:1029)
  at com.onesignal.OneSignal.doSessionInit(OneSignal.java:1012)
  at com.onesignal.OneSignal.onAppFocusLogic(OneSignal.java:1438)
  at com.onesignal.OneSignal.onAppFocus(OneSignal.java:1420)
  at com.onesignal.OSFocusHandler.startOnFocusWork(OSFocusHandler.java:53)
  at com.onesignal.ActivityLifecycleHandler.handleFocus(ActivityLifecycleHandler.java:197)
  at com.onesignal.ActivityLifecycleHandler.onActivityResumed(ActivityLifecycleHandler.java:95)
  at com.onesignal.ActivityLifecycleListener.onActivityResumed(ActivityLifecycleListener.java:91)
  at android.app.Application.dispatchActivityResumed(Application.java:239)
  at android.app.Activity.onResume(Activity.java:1343)
  at androidx.core.app.ComponentActivity.onResume(ComponentActivity.java)
  at androidx.activity.ComponentActivity.onResume(ComponentActivity.java)
  at androidx.fragment.app.FragmentActivity.onResume(FragmentActivity.java:310)
  at androidx.appcompat.app.AppCompatActivity.onResume(AppCompatActivity.java)
```

#### Crash 3
```
java.lang.OutOfMemoryError: pthread_create (1040KB stack) failed: Try again
  at java.lang.Thread.nativeCreate(Thread.java:-2)
  at java.lang.Thread.start(Thread.java:883)
  at com.onesignal.OneSignalRestClient.makeRequest(OneSignalRestClient.java:118)
  at com.onesignal.OneSignalRestClient.$$c(OneSignalRestClient.java:118)
  at com.onesignal.OneSignalRestClient.putSync(OneSignalRestClient.java:96)
  at com.onesignal.UserStateSynchronizer.addOnSessionOrCreateExtras(UserStateSynchronizer.java:357)
  at com.onesignal.UserStateSynchronizer.doPutSync(UserStateSynchronizer.java:357)
  at com.onesignal.UserStateSynchronizer.getId(UserStateSynchronizer.java:357)
  at com.onesignal.UserStateSynchronizer.fireEventsForUpdateFailure(UserStateSynchronizer.java:285)
  at com.onesignal.UserStateSynchronizer.internalSyncUserState(UserStateSynchronizer.java:285)
  at com.onesignal.UserStateSynchronizer.updateIdDependents(UserStateSynchronizer.java:285)
  at com.onesignal.UserStateSynchronizer.syncUserState(UserStateSynchronizer.java:251)
  at com.onesignal.UserStateSynchronizer$NetworkHandlerThread$1.run(UserStateSynchronizer.java:141)
  at android.os.Handler.handleCallback(Handler.java:883)
  at android.os.Handler.dispatchMessage(Handler.java:100)
  at android.os.Looper.loop(Looper.java:214)
  at android.os.HandlerThread.run(HandlerThread.java:67)
```

#### Crash 4
```
java.lang.OutOfMemoryError: pthread_create (1040KB stack) failed: Try again
  at java.lang.Thread.nativeCreate(Thread.java:-2)
  at java.lang.Thread.start(Thread.java:883)
  at com.onesignal.OSBackgroundSync.doBackgroundSync(OSBackgroundSync.java:66)
  at com.onesignal.OSBackgroundSync.getSyncTaskId(OSBackgroundSync.java:66)
  at com.onesignal.SyncJobService.onStartJob(SyncJobService.java:40)
  at android.app.job.JobService$1.onStartJob(JobService.java:62)
  at android.app.job.JobServiceEngine$JobHandler.handleMessage(JobServiceEngine.java:108)
  at android.os.Handler.dispatchMessage(Handler.java:107)
  at android.os.Looper.loop(Looper.java:264)
  at android.app.ActivityThread.main(ActivityThread.java:7663)
  at java.lang.reflect.Method.invoke(Method.java:-2)
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:492)
  at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:980)
```

# Testing
## Manual testing
Ensured SDK run on an Android 14 emulator and network calls are being made.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
         - Test are not passing on player-model-main
   - [X I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2027)
<!-- Reviewable:end -->
