### PR TITLE
Fix for WorkManager not Initialized Crash 

### DIFF
--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/common/OSWorkManagerHelper.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/common/OSWorkManagerHelper.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import androidx.work.Configuration
 import androidx.work.WorkManager
 import androidx.work.impl.WorkManagerImpl
+import com.onesignal.debug.internal.logging.Logging
 
 object OSWorkManagerHelper {
     /**
@@ -34,11 +35,15 @@ object OSWorkManagerHelper {
     fun getInstance(context: Context): WorkManager {
         if (!isInitialized()) {
             try {
-                // Initialization can fail if another thread initializes in the small time gap
-                // https://android.googlesource.com/platform/frameworks/support/+/60ae0eec2a32396c22ad92502cde952c80d514a0/work/workmanager/src/main/java/androidx/work/impl/WorkManagerImpl.java#177
                 WorkManager.initialize(context, Configuration.Builder().build())
             } catch (e: IllegalStateException) {
-                // Admittedly starting to get hacky
+                /*
+                This catch is meant for the exception -
+                https://android.googlesource.com/platform/frameworks/support/+/60ae0eec2a32396c22ad92502cde952c80d514a0/work/workmanager/src/main/java/androidx/work/impl/WorkManagerImpl.java#177
+                1. We lost the race with another call to  WorkManager.initialize outside of OneSignal.
+                2. It is possible for some other unexpected error is thrown from WorkManager.
+                 */
+                Logging.error("OSWorkManagerHelper initializing WorkManager failed: ", e)
             }
         }
         return WorkManager.getInstance(context)

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/common/OSWorkManagerHelper.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/common/OSWorkManagerHelper.kt
@@ -1,0 +1,46 @@
+package com.onesignal.notifications.internal.common
+
+import android.annotation.SuppressLint
+import android.content.Context
+import androidx.work.Configuration
+import androidx.work.WorkManager
+import androidx.work.impl.WorkManagerImpl
+
+object OSWorkManagerHelper {
+    /**
+     * Helper method to provide a way to check if WorkManager is initialized in this process.
+     * The purpose of this helper is to work around this bug - https://issuetracker.google.com/issues/258176803
+     *
+     * This is effectively the `WorkManager.isInitialized()` public method introduced in androidx.work:work-*:2.8.0-alpha02.
+     * Please see https://android-review.googlesource.com/c/platform/frameworks/support/+/1941186.
+     *
+     * @return `true` if WorkManager has been initialized in this process.
+     */
+    @SuppressWarnings("deprecation")
+    @SuppressLint("RestrictedApi")
+    private fun isInitialized(): Boolean {
+        return WorkManagerImpl.getInstance() != null
+    }
+
+    /**
+     * If there is an instance of WorkManager available, use it. Else, in rare cases, initialize it ourselves.
+     *
+     * Calling `WorkManager.getInstance(context)` directly can cause an exception if it is null.
+     *
+     * @return an instance of WorkManager
+     */
+    @JvmStatic
+    @Synchronized
+    fun getInstance(context: Context): WorkManager {
+        if (!isInitialized()) {
+            try {
+                // Initialization can fail if another thread initializes in the small time gap
+                // https://android.googlesource.com/platform/frameworks/support/+/60ae0eec2a32396c22ad92502cde952c80d514a0/work/workmanager/src/main/java/androidx/work/impl/WorkManagerImpl.java#177
+                WorkManager.initialize(context, Configuration.Builder().build())
+            } catch (e: IllegalStateException) {
+                // Admittedly starting to get hacky
+            }
+        }
+        return WorkManager.getInstance(context)
+    }
+}

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/generation/impl/NotificationGenerationWorkManager.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/generation/impl/NotificationGenerationWorkManager.kt
@@ -5,12 +5,12 @@ import androidx.work.CoroutineWorker
 import androidx.work.Data
 import androidx.work.ExistingWorkPolicy
 import androidx.work.OneTimeWorkRequest
-import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import com.onesignal.OneSignal
 import com.onesignal.common.AndroidUtils
 import com.onesignal.debug.internal.logging.Logging
 import com.onesignal.notifications.internal.common.NotificationFormatHelper
+import com.onesignal.notifications.internal.common.OSWorkManagerHelper
 import com.onesignal.notifications.internal.generation.INotificationGenerationProcessor
 import com.onesignal.notifications.internal.generation.INotificationGenerationWorkManager
 import org.json.JSONException
@@ -55,7 +55,7 @@ internal class NotificationGenerationWorkManager : INotificationGenerationWorkMa
         Logging.debug(
             "NotificationWorkManager enqueueing notification work with notificationId: $osNotificationId and jsonPayload: $jsonPayload",
         )
