### PR TITLE
[Improve] Handle HTTP header Retry-After from responses from OneSignal

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/NetworkUtils.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/NetworkUtils.kt
@@ -17,6 +17,7 @@ object NetworkUtils {
             401, 403 -> ResponseStatusType.UNAUTHORIZED
             404, 410 -> ResponseStatusType.MISSING
             409 -> ResponseStatusType.CONFLICT
+            429 -> ResponseStatusType.RETRYABLE
             else -> ResponseStatusType.RETRYABLE
         }
     }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/exceptions/BackendException.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/exceptions/BackendException.kt
@@ -12,4 +12,9 @@ class BackendException(
      * The response, if one exists.
      */
     val response: String? = null,
+    /**
+     * Optional Integer value maybe returned from the backend.
+     * The module handing this should delay any future requests by this time.
+     */
+    val retryAfterSeconds: Int? = null,
 ) : Exception()

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/backend/impl/ParamsBackendService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/backend/impl/ParamsBackendService.kt
@@ -34,7 +34,7 @@ internal class ParamsBackendService(
         val response = _http.get(paramsUrl, CacheKeys.REMOTE_PARAMS)
 
         if (!response.isSuccess) {
-            throw BackendException(response.statusCode, response.payload)
+            throw BackendException(response.statusCode, response.payload, response.retryAfterSeconds)
         }
 
         val responseJson = JSONObject(response.payload!!)

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/config/ConfigModel.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/config/ConfigModel.kt
@@ -178,6 +178,18 @@ class ConfigModel : Model() {
         }
 
     /**
+     * The number of milliseconds times the number of times FAIL_RETRY
+     * is returned from an executor for a specific operation. AKA this
+     * backoff will increase each time we retry a specific operation
+     * by this value.
+     */
+    var opRepoDefaultFailRetryBackoff: Long
+        get() = getLongProperty(::opRepoDefaultFailRetryBackoff.name) { 15_000 }
+        set(value) {
+            setLongProperty(::opRepoDefaultFailRetryBackoff.name, value)
+        }
+
+    /**
      * The minimum number of milliseconds required to pass to allow the fetching of IAM to occur.
      */
     var fetchIAMMinInterval: Long

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/config/ConfigModel.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/config/ConfigModel.kt
@@ -112,6 +112,16 @@ class ConfigModel : Model() {
         }
 
     /**
+     * The fallback Retry-After to use if the header is present, but the server
+     * give us a format we can't parse.
+     */
+    var httpRetryAfterParseFailFallback: Int
+        get() = getIntProperty(::httpRetryAfterParseFailFallback.name) { 60 }
+        set(value) {
+            setIntProperty(::httpRetryAfterParseFailFallback.name, value)
+        }
+
+    /**
      * Maximum time in milliseconds a user can spend out of focus before a new session is created.
      */
     var sessionFocusTimeout: Long

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/http/HttpResponse.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/http/HttpResponse.kt
@@ -18,6 +18,11 @@ class HttpResponse(
      * When non-null, the throwable that was thrown during processing.
      */
     val throwable: Throwable? = null,
+    /**
+     * Optional Integer value maybe returned from the backend.
+     * The module handing this should delay any future requests by this time.
+     */
+    val retryAfterSeconds: Int? = null,
 ) {
     /**
      * Whether the response is a successful one.

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/IOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/IOperationExecutor.kt
@@ -37,6 +37,11 @@ class ExecutionResponse(
      * When specified, any operations that should be prepended to the operation repo.
      */
     val operations: List<Operation>? = null,
+    /**
+     * Optional Integer value maybe returned from the backend.
+     * The module handing this should delay any future requests by this time.
+     */
+    val retryAfterSeconds: Int? = null,
 )
 
 enum class ExecutionResult {

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/session/internal/outcomes/impl/OutcomeEventsBackendService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/session/internal/outcomes/impl/OutcomeEventsBackendService.kt
@@ -49,7 +49,7 @@ internal class OutcomeEventsBackendService(private val _http: IHttpClient) :
         val response = _http.post("outcomes/measure", jsonObject)
 
         if (!response.isSuccess) {
-            throw BackendException(response.statusCode, response.payload)
+            throw BackendException(response.statusCode, response.payload, response.retryAfterSeconds)
         }
     }
 }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/backend/impl/IdentityBackendService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/backend/impl/IdentityBackendService.kt
