### PR TITLE
Add AndroidManifest option to override In-App Messages gray overlay and dropshadow

### DIFF
--- a/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/display/impl/InAppMessageView.kt
+++ b/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/display/impl/InAppMessageView.kt
@@ -49,6 +49,7 @@ internal class InAppMessageView(
     private var webView: WebView?,
     private val messageContent: InAppMessageContent,
     private val disableDragDismiss: Boolean,
+    private val hideGrayOverlay: Boolean,
 ) {
     private var popupWindow: PopupWindow? = null
 
@@ -611,13 +612,19 @@ internal class InAppMessageView(
                 cardViewAnimCallback,
             )
 
+        var overlayColor = Color.parseColor("#BB000000")
+
+        if (hideGrayOverlay) {
+            overlayColor = Color.TRANSPARENT
+        }
+
         // Animate background behind the message so it doesn't just show the dark transparency
         val backgroundAnimation =
             animateBackgroundColor(
                 backgroundView,
                 IN_APP_BACKGROUND_ANIMATION_DURATION_MS,
                 ACTIVITY_BACKGROUND_COLOR_EMPTY,
-                ACTIVITY_BACKGROUND_COLOR_FULL,
+                overlayColor,
                 backgroundAnimCallback,
             )
         messageAnimation.start()
@@ -634,11 +641,17 @@ internal class InAppMessageView(
                 }
             }
 
+        var overlayColor = Color.parseColor("#BB000000")
+
+        if (hideGrayOverlay) {
+            overlayColor = Color.TRANSPARENT
+        }
+
         // Animate background behind the message so it hides before being removed from the view
         animateBackgroundColor(
             backgroundView,
             IN_APP_BACKGROUND_ANIMATION_DURATION_MS,
-            ACTIVITY_BACKGROUND_COLOR_FULL,
+            overlayColor,
             ACTIVITY_BACKGROUND_COLOR_EMPTY,
             animCallback,
         )
