### PR TITLE
[Player Model] Corrected DeadSystemException handling

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationChannelManager.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationChannelManager.java
@@ -262,13 +262,15 @@ class NotificationChannelManager {
          // "Attempt to invoke virtual method 'boolean android.app.NotificationChannel.isDeleted()' on a null object reference"
          // https://github.com/OneSignal/OneSignal-Android-SDK/issues/1291
          OneSignal.onesignalLog(OneSignal.LOG_LEVEL.ERROR, "Error when trying to delete notification channel: " + e.getMessage());
-      }
-      catch (Exception e) {
+      } catch (RuntimeException e) {
+         // Android internally throws this via RemoteException.rethrowFromSystemServer()
+         // so we must catch RuntimeException and check the cause.
+
          // Suppressing DeadSystemException as the app is already dying for
          // another reason and allowing this exception to bubble up would
          // create a red herring for app developers. We still re-throw
          // others, as we don't want to silently hide other issues.
-         if (!(e instanceof DeadSystemException)) {
+         if (!(e.getCause() instanceof DeadSystemException)) {
             throw e;
          }
       }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSUtils.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSUtils.java
@@ -306,15 +306,18 @@ class OSUtils {
       HuaweiApiAvailability availability = HuaweiApiAvailability.getInstance();
       try {
          return availability.isHuaweiMobileServicesAvailable(OneSignal.appContext) == HMS_AVAILABLE_SUCCESSFUL;
-      } catch (Exception e) {
+      } catch (RuntimeException e) {
+         // Android internally throws this via RemoteException.rethrowFromSystemServer()
+         // so we must catch RuntimeException and check the cause.
+
          // Suppressing DeadSystemException as the app is already dying for
          // another reason and allowing this exception to bubble up would
          // create a red herring for app developers. We still re-throw
          // others, as we don't want to silently hide other issues.
-         if (!(e instanceof DeadSystemException)) {
-            throw e;
+         if (e.getCause() instanceof DeadSystemException) {
+            return false;
          }
-         return false;
+         throw e;
       }
    }
 


### PR DESCRIPTION
# Description
## One Line Summary
Corrects `DeadSystemException` handling that was originally added in PR #1937, as it wasn't catching.

## Details
After reading through the AOSP source code I discovered that it throws RuntimeException and set its cause to RuntimeException via RemoteException.rethrowFromSystemServer(). The original code was trying to catch AndroidException which would have never happened.

### Motivation
`DeadSystemException` happens after a the app is in a bad state, not the root cause. Suppressing these as they are a red herring.

### Scope
Code that calls getApplicationInfo, getPackageInfo, and isHuaweiMobileServicesAvailable (seems to use getPackageInfo under its hood).

### Related
PR #1937 originally added catching for `DeadSystemException`, however the way it was catching didn't work so this PR corrects that.

### ASOP
Where `DeadSystemException` is thrown from in AOSP:
https://cs.android.com/android/_/android/platform/frameworks/base/+/64ee6e2bc6a57d5649fddddaba456fdb7521e15e:core/java/android/app/ApplicationPackageManager.java;l=201;drc=09014f10482fa6300e80a4bbb51d7f404129bc06;bpv=1;bpt=0

A commit in on 2020-02-20 to AOSP that adds some internal caching:
https://cs.android.com/android/_/android/platform/frameworks/base/+/a46b7b3f5e9398a245d0730d365d1f847d313938
That caching means that newer Android version (Android 12 plus maybe?) had a lower chance of running into this exception. However it still uses `rethrowFromSystemServer()` so the exception will be caught by this PR.

# Testing
## Unit testing
player-model-main unit tests are not running currently.

## Manual testing
Tested on Android 14, ensuring the device subscribes for push.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [ ] I have filled out all **REQUIRED** sections above
   - [ ] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [ ] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [ ] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.
