### PR TITLE
[Fix]Handle incorrect 404 responses; add a delay after creates and retries on 404 of new ids

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/config/ConfigModel.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/config/ConfigModel.kt
@@ -142,6 +142,19 @@ class ConfigModel : Model() {
         }
 
     /**
+     * The number milliseconds to delay after an operation completes
+     * that creates or changes ids.
+     * This is a "cold down" period to avoid a caveat with OneSignal's backend
+     * replication, where you may incorrectly get a 404 when attempting a GET
+     * or PATCH REST API call on something just after it is created.
+     */
+    var opRepoPostCreateDelay: Long
+        get() = getLongProperty(::opRepoPostCreateDelay.name) { 5_000 }
+        set(value) {
+            setLongProperty(::opRepoPostCreateDelay.name, value)
+        }
+
+    /**
      * The minimum number of milliseconds required to pass to allow the fetching of IAM to occur.
      */
     var fetchIAMMinInterval: Long

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/config/ConfigModel.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/config/ConfigModel.kt
@@ -142,7 +142,7 @@ class ConfigModel : Model() {
         }
 
     /**
-     * The number milliseconds to delay after an operation completes
+     * The number of milliseconds to delay after an operation completes
      * that creates or changes ids.
      * This is a "cold down" period to avoid a caveat with OneSignal's backend
      * replication, where you may incorrectly get a 404 when attempting a GET
@@ -152,6 +152,19 @@ class ConfigModel : Model() {
         get() = getLongProperty(::opRepoPostCreateDelay.name) { 5_000 }
         set(value) {
             setLongProperty(::opRepoPostCreateDelay.name, value)
+        }
+
+    /**
+     * The number of milliseconds to retry operations for new models.
+     * This is a fallback to opRepoPostCreateDelay, where it's delay may
+     * not be enough. The server may be unusually overloaded so we will
+     * retry these (back-off rules apply to all retries) as we only want
+     * to re-create records as a last resort.
+     */
+    var opRepoPostCreateRetryUpTo: Long
+        get() = getLongProperty(::opRepoPostCreateRetryUpTo.name) { 60_000 }
+        set(value) {
+            setLongProperty(::opRepoPostCreateRetryUpTo.name, value)
         }
 
     /**

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/Operation.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/Operation.kt
@@ -21,6 +21,12 @@ abstract class Operation(name: String) : Model() {
     }
 
     /**
+     * This is a unique id that points to a record this operation will affect.
+     * Example: If the operation is updating tags on a User this will be the onesignalId.
+     */
+    abstract val applyToRecordId: String
+
+    /**
      * The key of this operation for when the starting operation has a [groupComparisonType]
      * of [GroupComparisonType.CREATE]
      */

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/UserModule.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/UserModule.kt
@@ -25,6 +25,7 @@ import com.onesignal.user.internal.operations.impl.executors.UpdateUserOperation
 import com.onesignal.user.internal.operations.impl.listeners.IdentityModelStoreListener
 import com.onesignal.user.internal.operations.impl.listeners.PropertiesModelStoreListener
 import com.onesignal.user.internal.operations.impl.listeners.SubscriptionModelStoreListener
+import com.onesignal.user.internal.operations.impl.states.NewRecordsState
 import com.onesignal.user.internal.properties.PropertiesModelStore
 import com.onesignal.user.internal.service.UserRefreshService
 import com.onesignal.user.internal.subscriptions.ISubscriptionManager
@@ -68,5 +69,8 @@ internal class UserModule : IModule {
         builder.register<UserRefreshService>().provides<IStartableService>()
 
         builder.register<RecoverFromDroppedLoginBug>().provides<IStartableService>()
+
+        // Shared state between Executors
+        builder.register<NewRecordsState>().provides<NewRecordsState>()
     }
 }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/CreateSubscriptionOperation.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/CreateSubscriptionOperation.kt
