### PR TITLE
[Fix]: Cancelling permission request dialog does not fire continuation

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/permissions/AlertDialogPrepromptForAndroidSettings.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/permissions/AlertDialogPrepromptForAndroidSettings.kt
@@ -62,6 +62,9 @@ object AlertDialogPrepromptForAndroidSettings {
             .setNegativeButton(android.R.string.no) { dialog, which ->
                 callback.onDecline()
             }
+            .setOnCancelListener {
+                callback.onDecline()
+            }
             .show()
     }
 }


### PR DESCRIPTION
# Description
## One Line Summary
Add a OnCancelListener to permission prompt so that dismissing (clicking outside of the dialog box) is treated as denying permission.

## Details

### Motivation
We want to correctly update the permission grant status to false when the user dismisses the permission request prompt without either rejecting or accepting it.

### Scope
Clicking outside of permission request box will now treated as denying the permission. This will works for both notification permission and location permission.

# Testing
## Manual testing
Step to reproduce: 
  1. Turn off notification permission in app setting
  2. Open the app and prompt for notification permission
  3. Click outside to dismiss the alert dialog asking to allow OneSignal to send notification
  4. Click outside to dismiss next dialog directing to app settings
  5. Notice that the break point at onDecline is reached; this is not the case before the fix.
![image](https://github.com/OneSignal/OneSignal-Android-SDK/assets/14221056/2873f5cf-e0b8-49a8-9211-c98817ce8c2a)


# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2085)
<!-- Reviewable:end -->