-        WorkManager.getInstance(context)
+        OSWorkManagerHelper.getInstance(context)
             .enqueueUniqueWork(osNotificationId, ExistingWorkPolicy.KEEP, workRequest)
 
         return true

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/receivereceipt/impl/ReceiveReceiptWorkManager.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/receivereceipt/impl/ReceiveReceiptWorkManager.kt
@@ -7,13 +7,13 @@ import androidx.work.Data
 import androidx.work.ExistingWorkPolicy
 import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequest
-import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import com.onesignal.OneSignal
 import com.onesignal.common.AndroidUtils
 import com.onesignal.core.internal.application.IApplicationService
 import com.onesignal.core.internal.config.ConfigModelStore
 import com.onesignal.debug.internal.logging.Logging
+import com.onesignal.notifications.internal.common.OSWorkManagerHelper
 import com.onesignal.notifications.internal.receivereceipt.IReceiveReceiptProcessor
 import com.onesignal.notifications.internal.receivereceipt.IReceiveReceiptWorkManager
 import com.onesignal.user.internal.subscriptions.ISubscriptionManager
@@ -57,7 +57,7 @@ internal class ReceiveReceiptWorkManager(
         Logging.debug(
             "OSReceiveReceiptController enqueueing send receive receipt work with notificationId: $notificationId and delay: $delay seconds",
         )
-        WorkManager.getInstance(_applicationService.appContext)
+        OSWorkManagerHelper.getInstance(_applicationService.appContext)
             .enqueueUniqueWork(
                 notificationId + "_receive_receipt",
                 ExistingWorkPolicy.KEEP,

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/restoration/impl/NotificationRestoreWorkManager.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/restoration/impl/NotificationRestoreWorkManager.kt
@@ -4,10 +4,10 @@ import android.content.Context
 import androidx.work.CoroutineWorker
 import androidx.work.ExistingWorkPolicy
 import androidx.work.OneTimeWorkRequest
-import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import com.onesignal.OneSignal
 import com.onesignal.notifications.internal.common.NotificationHelper
+import com.onesignal.notifications.internal.common.OSWorkManagerHelper
 import com.onesignal.notifications.internal.restoration.INotificationRestoreProcessor
 import com.onesignal.notifications.internal.restoration.INotificationRestoreWorkManager
 import java.util.concurrent.TimeUnit
@@ -36,7 +36,7 @@ internal class NotificationRestoreWorkManager : INotificationRestoreWorkManager 
             OneTimeWorkRequest.Builder(NotificationRestoreWorker::class.java)
                 .setInitialDelay(restoreDelayInSeconds.toLong(), TimeUnit.SECONDS)
                 .build()
-        WorkManager.getInstance(context!!)
+        OSWorkManagerHelper.getInstance(context!!)
             .enqueueUniqueWork(
                 NOTIFICATION_RESTORE_WORKER_IDENTIFIER,
                 ExistingWorkPolicy.KEEP,


### PR DESCRIPTION
# Description
## One Line Summary
This is a fix for the non-reproducible WorkManager is not Initialized Crash we did in `v4` already, with one small change in a try-catch.

## Details

### Motivation
Based on the the fix we made for `v4` at #1721 

The change I added was an additional try-catch after [this comment](https://github.com/OneSignal/OneSignal-Android-SDK/issues/1672#issuecomment-1720744291) from an SDK user after we made the `v4` fix. They ran into the "WorkManager is already initialized" exception.

At the time that PR was made, the fixes were speculative and we didn't completely understand this crash. By now, and seeing other reports from SDK authors at our submitted [Google Issue Tracker](https://issuetracker.google.com/issues/258176803), I believe it is a bug in the library. 

### Scope
* Before using WorkManager, check for its existence. Else, in rare cases that caused crashing, initialize it ourselves.
* Additionally, as another layer to handling this issue, when initializing WorkManager ourselves, surround it in a try-catch as it is may be the slightest bit possible for another thread to initialize it in the interim between checking and initializing.
* Provides a method to check if WorkManager is initialized in this process.
  - This is effectively the `WorkManager.isInitialized()` public method introduced in `androidx.work:work-*:2.8.0-alpha02`.
  - Please see https://android-review.googlesource.com/c/platform/frameworks/support/+/1941186 for the library's implementation

### ⚠️ Concerns ⚠️
* There was a known issue with Hilt dependency manager that we were not able to figure out in the `v4` of the SDK

# Testing
## Unit testing
No unit testing

## Manual testing
Limited ability to test manually due to unable to reproduce
- Tested normal app flow in an emulator
- Receiving notifications in background and swiped away state
- Opening app, etc.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2052)
<!-- Reviewable:end -->
