### PR TITLE
[Improvement] Never set OperationRepo.enqueue's flush to true

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/impl/OperationRepo.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/impl/OperationRepo.kt
@@ -110,6 +110,7 @@ internal class OperationRepo(
         return waiter.waitForWake()
     }
 
+    // WARNING: Never set to true, until budget rules are added, even for internal use!
     private fun internalEnqueue(
         queueItem: OperationQueueItem,
         flush: Boolean,

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
@@ -380,7 +380,6 @@ internal class OneSignalImp : IOneSignal, IServiceProvider {
                         externalId,
                         if (currentIdentityExternalId == null) currentIdentityOneSignalId else null,
                     ),
-                    true,
                 )
 
             if (!result) {
@@ -395,7 +394,6 @@ internal class OneSignalImp : IOneSignal, IServiceProvider {
                         configModel!!.appId,
                         identityModelStore!!.model.onesignalId,
                     ),
-                    true,
                 )
             }
         }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/migrations/RecoverFromDroppedLoginBug.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/migrations/RecoverFromDroppedLoginBug.kt
@@ -79,7 +79,6 @@ class RecoverFromDroppedLoginBug(
                 _identityModelStore.model.externalId,
                 null,
             ),
-            true,
         )
     }
 }


### PR DESCRIPTION
# Description
## One Line Summary
Never set `OperationRepo.enqueue`'s `flush` to `true` to improve network batching.

## Details

### Motivation
The 5.x.x branch of the OneSignal SDK is not as efficient on it's network calls as 4.x.x was. This is one small change to help improve some of this.

### Scope
Only effects delaying networks calls generated when calling `OneSignal.login` by up to seconds 5.

# Testing

## Manual testing
Tested calling `OneSignal.login` and ensured it was delayed by 5 seconds as expected. 

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2055)
<!-- Reviewable:end -->
