### PR TITLE
[Fix] RecoverFromDroppedLoginBug not running in very rare cases

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/IOperationRepo.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/IOperationRepo.kt
@@ -39,7 +39,7 @@ interface IOperationRepo {
      */
     fun <T : Operation> containsInstanceOf(type: KClass<T>): Boolean
 
-    fun addOperationLoadedListener(handler: IOperationRepoLoadedListener)
+    suspend fun awaitInitialized()
 }
 
 // Extension function so the syntax containsInstanceOf<Operation>() can be used over

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/IOperationRepoLoadedListener.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/IOperationRepoLoadedListener.kt
@@ -1,5 +1,0 @@
-package com.onesignal.core.internal.operations
-
-interface IOperationRepoLoadedListener {
-    fun onOperationRepoLoaded()
-}

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/migrations/RecoverFromDroppedLoginBugTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/migrations/RecoverFromDroppedLoginBugTests.kt
@@ -15,44 +15,84 @@ import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.spyk
 import io.mockk.verify
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withTimeout
+
+private class Mocks {
+    val operationModelStore: OperationModelStore =
+        run {
+            val mockOperationModelStore = mockk<OperationModelStore>()
+            every { mockOperationModelStore.loadOperations() } just runs
+            every { mockOperationModelStore.list() } returns listOf()
+            mockOperationModelStore
+        }
+    val configModelStore = mockk<ConfigModelStore>()
+    val operationRepo =
+        spyk(
+            OperationRepo(
+                listOf(),
+                operationModelStore,
+                configModelStore,
+                Time(),
+                ExecutorMocks.getNewRecordState(configModelStore),
+            ),
+        )
+
+    val recovery = spyk(RecoverFromDroppedLoginBug(operationRepo, MockHelper.identityModelStore(), configModelStore))
+}
 
 class RecoverFromDroppedLoginBugTests : FunSpec({
-    test("ensure RecoverFromDroppedLoginBug receive onOperationRepoLoaded callback from operationRepo") {
+    test("ensure onOperationRepoLoaded callback fires from operationRepo") {
         // Given
-        val mockOperationModelStore = mockk<OperationModelStore>()
-        val mockConfigModelStore = mockk<ConfigModelStore>()
-        val operationRepo =
-            spyk(
-                OperationRepo(
-                    listOf(),
-                    mockOperationModelStore,
-                    mockConfigModelStore,
-                    Time(),
-                    ExecutorMocks.getNewRecordState(mockConfigModelStore),
-                ),
-            )
-        every { mockOperationModelStore.loadOperations() } just runs
-        every { mockOperationModelStore.list() } returns listOf()
-        val recovery = spyk(RecoverFromDroppedLoginBug(operationRepo, MockHelper.identityModelStore(), mockConfigModelStore))
+        val mocks = Mocks()
 
         // When
-        recovery.start()
+        mocks.recovery.start()
         val waiter = Waiter()
-        operationRepo.addOperationLoadedListener(
+        mocks.operationRepo.addOperationLoadedListener(
             object : IOperationRepoLoadedListener {
                 override fun onOperationRepoLoaded() {
                     waiter.wake()
                 }
             },
         )
-        operationRepo.start()
+        mocks.operationRepo.start()
         // Waiting here ensures recovery.onOperationRepoLoaded() is called consistently
         waiter.waitForWake()
 
         // Then
         verify(exactly = 1) {
-            operationRepo.subscribe(recovery)
-            recovery.onOperationRepoLoaded()
+            mocks.operationRepo.subscribe(mocks.recovery)
+            mocks.recovery.onOperationRepoLoaded()
+        }
+    }
+
+    test("ensure onOperationRepoLoaded callback fires from operationRepo, even if started first") {
+        // Given
+        val mocks = Mocks()
+
+        // When
+        mocks.operationRepo.start()
+        // give operation repo some time to fully initialize
+        delay(200)
+
+        mocks.recovery.start()
+
+        val waiter = Waiter()
+        mocks.operationRepo.addOperationLoadedListener(
+            object : IOperationRepoLoadedListener {
+                override fun onOperationRepoLoaded() {
+                    waiter.wake()
+                }
+            },
+        )
+        // Waiting here ensures recovery.onOperationRepoLoaded() is called consistently
+        withTimeout(1_000) { waiter.waitForWake() }
+
+        // Then
+        verify(exactly = 1) {
+            mocks.operationRepo.subscribe(mocks.recovery)
+            mocks.recovery.onOperationRepoLoaded()
         }
     }
 })


### PR DESCRIPTION
# Description
## One Line Summary
Fix a very rare case where RecoverFromDroppedLoginBug may not run.

## Details

### Motivation
We want to ensure `RecoverFromDroppedLoginBug` always runs, otherwise we can't recover some end-users who would be stuck in a bad state, where the OperationRepo queue stalls. While the case where this would happen would be extremely rare, the orignal code had a landmine, where if initialization code was refactored the rare case could be become much more common. The existing Unit Test did not cover out of order initialization either.

### Scope
Only affects `RecoverFromDroppedLoginBug.kt`

# Testing
## Unit testing
* New [failing test](https://github.com/OneSignal/OneSignal-Android-SDK/actions/runs/9024860167/job/24799515444?pr=2084#step:6:1166) to prove issue
* Test is passing and was also refactored in the same commit as the interface changed.

## Manual testing
On a Android 6 emulator ensured `RecoverFromDroppedLoginBug.isInBadState()` runs.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2084)
<!-- Reviewable:end -->
