### PR TITLE
[Fix] thread safety with EventProducer's fire events

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/events/EventProducer.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/events/EventProducer.kt
@@ -45,7 +45,7 @@ open class EventProducer<THandler> : IEventNotifier<THandler> {
      * @param callback The callback will be invoked for each subscribed handler, allowing you to call the handler.
      */
     fun fire(callback: (THandler) -> Unit) {
-        val localList = subscribers.toList()
+        val localList = synchronized(subscribers) { subscribers.toList() }
         for (s in localList) {
             callback(s)
         }
@@ -60,7 +60,7 @@ open class EventProducer<THandler> : IEventNotifier<THandler> {
      */
     fun fireOnMain(callback: (THandler) -> Unit) {
         suspendifyOnMain {
-            val localList = subscribers.toList()
+            val localList = synchronized(subscribers) { subscribers.toList() }
             for (s in localList) {
                 callback(s)
             }
@@ -74,7 +74,7 @@ open class EventProducer<THandler> : IEventNotifier<THandler> {
      * @param callback The callback will be invoked for each subscribed handler, allowing you to call the handler.
      */
     suspend fun suspendingFire(callback: suspend (THandler) -> Unit) {
-        val localList = subscribers.toList()
+        val localList = synchronized(subscribers) { subscribers.toList() }
         for (s in localList) {
             callback(s)
         }
@@ -88,7 +88,7 @@ open class EventProducer<THandler> : IEventNotifier<THandler> {
      */
     suspend fun suspendingFireOnMain(callback: suspend (THandler) -> Unit) {
         withContext(Dispatchers.Main) {
-            val localList = subscribers.toList()
+            val localList = synchronized(subscribers) { subscribers.toList() }
             for (s in localList) {
                 callback(s)
             }

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/common/EventProducerTest.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/common/EventProducerTest.kt
@@ -1,0 +1,50 @@
+package com.onesignal.common
+
+import com.onesignal.common.events.EventProducer
+import io.kotest.core.spec.style.FunSpec
+import kotlin.concurrent.thread
+
+class EventProducerTest : FunSpec({
+
+    fun modifyingSubscribersThread(eventProducer: EventProducer<Boolean>): Thread {
+        return thread(start = true) {
+            repeat(10_000) {
+                eventProducer.subscribe(true)
+                eventProducer.unsubscribe(true)
+            }
+        }
+    }
+
+    test("fire is thread safe") {
+        val eventProducer = EventProducer<Boolean>()
+        val modifyingSubscribersThread = modifyingSubscribersThread(eventProducer)
+
+        repeat(10_000) {
+            eventProducer.fire { }
+        }
+
+        modifyingSubscribersThread.join()
+    }
+
+    test("suspendingFire is thread safe") {
+        val eventProducer = EventProducer<Boolean>()
+        val modifyingSubscribersThread = modifyingSubscribersThread(eventProducer)
+
+        repeat(10_000) {
+            eventProducer.suspendingFire { }
+        }
+
+        modifyingSubscribersThread.join()
+    }
+
+    test("hasSubscribers is thread safe") {
+        val eventProducer = EventProducer<Boolean>()
+        val modifyingSubscribersThread = modifyingSubscribersThread(eventProducer)
+
+        repeat(10_000) {
+            eventProducer.hasSubscribers
+        }
+
+        modifyingSubscribersThread.join()
+    }
+})


### PR DESCRIPTION
# Description
## One Line Summary
Fixes bug where `EventProducer.fire` can throw when another thread calls `EventProducer.remove`.

## Details

### Motivation
SDK should be stable and not cause crashes.

### Related Issues
Fixes #2007

### Scope
Only affects `EventProducer`.

# Testing
## Unit testing
Added a new `EventProducerTest`.

## Manual testing
Ran on an Android 6 emulator ensuring it subscribes for push.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.

   - [X] I have reviewed this PR myself, ensuring it meets each checklist

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2034)
<!-- Reviewable:end -->
