### PR TITLE
Release 5.1.7

### DIFF
--- a/Examples/OneSignalDemo/app/build.gradle
+++ b/Examples/OneSignalDemo/app/build.gradle
@@ -84,12 +84,12 @@ dependencies {
     implementation 'com.github.bumptech.glide:glide:4.12.0'
 
     /** START - Google Play Builds **/
-    gmsImplementation('com.onesignal:OneSignal:5.1.6')
+    gmsImplementation('com.onesignal:OneSignal:5.1.7')
     /** END - Google Play Builds **/
 
     /** START - Huawei Builds **/
     // Omit Google / Firebase libraries for Huawei builds.
-    huaweiImplementation('com.onesignal:OneSignal:5.1.6') {
+    huaweiImplementation('com.onesignal:OneSignal:5.1.7') {
         exclude group: 'com.google.android.gms', module: 'play-services-gcm'
         exclude group: 'com.google.android.gms', module: 'play-services-analytics'
         exclude group: 'com.google.android.gms', module: 'play-services-location'

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/OneSignalUtils.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/OneSignalUtils.kt
@@ -6,7 +6,7 @@ object OneSignalUtils {
     /**
      * The version of this SDK.
      */
-    const val SDK_VERSION: String = "050106"
+    const val SDK_VERSION: String = "050107"
 
     fun isValidEmail(email: String): Boolean {
         if (email.isEmpty()) {

--- a/OneSignalSDK/settings.gradle
+++ b/OneSignalSDK/settings.gradle
@@ -3,7 +3,7 @@
 gradle.rootProject {
     allprojects {
         group = 'com.onesignal'
-        version = '5.1.6'
+        version = '5.1.7'
         configurations.all {
             resolutionStrategy.dependencySubstitution {
                 substitute(module('com.onesignal:OneSignal')).using(project(':OneSignal'))


### PR DESCRIPTION
### 🐛 Bug Fixes
- `optIn()` not prompting if called before push subscription is created on backend (#2037)
- Fix crash with EventProducer's fire events (#2034)
- Fixes for context not being set on all entry points (#2018)
 
### 🔧 Maintenance
- Limit refresh User and GET IAMs to foreground (#2036)
- Battery improvements
    - Prevent OperationRepo from continuously pulling when empty (#2033)
    - Add backoff to OperationRepo when retrying network calls (#2017)
- Duplicate GET /user call on cold start when calling login with the same external_id (#2015)
- [Docs] Update supported android versions in readme to include Android 14 (#2024)
   - This was already the case, just the docs didn't reflect this.
- [Internal Only] Switch to kotest-extensions-android (#2023)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2039)
<!-- Reviewable:end -->
