### PR TITLE
[Fix] optIn() not prompting if called before push subscription is created on backend

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/IDManager.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/IDManager.kt
@@ -7,7 +7,7 @@ import java.util.UUID
  * and detect whether a provided ID was generated locally.
  */
 object IDManager {
-    private const val LOCAL_PREFIX = "local-"
+    internal const val LOCAL_PREFIX = "local-"
 
     /**
      * Create a new local ID to be used temporarily prior to backend generation.

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/subscriptions/impl/SubscriptionManager.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/subscriptions/impl/SubscriptionManager.kt
@@ -157,7 +157,10 @@ internal class SubscriptionManager(
         args: ModelChangedArgs,
         tag: String,
     ) {
-        val subscription = subscriptions.collection.firstOrNull { it.id == args.model.id }
+        val subscription =
+            subscriptions.collection.firstOrNull {
+                args.model == (it as Subscription).model
+            }
 
         if (subscription == null) {
             // this shouldn't happen, but create a new subscription if a model was updated and we


### PR DESCRIPTION
# Description
## One Line Summary
Fix `optIn()` not prompting if called before push subscription is created on backend .

## Details

### Motivation
It's common for developers to call `OneSignal.User.pushSubscription.optIn()` and it should prompt even if the device is offline or has connection issues.

### Scope
Effects internal push subscription property change events.

# Testing
## Unit testing
Created a new unit test to cover this case.
* Ensured it failed before my change, then passes after my change.

## Manual testing
Tested on a real Samsung S21 with Android 14 (security patch level Feb 1, 2024). Clean installed example app while the device was in airplane mode, ensuring calling `optIn()` now prompts. Also tested adding an email and sms when the device was offline and then when I turn back on network connect it successfully created all the subscriptions as expected.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2037)
<!-- Reviewable:end -->
