### PR TITLE
Release 5.1.11

### DIFF
--- a/Examples/OneSignalDemo/app/build.gradle
+++ b/Examples/OneSignalDemo/app/build.gradle
@@ -84,12 +84,12 @@ dependencies {
     implementation 'com.github.bumptech.glide:glide:4.12.0'
 
     /** START - Google Play Builds **/
-    gmsImplementation('com.onesignal:OneSignal:5.1.10')
+    gmsImplementation('com.onesignal:OneSignal:5.1.11')
     /** END - Google Play Builds **/
 
     /** START - Huawei Builds **/
     // Omit Google / Firebase libraries for Huawei builds.
-    huaweiImplementation('com.onesignal:OneSignal:5.1.10') {
+    huaweiImplementation('com.onesignal:OneSignal:5.1.11') {
         exclude group: 'com.google.android.gms', module: 'play-services-gcm'
         exclude group: 'com.google.android.gms', module: 'play-services-analytics'
         exclude group: 'com.google.android.gms', module: 'play-services-location'

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/OneSignalUtils.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/OneSignalUtils.kt
@@ -6,7 +6,7 @@ object OneSignalUtils {
     /**
      * The version of this SDK.
      */
-    const val SDK_VERSION: String = "050110"
+    const val SDK_VERSION: String = "050111"
 
     fun isValidEmail(email: String): Boolean {
         if (email.isEmpty()) {

--- a/OneSignalSDK/settings.gradle
+++ b/OneSignalSDK/settings.gradle
@@ -3,7 +3,7 @@
 gradle.rootProject {
     allprojects {
         group = 'com.onesignal'
-        version = '5.1.10'
+        version = '5.1.11'
         configurations.all {
             resolutionStrategy.dependencySubstitution {
                 substitute(module('com.onesignal:OneSignal')).using(project(':OneSignal'))


### PR DESCRIPTION
### 🔧 Maintenance
Add HTTP header OneSignal-Install-ID that allows the OneSignal's backend know where traffic is coming from (https://github.com/OneSignal/OneSignal-Android-SDK/pull/2072)

### 🐛 Bug Fixes
Fix the ANR issue caused by prolonged loading of OperationRepo and potentially by extended holding of the model lock during disk I/O read operations. (https://github.com/OneSignal/OneSignal-Android-SDK/pull/2068)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2077)
<!-- Reviewable:end -->