@@ -681,7 +694,6 @@ internal class InAppMessageView(
     companion object {
         private const val IN_APP_MESSAGE_CARD_VIEW_TAG = "IN_APP_MESSAGE_CARD_VIEW_TAG"
         private val ACTIVITY_BACKGROUND_COLOR_EMPTY = Color.parseColor("#00000000")
-        private val ACTIVITY_BACKGROUND_COLOR_FULL = Color.parseColor("#BB000000")
         private const val IN_APP_BANNER_ANIMATION_DURATION_MS = 1000
         private const val IN_APP_CENTER_ANIMATION_DURATION_MS = 1000
         private const val IN_APP_BACKGROUND_ANIMATION_DURATION_MS = 400

--- a/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/display/impl/InAppMessageView.kt
+++ b/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/display/impl/InAppMessageView.kt
@@ -385,7 +385,7 @@ internal class InAppMessageView(
             cardView.cardElevation =
                 0f
         } else {
-            if (getInAppMessageHideDropShadow(context)) {
+            if (getHideDropShadow(context)) {
                 cardView.cardElevation = 0f
             } else {
                 cardView.cardElevation = ViewUtils.dpToPx(5).toFloat()
@@ -399,7 +399,7 @@ internal class InAppMessageView(
         return cardView
     }
 
-    private fun getInAppMessageHideDropShadow(context: Context): Boolean {
+    private fun getHideDropShadow(context: Context): Boolean {
         return AndroidUtils.getManifestMetaBoolean(context, "com.onesignal.inAppMessageHideDropShadow")
     }
 
@@ -612,19 +612,13 @@ internal class InAppMessageView(
                 cardViewAnimCallback,
             )
 
-        var overlayColor = Color.parseColor("#BB000000")
-
-        if (hideGrayOverlay) {
-            overlayColor = Color.TRANSPARENT
-        }
-
         // Animate background behind the message so it doesn't just show the dark transparency
         val backgroundAnimation =
             animateBackgroundColor(
                 backgroundView,
                 IN_APP_BACKGROUND_ANIMATION_DURATION_MS,
                 ACTIVITY_BACKGROUND_COLOR_EMPTY,
-                overlayColor,
+                getOverlayColor(),
                 backgroundAnimCallback,
             )
         messageAnimation.start()
@@ -641,17 +635,11 @@ internal class InAppMessageView(
                 }
             }
 
-        var overlayColor = Color.parseColor("#BB000000")
-
-        if (hideGrayOverlay) {
-            overlayColor = Color.TRANSPARENT
-        }
-
         // Animate background behind the message so it hides before being removed from the view
         animateBackgroundColor(
             backgroundView,
             IN_APP_BACKGROUND_ANIMATION_DURATION_MS,
-            overlayColor,
+            getOverlayColor(),
             ACTIVITY_BACKGROUND_COLOR_EMPTY,
             animCallback,
         )
@@ -691,9 +679,18 @@ internal class InAppMessageView(
             '}'
     }
 
+    private fun getOverlayColor(): Int {
+        return if (hideGrayOverlay) {
+            ACTIVITY_BACKGROUND_COLOR_EMPTY
+        } else {
+            ACTIVITY_BACKGROUND_COLOR_FULL
+        }
+    }
+
     companion object {
         private const val IN_APP_MESSAGE_CARD_VIEW_TAG = "IN_APP_MESSAGE_CARD_VIEW_TAG"
-        private val ACTIVITY_BACKGROUND_COLOR_EMPTY = Color.parseColor("#00000000")
+        private const val ACTIVITY_BACKGROUND_COLOR_EMPTY = Color.TRANSPARENT
+        private val ACTIVITY_BACKGROUND_COLOR_FULL = Color.parseColor("#BB000000")
         private const val IN_APP_BANNER_ANIMATION_DURATION_MS = 1000
         private const val IN_APP_CENTER_ANIMATION_DURATION_MS = 1000
         private const val IN_APP_BACKGROUND_ANIMATION_DURATION_MS = 400

--- a/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/display/impl/InAppMessageView.kt
+++ b/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/display/impl/InAppMessageView.kt
@@ -384,7 +384,11 @@ internal class InAppMessageView(
             cardView.cardElevation =
                 0f
         } else {
-            cardView.cardElevation = ViewUtils.dpToPx(5).toFloat()
+            if (getInAppMessageHideDropShadow(context)) {
+                cardView.cardElevation = 0f
+            } else {
+                cardView.cardElevation = ViewUtils.dpToPx(5).toFloat()
+            }
         }
         cardView.radius = ViewUtils.dpToPx(8).toFloat()
         cardView.clipChildren = false
@@ -392,6 +396,10 @@ internal class InAppMessageView(
         cardView.preventCornerOverlap = false
         cardView.setCardBackgroundColor(Color.TRANSPARENT)
         return cardView
+    }
+
+    private fun getInAppMessageHideDropShadow(context: Context): Boolean {
+        return AndroidUtils.getManifestMetaBoolean(context, "com.onesignal.inAppMessageHideDropShadow")
     }
 
     /**

--- a/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/display/impl/WebViewManager.kt
+++ b/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/display/impl/WebViewManager.kt
@@ -7,6 +7,7 @@ import android.os.Build
 import android.view.View
 import android.webkit.JavascriptInterface
 import android.webkit.WebView
+import com.onesignal.common.AndroidUtils
 import com.onesignal.common.ViewUtils
 import com.onesignal.common.safeString
 import com.onesignal.common.threading.suspendifyOnMain
@@ -359,7 +360,8 @@ internal class WebViewManager(
 
     fun createNewInAppMessageView(dragToDismissDisabled: Boolean) {
         lastPageHeight = messageContent.pageHeight
-        val newView = InAppMessageView(webView!!, messageContent, dragToDismissDisabled)
+        val hideGrayOverlay = AndroidUtils.getManifestMetaBoolean(_applicationService.appContext, "com.onesignal.inAppMessageHideGrayOverlay")
+        val newView = InAppMessageView(webView!!, messageContent, dragToDismissDisabled, hideGrayOverlay)
         setMessageView(newView)
         val self = this
         messageView!!.setMessageController(


### PR DESCRIPTION
# Description
## One Line Summary
Add AndroidManifest option to override In-App Messages gray overlay and dropshadow.

## Details
Customers would like the ability to control some In-App Message display "defaults":

- a dark gray background in center modal and full screen IAMs
- a dropshadow on all IAMs

 Customers would like the option to disable this overlay.

With this PR, developers can now add `com.onesignal.inAppMessageHideGrayOverlay` and `com.onesignal.inAppMessageHideDropShadow` to AndroidManifest.xml. Setting these values to true will not show a shadow or gray overlay. Omitting these values or setting them to false will display the default In-App design with drop shadow and gray overlay.

```
<meta-data android:name="com.onesignal.inAppMessageHideGrayOverlay" android:value="true"/> 
<meta-data android:name="com.onesignal.inAppMessageHideDropShadow" android:value="true"/>
```

**Examples without the dropshadow**
<img src="https://github.com/OneSignal/OneSignal-Android-SDK/assets/46546946/c302f84a-4d37-4845-935b-aaed77e19b19"> <img src="https://github.com/OneSignal/OneSignal-Android-SDK/assets/46546946/363aa604-653f-4030-8e51-e2ddcae172e7">

**Example with the dropshadow**
<img src="https://github.com/OneSignal/OneSignal-Android-SDK/assets/46546946/5b3e2dd3-8d04-4fcd-b8a8-590e9fe3a1e5"> 

**Example with the gray overlay**
<img src="https://github.com/OneSignal/OneSignal-Android-SDK/assets/46546946/64ffc5dd-089d-416b-a56a-555d4254b3c5"> 

**Example without the gray overlay**
<img src="https://github.com/OneSignal/OneSignal-Android-SDK/assets/46546946/8d3f21c9-8713-49eb-9333-08e8e0615c17">

### Scope
New and existing In-App Message visual behavior.

### Other
In the future, we can further consider the use case of having a drop shadow _and_ transparent background:
<img src="https://github.com/OneSignal/OneSignal-Android-SDK/assets/46546946/b9ab5432-31c1-48ba-ab7e-b97791fff3c4">

Currently, the drop shadow is for the entire IAM, including the transparent parts. The question would be whether this is expected, or a shadow around each visible element only.

Future work could include aligning Android and iOS appearance based on whatever is deemed "expected".

# Testing
## Manual testing
Tested on all IAM types with a Pixel 7 Pro emulator running Android 14 without AndroidManifest meta-data, with meta-data set to `true`, and with meta-data set to `false`.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [X] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2051)
<!-- Reviewable:end -->
