### PR TITLE
Follow Up: add operationRepoLoadedListener and implement it to RecoverFromDroppe…

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/IOperationRepo.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/IOperationRepo.kt
@@ -38,6 +38,8 @@ interface IOperationRepo {
      * Check if the queue contains a specific operation type
      */
     fun <T : Operation> containsInstanceOf(type: KClass<T>): Boolean
+
+    fun addOperationLoadedListener(handler: IOperationRepoLoadedListener)
 }
 
 // Extension function so the syntax containsInstanceOf<Operation>() can be used over

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/IOperationRepoLoadedListener.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/IOperationRepoLoadedListener.kt
@@ -1,0 +1,5 @@
+package com.onesignal.core.internal.operations
+
+interface IOperationRepoLoadedListener {
+    fun onOperationRepoLoaded()
+}

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/impl/OperationRepo.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/impl/OperationRepo.kt
@@ -58,11 +58,11 @@ internal class OperationRepo(
         get() = loadedSubscription.hasSubscribers
 
     override fun unsubscribe(handler: IOperationRepoLoadedListener) {
-        loadedSubscription.subscribe(handler)
+        loadedSubscription.unsubscribe(handler)
     }
 
     override fun subscribe(handler: IOperationRepoLoadedListener) {
-        loadedSubscription.unsubscribe(handler)
+        loadedSubscription.subscribe(handler)
     }
 
     /** *** Buckets ***

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/impl/OperationRepo.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/impl/OperationRepo.kt
@@ -1,11 +1,14 @@
 package com.onesignal.core.internal.operations.impl
 
+import com.onesignal.common.events.EventProducer
+import com.onesignal.common.events.IEventNotifier
 import com.onesignal.common.threading.WaiterWithValue
 import com.onesignal.core.internal.config.ConfigModelStore
 import com.onesignal.core.internal.operations.ExecutionResult
 import com.onesignal.core.internal.operations.GroupComparisonType
 import com.onesignal.core.internal.operations.IOperationExecutor
 import com.onesignal.core.internal.operations.IOperationRepo
+import com.onesignal.core.internal.operations.IOperationRepoLoadedListener
 import com.onesignal.core.internal.operations.Operation
 import com.onesignal.core.internal.startup.IStartableService
 import com.onesignal.core.internal.time.ITime
@@ -27,7 +30,7 @@ internal class OperationRepo(
     private val _configModelStore: ConfigModelStore,
     private val _time: ITime,
     private val _newRecordState: NewRecordsState,
-) : IOperationRepo, IStartableService {
+) : IOperationRepo, IStartableService, IEventNotifier<IOperationRepoLoadedListener> {
     internal class OperationQueueItem(
         val operation: Operation,
         val waiter: WaiterWithValue<Boolean>? = null,
@@ -49,6 +52,18 @@ internal class OperationRepo(
     private val waiter = WaiterWithValue<LoopWaiterMessage>()
     private var paused = false
     private var coroutineScope = CoroutineScope(newSingleThreadContext(name = "OpRepo"))
+    private val loadedSubscription: EventProducer<IOperationRepoLoadedListener> = EventProducer()
+
+    override val hasSubscribers: Boolean
+        get() = loadedSubscription.hasSubscribers
+
+    override fun unsubscribe(handler: IOperationRepoLoadedListener) {
+        loadedSubscription.subscribe(handler)
+    }
+
+    override fun subscribe(handler: IOperationRepoLoadedListener) {
+        loadedSubscription.unsubscribe(handler)
+    }
 
     /** *** Buckets ***
      * Purpose: Bucketing is a pattern we are using to help save network
@@ -84,6 +99,10 @@ internal class OperationRepo(
         synchronized(queue) {
             return queue.any { type.isInstance(it.operation) }
         }
+    }
+
+    override fun addOperationLoadedListener(handler: IOperationRepoLoadedListener) {
+        subscribe(handler)
     }
 
     override fun start() {
@@ -393,5 +412,6 @@ internal class OperationRepo(
                 operation.index,
             )
         }
+        loadedSubscription.fire { it.onOperationRepoLoaded() }
     }
 }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/migrations/RecoverFromDroppedLoginBug.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/migrations/RecoverFromDroppedLoginBug.kt
@@ -3,6 +3,7 @@ package com.onesignal.user.internal.migrations
 import com.onesignal.common.IDManager
 import com.onesignal.core.internal.config.ConfigModelStore
 import com.onesignal.core.internal.operations.IOperationRepo
+import com.onesignal.core.internal.operations.IOperationRepoLoadedListener
 import com.onesignal.core.internal.operations.containsInstanceOf
 import com.onesignal.core.internal.startup.IStartableService
 import com.onesignal.debug.internal.logging.Logging
@@ -30,8 +31,12 @@ class RecoverFromDroppedLoginBug(
     private val _operationRepo: IOperationRepo,
     private val _identityModelStore: IdentityModelStore,
     private val _configModelStore: ConfigModelStore,
-) : IStartableService {
+) : IStartableService, IOperationRepoLoadedListener {
     override fun start() {
+        _operationRepo.addOperationLoadedListener(this)
+    }
+
+    override fun onOperationRepoLoaded() {
         if (isInBadState()) {
             Logging.warn(
                 "User with externalId:" +

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/operations/OperationRepoTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/operations/OperationRepoTests.kt
@@ -9,6 +9,9 @@ import com.onesignal.core.internal.time.impl.Time
 import com.onesignal.debug.LogLevel
 import com.onesignal.debug.internal.logging.Logging
 import com.onesignal.mocks.MockHelper
+import com.onesignal.user.internal.identity.IdentityModel
+import com.onesignal.user.internal.identity.IdentityModelStore
+import com.onesignal.user.internal.migrations.RecoverFromDroppedLoginBug
 import com.onesignal.user.internal.operations.ExecutorMocks.Companion.getNewRecordState
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
@@ -589,6 +592,20 @@ class OperationRepoTests : FunSpec({
 
         // Then
         result shouldBe null
+    }
+
+    test("IOperationRepoLoadedListener") {
+        val mocks = Mocks()
+        val mockIdentityModel = mockk<IdentityModel>()
+        val mockIdentityModelStore = mockk<IdentityModelStore>()
+        val recovery = RecoverFromDroppedLoginBug(mocks.operationRepo, mockIdentityModelStore, mocks.configModelStore)
+
+        mocks.operationRepo.start()
+        recovery.start()
+
+        verify {
+            mocks.operationRepo.subscribe(recovery)
+        }
     }
 }) {
     companion object {

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/migrations/RecoverFromDroppedLoginBugTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/migrations/RecoverFromDroppedLoginBugTests.kt
@@ -1,0 +1,48 @@
+package com.onesignal.user.internal.migrations
+
+import com.onesignal.core.internal.config.ConfigModelStore
+import com.onesignal.core.internal.operations.impl.OperationModelStore
+import com.onesignal.core.internal.operations.impl.OperationRepo
+import com.onesignal.core.internal.time.impl.Time
+import com.onesignal.mocks.MockHelper
+import com.onesignal.user.internal.operations.ExecutorMocks
+import io.kotest.core.spec.style.FunSpec
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.spyk
+import io.mockk.verify
+
+class RecoverFromDroppedLoginBugTests : FunSpec({
+    test("ensure RecoverFromDroppedLoginBug receive onOperationRepoLoaded callback from operationRepo") {
+        // Given
+        val mockOperationModelStore = mockk<OperationModelStore>()
+        val mockConfigModelStore = mockk<ConfigModelStore>()
+        val operationRepo =
+            spyk(
+                OperationRepo(
+                    listOf(),
+                    mockOperationModelStore,
+                    mockConfigModelStore,
+                    Time(),
+                    ExecutorMocks.getNewRecordState(mockConfigModelStore),
+                ),
+            )
+        every { mockOperationModelStore.loadOperations() } just runs
+        every { mockOperationModelStore.list() } returns listOf()
+
+        val recovery = RecoverFromDroppedLoginBug(operationRepo, MockHelper.identityModelStore(), mockConfigModelStore)
+        every { recovery.onOperationRepoLoaded() } just runs
+
+        // When
+        operationRepo.start()
+        recovery.start()
+
+        // Then
+        verify {
+            operationRepo.subscribe(recovery)
+            recovery.onOperationRepoLoaded()
+        }
+    }
+})


### PR DESCRIPTION
# Description
## One Line Summary
This is a followup PR to address a broken change made by this PR https://github.com/OneSignal/OneSignal-Android-SDK/pull/2068

## Details

### Motivation
The PR mentioned above has made the initialization of OperationRepo asynchronous that we can no longer assume all saved operations are loaded at start. This PR adds an event listener to RecoverFromDroppedLoginBug so that it listens to the loading completion event and starts the recovery after the loading has completed.

### Scope
The recover does no longer begin at start. Instead, it will begin when it receives the event notifier that the loading of OperationRepo has completed.

# Testing
## Unit testing
I have added two test units to ensure both classes are working properly.

## Manual testing
My manual testing step:
  1. enter the example app and turn wifi off
  2. perform a Login
  3. kill and re-enter the app
  4. notice that RecoverFromDroppedLoginBug inserts a LoginUser operation into the operationRepo queue, after the loading is completed

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2075)
<!-- Reviewable:end -->
