### PR TITLE
BadTokenException  and WindowLeaked bug fix

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/permissions/AlertDialogPrepromptForAndroidSettings.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/permissions/AlertDialogPrepromptForAndroidSettings.kt
@@ -53,15 +53,17 @@ object AlertDialogPrepromptForAndroidSettings {
         val messageTemplate = activity.getString(R.string.permission_not_available_message)
         val message = messageTemplate.format(previouslyDeniedPostfix)
 
-        AlertDialog.Builder(activity)
-            .setTitle(title)
-            .setMessage(message)
-            .setPositiveButton(R.string.permission_not_available_open_settings_option) { dialog, which ->
-                callback.onAccept()
-            }
-            .setNegativeButton(android.R.string.no) { dialog, which ->
-                callback.onDecline()
-            }
-            .show()
+        if (!activity.isFinishing && !activity.isDestroyed) {
+            AlertDialog.Builder(activity)
+                .setTitle(title)
+                .setMessage(message)
+                .setPositiveButton(R.string.permission_not_available_open_settings_option) { dialog, which ->
+                    callback.onAccept()
+                }
+                .setNegativeButton(android.R.string.no) { dialog, which ->
+                    callback.onDecline()
+                }
+                .show()
+        }
     }
 }


### PR DESCRIPTION
This code has fix for
#2014 [Bug]: android.view.WindowManager$BadTokenException - Unable to add window
and
android.view.WindowLeaked:

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2073)
<!-- Reviewable:end -->