@@ -86,6 +86,7 @@ class CreateSubscriptionOperation() : Operation(SubscriptionOperationExecutor.CR
     override val modifyComparisonKey: String get() = "$appId.User.$onesignalId.Subscription.$subscriptionId"
     override val groupComparisonType: GroupComparisonType = GroupComparisonType.ALTER
     override val canStartExecute: Boolean get() = !IDManager.isLocalId(onesignalId)
+    override val applyToRecordId: String get() = onesignalId
 
     constructor(appId: String, onesignalId: String, subscriptionId: String, type: SubscriptionType, enabled: Boolean, address: String, status: SubscriptionStatus) : this() {
         this.appId = appId

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/DeleteAliasOperation.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/DeleteAliasOperation.kt
@@ -41,6 +41,7 @@ class DeleteAliasOperation() : Operation(IdentityOperationExecutor.DELETE_ALIAS)
     override val modifyComparisonKey: String get() = "$appId.User.$onesignalId.Alias.$label"
     override val groupComparisonType: GroupComparisonType = GroupComparisonType.NONE
     override val canStartExecute: Boolean get() = !IDManager.isLocalId(onesignalId)
+    override val applyToRecordId: String get() = onesignalId
 
     constructor(appId: String, onesignalId: String, label: String) : this() {
         this.appId = appId

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/DeleteSubscriptionOperation.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/DeleteSubscriptionOperation.kt
@@ -42,6 +42,7 @@ class DeleteSubscriptionOperation() : Operation(SubscriptionOperationExecutor.DE
     override val modifyComparisonKey: String get() = "$appId.User.$onesignalId.Subscription.$subscriptionId"
     override val groupComparisonType: GroupComparisonType = GroupComparisonType.NONE
     override val canStartExecute: Boolean get() = !IDManager.isLocalId(onesignalId) && !IDManager.isLocalId(onesignalId)
+    override val applyToRecordId: String get() = subscriptionId
 
     constructor(appId: String, onesignalId: String, subscriptionId: String) : this() {
         this.appId = appId

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/DeleteTagOperation.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/DeleteTagOperation.kt
@@ -42,6 +42,7 @@ class DeleteTagOperation() : Operation(UpdateUserOperationExecutor.DELETE_TAG) {
     override val modifyComparisonKey: String get() = "$appId.User.$onesignalId"
     override val groupComparisonType: GroupComparisonType = GroupComparisonType.ALTER
     override val canStartExecute: Boolean get() = !IDManager.isLocalId(onesignalId)
+    override val applyToRecordId: String get() = onesignalId
 
     constructor(appId: String, onesignalId: String, key: String) : this() {
         this.appId = appId

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/LoginUserFromSubscriptionOperation.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/LoginUserFromSubscriptionOperation.kt
@@ -40,6 +40,7 @@ class LoginUserFromSubscriptionOperation() : Operation(LoginUserFromSubscription
     override val modifyComparisonKey: String get() = "$appId.Subscription.$subscriptionId.Login"
     override val groupComparisonType: GroupComparisonType = GroupComparisonType.NONE
     override val canStartExecute: Boolean = true
+    override val applyToRecordId: String get() = subscriptionId
 
     constructor(appId: String, onesignalId: String, subscriptionId: String) : this() {
         this.appId = appId

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/LoginUserOperation.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/LoginUserOperation.kt
@@ -56,7 +56,7 @@ class LoginUserOperation() : Operation(LoginUserOperationExecutor.LOGIN_USER) {
     override val modifyComparisonKey: String = ""
     override val groupComparisonType: GroupComparisonType = GroupComparisonType.CREATE
     override val canStartExecute: Boolean get() = existingOnesignalId == null || !IDManager.isLocalId(existingOnesignalId!!)
-    override val applyToRecordId: String get() = onesignalId
+    override val applyToRecordId: String get() = existingOnesignalId ?: onesignalId
 
     constructor(appId: String, onesignalId: String, externalId: String?, existingOneSignalId: String? = null) : this() {
         this.appId = appId

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/LoginUserOperation.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/LoginUserOperation.kt
@@ -56,6 +56,7 @@ class LoginUserOperation() : Operation(LoginUserOperationExecutor.LOGIN_USER) {
     override val modifyComparisonKey: String = ""
     override val groupComparisonType: GroupComparisonType = GroupComparisonType.CREATE
     override val canStartExecute: Boolean get() = existingOnesignalId == null || !IDManager.isLocalId(existingOnesignalId!!)
+    override val applyToRecordId: String get() = onesignalId
 
     constructor(appId: String, onesignalId: String, externalId: String?, existingOneSignalId: String? = null) : this() {
         this.appId = appId

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/RefreshUserOperation.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/RefreshUserOperation.kt
@@ -33,6 +33,7 @@ class RefreshUserOperation() : Operation(RefreshUserOperationExecutor.REFRESH_US
     override val modifyComparisonKey: String get() = "$appId.User.$onesignalId.Refresh"
     override val groupComparisonType: GroupComparisonType = GroupComparisonType.CREATE
     override val canStartExecute: Boolean get() = !IDManager.isLocalId(onesignalId)
+    override val applyToRecordId: String get() = onesignalId
 
     constructor(appId: String, onesignalId: String) : this() {
         this.appId = appId

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/SetAliasOperation.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/SetAliasOperation.kt
@@ -51,6 +51,7 @@ class SetAliasOperation() : Operation(IdentityOperationExecutor.SET_ALIAS) {
     override val modifyComparisonKey: String get() = "$appId.User.$onesignalId.Identity.$label"
     override val groupComparisonType: GroupComparisonType = GroupComparisonType.ALTER
     override val canStartExecute: Boolean get() = !IDManager.isLocalId(onesignalId)
+    override val applyToRecordId: String get() = onesignalId
 
     constructor(appId: String, onesignalId: String, label: String, value: String) : this() {
         this.appId = appId

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/SetPropertyOperation.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/SetPropertyOperation.kt
@@ -50,6 +50,7 @@ class SetPropertyOperation() : Operation(UpdateUserOperationExecutor.SET_PROPERT
     override val modifyComparisonKey: String get() = "$appId.User.$onesignalId"
     override val groupComparisonType: GroupComparisonType = GroupComparisonType.ALTER
     override val canStartExecute: Boolean get() = !IDManager.isLocalId(onesignalId)
+    override val applyToRecordId: String get() = onesignalId
 
     constructor(appId: String, onesignalId: String, property: String, value: Any?) : this() {
         this.appId = appId

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/SetTagOperation.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/SetTagOperation.kt
@@ -51,6 +51,7 @@ class SetTagOperation() : Operation(UpdateUserOperationExecutor.SET_TAG) {
     override val modifyComparisonKey: String get() = "$appId.User.$onesignalId"
     override val groupComparisonType: GroupComparisonType = GroupComparisonType.ALTER
     override val canStartExecute: Boolean get() = !IDManager.isLocalId(onesignalId)
+    override val applyToRecordId: String get() = onesignalId
 
     constructor(appId: String, onesignalId: String, key: String, value: String) : this() {
         this.appId = appId

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/TrackPurchaseOperation.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/TrackPurchaseOperation.kt
@@ -63,6 +63,7 @@ class TrackPurchaseOperation() : Operation(UpdateUserOperationExecutor.TRACK_PUR
     override val modifyComparisonKey: String get() = "$appId.User.$onesignalId"
     override val groupComparisonType: GroupComparisonType = GroupComparisonType.ALTER
     override val canStartExecute: Boolean get() = !IDManager.isLocalId(onesignalId)
+    override val applyToRecordId: String get() = onesignalId
 
     constructor(appId: String, onesignalId: String, treatNewAsExisting: Boolean, amountSpent: BigDecimal, purchases: List<PurchaseInfo>) : this() {
         this.appId = appId

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/TrackSessionEndOperation.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/TrackSessionEndOperation.kt
@@ -41,6 +41,7 @@ class TrackSessionEndOperation() : Operation(UpdateUserOperationExecutor.TRACK_S
     override val modifyComparisonKey: String get() = "$appId.User.$onesignalId"
     override val groupComparisonType: GroupComparisonType = GroupComparisonType.ALTER
     override val canStartExecute: Boolean get() = !IDManager.isLocalId(onesignalId)
+    override val applyToRecordId: String get() = onesignalId
 
     constructor(appId: String, onesignalId: String, sessionTime: Long) : this() {
         this.appId = appId

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/TrackSessionStartOperation.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/TrackSessionStartOperation.kt
@@ -32,6 +32,7 @@ class TrackSessionStartOperation() : Operation(UpdateUserOperationExecutor.TRACK
     override val modifyComparisonKey: String get() = "$appId.User.$onesignalId"
     override val groupComparisonType: GroupComparisonType = GroupComparisonType.ALTER
     override val canStartExecute: Boolean get() = !IDManager.isLocalId(onesignalId)
+    override val applyToRecordId: String get() = onesignalId
 
     constructor(appId: String, onesignalId: String) : this() {
         this.appId = appId

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/TransferSubscriptionOperation.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/TransferSubscriptionOperation.kt
@@ -42,6 +42,7 @@ class TransferSubscriptionOperation() : Operation(SubscriptionOperationExecutor.
     override val modifyComparisonKey: String get() = "$appId.Subscription.$subscriptionId.Transfer"
     override val groupComparisonType: GroupComparisonType = GroupComparisonType.NONE
     override val canStartExecute: Boolean get() = !IDManager.isLocalId(onesignalId) && !IDManager.isLocalId(subscriptionId)
+    override val applyToRecordId: String get() = subscriptionId
 
     constructor(appId: String, subscriptionId: String, onesignalId: String) : this() {
         this.appId = appId

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/UpdateSubscriptionOperation.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/UpdateSubscriptionOperation.kt
@@ -85,6 +85,7 @@ class UpdateSubscriptionOperation() : Operation(SubscriptionOperationExecutor.UP
     override val modifyComparisonKey: String get() = "$appId.User.$onesignalId.Subscription.$subscriptionId"
     override val groupComparisonType: GroupComparisonType = GroupComparisonType.ALTER
     override val canStartExecute: Boolean get() = !IDManager.isLocalId(onesignalId) && !IDManager.isLocalId(onesignalId)
+    override val applyToRecordId: String get() = subscriptionId
 
     constructor(appId: String, onesignalId: String, subscriptionId: String, type: SubscriptionType, enabled: Boolean, address: String, status: SubscriptionStatus) : this() {
         this.appId = appId

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/IdentityOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/IdentityOperationExecutor.kt
@@ -69,7 +69,7 @@ internal class IdentityOperationExecutor(
                     NetworkUtils.ResponseStatusType.UNAUTHORIZED ->
                         ExecutionResponse(ExecutionResult.FAIL_UNAUTHORIZED)
                     NetworkUtils.ResponseStatusType.MISSING -> {
-                        if (_newRecordState.isInMissingRetryWindow(lastOperation.onesignalId)) {
+                        if (ex.statusCode == 404 && _newRecordState.isInMissingRetryWindow(lastOperation.onesignalId)) {
                             return ExecutionResponse(ExecutionResult.FAIL_RETRY)
                         }
 
@@ -109,7 +109,7 @@ internal class IdentityOperationExecutor(
                     NetworkUtils.ResponseStatusType.UNAUTHORIZED ->
                         ExecutionResponse(ExecutionResult.FAIL_UNAUTHORIZED)
                     NetworkUtils.ResponseStatusType.MISSING -> {
-                        return if (_newRecordState.isInMissingRetryWindow(lastOperation.onesignalId)) {
+                        return if (ex.statusCode == 404 && _newRecordState.isInMissingRetryWindow(lastOperation.onesignalId)) {
                             ExecutionResponse(ExecutionResult.FAIL_RETRY)
                         } else {
                             // This means either the User or the Alias was already

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/RefreshUserOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/RefreshUserOperationExecutor.kt
@@ -137,7 +137,7 @@ internal class RefreshUserOperationExecutor(
                 NetworkUtils.ResponseStatusType.UNAUTHORIZED ->
                     ExecutionResponse(ExecutionResult.FAIL_UNAUTHORIZED)
                 NetworkUtils.ResponseStatusType.MISSING -> {
-                    if (_newRecordState.isInMissingRetryWindow(op.onesignalId)) {
+                    if (ex.statusCode == 404 && _newRecordState.isInMissingRetryWindow(op.onesignalId)) {
                         return ExecutionResponse(ExecutionResult.FAIL_RETRY)
                     }
                     val operations = _buildUserService.getRebuildOperationsIfCurrentUser(op.appId, op.onesignalId)

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/RefreshUserOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/RefreshUserOperationExecutor.kt
@@ -17,6 +17,7 @@ import com.onesignal.user.internal.builduser.IRebuildUserService
 import com.onesignal.user.internal.identity.IdentityModel
 import com.onesignal.user.internal.identity.IdentityModelStore
 import com.onesignal.user.internal.operations.RefreshUserOperation
+import com.onesignal.user.internal.operations.impl.states.NewRecordsState
 import com.onesignal.user.internal.properties.PropertiesModel
 import com.onesignal.user.internal.properties.PropertiesModelStore
 import com.onesignal.user.internal.subscriptions.SubscriptionModel
@@ -31,6 +32,7 @@ internal class RefreshUserOperationExecutor(
     private val _subscriptionsModelStore: SubscriptionModelStore,
     private val _configModelStore: ConfigModelStore,
     private val _buildUserService: IRebuildUserService,
+    private val _newRecordState: NewRecordsState,
 ) : IOperationExecutor {
     override val operations: List<String>
         get() = listOf(REFRESH_USER)
@@ -135,6 +137,9 @@ internal class RefreshUserOperationExecutor(
                 NetworkUtils.ResponseStatusType.UNAUTHORIZED ->
                     ExecutionResponse(ExecutionResult.FAIL_UNAUTHORIZED)
                 NetworkUtils.ResponseStatusType.MISSING -> {
+                    if (_newRecordState.isInMissingRetryWindow(op.onesignalId)) {
+                        return ExecutionResponse(ExecutionResult.FAIL_RETRY)
+                    }
                     val operations = _buildUserService.getRebuildOperationsIfCurrentUser(op.appId, op.onesignalId)
                     if (operations == null) {
                         return ExecutionResponse(ExecutionResult.FAIL_NORETRY)

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/UpdateUserOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/UpdateUserOperationExecutor.kt
@@ -165,7 +165,7 @@ internal class UpdateUserOperationExecutor(
                     NetworkUtils.ResponseStatusType.UNAUTHORIZED ->
                         ExecutionResponse(ExecutionResult.FAIL_UNAUTHORIZED)
                     NetworkUtils.ResponseStatusType.MISSING -> {
-                        if (_newRecordState.isInMissingRetryWindow(onesignalId)) {
+                        if (ex.statusCode == 404 && _newRecordState.isInMissingRetryWindow(onesignalId)) {
                             return ExecutionResponse(ExecutionResult.FAIL_RETRY)
                         }
                         val operations = _buildUserService.getRebuildOperationsIfCurrentUser(appId, onesignalId)

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/UpdateUserOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/UpdateUserOperationExecutor.kt
@@ -22,6 +22,7 @@ import com.onesignal.user.internal.operations.SetTagOperation
 import com.onesignal.user.internal.operations.TrackPurchaseOperation
 import com.onesignal.user.internal.operations.TrackSessionEndOperation
 import com.onesignal.user.internal.operations.TrackSessionStartOperation
+import com.onesignal.user.internal.operations.impl.states.NewRecordsState
 import com.onesignal.user.internal.properties.PropertiesModelStore
 
 internal class UpdateUserOperationExecutor(
@@ -29,6 +30,7 @@ internal class UpdateUserOperationExecutor(
     private val _identityModelStore: IdentityModelStore,
     private val _propertiesModelStore: PropertiesModelStore,
     private val _buildUserService: IRebuildUserService,
+    private val _newRecordState: NewRecordsState,
 ) : IOperationExecutor {
     override val operations: List<String>
         get() = listOf(SET_TAG, DELETE_TAG, SET_PROPERTY, TRACK_SESSION_START, TRACK_SESSION_END, TRACK_PURCHASE)
@@ -163,6 +165,9 @@ internal class UpdateUserOperationExecutor(
                     NetworkUtils.ResponseStatusType.UNAUTHORIZED ->
                         ExecutionResponse(ExecutionResult.FAIL_UNAUTHORIZED)
                     NetworkUtils.ResponseStatusType.MISSING -> {
+                        if (_newRecordState.isInMissingRetryWindow(onesignalId)) {
+                            return ExecutionResponse(ExecutionResult.FAIL_RETRY)
+                        }
                         val operations = _buildUserService.getRebuildOperationsIfCurrentUser(appId, onesignalId)
                         if (operations == null) {
                             return ExecutionResponse(ExecutionResult.FAIL_NORETRY)

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/states/NewRecordsState.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/states/NewRecordsState.kt
@@ -6,7 +6,8 @@ import com.onesignal.core.internal.time.ITime
 /**
  * Purpose: Keeps track of ids that were just created on the backend.
  * This list gets used to delay network calls to ensure upcoming
- * requests are ready to be accepted by the backend.
+ * requests are ready to be accepted by the backend. Also used for retries
+ * as a fallback if the server is under extra load.
  */
 class NewRecordsState(
     private val _time: ITime,
@@ -23,5 +24,10 @@ class NewRecordsState(
     fun canAccess(key: String): Boolean {
         val timeLastMovedOrCreated = records[key] ?: return true
         return _time.currentTimeMillis - timeLastMovedOrCreated > _configModelStore.model.opRepoPostCreateDelay
+    }
+
+    fun isInMissingRetryWindow(key: String): Boolean {
+        val timeLastMovedOrCreated = records[key] ?: return false
+        return _time.currentTimeMillis - timeLastMovedOrCreated <= _configModelStore.model.opRepoPostCreateRetryUpTo
     }
 }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/states/NewRecordsState.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/states/NewRecordsState.kt
@@ -1,0 +1,27 @@
+package com.onesignal.user.internal.operations.impl.states
+
+import com.onesignal.core.internal.config.ConfigModelStore
+import com.onesignal.core.internal.time.ITime
+
+/**
+ * Purpose: Keeps track of ids that were just created on the backend.
+ * This list gets used to delay network calls to ensure upcoming
+ * requests are ready to be accepted by the backend.
+ */
+class NewRecordsState(
+    private val _time: ITime,
+    private val _configModelStore: ConfigModelStore,
+) {
+    // Key = a string id
+    // Value = A Timestamp in ms of when the id was created
+    private val records: MutableMap<String, Long> = mutableMapOf()
+
+    fun add(key: String) {
+        records[key] = _time.currentTimeMillis
+    }
+
+    fun canAccess(key: String): Boolean {
+        val timeLastMovedOrCreated = records[key] ?: return true
+        return _time.currentTimeMillis - timeLastMovedOrCreated > _configModelStore.model.opRepoPostCreateDelay
+    }
+}

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/operations/OperationRepoTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/operations/OperationRepoTests.kt
@@ -23,7 +23,9 @@ import io.mockk.slot
 import io.mockk.spyk
 import io.mockk.verify
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.coroutines.yield
 
 // Mocks used by every test in this file
 private class Mocks {
@@ -485,6 +487,54 @@ class OperationRepoTests : FunSpec({
             executor.execute(withArg { it[0] shouldBe secondOp })
         }
     }
+
+    // This is to account for the case where we create a User or Subscription
+    // and attempt to immediately access it (via GET or PATCH). A delay is
+    // needed as the backend may incorrectly 404 otherwise, due to a small
+    // delay in it's server replication.
+    // A cold down period like this also helps improve batching as well.
+    test("execution of an operation with translation IDs delays follow up operations") {
+        // Given
+        val mocks = Mocks()
+        mocks.configModelStore.model.opRepoPostCreateDelay = 100
+        val operation1 = mockOperation(groupComparisonType = GroupComparisonType.NONE)
+        val operation2 = mockOperation(groupComparisonType = GroupComparisonType.NONE, applyToRecordId = "id2")
+        val operation3 = mockOperation(groupComparisonType = GroupComparisonType.NONE)
+        coEvery {
+            mocks.executor.execute(listOf(operation1))
+        } returns ExecutionResponse(ExecutionResult.SUCCESS, mapOf("local-id1" to "id2"))
+
+        // When
+        mocks.operationRepo.start()
+        mocks.operationRepo.enqueue(operation1)
+        val job = launch { mocks.operationRepo.enqueueAndWait(operation2) }.also { yield() }
+        mocks.operationRepo.enqueue(operation3)
+        job.join()
+
+        // Then
+        coVerifyOrder {
+            mocks.executor.execute(
+                withArg {
+                    it.count() shouldBe 1
+                    it[0] shouldBe operation1
+                },
+            )
+            operation2.translateIds(mapOf("local-id1" to "id2"))
+            mocks.executor.execute(
+                withArg {
+                    it.count() shouldBe 1
+                    it[0] shouldBe operation3
+                },
+            )
+            // Ensure operation2 runs after operation3 as it has to wait for the create delay
+            mocks.executor.execute(
+                withArg {
+                    it.count() shouldBe 1
+                    it[0] shouldBe operation2
+                },
+            )
+        }
+    }
 }) {
     companion object {
         private fun mockOperation(
@@ -495,6 +545,7 @@ class OperationRepoTests : FunSpec({
             createComparisonKey: String = "create-key",
             modifyComparisonKey: String = "modify-key",
             operationIdSlot: CapturingSlot<String>? = null,
+            applyToRecordId: String = "",
         ): Operation {
             val operation = mockk<Operation>()
             val opIdSlot = operationIdSlot ?: slot()

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/operations/OperationRepoTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/operations/OperationRepoTests.kt
@@ -9,6 +9,7 @@ import com.onesignal.core.internal.time.impl.Time
 import com.onesignal.debug.LogLevel
 import com.onesignal.debug.internal.logging.Logging
 import com.onesignal.mocks.MockHelper
+import com.onesignal.user.internal.operations.ExecutorMocks.Companion.getNewRecordState
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.CapturingSlot
@@ -55,6 +56,7 @@ private class Mocks {
                 operationModelStore,
                 configModelStore,
                 Time(),
+                getNewRecordState(configModelStore),
             ),
         )
     }
@@ -75,6 +77,7 @@ class OperationRepoTests : FunSpec({
             override val modifyComparisonKey = ""
             override val groupComparisonType = GroupComparisonType.NONE
             override val canStartExecute = false
+            override val applyToRecordId = ""
         }
 
         class MyOperation2 : MyOperation()
@@ -558,6 +561,7 @@ class OperationRepoTests : FunSpec({
             every { operation.createComparisonKey } returns createComparisonKey
             every { operation.modifyComparisonKey } returns modifyComparisonKey
             every { operation.translateIds(any()) } just runs
+            every { operation.applyToRecordId } returns applyToRecordId
 
             return operation
         }

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/ExecutorMocks.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/ExecutorMocks.kt
@@ -1,0 +1,12 @@
+package com.onesignal.user.internal.operations
+
+import com.onesignal.core.internal.config.ConfigModelStore
+import com.onesignal.core.internal.time.impl.Time
+import com.onesignal.mocks.MockHelper
+import com.onesignal.user.internal.operations.impl.states.NewRecordsState
+
+class ExecutorMocks {
+    companion object {
+        fun getNewRecordState(configModelStore: ConfigModelStore = MockHelper.configModelStore()) = NewRecordsState(Time(), configModelStore)
+    }
+}

--- a/OneSignalSDK/onesignal/testhelpers/src/main/java/com/onesignal/mocks/MockHelper.kt
+++ b/OneSignalSDK/onesignal/testhelpers/src/main/java/com/onesignal/mocks/MockHelper.kt
@@ -47,6 +47,7 @@ object MockHelper {
         configModel.opRepoExecutionInterval = 1
         configModel.opRepoPostWakeDelay = 1
         configModel.opRepoPostCreateDelay = 1
+        configModel.opRepoPostCreateRetryUpTo = 1
 
         configModel.appId = DEFAULT_APP_ID
 

--- a/OneSignalSDK/onesignal/testhelpers/src/main/java/com/onesignal/mocks/MockHelper.kt
+++ b/OneSignalSDK/onesignal/testhelpers/src/main/java/com/onesignal/mocks/MockHelper.kt
@@ -46,6 +46,7 @@ object MockHelper {
 
         configModel.opRepoExecutionInterval = 1
         configModel.opRepoPostWakeDelay = 1
+        configModel.opRepoPostCreateDelay = 1
 
         configModel.appId = DEFAULT_APP_ID
 


### PR DESCRIPTION
# Description
## One Line Summary
Handle incorrect 404 responses from the OneSignal's backend by; 1. Add a delay after creates; 2. Retry on 404 for a short window after create.

## Details
### Backend Issue
OneSignal sometimes returns a 404 on GET an PATCH requests if you are accessing something immediately after it was created. Normally the OneSignal backend can accept fetch/updates right way, but it all depends on it's server load. There isn't a guaranteed amount of time a client can wait, so SDKs has to work around this problem.

### SDK's work around strategy
This PR introduces two ways to work around this 404 problem:
1. Add a minimum delay after creating records (User or Subscription) before allowing any operations to fetch or update that specific record, based on the onesignalId or subscriptionId.
   * We picked 5 second as this "cool down". This is a best guess, we are balancing SDK responsiveness with the chance of running into this issue.
   * This has a trade off side-effect, improving batching, which may save some network calls, but again, at the cost of some SDK responsiveness.
2. As the 404/410 may still happen when the backend is under unusual load (a 5 second delay may not always be enough) we also retry on 404/410 within a longer but still short window
   * We picked 60 seconds, again this is a best guess, we are balancing the same things here.

### Motivation
404/410 responses are being handled by recreating the missing record (User or Subscription), however this isn't always the right way to handle these, give the backend caveat noted above. Recreating these records can create side-effects and extra load we want to avoid.

### Scope
Add a delay processing some operations in the `OperationRepo`, and affects 404/410 handling in executors.

### Future Considerations
* Calls that do not go through the OperationRepo could have this same logic applied.
    - Such as GET /iams, or maybe this could be move to the OperationRepo.
* The two new parameters (and existing operation repo ones) could be read from remote params, so they can be tweaked later.

# Testing
## Unit testing
* [Failing test to prove the issue](https://github.com/OneSignal/OneSignal-Android-SDK/actions/runs/8728583277/job/23948694395?pr=2059#step:6:783)
* [Test passing after ](https://github.com/OneSignal/OneSignal-Android-SDK/actions/runs/8728911515/job/23949744945#step:6:781)
* [New 404 tests added](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2059/commits/bc9f938dfe46ef93b0000843e75a900310504516)

## Manual testing
Tested on an Android 14 emulator.
Tested with the following code:
```Java
OneSignal.initWithContext(this, appId);
OneSignal.login("a");
OneSignal.getUser().addTag("tagKey", "tagValue");
```
Which produced the following log:
```logcat
// We create the anonymous User and get IAMs right away
2024-04-17 21:26:34.834  2096-2146  OneSignal               com.onesignal.sdktest                D  [DefaultDispatcher-worker-2] HttpClient: POST apps/77e32082-ea27-42e3-a898-c72e141824ef/users - {"subscriptions":[{"type":"AndroidPush","token":"","enabled":false,"notification_types":0,"sdk":"050109","device_model":"sdk_gphone64_x86_64","device_os":"14","rooted":false,"net_type":0,"carrier":"T-Mobile","app_version":"1"}],"properties":{...},"refresh_device_metadata":true}
2024-04-17 21:26:35.062  2096-2146  OneSignal               com.onesignal.sdktest                D  [DefaultDispatcher-worker-2] HttpClient: POST apps/77e32082-ea27-42e3-a898-c72e141824ef/users - STATUS: 201 JSON: {"properties":{.....},"identity":{"onesignal_id":"cf2e5aba-9c5b-4c9a-8bac-c633187e78c9"},"subscriptions":[{"id":"3adec8d7-5808-432b-b18b-257d3a99b7a8","app_id":"77e32082-ea27-42e3-a898-c72e141824ef","type":"AndroidPush","token":""}]}
2024-04-17 21:26:35.113  2096-2147  OneSignal               com.onesignal.sdktest                D  [DefaultDispatcher-worker-3] HttpClient: GET apps/77e32082-ea27-42e3-a898-c72e141824ef/subscriptions/3adec8d7-5808-432b-b18b-257d3a99b7a8/iams
2024-04-17 21:26:35.301  2096-2147  OneSignal               com.onesignal.sdktest                D  [DefaultDispatcher-worker-3] HttpClient: GET apps/77e32082-ea27-42e3-a898-c72e141824ef/subscriptions/3adec8d7-5808-432b-b18b-257d3a99b7a8/iams - STATUS: 200 JSON: {"in_app_messages":[...]}

// ~5 seconds go by 
// We waited the expected 5 seconds before touching the User we just created above.

2024-04-17 21:26:40.204  2096-2147  OneSignal               com.onesignal.sdktest                D  [DefaultDispatcher-worker-3] HttpClient: PATCH apps/77e32082-ea27-42e3-a898-c72e141824ef/users/by/onesignal_id/cf2e5aba-9c5b-4c9a-8bac-c633187e78c9/identity - {"identity":{"external_id":"a"}}
2024-04-17 21:26:40.368  2096-2147  OneSignal               com.onesignal.sdktest                D  [DefaultDispatcher-worker-3] HttpClient: PATCH apps/77e32082-ea27-42e3-a898-c72e141824ef/users/by/onesignal_id/cf2e5aba-9c5b-4c9a-8bac-c633187e78c9/identity - FAILED STATUS: 409
2024-04-17 21:26:40.377  2096-2147  OneSignal               com.onesignal.sdktest                W  [DefaultDispatcher-worker-3] HttpClient: PATCH RECEIVED JSON: {"errors":[{"code":"user-2","title":"One or more Aliases claimed by another User","meta":{"external_id":"a"}}]}
2024-04-17 21:26:40.392  2096-2147  OneSignal               com.onesignal.sdktest                D  [DefaultDispatcher-worker-3] HttpClient: POST apps/77e32082-ea27-42e3-a898-c72e141824ef/users - {"identity":{"external_id":"a"},"subscriptions":[{"id":"3adec8d7-5808-432b-b18b-257d3a99b7a8","token":"dbRAEK1wRPquPDWhCmJQJy:....","enabled":false,"notification_types":0}],"properties":{"timezone_id":"America\/New_York","language":"en"},"refresh_device_metadata":true}
2024-04-17 21:26:40.636  2096-2147  OneSignal               com.onesignal.sdktest                D  [DefaultDispatcher-worker-3] HttpClient: POST apps/77e32082-ea27-42e3-a898-c72e141824ef/users - STATUS: 202 JSON: {"properties":{...},"identity":{"external_id":"a","onesignal_id":"75f1a08e-c2e1-4691-9473-92713e6300a7"},"subscriptions":[{"id":"3adec8d7-5808-432b-b18b-257d3a99b7a8","app_id":"77e32082-ea27-42e3-a898-c72e141824ef","type":"AndroidPush","token":""}]}

// ~5 seconds go by 
// Assigned the externalId failed (an normal case where User already logged into another device) so we called create user again, with the externalId: "a" this time. This is done so backend finds the existing User
//    * The SDK can't be sure if it is creating a User or finding an existing User, we waited the expected 5 second here

2024-04-17 21:26:45.930  2096-2158  OneSignal               com.onesignal.sdktest                D  [DefaultDispatcher-worker-5] HttpClient: PATCH apps/77e32082-ea27-42e3-a898-c72e141824ef/users/by/onesignal_id/75f1a08e-c2e1-4691-9473-92713e6300a7 - {"refresh_device_metadata":false,"properties":{"tags":{"tagKey":"tagValue"}}}
2024-04-17 21:26:46.124  2096-2158  OneSignal               com.onesignal.sdktest                D  [DefaultDispatcher-worker-5] HttpClient: PATCH apps/77e32082-ea27-42e3-a898-c72e141824ef/users/by/onesignal_id/75f1a08e-c2e1-4691-9473-92713e6300a7 - STATUS: 202 JSON: {"properties":{"tags":{"tagKey":"tagValue"}}}
2024-04-17 21:26:46.346  2096-2158  OneSignal               com.onesignal.sdktest                D  [DefaultDispatcher-worker-5] HttpClient: GET apps/77e32082-ea27-42e3-a898-c72e141824ef/users/by/onesignal_id/75f1a08e-c2e1-4691-9473-92713e6300a7

// Both the set tag and fetch User happen back-to-back now that we are past all the new create delays 

```

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2059)
<!-- Reviewable:end -->
