### PR TITLE
[Fix] loadSavedOperations IndexOutOfBoundsException (5.1.11 only issue)

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/modeling/ModelStore.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/modeling/ModelStore.kt
@@ -65,8 +65,11 @@ abstract class ModelStore<TModel>(
         }
     }
 
+    /**
+     * @return list of read-only models, cloned for thread safety
+     */
     override fun list(): Collection<TModel> {
-        return models
+        return synchronized(models) { models.toList() }
     }
 
     override fun get(id: String): TModel? {

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/operations/OperationRepoTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/operations/OperationRepoTests.kt
@@ -630,6 +630,26 @@ class OperationRepoTests : FunSpec({
         mocks.operationRepo.queue.size shouldBe 1
         mocks.operationRepo.queue.first().operation shouldBe op
     }
+
+    // Real world scenario is this can happen if a few operations are added when the device is
+    // offline then the app is restarted.
+    test("ensure loadSavedOperations doesn't index out of bounds on queue when duplicates exist") {
+        // Given
+        val mocks = Mocks()
+        val op1 = mockOperation()
+        val op2 = mockOperation()
+
+        repeat(2) { mocks.operationModelStore.add(op1) }
+        mocks.operationModelStore.add(op2)
+
+        // When
+        mocks.operationRepo.loadSavedOperations()
+
+        // Then
+        mocks.operationRepo.queue.size shouldBe 2
+        mocks.operationRepo.queue[0].operation shouldBe op1
+        mocks.operationRepo.queue[1].operation shouldBe op2
+    }
 }) {
     companion object {
         private fun mockOperation(

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/operations/OperationRepoTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/operations/OperationRepoTests.kt
@@ -38,7 +38,7 @@ private class Mocks {
             val operationStoreList = mutableListOf<Operation>()
             val mockOperationModelStore = mockk<OperationModelStore>()
             every { mockOperationModelStore.loadOperations() } just runs
-            every { mockOperationModelStore.list() } returns operationStoreList
+            every { mockOperationModelStore.list() } answers { operationStoreList.toList() }
             every { mockOperationModelStore.add(any()) } answers { operationStoreList.add(firstArg<Operation>()) }
             every { mockOperationModelStore.remove(any()) } answers {
                 val id = firstArg<String>()


### PR DESCRIPTION
# Description
## One Line Summary
Fixes `IndexOutOfBounds` exception thrown from `OperationRepo.loadSavedOperations` if app was opened offline, some operations done, and then the app is opened again.

## Details

### Motivation
SDK needs to be stable, even if the device goes offline at any point.

### Scope
Only affects `OperationRepo.loadSavedOperations` used on cold start of the app.

### Related
Fixes bug introduced in PR #2068 (released in 5.1.11)

# Testing
## Unit testing
* [Result of failing test](https://github.com/OneSignal/OneSignal-Android-SDK/actions/runs/8993489887/job/24705370520?pr=2081#step:6:830) proving the issue.

## Manual testing
Tested on an Android 14 emulator.
1. Clear app storage
2. Turn on airplane mode
3. Open the app
4. Perform operations, such as login and addTag
5. Close and re-open the app, observe the runtime error no longer happens.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2081)
<!-- Reviewable:end -->
