### PR TITLE
WIP: Fix ANR on some devices when calling addTags

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/modeling/ModelStore.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/modeling/ModelStore.kt
@@ -169,15 +169,15 @@ abstract class ModelStore<TModel>(
     }
 
     fun persist() {
-        synchronized(models) {
-            if (name != null && _prefs != null) {
-                val jsonArray = JSONArray()
+        if (name != null && _prefs != null) {
+            val jsonArray = JSONArray()
+            synchronized(models) {
                 for (model in models) {
                     jsonArray.put(model.toJSON())
                 }
-
-                _prefs.saveString(PreferenceStores.ONESIGNAL, PreferenceOneSignalKeys.MODEL_STORE_PREFIX + name, jsonArray.toString())
             }
+
+            _prefs.saveString(PreferenceStores.ONESIGNAL, PreferenceOneSignalKeys.MODEL_STORE_PREFIX + name, jsonArray.toString())
         }
     }
 

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/common/ModelingTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/common/ModelingTests.kt
@@ -1,15 +1,18 @@
 package com.onesignal.common
 
+import android.content.SharedPreferences
 import com.onesignal.common.events.EventProducer
 import com.onesignal.common.modeling.IModelChangedHandler
 import com.onesignal.common.modeling.IModelStoreChangeHandler
 import com.onesignal.common.modeling.ModelChangedArgs
+import com.onesignal.core.internal.config.ConfigModelStore
 import com.onesignal.mocks.MockHelper
 import com.onesignal.mocks.MockPreferencesService
 import com.onesignal.user.internal.subscriptions.SubscriptionModel
 import com.onesignal.user.internal.subscriptions.SubscriptionModelStore
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import io.mockk.every
 
 class ModelingTests : FunSpec({
 
@@ -135,5 +138,38 @@ class ModelingTests : FunSpec({
 
         // ensure no concurrent modification exception is thrown and "subcribers" is clear
         model.hasSubscribers shouldBe false
+    }
+
+    // sometimes accessing the shared preference may be unexpectedly slow and occupy the models for too long
+    test("ensure the lock on models is released before accessing preference when calling persist()") {
+        // Given
+        val mockPreference = MockPreferencesService()
+        val modelStore = ConfigModelStore(mockPreference)
+        val model = modelStore.model
+
+        // suppose accessing the preference takes 5 seconds
+        every { mockPreference.saveString(any(), any(), any()) } answers { Thread.sleep(1_000) }
+
+        val t1 =
+                Thread {
+                    // will call persist that locks models
+                    model.setOptAnyProperty("key1", "value1")
+                }
+
+        val t2 =
+                Thread {
+                    // will call persist and wait for t1 to release models
+                    model.setOptAnyProperty("key2", "value2")
+                }
+
+        // when
+        t1.start()
+        t2.start()
+
+        // Set 1s timeout for t2 to complete the task
+        t2.join(1_200)
+
+        // verify if the thread has been successfully terminated without waiting for twice the preference access time
+        t2.state shouldBe Thread.State.TERMINATED
     }
 })


### PR DESCRIPTION
# Description
## One Line Summary
Fix an ANR issue triggered by delays in accessing shared preferences when invoking the addTags function

## Details

### Motivation
Some ANR stack traces reveals that often time the main thread is waiting for the lock on models to release, but it was occupied and waiting for the shared preference "save" operation that takes unexpectedly long time. By removing the shared preference usage out of the lock allows us to release the lock early. 

### Scope
All ModelStores changes that trigger persist() to save the changes. 

# Testing
## Unit testing
I have added a test unit to ensure the lock on models is released before accessing preference when calling persist()

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2066)
<!-- Reviewable:end -->
