### PR TITLE
[Improvement] Prevent OperationRepo from continuously pulling when empty

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/threading/Waiter.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/threading/Waiter.kt
@@ -1,7 +1,6 @@
 package com.onesignal.common.threading
 
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.runBlocking
 
 /**
  * An abstraction which allows for a suspending function to coordinate
@@ -18,7 +17,13 @@ class Waiter {
     /**
      * Wake the suspending function that has called [waitForWake].
      */
-    fun wake() = runBlocking { channel.send(null) }
+    fun wake() {
+        val result = channel.trySend(null)
+        if (result.isFailure) {
+            // Most likely only happens when the chanel is misconfigured or misused
+            throw Exception("Waiter.wait failed", result.exceptionOrNull())
+        }
+    }
 }
 
 /**
@@ -40,5 +45,11 @@ open class WaiterWithValue<TType> {
      *
      * @param value The data to be returned by the [waitForWake].
      */
-    fun wake(value: TType) = runBlocking { channel.send(value) }
+    fun wake(value: TType) {
+        val result = channel.trySend(value)
+        if (result.isFailure) {
+            // Most likely only happens when the chanel is misconfigured or misused
+            throw Exception("WaiterWithValue.wait failed", result.exceptionOrNull())
+        }
+    }
 }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/impl/OperationRepo.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/impl/OperationRepo.kt