@@ -23,7 +23,7 @@ internal class IdentityBackendService(
         val response = _httpClient.patch("apps/$appId/users/by/$aliasLabel/$aliasValue/identity", requestJSONObject)
 
         if (!response.isSuccess) {
-            throw BackendException(response.statusCode, response.payload)
+            throw BackendException(response.statusCode, response.payload, response.retryAfterSeconds)
         }
 
         val responseJSON = JSONObject(response.payload!!)
@@ -40,7 +40,7 @@ internal class IdentityBackendService(
         val response = _httpClient.delete("apps/$appId/users/by/$aliasLabel/$aliasValue/identity/$aliasLabelToDelete")
 
         if (!response.isSuccess) {
-            throw BackendException(response.statusCode, response.payload)
+            throw BackendException(response.statusCode, response.payload, response.retryAfterSeconds)
         }
     }
 }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/backend/impl/SubscriptionBackendService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/backend/impl/SubscriptionBackendService.kt
@@ -24,7 +24,7 @@ internal class SubscriptionBackendService(
         val response = _httpClient.post("apps/$appId/users/by/$aliasLabel/$aliasValue/subscriptions", requestJSON)
 
         if (!response.isSuccess) {
-            throw BackendException(response.statusCode, response.payload)
+            throw BackendException(response.statusCode, response.payload, response.retryAfterSeconds)
         }
 
         val responseJSON = JSONObject(response.payload!!)
@@ -48,7 +48,7 @@ internal class SubscriptionBackendService(
         val response = _httpClient.patch("apps/$appId/subscriptions/$subscriptionId", requestJSON)
 
         if (!response.isSuccess) {
-            throw BackendException(response.statusCode, response.payload)
+            throw BackendException(response.statusCode, response.payload, response.retryAfterSeconds)
         }
     }
 
@@ -59,7 +59,7 @@ internal class SubscriptionBackendService(
         val response = _httpClient.delete("apps/$appId/subscriptions/$subscriptionId")
 
         if (!response.isSuccess) {
-            throw BackendException(response.statusCode, response.payload)
+            throw BackendException(response.statusCode, response.payload, response.retryAfterSeconds)
         }
     }
 
@@ -76,7 +76,7 @@ internal class SubscriptionBackendService(
         val response = _httpClient.patch("apps/$appId/subscriptions/$subscriptionId/owner", requestJSON)
 
         if (!response.isSuccess) {
-            throw BackendException(response.statusCode, response.payload)
+            throw BackendException(response.statusCode, response.payload, response.retryAfterSeconds)
         }
     }
 
@@ -87,7 +87,7 @@ internal class SubscriptionBackendService(
         val response = _httpClient.get("apps/$appId/subscriptions/$subscriptionId/user/identity")
 
         if (!response.isSuccess) {
-            throw BackendException(response.statusCode, response.payload)
+            throw BackendException(response.statusCode, response.payload, response.retryAfterSeconds)
         }
 
         val responseJSON = JSONObject(response.payload!!)

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/backend/impl/UserBackendService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/backend/impl/UserBackendService.kt
@@ -39,7 +39,7 @@ internal class UserBackendService(
         val response = _httpClient.post("apps/$appId/users", requestJSON)
 
         if (!response.isSuccess) {
-            throw BackendException(response.statusCode, response.payload)
+            throw BackendException(response.statusCode, response.payload, response.retryAfterSeconds)
         }
 
         return JSONConverter.convertToCreateUserResponse(JSONObject(response.payload!!))
@@ -68,7 +68,7 @@ internal class UserBackendService(
         val response = _httpClient.patch("apps/$appId/users/by/$aliasLabel/$aliasValue", jsonObject)
 
         if (!response.isSuccess) {
-            throw BackendException(response.statusCode, response.payload)
+            throw BackendException(response.statusCode, response.payload, response.retryAfterSeconds)
         }
     }
 
@@ -80,7 +80,7 @@ internal class UserBackendService(
         val response = _httpClient.get("apps/$appId/users/by/$aliasLabel/$aliasValue")
 
         if (!response.isSuccess) {
-            throw BackendException(response.statusCode, response.payload)
+            throw BackendException(response.statusCode, response.payload, response.retryAfterSeconds)
         }
 
         return JSONConverter.convertToCreateUserResponse(JSONObject(response.payload))

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/LoginUserOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/LoginUserOperationExecutor.kt
@@ -211,9 +211,9 @@ internal class LoginUserOperationExecutor(
 
             return when (responseType) {
                 NetworkUtils.ResponseStatusType.RETRYABLE ->
-                    ExecutionResponse(ExecutionResult.FAIL_RETRY)
+                    ExecutionResponse(ExecutionResult.FAIL_RETRY, retryAfterSeconds = ex.retryAfterSeconds)
                 NetworkUtils.ResponseStatusType.UNAUTHORIZED ->
-                    ExecutionResponse(ExecutionResult.FAIL_UNAUTHORIZED)
+                    ExecutionResponse(ExecutionResult.FAIL_UNAUTHORIZED, retryAfterSeconds = ex.retryAfterSeconds)
                 else ->
                     ExecutionResponse(ExecutionResult.FAIL_PAUSE_OPREPO)
             }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/SubscriptionOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/SubscriptionOperationExecutor.kt
@@ -130,22 +130,22 @@ internal class SubscriptionOperationExecutor(
 
             return when (responseType) {
                 NetworkUtils.ResponseStatusType.RETRYABLE ->
-                    ExecutionResponse(ExecutionResult.FAIL_RETRY)
+                    ExecutionResponse(ExecutionResult.FAIL_RETRY, retryAfterSeconds = ex.retryAfterSeconds)
                 NetworkUtils.ResponseStatusType.CONFLICT,
                 NetworkUtils.ResponseStatusType.INVALID,
                 ->
                     ExecutionResponse(ExecutionResult.FAIL_NORETRY)
                 NetworkUtils.ResponseStatusType.UNAUTHORIZED ->
-                    ExecutionResponse(ExecutionResult.FAIL_UNAUTHORIZED)
+                    ExecutionResponse(ExecutionResult.FAIL_UNAUTHORIZED, retryAfterSeconds = ex.retryAfterSeconds)
                 NetworkUtils.ResponseStatusType.MISSING -> {
                     if (ex.statusCode == 404 && _newRecordState.isInMissingRetryWindow(createOperation.onesignalId)) {
-                        return ExecutionResponse(ExecutionResult.FAIL_RETRY)
+                        return ExecutionResponse(ExecutionResult.FAIL_RETRY, retryAfterSeconds = ex.retryAfterSeconds)
                     }
                     val operations = _buildUserService.getRebuildOperationsIfCurrentUser(createOperation.appId, createOperation.onesignalId)
                     if (operations == null) {
                         return ExecutionResponse(ExecutionResult.FAIL_NORETRY)
                     } else {
-                        return ExecutionResponse(ExecutionResult.FAIL_RETRY, operations = operations)
+                        return ExecutionResponse(ExecutionResult.FAIL_RETRY, operations = operations, retryAfterSeconds = ex.retryAfterSeconds)
                     }
                 }
             }
@@ -181,7 +181,7 @@ internal class SubscriptionOperationExecutor(
 
             return when (responseType) {
                 NetworkUtils.ResponseStatusType.RETRYABLE ->
-                    ExecutionResponse(ExecutionResult.FAIL_RETRY)
+                    ExecutionResponse(ExecutionResult.FAIL_RETRY, retryAfterSeconds = ex.retryAfterSeconds)
                 NetworkUtils.ResponseStatusType.MISSING -> {
                     if (ex.statusCode == 404 &&
                         listOf(
@@ -189,7 +189,7 @@ internal class SubscriptionOperationExecutor(
                             lastOperation.subscriptionId,
                         ).any { _newRecordState.isInMissingRetryWindow(it) }
                     ) {
-                        return ExecutionResponse(ExecutionResult.FAIL_RETRY)
+                        return ExecutionResponse(ExecutionResult.FAIL_RETRY, retryAfterSeconds = ex.retryAfterSeconds)
                     }
                     // toss this, but create an identical CreateSubscriptionOperation to re-create the subscription being updated.
                     ExecutionResponse(
@@ -229,7 +229,7 @@ internal class SubscriptionOperationExecutor(
 
             return when (responseType) {
                 NetworkUtils.ResponseStatusType.RETRYABLE ->
-                    ExecutionResponse(ExecutionResult.FAIL_RETRY)
+                    ExecutionResponse(ExecutionResult.FAIL_RETRY, retryAfterSeconds = ex.retryAfterSeconds)
                 else ->
                     ExecutionResponse(ExecutionResult.FAIL_NORETRY)
             }
@@ -269,14 +269,14 @@ internal class SubscriptionOperationExecutor(
                             op.subscriptionId,
                         ).any { _newRecordState.isInMissingRetryWindow(it) }
                     ) {
-                        ExecutionResponse(ExecutionResult.FAIL_RETRY)
+                        ExecutionResponse(ExecutionResult.FAIL_RETRY, retryAfterSeconds = ex.retryAfterSeconds)
                     } else {
                         // if the subscription is missing, we are good!
                         ExecutionResponse(ExecutionResult.SUCCESS)
                     }
                 }
                 NetworkUtils.ResponseStatusType.RETRYABLE ->
-                    ExecutionResponse(ExecutionResult.FAIL_RETRY)
+                    ExecutionResponse(ExecutionResult.FAIL_RETRY, retryAfterSeconds = ex.retryAfterSeconds)
                 else ->
                     ExecutionResponse(ExecutionResult.FAIL_NORETRY)
             }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/UpdateUserOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/UpdateUserOperationExecutor.kt
@@ -161,18 +161,22 @@ internal class UpdateUserOperationExecutor(
 
                 return when (responseType) {
                     NetworkUtils.ResponseStatusType.RETRYABLE ->
-                        ExecutionResponse(ExecutionResult.FAIL_RETRY)
+                        ExecutionResponse(ExecutionResult.FAIL_RETRY, retryAfterSeconds = ex.retryAfterSeconds)
                     NetworkUtils.ResponseStatusType.UNAUTHORIZED ->
-                        ExecutionResponse(ExecutionResult.FAIL_UNAUTHORIZED)
+                        ExecutionResponse(ExecutionResult.FAIL_UNAUTHORIZED, retryAfterSeconds = ex.retryAfterSeconds)
                     NetworkUtils.ResponseStatusType.MISSING -> {
                         if (ex.statusCode == 404 && _newRecordState.isInMissingRetryWindow(onesignalId)) {
-                            return ExecutionResponse(ExecutionResult.FAIL_RETRY)
+                            return ExecutionResponse(ExecutionResult.FAIL_RETRY, retryAfterSeconds = ex.retryAfterSeconds)
                         }
                         val operations = _buildUserService.getRebuildOperationsIfCurrentUser(appId, onesignalId)
                         if (operations == null) {
                             return ExecutionResponse(ExecutionResult.FAIL_NORETRY)
                         } else {
-                            return ExecutionResponse(ExecutionResult.FAIL_RETRY, operations = operations)
+                            return ExecutionResponse(
+                                ExecutionResult.FAIL_RETRY,
+                                operations = operations,
+                                retryAfterSeconds = ex.retryAfterSeconds,
+                            )
                         }
                     }
                     else ->

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/http/HttpClientTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/http/HttpClientTests.kt
@@ -14,6 +14,15 @@ import io.kotest.matchers.types.beInstanceOf
 import kotlinx.coroutines.TimeoutCancellationException
 import org.json.JSONObject
 
+class Mocks {
+    internal val mockConfigModel = MockHelper.configModelStore()
+    internal val response = MockHttpConnectionFactory.MockResponse()
+    internal val factory = MockHttpConnectionFactory(response)
+    internal val httpClient by lazy {
+        HttpClient(factory, MockPreferencesService(), mockConfigModel)
+    }
+}
+
 class HttpClientTests : FunSpec({
 
     beforeAny {
@@ -22,20 +31,16 @@ class HttpClientTests : FunSpec({
 
     test("timeout request will give a bad response") {
         // Given
-        val mockResponse = MockHttpConnectionFactory.MockResponse()
-        mockResponse.mockRequestTime = 10000 // HttpClient will add 5 seconds to the httpTimeout to "give up" so we need to fail the request more than 5 seconds beyond our timeout.
-
-        val mockConfigModel =
-            MockHelper.configModelStore {
-                it.httpTimeout = 200
-                it.httpGetTimeout = 200
-            }
-
-        val factory = MockHttpConnectionFactory(mockResponse)
-        val httpClient = HttpClient(factory, MockPreferencesService(), mockConfigModel)
+        val mocks = Mocks()
+        // HttpClient will add 5 seconds to the httpTimeout to "give up" so we need to fail the request more than 5 seconds beyond our timeout.
+        mocks.response.mockRequestTime = 10_000
+        mocks.mockConfigModel.model.let {
+            it.httpGetTimeout = 200
+            it.httpGetTimeout = 200
+        }
 
         // When
-        val response = httpClient.get("URL")
+        val response = mocks.httpClient.get("URL")
 
         // Then
         response.statusCode shouldBe 0
@@ -45,9 +50,8 @@ class HttpClientTests : FunSpec({
 
     test("SDKHeader is included in all requests") {
         // Given
-        val mockResponse = MockHttpConnectionFactory.MockResponse()
-        val factory = MockHttpConnectionFactory(mockResponse)
-        val httpClient = HttpClient(factory, MockPreferencesService(), MockHelper.configModelStore())
+        val mocks = Mocks()
+        val httpClient = mocks.httpClient
 
         // When
         httpClient.get("URL")
@@ -57,30 +61,31 @@ class HttpClientTests : FunSpec({
         httpClient.put("URL", JSONObject())
 
         // Then
-        for (connection in factory.connections) {
+        for (connection in mocks.factory.connections) {
             connection.getRequestProperty("SDK-Version") shouldBe "onesignal/android/${OneSignalUtils.SDK_VERSION}"
         }
     }
 
     test("GET with cache key uses cache when unchanged") {
         // Given
+        val mocks = Mocks()
         val payload = "RESPONSE IS THIS"
         val mockResponse1 = MockHttpConnectionFactory.MockResponse()
         mockResponse1.status = 200
         mockResponse1.responseBody = payload
         mockResponse1.mockProps.put("etag", "MOCK_ETAG")
+        mocks.factory.mockResponse = mockResponse1
 
         val mockResponse2 = MockHttpConnectionFactory.MockResponse()
         mockResponse2.status = 304
 
-        val factory = MockHttpConnectionFactory(mockResponse1)
-        val httpClient = HttpClient(factory, MockPreferencesService(), MockHelper.configModelStore())
+        val factory = mocks.factory
+        val httpClient = mocks.httpClient
 
         // When
-        var response1 = httpClient.get("URL", "CACHE_KEY")
-
+        val response1 = httpClient.get("URL", "CACHE_KEY")
         factory.mockResponse = mockResponse2
-        var response2 = httpClient.get("URL", "CACHE_KEY")
+        val response2 = httpClient.get("URL", "CACHE_KEY")
 
         // Then
         response1.statusCode shouldBe 200
@@ -92,12 +97,14 @@ class HttpClientTests : FunSpec({
 
     test("GET with cache key replaces cache when changed") {
         // Given
+        val mocks = Mocks()
         val payload1 = "RESPONSE IS THIS"
         val payload2 = "A DIFFERENT RESPONSE"
         val mockResponse1 = MockHttpConnectionFactory.MockResponse()
         mockResponse1.status = 200
         mockResponse1.responseBody = payload1
         mockResponse1.mockProps.put("etag", "MOCK_ETAG1")
+        mocks.factory.mockResponse = mockResponse1
 
         val mockResponse2 = MockHttpConnectionFactory.MockResponse()
         mockResponse2.status = 200
@@ -107,17 +114,17 @@ class HttpClientTests : FunSpec({
         val mockResponse3 = MockHttpConnectionFactory.MockResponse()
         mockResponse3.status = 304
 
-        val factory = MockHttpConnectionFactory(mockResponse1)
-        val httpClient = HttpClient(factory, MockPreferencesService(), MockHelper.configModelStore())
+        val factory = mocks.factory
+        val httpClient = mocks.httpClient
 
         // When
-        var response1 = httpClient.get("URL", "CACHE_KEY")
+        val response1 = httpClient.get("URL", "CACHE_KEY")
 
         factory.mockResponse = mockResponse2
-        var response2 = httpClient.get("URL", "CACHE_KEY")
+        val response2 = httpClient.get("URL", "CACHE_KEY")
 
         factory.mockResponse = mockResponse3
-        var response3 = httpClient.get("URL", "CACHE_KEY")
+        val response3 = httpClient.get("URL", "CACHE_KEY")
 
         // Then
         response1.statusCode shouldBe 200
@@ -132,16 +139,13 @@ class HttpClientTests : FunSpec({
 
     test("Error response") {
         // Given
+        val mocks = Mocks()
         val payload = "ERROR RESPONSE"
-        val mockResponse = MockHttpConnectionFactory.MockResponse()
-        mockResponse.status = 400
-        mockResponse.errorResponseBody = payload
-
-        val factory = MockHttpConnectionFactory(mockResponse)
-        val httpClient = HttpClient(factory, MockPreferencesService(), MockHelper.configModelStore())
+        mocks.response.status = 400
+        mocks.response.errorResponseBody = payload
 
         // When
-        var response = httpClient.post("URL", JSONObject())
+        val response = mocks.httpClient.post("URL", JSONObject())
 
         // Then
         response.statusCode shouldBe 400
@@ -150,16 +154,13 @@ class HttpClientTests : FunSpec({
 
     test("should parse valid Retry-After, on 429") {
         // Given
-        val mockResponse = MockHttpConnectionFactory.MockResponse()
-        mockResponse.status = 429
-        mockResponse.mockProps["Retry-After"] = "1234"
-        mockResponse.errorResponseBody = "{}"
-
-        val factory = MockHttpConnectionFactory(mockResponse)
-        val httpClient = HttpClient(factory, MockPreferencesService(), MockHelper.configModelStore())
+        val mocks = Mocks()
+        mocks.response.status = 429
+        mocks.response.mockProps["Retry-After"] = "1234"
+        mocks.response.errorResponseBody = "{}"
 
         // When
-        val response = httpClient.post("URL", JSONObject())
+        val response = mocks.httpClient.post("URL", JSONObject())
 
         // Then
         response.retryAfterSeconds shouldBe 1234
@@ -167,16 +168,13 @@ class HttpClientTests : FunSpec({
 
     test("should parse valid Retry-After, on 500") {
         // Given
-        val mockResponse = MockHttpConnectionFactory.MockResponse()
-        mockResponse.status = 500
-        mockResponse.mockProps["Retry-After"] = "1234"
-        mockResponse.errorResponseBody = "{}"
-
-        val factory = MockHttpConnectionFactory(mockResponse)
-        val httpClient = HttpClient(factory, MockPreferencesService(), MockHelper.configModelStore())
+        val mocks = Mocks()
+        mocks.response.status = 500
+        mocks.response.mockProps["Retry-After"] = "1234"
+        mocks.response.errorResponseBody = "{}"
 
         // When
-        val response = httpClient.post("URL", JSONObject())
+        val response = mocks.httpClient.post("URL", JSONObject())
 
         // Then
         response.retryAfterSeconds shouldBe 1234
@@ -184,16 +182,13 @@ class HttpClientTests : FunSpec({
 
     test("should use set fallback retryAfterSeconds if can't parse Retry-After") {
         // Given
-        val mockResponse = MockHttpConnectionFactory.MockResponse()
-        mockResponse.status = 429
-        mockResponse.mockProps["Retry-After"] = "INVALID FORMAT"
-        mockResponse.errorResponseBody = "{}"
-
-        val factory = MockHttpConnectionFactory(mockResponse)
-        val httpClient = HttpClient(factory, MockPreferencesService(), MockHelper.configModelStore())
+        val mocks = Mocks()
+        mocks.response.status = 429
+        mocks.response.mockProps["Retry-After"] = "INVALID FORMAT"
+        mocks.response.errorResponseBody = "{}"
 
         // When
-        val response = httpClient.post("URL", JSONObject())
+        val response = mocks.httpClient.post("URL", JSONObject())
 
         // Then
         response.retryAfterSeconds shouldBe 60
@@ -203,15 +198,12 @@ class HttpClientTests : FunSpec({
     // Retry-After we should assume a our safe fallback.
     test("should use set fallback retryAfterSeconds if 429 and Retry-After is missing") {
         // Given
-        val mockResponse = MockHttpConnectionFactory.MockResponse()
-        mockResponse.status = 429
-        mockResponse.errorResponseBody = "{}"
-
-        val factory = MockHttpConnectionFactory(mockResponse)
-        val httpClient = HttpClient(factory, MockPreferencesService(), MockHelper.configModelStore())
+        val mocks = Mocks()
+        mocks.response.status = 429
+        mocks.response.errorResponseBody = "{}"
 
         // When
-        val response = httpClient.post("URL", JSONObject())
+        val response = mocks.httpClient.post("URL", JSONObject())
 
         // Then
         response.retryAfterSeconds shouldBe 60

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/http/MockHttpConnectionFactory.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/http/MockHttpConnectionFactory.kt
@@ -42,8 +42,8 @@ internal class MockHttpConnectionFactory(
         override fun connect() {
         }
 
-        override fun getHeaderField(name: String): String {
-            return mockResponse.mockProps[name]!!
+        override fun getHeaderField(name: String): String? {
+            return mockResponse.mockProps[name]
         }
 
         @Throws(IOException::class)

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/IdentityOperationExecutorTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/IdentityOperationExecutorTests.kt
@@ -56,7 +56,14 @@ class IdentityOperationExecutorTests : FunSpec({
     test("execution of set alias operation with network timeout") {
         // Given
         val mockIdentityBackendService = mockk<IIdentityBackendService>()
-        coEvery { mockIdentityBackendService.setAlias(any(), any(), any(), any()) } throws BackendException(408, "TIMEOUT")
+        coEvery {
+            mockIdentityBackendService.setAlias(
+                any(),
+                any(),
+                any(),
+                any(),
+            )
+        } throws BackendException(408, "TIMEOUT", retryAfterSeconds = 10)
 
         val mockIdentityModelStore = MockHelper.identityModelStore()
         val mockBuildUserService = mockk<IRebuildUserService>()
@@ -71,6 +78,7 @@ class IdentityOperationExecutorTests : FunSpec({
 
         // Then
         response.result shouldBe ExecutionResult.FAIL_RETRY
+        response.retryAfterSeconds shouldBe 10
     }
 
     test("execution of set alias operation with non-retryable error") {

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/LoginUserOperationExecutorTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/LoginUserOperationExecutorTests.kt
@@ -87,7 +87,7 @@ class LoginUserOperationExecutorTests : FunSpec({
     test("login anonymous user fails with retry when network condition exists") {
         // Given
         val mockUserBackendService = mockk<IUserBackendService>()
-        coEvery { mockUserBackendService.createUser(any(), any(), any(), any()) } throws BackendException(408, "TIMEOUT")
+        coEvery { mockUserBackendService.createUser(any(), any(), any(), any()) } throws BackendException(408, "TIMEOUT", retryAfterSeconds = 10)
 
         val mockIdentityOperationExecutor = mockk<IdentityOperationExecutor>()
 
@@ -96,7 +96,17 @@ class LoginUserOperationExecutorTests : FunSpec({
         val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
 
         val loginUserOperationExecutor =
-            LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext())
+            LoginUserOperationExecutor(
+                mockIdentityOperationExecutor,
+                MockHelper.applicationService(),
+                MockHelper.deviceService(),
+                mockUserBackendService,
+                mockIdentityModelStore,
+                mockPropertiesModelStore,
+                mockSubscriptionsModelStore,
+                MockHelper.configModelStore(),
+                MockHelper.languageContext(),
+            )
         val operations = listOf<Operation>(LoginUserOperation(appId, localOneSignalId, null, null))
 
         // When
@@ -104,6 +114,7 @@ class LoginUserOperationExecutorTests : FunSpec({
 
         // Then
         response.result shouldBe ExecutionResult.FAIL_RETRY
+        response.retryAfterSeconds shouldBe 10
         coVerify(exactly = 1) { mockUserBackendService.createUser(appId, mapOf(), any(), any()) }
     }
 

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/RefreshUserOperationExecutorTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/RefreshUserOperationExecutorTests.kt
@@ -177,7 +177,9 @@ class RefreshUserOperationExecutorTests : FunSpec({
     test("refresh user fails with retry when there is a network condition") {
         // Given
         val mockUserBackendService = mockk<IUserBackendService>()
-        coEvery { mockUserBackendService.getUser(appId, IdentityConstants.ONESIGNAL_ID, remoteOneSignalId) } throws BackendException(408)
+        coEvery {
+            mockUserBackendService.getUser(appId, IdentityConstants.ONESIGNAL_ID, remoteOneSignalId)
+        } throws BackendException(408, retryAfterSeconds = 10)
 
         // Given
         val mockIdentityModelStore = MockHelper.identityModelStore()
@@ -203,6 +205,7 @@ class RefreshUserOperationExecutorTests : FunSpec({
 
         // Then
         response.result shouldBe ExecutionResult.FAIL_RETRY
+        response.retryAfterSeconds shouldBe 10
         coVerify(exactly = 1) {
             mockUserBackendService.getUser(appId, IdentityConstants.ONESIGNAL_ID, remoteOneSignalId)
         }

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/SubscriptionOperationExecutorTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/SubscriptionOperationExecutorTests.kt
@@ -93,7 +93,7 @@ class SubscriptionOperationExecutorTests : FunSpec({
     test("create subscription fails with retry when there is a network condition") {
         // Given
         val mockSubscriptionBackendService = mockk<ISubscriptionBackendService>()
-        coEvery { mockSubscriptionBackendService.createSubscription(any(), any(), any(), any()) } throws BackendException(408)
+        coEvery { mockSubscriptionBackendService.createSubscription(any(), any(), any(), any()) } throws BackendException(408, retryAfterSeconds = 10)
 
         val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
         val mockBuildUserService = mockk<IRebuildUserService>()
@@ -127,6 +127,7 @@ class SubscriptionOperationExecutorTests : FunSpec({
 
         // Then
         response.result shouldBe ExecutionResult.FAIL_RETRY
+        response.retryAfterSeconds shouldBe 10
         coVerify(exactly = 1) {
             mockSubscriptionBackendService.createSubscription(
                 appId,

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/UpdateUserOperationExecutorTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/UpdateUserOperationExecutorTests.kt
@@ -311,7 +311,7 @@ class UpdateUserOperationExecutorTests : FunSpec({
     test("update user single operation fails with MISSING, but isInMissingRetryWindow") {
         // Given
         val mockUserBackendService = mockk<IUserBackendService>()
-        coEvery { mockUserBackendService.updateUser(any(), any(), any(), any(), any(), any()) } throws BackendException(404)
+        coEvery { mockUserBackendService.updateUser(any(), any(), any(), any(), any(), any()) } throws BackendException(404, retryAfterSeconds = 10)
 
         // Given
         val mockIdentityModelStore = MockHelper.identityModelStore()
@@ -337,5 +337,6 @@ class UpdateUserOperationExecutorTests : FunSpec({
 
         // Then
         response.result shouldBe ExecutionResult.FAIL_RETRY
+        response.retryAfterSeconds shouldBe 10
     }
 })

--- a/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/backend/impl/InAppBackendService.kt
+++ b/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/backend/impl/InAppBackendService.kt
@@ -123,7 +123,7 @@ internal class InAppBackendService(
                 response.payload,
             )
 
-            throw BackendException(response.statusCode, response.payload)
+            throw BackendException(response.statusCode, response.payload, response.retryAfterSeconds)
         }
     }
 
@@ -151,7 +151,7 @@ internal class InAppBackendService(
             printHttpSuccessForInAppMessageRequest("page impression", response.payload!!)
         } else {
             printHttpErrorForInAppMessageRequest("page impression", response.statusCode, response.payload)
-            throw BackendException(response.statusCode, response.payload)
+            throw BackendException(response.statusCode, response.payload, response.retryAfterSeconds)
         }
     }
 
@@ -178,7 +178,7 @@ internal class InAppBackendService(
             printHttpSuccessForInAppMessageRequest("impression", response.payload!!)
         } else {
             printHttpErrorForInAppMessageRequest("impression", response.statusCode, response.payload)
-            throw BackendException(response.statusCode, response.payload)
+            throw BackendException(response.statusCode, response.payload, response.retryAfterSeconds)
         }
     }
 

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/backend/impl/NotificationBackendService.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/backend/impl/NotificationBackendService.kt
@@ -24,7 +24,7 @@ internal class NotificationBackendService(
         var response = _httpClient.put("notifications/$notificationId/report_received", jsonBody)
 
         if (!response.isSuccess) {
-            throw BackendException(response.statusCode, response.payload)
+            throw BackendException(response.statusCode, response.payload, response.retryAfterSeconds)
         }
     }
 
@@ -43,7 +43,7 @@ internal class NotificationBackendService(
         var response = _httpClient.put("notifications/$notificationId", jsonBody)
 
         if (!response.isSuccess) {
-            throw BackendException(response.statusCode, response.payload)
+            throw BackendException(response.statusCode, response.payload, response.retryAfterSeconds)
         }
     }
 }

--- a/OneSignalSDK/onesignal/testhelpers/src/main/java/com/onesignal/mocks/MockHelper.kt
+++ b/OneSignalSDK/onesignal/testhelpers/src/main/java/com/onesignal/mocks/MockHelper.kt
@@ -48,6 +48,7 @@ object MockHelper {
         configModel.opRepoPostWakeDelay = 1
         configModel.opRepoPostCreateDelay = 1
         configModel.opRepoPostCreateRetryUpTo = 1
+        configModel.opRepoDefaultFailRetryBackoff = 1
 
         configModel.appId = DEFAULT_APP_ID
 


### PR DESCRIPTION
# Description
## One Line Summary
Respect [standard HTTP Retry-After header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After) from any responses from OneSignal's backend.

## Details

### Motivation
When OneSignal's backend is under heavy load they want to be able to throttle back requests to them.

### Scope
Only effects delaying follow up network requests after we receive `Retry-After` in a response. If `OpeartionRepo` triggers this then it handles this smartly by delaying future requests, so more batching can be done. Other code that depends on the `HttpClient` simply delays requests to respect this header.

# Testing
## Unit testing
Added and updated a number of Unit tests. OperationRepo, it's executors, and HttpClientTests. 

## Manual testing
Tested on Android 14 emulator. Ensured we correctly handled 429 with it's `Retry-After` by doing the following.
1. In a browser on my machine refreshed /users fetch over and over until I got a `429`
   * https://api.onesignal.com/apps/{{APP_ID_HERE}}/users/by/onesignal_id/{{ONESIGNAL_ID_HERE}}
2. Opened the app on my emulator (using the same internet connection)
3. Check the logcat to ensure the delay was respected.
```
2024-04-24 22:14:24.572  4583-4616  OneSignal               com.onesignal.sdktest                D  [DefaultDispatcher-worker-1] HttpClient: GET apps/77e32082-ea27-42e3-a898-c72e141824ef/users/by/onesignal_id/102c7c89-54f8-49fb-96cb-f55420f1b789
2024-04-24 22:14:24.603  4583-4616  OneSignal               com.onesignal.sdktest                D  [DefaultDispatcher-worker-1] HttpClient: Response Retry-After: 44
2024-04-24 22:14:24.605  4583-4616  OneSignal               com.onesignal.sdktest                D  [DefaultDispatcher-worker-1] HttpClient: GET apps/77e32082-ea27-42e3-a898-c72e141824ef/users/by/onesignal_id/102c7c89-54f8-49fb-96cb-f55420f1b789 - FAILED STATUS: 429
2024-04-24 22:14:24.612  4583-4616  OneSignal               com.onesignal.sdktest                W  [DefaultDispatcher-worker-1] HttpClient: null RECEIVED JSON: {"errors":["API rate limit exceeded"],"limit":"API Per App"}



2024-04-24 22:15:08.839  4583-4618  OneSignal               com.onesignal.sdktest                D  [DefaultDispatcher-worker-3] HttpClient: GET apps/77e32082-ea27-42e3-a898-c72e141824ef/users/by/onesignal_id/102c7c89-54f8-49fb-96cb-f55420f1b789
2024-04-24 22:15:09.010  4583-4618  OneSignal               com.onesignal.sdktest                D  [DefaultDispatcher-worker-3] HttpClient: GET apps/77e32082-ea27-42e3-a898-c72e141824ef/users/by/onesignal_id/102c7c89-54f8-49fb-96cb-f55420f1b789 - STATUS: 200 JSON: 
```

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [X] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2064)
<!-- Reviewable:end -->
