### PR TITLE
Release 5.1.10

### DIFF
--- a/Examples/OneSignalDemo/app/build.gradle
+++ b/Examples/OneSignalDemo/app/build.gradle
@@ -84,12 +84,12 @@ dependencies {
     implementation 'com.github.bumptech.glide:glide:4.12.0'
 
     /** START - Google Play Builds **/
-    gmsImplementation('com.onesignal:OneSignal:5.1.9')
+    gmsImplementation('com.onesignal:OneSignal:5.1.10')
     /** END - Google Play Builds **/
 
     /** START - Huawei Builds **/
     // Omit Google / Firebase libraries for Huawei builds.
-    huaweiImplementation('com.onesignal:OneSignal:5.1.9') {
+    huaweiImplementation('com.onesignal:OneSignal:5.1.10') {
         exclude group: 'com.google.android.gms', module: 'play-services-gcm'
         exclude group: 'com.google.android.gms', module: 'play-services-analytics'
         exclude group: 'com.google.android.gms', module: 'play-services-location'

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/OneSignalUtils.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/OneSignalUtils.kt
@@ -6,7 +6,7 @@ object OneSignalUtils {
     /**
      * The version of this SDK.
      */
-    const val SDK_VERSION: String = "050109"
+    const val SDK_VERSION: String = "050110"
 
     fun isValidEmail(email: String): Boolean {
         if (email.isEmpty()) {

--- a/OneSignalSDK/settings.gradle
+++ b/OneSignalSDK/settings.gradle
@@ -3,7 +3,7 @@
 gradle.rootProject {
     allprojects {
         group = 'com.onesignal'
-        version = '5.1.9'
+        version = '5.1.10'
         configurations.all {
             resolutionStrategy.dependencySubstitution {
                 substitute(module('com.onesignal:OneSignal')).using(project(':OneSignal'))


### PR DESCRIPTION
### 🔧 Maintenance
#### Network call optimizations
* Handle HTTP header `Retry-After` from responses from OneSignal (https://github.com/OneSignal/OneSignal-Android-SDK/pull/2064)
* Avoid unnecessary user fetchs; on first app open and first login (https://github.com/OneSignal/OneSignal-Android-SDK/pull/2061)
* Further improve batching by restarting OperationRepo's delay on every enqueue call (https://github.com/OneSignal/OneSignal-Android-SDK/pull/2060)

### 🐛 Bug Fixes
* Handle incorrect 404 responses; add a delay after creates and retries on 404 of new ids (https://github.com/OneSignal/OneSignal-Android-SDK/pull/2059)

### 📖 Documentation 
* Update Readme and Migration_Guide with migration advisory (https://github.com/OneSignal/OneSignal-Android-SDK/pull/2054)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2071)
<!-- Reviewable:end -->