@@ -97,7 +97,7 @@ internal class OperationRepo(
      * dedicated thread.
      */
     private suspend fun processQueueForever() {
-        var force = waitForWake()
+        waitForNewOperationAndExecutionInterval()
         while (true) {
             if (paused) {
                 Logging.debug("OperationRepo is paused")
@@ -105,29 +105,39 @@ internal class OperationRepo(
             }
 
             val ops = getNextOps()
-            Logging.debug("processQueueForever:force:$force, ops:$ops")
+            Logging.debug("processQueueForever:ops:$ops")
 
             if (ops != null) {
                 executeOperations(ops)
                 // Allows for any subsequent operations (beyond the first one
                 // that woke us) to be enqueued before we pull from the queue.
                 delay(_configModelStore.model.opRepoPostWakeDelay)
-            } else if (!force) {
-                force = waitForWake()
             } else {
-                force = false
+                waitForNewOperationAndExecutionInterval()
             }
         }
     }
 
-    private suspend fun waitForWake(): Boolean {
+    /**
+     *  Waits until a new operation is enqueued, then wait an additional
+     *  amount of time afterwards, so operations can be grouped/batched.
+     */
+    private suspend fun waitForNewOperationAndExecutionInterval() {
+        // 1. Wait for an operation to be enqueued
         var force = waiter.waitForWake()
-        if (!force) {
-            withTimeoutOrNull(_configModelStore.model.opRepoExecutionInterval) {
+
+        // 2. Wait at least the time defined in opRepoExecutionInterval
+        //    so operations can be grouped, unless one of them used
+        //    flush=true (AKA force)
+        var lastTime = _time.currentTimeMillis
+        var remainingTime = _configModelStore.model.opRepoExecutionInterval
+        while (!force && remainingTime > 0) {
+            withTimeoutOrNull(remainingTime) {
                 force = waiter.waitForWake()
             }
+            remainingTime -= _time.currentTimeMillis - lastTime
+            lastTime = _time.currentTimeMillis
         }
-        return force
     }
 
     private suspend fun executeOperations(ops: List<OperationQueueItem>) {

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/operations/OperationRepoTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/operations/OperationRepoTests.kt
@@ -20,6 +20,38 @@ import io.mockk.spyk
 import io.mockk.verify
 import kotlinx.coroutines.delay
 
+// Mocks used by every test in this file
+private class Mocks {
+    val operationModelStore: OperationModelStore =
+        run {
+            val mockOperationModelStore = mockk<OperationModelStore>()
+            every { mockOperationModelStore.list() } returns listOf()
+            every { mockOperationModelStore.add(any()) } just runs
+            every { mockOperationModelStore.remove(any()) } just runs
+            mockOperationModelStore
+        }
+
+    val executor: IOperationExecutor =
+        run {
+            val mockExecutor = mockk<IOperationExecutor>()
+            every { mockExecutor.operations } returns listOf("DUMMY_OPERATION")
+            coEvery { mockExecutor.execute(any()) } returns ExecutionResponse(ExecutionResult.SUCCESS)
+            mockExecutor
+        }
+
+    val operationRepo: OperationRepo =
+        run {
+            spyk(
+                OperationRepo(
+                    listOf(executor),
+                    operationModelStore,
+                    MockHelper.configModelStore(),
+                    MockHelper.time(1000),
+                ),
+            )
+        }
+}
+
 class OperationRepoTests : FunSpec({
 
     beforeAny {
@@ -29,31 +61,11 @@ class OperationRepoTests : FunSpec({
     // Ensures we are not continuously waking the CPU
     test("ensure processQueueForever suspends when queue is empty") {
         // Given
-        val mockExecutor = mockk<IOperationExecutor>()
-        every { mockExecutor.operations } returns listOf("DUMMY_OPERATION")
-        coEvery { mockExecutor.execute(any()) } returns ExecutionResponse(ExecutionResult.SUCCESS)
-
-        val mockOperationModelStore = mockk<OperationModelStore>()
-        every { mockOperationModelStore.list() } returns listOf()
-        every { mockOperationModelStore.add(any()) } just runs
-        every { mockOperationModelStore.remove(any()) } just runs
-
-        val operationRepo =
-            spyk(
-                OperationRepo(
-                    listOf(mockExecutor),
-                    mockOperationModelStore,
-                    MockHelper.configModelStore(),
-                    MockHelper.time(1000),
-                ),
-            )
-
-        val operationIdSlot = slot<String>()
-        val operation = mockOperation(operationIdSlot = operationIdSlot)
+        val mocks = Mocks()
 
         // When
-        operationRepo.start()
-        val response = operationRepo.enqueueAndWait(operation)
+        mocks.operationRepo.start()
+        val response = mocks.operationRepo.enqueueAndWait(mockOperation())
         // Must wait for background logic to spin to see how many times it
         // will call getNextOps()
         delay(1_000)
@@ -64,309 +76,240 @@ class OperationRepoTests : FunSpec({
             // 1st: gets the operation
             // 2nd: will be empty
             // 3rd: shouldn't be called, loop should be waiting on next operation
-            operationRepo.getNextOps()
+            mocks.operationRepo.getNextOps()
         }
     }
 
     test("enqueue operation executes and is removed when executed") {
         // Given
-        val mockExecutor = mockk<IOperationExecutor>()
-        every { mockExecutor.operations } returns listOf("DUMMY_OPERATION")
-        coEvery { mockExecutor.execute(any()) } returns ExecutionResponse(ExecutionResult.SUCCESS)
-
-        val mockOperationModelStore = mockk<OperationModelStore>()
-        every { mockOperationModelStore.list() } returns listOf()
-        every { mockOperationModelStore.add(any()) } just runs
-        every { mockOperationModelStore.remove(any()) } just runs
-
-        val operationRepo =
-            OperationRepo(listOf(mockExecutor), mockOperationModelStore, MockHelper.configModelStore(), MockHelper.time(1000))
+        val mocks = Mocks()
 
         val operationIdSlot = slot<String>()
         val operation = mockOperation(operationIdSlot = operationIdSlot)
 
         // When
-        operationRepo.start()
-        val response = operationRepo.enqueueAndWait(operation)
+        mocks.operationRepo.start()
+        val response = mocks.operationRepo.enqueueAndWait(operation)
 
         // Then
         response shouldBe true
         operationIdSlot.isCaptured shouldBe true
         coVerifyOrder {
-            mockOperationModelStore.add(operation)
-            mockExecutor.execute(
+            mocks.operationModelStore.add(operation)
+            mocks.executor.execute(
                 withArg {
                     it.count() shouldBe 1
                     it[0] shouldBe operation
                 },
             )
-            mockOperationModelStore.remove("operationId")
+            mocks.operationModelStore.remove("operationId")
         }
     }
 
     test("enqueue operation executes and is removed when executed after retry") {
         // Given
-        val mockExecutor = mockk<IOperationExecutor>()
-        every { mockExecutor.operations } returns listOf("DUMMY_OPERATION")
+        val mocks = Mocks()
+        coEvery { mocks.operationRepo.delayBeforeRetry(any()) } just runs
         coEvery {
-            mockExecutor.execute(any())
+            mocks.executor.execute(any())
         } returns ExecutionResponse(ExecutionResult.FAIL_RETRY) andThen ExecutionResponse(ExecutionResult.SUCCESS)
-
-        val mockOperationModelStore = mockk<OperationModelStore>()
-        every { mockOperationModelStore.list() } returns listOf()
-        every { mockOperationModelStore.add(any()) } just runs
-        every { mockOperationModelStore.remove(any()) } just runs
-
-        val operationRepo =
-            spyk(
-                OperationRepo(
-                    listOf(mockExecutor),
-                    mockOperationModelStore,
-                    MockHelper.configModelStore(),
-                    MockHelper.time(1000),
-                ),
-            )
-        coEvery { operationRepo.delayBeforeRetry(any()) } just runs
 
         val operationIdSlot = slot<String>()
         val operation = mockOperation(operationIdSlot = operationIdSlot)
 
         // When
-        operationRepo.start()
-        val response = operationRepo.enqueueAndWait(operation)
+        mocks.operationRepo.start()
+        val response = mocks.operationRepo.enqueueAndWait(operation)
 
         // Then
         response shouldBe true
         operationIdSlot.isCaptured shouldBe true
         coVerifyOrder {
-            mockOperationModelStore.add(operation)
-            mockExecutor.execute(
+            mocks.operationModelStore.add(operation)
+            mocks.executor.execute(
                 withArg {
                     it.count() shouldBe 1
                     it[0] shouldBe operation
                 },
             )
-            operationRepo.delayBeforeRetry(1)
-            mockExecutor.execute(
+            mocks.operationRepo.delayBeforeRetry(1)
+            mocks.executor.execute(
                 withArg {
                     it.count() shouldBe 1
                     it[0] shouldBe operation
                 },
             )
-            mockOperationModelStore.remove("operationId")
+            mocks.operationModelStore.remove("operationId")
         }
     }
 
     test("enqueue operation executes and is removed when executed after fail") {
         // Given
-        val mockExecutor = mockk<IOperationExecutor>()
-        every { mockExecutor.operations } returns listOf("DUMMY_OPERATION")
-        coEvery { mockExecutor.execute(any()) } returns ExecutionResponse(ExecutionResult.FAIL_NORETRY)
-
-        val mockOperationModelStore = mockk<OperationModelStore>()
-        every { mockOperationModelStore.list() } returns listOf()
-        every { mockOperationModelStore.add(any()) } just runs
-        every { mockOperationModelStore.remove(any()) } just runs
-
-        val operationRepo =
-            OperationRepo(listOf(mockExecutor), mockOperationModelStore, MockHelper.configModelStore(), MockHelper.time(1000))
+        val mocks = Mocks()
+        coEvery { mocks.executor.execute(any()) } returns ExecutionResponse(ExecutionResult.FAIL_NORETRY)
 
         val operationIdSlot = slot<String>()
         val operation = mockOperation(operationIdSlot = operationIdSlot)
 
         // When
-        operationRepo.start()
-        val response = operationRepo.enqueueAndWait(operation)
+        mocks.operationRepo.start()
+        val response = mocks.operationRepo.enqueueAndWait(operation)
 
         // Then
         response shouldBe false
         operationIdSlot.isCaptured shouldBe true
         coVerifyOrder {
-            mockOperationModelStore.add(operation)
-            mockExecutor.execute(
+            mocks.operationModelStore.add(operation)
+            mocks.executor.execute(
                 withArg {
                     it.count() shouldBe 1
                     it[0] shouldBe operation
                 },
             )
-            mockOperationModelStore.remove("operationId")
+            mocks.operationModelStore.remove("operationId")
         }
     }
 
     test("enqueue 2 operations that cannot be grouped will be executed separately from each other") {
         // Given
+        val mocks = Mocks()
         val waiter = Waiter()
-        val mockExecutor = mockk<IOperationExecutor>()
-        every { mockExecutor.operations } returns listOf("DUMMY_OPERATION")
-        coEvery { mockExecutor.execute(any()) } returns ExecutionResponse(ExecutionResult.SUCCESS)
-
-        val mockOperationModelStore = mockk<OperationModelStore>()
-        every { mockOperationModelStore.list() } returns listOf()
-        every { mockOperationModelStore.add(any()) } just runs
-        every { mockOperationModelStore.remove(any()) } answers {} andThenAnswer { waiter.wake() }
-
-        val operationRepo =
-            OperationRepo(listOf(mockExecutor), mockOperationModelStore, MockHelper.configModelStore(), MockHelper.time(1000))
+        every { mocks.operationModelStore.remove(any()) } answers {} andThenAnswer { waiter.wake() }
 
         val operation1 = mockOperation("operationId1", groupComparisonType = GroupComparisonType.CREATE)
         val operation2 = mockOperation("operationId2", createComparisonKey = "create-key2")
 
         // When
-        operationRepo.enqueue(operation1)
-        operationRepo.enqueue(operation2)
-        operationRepo.start()
+        mocks.operationRepo.enqueue(operation1)
+        mocks.operationRepo.enqueue(operation2)
+        mocks.operationRepo.start()
 
         waiter.waitForWake()
 
         // Then
         coVerifyOrder {
-            mockOperationModelStore.add(operation1)
-            mockOperationModelStore.add(operation2)
-            mockExecutor.execute(
+            mocks.operationModelStore.add(operation1)
+            mocks.operationModelStore.add(operation2)
+            mocks.executor.execute(
                 withArg {
                     it.count() shouldBe 1
                     it[0] shouldBe operation1
                 },
             )
-            mockOperationModelStore.remove("operationId1")
-            mockExecutor.execute(
+            mocks.operationModelStore.remove("operationId1")
+            mocks.executor.execute(
                 withArg {
                     it.count() shouldBe 1
                     it[0] shouldBe operation2
                 },
             )
-            mockOperationModelStore.remove("operationId2")
+            mocks.operationModelStore.remove("operationId2")
         }
     }
 
     test("enqueue 2 operations that can be grouped via create will be executed as a group") {
         // Given
+        val mocks = Mocks()
         val waiter = Waiter()
-        val mockExecutor = mockk<IOperationExecutor>()
-        every { mockExecutor.operations } returns listOf("DUMMY_OPERATION")
-        coEvery { mockExecutor.execute(any()) } returns ExecutionResponse(ExecutionResult.SUCCESS)
-
-        val mockOperationModelStore = mockk<OperationModelStore>()
-        every { mockOperationModelStore.list() } returns listOf()
-        every { mockOperationModelStore.add(any()) } just runs
-        every { mockOperationModelStore.remove(any()) } answers {} andThenAnswer { waiter.wake() }
-
-        val operationRepo =
-            OperationRepo(listOf(mockExecutor), mockOperationModelStore, MockHelper.configModelStore(), MockHelper.time(1000))
+        every { mocks.operationModelStore.remove(any()) } answers {} andThenAnswer { waiter.wake() }
 
         val operation1 = mockOperation("operationId1", groupComparisonType = GroupComparisonType.CREATE)
         val operation2 = mockOperation("operationId2")
 
         // When
-        operationRepo.enqueue(operation1)
-        operationRepo.enqueue(operation2)
-        operationRepo.start()
+        mocks.operationRepo.enqueue(operation1)
+        mocks.operationRepo.enqueue(operation2)
+        mocks.operationRepo.start()
 
         waiter.waitForWake()
 
         // Then
         coVerifyOrder {
-            mockOperationModelStore.add(operation1)
-            mockOperationModelStore.add(operation2)
-            mockExecutor.execute(
+            mocks.operationModelStore.add(operation1)
+            mocks.operationModelStore.add(operation2)
+            mocks.executor.execute(
                 withArg {
                     it.count() shouldBe 2
                     it[0] shouldBe operation1
                     it[1] shouldBe operation2
                 },
             )
-            mockOperationModelStore.remove("operationId1")
-            mockOperationModelStore.remove("operationId2")
+            mocks.operationModelStore.remove("operationId1")
+            mocks.operationModelStore.remove("operationId2")
         }
     }
 
     test("enqueue 2 operations where the first cannot be executed but can be grouped via create will be executed as a group") {
         // Given
+        val mocks = Mocks()
         val waiter = Waiter()
-        val mockExecutor = mockk<IOperationExecutor>()
-        every { mockExecutor.operations } returns listOf("DUMMY_OPERATION")
-        coEvery { mockExecutor.execute(any()) } returns ExecutionResponse(ExecutionResult.SUCCESS)
-
-        val mockOperationModelStore = mockk<OperationModelStore>()
-        every { mockOperationModelStore.list() } returns listOf()
-        every { mockOperationModelStore.add(any()) } just runs
-        every { mockOperationModelStore.remove(any()) } answers {} andThenAnswer { waiter.wake() }
-
-        val operationRepo =
-            OperationRepo(listOf(mockExecutor), mockOperationModelStore, MockHelper.configModelStore(), MockHelper.time(1000))
+        every { mocks.operationModelStore.remove(any()) } answers {} andThenAnswer { waiter.wake() }
 
         val operation1 = mockOperation("operationId1", canStartExecute = false, groupComparisonType = GroupComparisonType.ALTER)
         val operation2 = mockOperation("operationId2", groupComparisonType = GroupComparisonType.CREATE)
 
         // When
-        operationRepo.enqueue(operation1)
-        operationRepo.enqueue(operation2)
-        operationRepo.start()
+        mocks.operationRepo.enqueue(operation1)
+        mocks.operationRepo.enqueue(operation2)
+        mocks.operationRepo.start()
 
         waiter.waitForWake()
 
         // Then
         coVerifyOrder {
-            mockOperationModelStore.add(operation1)
-            mockOperationModelStore.add(operation2)
-            mockExecutor.execute(
+            mocks.operationModelStore.add(operation1)
+            mocks.operationModelStore.add(operation2)
+            mocks.executor.execute(
                 withArg {
                     it.count() shouldBe 2
                     it[0] shouldBe operation2
                     it[1] shouldBe operation1
                 },
             )
-            mockOperationModelStore.remove("operationId2")
-            mockOperationModelStore.remove("operationId1")
+            mocks.operationModelStore.remove("operationId2")
+            mocks.operationModelStore.remove("operationId1")
         }
     }
 
     test("execution of 1 operation with translation IDs will drive translateId of subsequence operations") {
         // Given
+        val mocks = Mocks()
         val waiter = Waiter()
-        val mockExecutor = mockk<IOperationExecutor>()
-        every { mockExecutor.operations } returns listOf("DUMMY_OPERATION")
         coEvery {
-            mockExecutor.execute(any())
+            mocks.executor.execute(any())
         } returns ExecutionResponse(ExecutionResult.SUCCESS, mapOf("id1" to "id2")) andThen ExecutionResponse(ExecutionResult.SUCCESS)
 
-        val mockOperationModelStore = mockk<OperationModelStore>()
-        every { mockOperationModelStore.list() } returns listOf()
-        every { mockOperationModelStore.add(any()) } just runs
-        every { mockOperationModelStore.remove(any()) } answers {} andThenAnswer { waiter.wake() }
-
-        val operationRepo =
-            OperationRepo(listOf(mockExecutor), mockOperationModelStore, MockHelper.configModelStore(), MockHelper.time(1000))
+        every { mocks.operationModelStore.remove(any()) } answers {} andThenAnswer { waiter.wake() }
 
         val operation1 = mockOperation("operationId1")
         val operation2 = mockOperation("operationId2")
 
         // When
-        operationRepo.enqueue(operation1)
-        operationRepo.enqueue(operation2)
-        operationRepo.start()
+        mocks.operationRepo.enqueue(operation1)
+        mocks.operationRepo.enqueue(operation2)
+        mocks.operationRepo.start()
 
         waiter.waitForWake()
 
         // Then
         coVerifyOrder {
-            mockOperationModelStore.add(operation1)
-            mockOperationModelStore.add(operation2)
-            mockExecutor.execute(
+            mocks.operationModelStore.add(operation1)
+            mocks.operationModelStore.add(operation2)
+            mocks.executor.execute(
                 withArg {
                     it.count() shouldBe 1
                     it[0] shouldBe operation1
                 },
             )
             operation2.translateIds(mapOf("id1" to "id2"))
-            mockOperationModelStore.remove("operationId1")
-            mockExecutor.execute(
+            mocks.operationModelStore.remove("operationId1")
+            mocks.executor.execute(
                 withArg {
                     it.count() shouldBe 1
                     it[0] shouldBe operation2
                 },
             )
-            mockOperationModelStore.remove("operationId2")
+            mocks.operationModelStore.remove("operationId2")
         }
     }
 }) {

--- a/OneSignalSDK/onesignal/testhelpers/src/main/java/com/onesignal/mocks/MockHelper.kt
+++ b/OneSignalSDK/onesignal/testhelpers/src/main/java/com/onesignal/mocks/MockHelper.kt
@@ -44,6 +44,9 @@ object MockHelper {
     fun configModelStore(action: ((ConfigModel) -> Unit)? = null): ConfigModelStore {
         val configModel = ConfigModel()
 
+        configModel.opRepoExecutionInterval = 1
+        configModel.opRepoPostWakeDelay = 1
+
         configModel.appId = DEFAULT_APP_ID
 
         if (action != null) {


### PR DESCRIPTION
# Description
## One Line Summary
Prevent `OperationRepo` from continuously pulling when empty, which might be putting extra load on the device.

## Details

### Motivation
The pulling might be causing some battery drain due to the app's process never fully sleeping or CPU continuing to be woken up. However the theory is this may only be noticable factor on some devices (probably more noticeable on watches running Android). 

### Scope
Only changes to the `OperationRepo` polling logic.

# Testing
## Unit testing
Added a new test to confirm it continuously pulls when the operations list is empty.

## Manual testing
Test setup
* Device = LGL58VL
* Android Version = 6.0.1
* Phone mode: Airplane mode on, with WiFi on

Tested the battery drain by unplugging the device for a long time then obserserving how much power it takes to rechanged the device to full again. Recharge was measured with a USB multiple meter, getting the Wh it took to recharge the device until it stopped accepting power.

We test 3 scenarios, baseline to see how much power the device loses over time without OneSignal, and then two more comparing before after. Results are as follows:

**Baseline (OneSignal app not installed on device)**
* Unplugged for ~1 hour, recharged 0.12Wh in 11:17 = Drain of .12Wh
* Unplugged for ~19 hours, recharged 0.77Wh in 57:56 = Drain of 0.0405Wh

**Test 1 - 5.1.6**
* Unplugged for ~1 hour, recharged.14Wh in 20:06 = Drain of .14Wh
* Unplugged for ~1 hour, recharged .09Wh in 8:50 = Drain of .09Wh
* Unplugged for ~50 minutes, recharged .10Wh in 12:57 = Drain of .12Wh
* Unplugged for ~23 hours, recharged .85Wh in 54:41 = Drain of 0.0370Wh

**Test 2 - 5.1.6 (with OperationRepo fix)**
* Unplugged for ~1 hour recharged .05Wh in 8:03 = Drain of .05Wh
* Unplugged for ~1 hour, recharged 0.12Wh in 9:38 = Drain of .12Wh
* Unplugged for ~6 hours, recharged .20Wh in 22:32 = Drain of .0333Wh
* Unplugged for ~84 hours, recharged 1.99Wh in 1:24:29  = Drain of .023Wh

**Summary of testing**
The data is inconclusive, unfortunately this method of testing is resulting in wildly different numbers between tests, even tests that last 24 hours. There stand to be some theory improvement still from this PR, but a different testing strategy and/or different devices would have to be tested.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2033)
<!-- Reviewable:end -->
