### PR TITLE
[Fix] Prevent operations added to queue while it's processing from being executed without delay

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/impl/OperationRepo.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/impl/OperationRepo.kt
@@ -151,7 +151,7 @@ internal class OperationRepo(
         }
     }
 
-    private suspend fun executeOperations(ops: List<OperationQueueItem>) {
+    internal suspend fun executeOperations(ops: List<OperationQueueItem>) {
         try {
             val startingOp = ops.first()
             val executor =

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/operations/OperationRepoTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/operations/OperationRepoTests.kt
@@ -103,7 +103,7 @@ class OperationRepoTests : FunSpec({
             // 1st: gets the operation
             // 2nd: will be empty
             // 3rd: shouldn't be called, loop should be waiting on next operation
-            mocks.operationRepo.getNextOps()
+            mocks.operationRepo.getNextOps(withArg { Any() })
         }
     }
 


### PR DESCRIPTION
# Description
## One Line Summary
Fixes new operations added to `OperationRepo`'s queue while its executing from skipping the `opRepoExecutionInterval` delay.

## Details

### Motivation
Preventing a misbehaving app adding operations (such as addTag()) in a tight loop, causing a number of back-to-back network calls to OneSignal's backend.

### Scope
Only affects `OperationRepo`'s batching logic.

### New OperationRepo Concept - Buckets
```kotlin
   /** *** Buckets ***
     * Purpose: Bucketing is a pattern we are using to help save network
     * calls. It works together with opRepoExecutionInterval to define
     * a time window operations can be added to the bucket.
     *
     * When enqueue() is called it creates a new OperationQueueItem with it's
     * bucket = enqueueIntoBucket. Just before we start processing a bucket we
     * enqueueIntoBucket++, this ensures anything new that comes in while
     * executing doesn't cause it to skip the opRepoExecutionInterval delay.
     *
     * NOTE: Bucketing only effects the starting operation we grab.
     *       The reason is we still want getGroupableOperations() to find
     *       other operations it can execute in one go (same network call).
     *       It's more efficient overall, as it lowers the total number of
     *       network calls.
     */
```
## Future Considerations
There is still a problem if someone rapidity adds login operations which switches users. (such calling `login()` with different external_ids, or `login()` and `logout()` over and over). They would all be in the same bucket and each would be its own network call and we would call them back-to-back without a delay. This isn't a problem with things like addTag, since those can be grouped into one network call.
Ideas to address this:
1. Maybe we always wait after creating a user then?
     - We probably already need to do this to account for the 404 problem.
          - 404 problem meaning the backend bug where it can return 404 if doing an operation on something you just created
2. maxCount - We only process x number of operations back-to-back in a bucket. Then we enforce the delay.
3. rateLimit - Only make x number of network calls per y amount of time.

## Related
This improves on the PR #2033, which fixed `opRepoExecutionInterval` from being skipped **anytime** two operations were called back-to-back.

# Testing
## Unit testing
1. Commit 0988977c07b1af558242b9359f92a15500e6ee33 with failing test to prove the batching issue
   - [Failing test results](https://github.com/OneSignal/OneSignal-Android-SDK/actions/runs/8668800520/job/23774501009?pr=2053#step:6:766)
2. Commit 0f718b70669f75d0a7b5dde88b3d39d5b1a67108 adding bucketing feature
   - [Test now passes](https://github.com/OneSignal/OneSignal-Android-SDK/actions/runs/8669116585/job/23775318132#step:6:797)
   - add a eba7081f233d600c71f78a3e79d7c5a727e3a9d7 ensuring we don't have a off-by-one errors 
3. Additional tests that cover lines changed (had no existing tests for lines)
   - [starting OperationModelStore should be processed, following normal delay rules](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2053/commits/c5fde006fbba94311f51c3d1dff7065aa870bcef)
   -  [ensure results from executeOperations are added to beginning of the queue](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2053/commits/8001c6e940c1f3f2a99d4dbc7134b415d0d21e12)

## Manual testing
Manually tested on an Android 14 emulator, tested to ensure prompting for notifications works and updates the subscription correctly. As well as logging into a new user.

Also tested running the following code no longer reproduces the orignal issue:
```java
    private void reproducesOperationRepoLoopingTooQuickly() {
        new Thread(() -> {
            while (true) {
                OneSignal.getUser().addTag("test", "Test");
                OneSignal.getUser().removeTag("test");
                OneSignal.getUser().addTag("test", "Test");
                OneSignal.getUser().removeTag("test");
                try {
                    Thread.sleep(1);
                } catch (InterruptedException e) {
                    throw new RuntimeException(e);
                }
            }
        }).start();
    }
````

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2053)
<!-- Reviewable:end -->
