### PR TITLE
Release 4.8.8

### DIFF
--- a/Examples/OneSignalDemo/app/build.gradle
+++ b/Examples/OneSignalDemo/app/build.gradle
@@ -65,12 +65,12 @@ dependencies {
     implementation 'com.github.bumptech.glide:glide:4.12.0'
 
     /** START - Google Play Builds **/
-    gmsImplementation('com.onesignal:OneSignal:4.6.3')
+    gmsImplementation('com.onesignal:OneSignal:4.8.8')
     /** END - Google Play Builds **/
 
     /** START - Huawei Builds **/
     // Omit Google / Firebase libraries for Huawei builds.
-    huaweiImplementation('com.onesignal:OneSignal:4.6.3') {
+    huaweiImplementation('com.onesignal:OneSignal:4.8.8') {
         exclude group: 'com.google.android.gms', module: 'play-services-gcm'
         exclude group: 'com.google.android.gms', module: 'play-services-analytics'
         exclude group: 'com.google.android.gms', module: 'play-services-location'

--- a/OneSignalSDK/onesignal/maven-push.gradle
+++ b/OneSignalSDK/onesignal/maven-push.gradle
@@ -32,7 +32,7 @@ class Global {
     static def POM_NAME = 'OneSignal'
     static def POM_ARTIFACT_ID = 'OneSignal'
     static def POM_PACKAGING = 'aar'
-    static def VERSION_NAME = '4.8.7'
+    static def VERSION_NAME = '4.8.8'
 
     static def GROUP_ID = 'com.onesignal'
     static def POM_DESCRIPTION = 'OneSignal Android SDK'

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -432,7 +432,7 @@ public class OneSignal {
    private static TrackAmazonPurchase trackAmazonPurchase;
    private static TrackFirebaseAnalytics trackFirebaseAnalytics;
 
-   private static final String VERSION = "040807";
+   private static final String VERSION = "040808";
    public static String getSdkVersionRaw() {
       return VERSION;
    }


### PR DESCRIPTION
**✨ Enhancements**
- Add setting to prefer HMS over FCM #1984
   - Add `<meta-data android:name="com.onesignal.preferHMS" android:value="true"/>` if you like to use this setting.

**🐛 Bug Fixes**
- Attempt retrying OutOfMemoryError errors when starting threads. #2027
    * Make sure your app doesn't have any memory leaks and is handling [onTrimMemory](https://developer.android.com/topic/performance/memory) so the SDK can move on once memory is free
- Fix rare null crash with `taskQueueWaitingForInit.poll()` #2026
- Fix rare null crash with `timeFocusedAtMs`  #2025

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2028)
<!-- Reviewable:end -->
