### PR TITLE
[Improvement] make part of operationrepo initialization async

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/modeling/ModelStore.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/modeling/ModelStore.kt
@@ -154,8 +154,9 @@ abstract class ModelStore<TModel>(
     }
 
     protected fun load() {
-        if (name == null || _prefs == null)
+        if (name == null || _prefs == null) {
             return
+        }
 
         val str = _prefs.getString(PreferenceStores.ONESIGNAL, PreferenceOneSignalKeys.MODEL_STORE_PREFIX + name, "[]")
         val jsonArray = JSONArray(str)
@@ -167,12 +168,12 @@ abstract class ModelStore<TModel>(
                 newModel.subscribe(this)
             }
         }
-
     }
 
     fun persist() {
-        if (name == null || _prefs == null)
+        if (name == null || _prefs == null) {
             return
+        }
 
         val jsonArray = JSONArray()
         synchronized(models) {

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/modeling/ModelStore.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/modeling/ModelStore.kt
@@ -154,31 +154,34 @@ abstract class ModelStore<TModel>(
     }
 
     protected fun load() {
+        if (name == null || _prefs == null)
+            return
+
+        val str = _prefs.getString(PreferenceStores.ONESIGNAL, PreferenceOneSignalKeys.MODEL_STORE_PREFIX + name, "[]")
+        val jsonArray = JSONArray(str)
         synchronized(models) {
-            if (name != null && _prefs != null) {
-                val str = _prefs.getString(PreferenceStores.ONESIGNAL, PreferenceOneSignalKeys.MODEL_STORE_PREFIX + name, "[]")
-                val jsonArray = JSONArray(str)
-                for (index in 0 until jsonArray.length()) {
-                    val newModel = create(jsonArray.getJSONObject(index)) ?: continue
-                    models.add(newModel)
-                    // listen for changes to this model
-                    newModel.subscribe(this)
-                }
+            for (index in 0 until jsonArray.length()) {
+                val newModel = create(jsonArray.getJSONObject(index)) ?: continue
+                models.add(newModel)
+                // listen for changes to this model
+                newModel.subscribe(this)
             }
         }
+
     }
 
     fun persist() {
-        synchronized(models) {
-            if (name != null && _prefs != null) {
-                val jsonArray = JSONArray()
-                for (model in models) {
-                    jsonArray.put(model.toJSON())
-                }
+        if (name == null || _prefs == null)
+            return
 
-                _prefs.saveString(PreferenceStores.ONESIGNAL, PreferenceOneSignalKeys.MODEL_STORE_PREFIX + name, jsonArray.toString())
+        val jsonArray = JSONArray()
+        synchronized(models) {
+            for (model in models) {
+                jsonArray.put(model.toJSON())
             }
         }
+
+        _prefs.saveString(PreferenceStores.ONESIGNAL, PreferenceOneSignalKeys.MODEL_STORE_PREFIX + name, jsonArray.toString())
     }
 
     override fun subscribe(handler: IModelStoreChangeHandler<TModel>) = changeSubscription.subscribe(handler)

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/impl/OperationModelStore.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/impl/OperationModelStore.kt
@@ -25,10 +25,15 @@ import com.onesignal.user.internal.operations.impl.executors.LoginUserOperationE
 import com.onesignal.user.internal.operations.impl.executors.RefreshUserOperationExecutor
 import com.onesignal.user.internal.operations.impl.executors.SubscriptionOperationExecutor
 import com.onesignal.user.internal.operations.impl.executors.UpdateUserOperationExecutor
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
 import org.json.JSONObject
 
 internal class OperationModelStore(prefs: IPreferencesService) : ModelStore<Operation>("operations", prefs) {
-    init {
+
+    fun loadOperations() {
         load()
     }
 

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/impl/OperationModelStore.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/impl/OperationModelStore.kt
@@ -25,14 +25,9 @@ import com.onesignal.user.internal.operations.impl.executors.LoginUserOperationE
 import com.onesignal.user.internal.operations.impl.executors.RefreshUserOperationExecutor
 import com.onesignal.user.internal.operations.impl.executors.SubscriptionOperationExecutor
 import com.onesignal.user.internal.operations.impl.executors.UpdateUserOperationExecutor
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.launch
 import org.json.JSONObject
 
 internal class OperationModelStore(prefs: IPreferencesService) : ModelStore<Operation>("operations", prefs) {
-
     fun loadOperations() {
         load()
     }

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/operations/OperationRepoTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/operations/OperationRepoTests.kt
@@ -35,7 +35,7 @@ private class Mocks {
     val operationModelStore: OperationModelStore =
         run {
             val mockOperationModelStore = mockk<OperationModelStore>()
-            every {mockOperationModelStore.loadOperations() } just runs
+            every { mockOperationModelStore.loadOperations() } just runs
             every { mockOperationModelStore.list() } returns listOf()
             every { mockOperationModelStore.add(any()) } just runs
             every { mockOperationModelStore.remove(any()) } just runs

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/operations/OperationRepoTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/operations/OperationRepoTests.kt
@@ -35,6 +35,7 @@ private class Mocks {
     val operationModelStore: OperationModelStore =
         run {
             val mockOperationModelStore = mockk<OperationModelStore>()
+            every {mockOperationModelStore.loadOperations() } just runs
             every { mockOperationModelStore.list() } returns listOf()
             every { mockOperationModelStore.add(any()) } just runs
             every { mockOperationModelStore.remove(any()) } just runs


### PR DESCRIPTION
# Description
## One Line Summary
Make part of the initialization of OperationRepo asynchronous so that previously saved operations can be added asynchronously, preventing long-loading operations from blocking the main thread.

## Details

### Motivation
We have observed numerous ANRs during the initialization phase, with OperationRepo.init being the top cause. This issue does not occur consistently, and we suspect it may be related to the device's state or having a problem accessing device's disk. To address this, we plan to make the initialization process asynchronous in OperationRepo. By moving the loading part to a background thread, we aim to prevent the main thread from being blocked when the initialization process unexpectedly takes a long time.

### Scope
Saved operations from previous session will not be executed until they are loaded successfully. The order may be incorrect depends on the timing of the loading completion This change will try to insert saved operations starting from the beginning of the queue, and any later operation will be added to the end of the queue. 

# Testing
## Manual testing
The manual test I have done to ensure the SDK is loading saved operation correctly:
  1. Turn off wifi
  2. Login user and add a tag
  3. Kill the app
  4. Re-enter the app with wifi on, and observe that the saved operations are successfully loaded and executed shortly after.
![image](https://github.com/OneSignal/OneSignal-Android-SDK/assets/14221056/2e7a669d-4cdd-4655-96ad-bfb53d27ef8b)

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2068)
<!-- Reviewable:end -->
