### PR TITLE
[Fix] grouping skipping opRepoPostCreateDelay, causing operations being applied out of order when multiple login operations are pending. (fixes issue since 5.1.10)

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/impl/OperationRepo.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/impl/OperationRepo.kt
@@ -358,8 +358,7 @@ internal class OperationRepo(
      * THIS SHOULD BE CALLED WHILE THE QUEUE IS SYNCHRONIZED!!
      */
     private fun getGroupableOperations(startingOp: OperationQueueItem): List<OperationQueueItem> {
-        val ops = mutableListOf<OperationQueueItem>()
-        ops.add(startingOp)
+        val ops = mutableListOf(startingOp)
 
         if (startingOp.operation.groupComparisonType == GroupComparisonType.NONE) {
             return ops

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/impl/OperationRepo.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/impl/OperationRepo.kt
@@ -372,27 +372,25 @@ internal class OperationRepo(
                 startingOp.operation.modifyComparisonKey
             }
 
-        if (queue.isNotEmpty()) {
-            for (item in queue.toList()) {
-                val itemKey =
-                    if (startingOp.operation.groupComparisonType == GroupComparisonType.CREATE) {
-                        item.operation.createComparisonKey
-                    } else {
-                        item.operation.modifyComparisonKey
-                    }
-
-                if (itemKey == "" && startingKey == "") {
-                    throw Exception("Both comparison keys can not be blank!")
+        for (item in queue.toList()) {
+            val itemKey =
+                if (startingOp.operation.groupComparisonType == GroupComparisonType.CREATE) {
+                    item.operation.createComparisonKey
+                } else {
+                    item.operation.modifyComparisonKey
                 }
 
-                if (!_newRecordState.canAccess(item.operation.applyToRecordId)) {
-                    continue
-                }
+            if (itemKey == "" && startingKey == "") {
+                throw Exception("Both comparison keys can not be blank!")
+            }
 
-                if (itemKey == startingKey) {
-                    queue.remove(item)
-                    ops.add(item)
-                }
+            if (!_newRecordState.canAccess(item.operation.applyToRecordId)) {
+                continue
+            }
+
+            if (itemKey == startingKey) {
+                queue.remove(item)
+                ops.add(item)
             }
         }
 

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/impl/OperationRepo.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/impl/OperationRepo.kt
@@ -386,6 +386,10 @@ internal class OperationRepo(
                     throw Exception("Both comparison keys can not be blank!")
                 }
 
+                if (!_newRecordState.canAccess(item.operation.applyToRecordId)) {
+                    continue
+                }
+
                 if (itemKey == startingKey) {
                     queue.remove(item)
                     ops.add(item)

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/impl/OperationRepo.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/impl/OperationRepo.kt
@@ -235,12 +235,17 @@ internal class OperationRepo(
                     queue.forEach { it.operation.translateIds(response.idTranslations) }
                 }
                 response.idTranslations.values.forEach { _newRecordState.add(it) }
-                coroutineScope.launch {
-                    val waitTime = _configModelStore.model.opRepoPostCreateDelay
-                    delay(waitTime)
-                    synchronized(queue) {
-                        if (queue.isNotEmpty()) waiter.wake(LoopWaiterMessage(false, waitTime))
-                    }
+                // Stall processing the queue so the backend's DB has to time
+                // reflect the change before we do any other operations to it.
+                // NOTE: Future: We could run this logic in a
+                // coroutineScope.launch() block so other operations not
+                // effecting this these id's can still be done in parallel,
+                // however other parts of the system don't currently account
+                // for this so this is not safe to do.
+                val waitTime = _configModelStore.model.opRepoPostCreateDelay
+                delay(waitTime)
+                synchronized(queue) {
+                    if (queue.isNotEmpty()) waiter.wake(LoopWaiterMessage(false, waitTime))
                 }
             }
 

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/states/NewRecordsState.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/states/NewRecordsState.kt
@@ -23,7 +23,7 @@ class NewRecordsState(
 
     fun canAccess(key: String): Boolean {
         val timeLastMovedOrCreated = records[key] ?: return true
-        return _time.currentTimeMillis - timeLastMovedOrCreated > _configModelStore.model.opRepoPostCreateDelay
+        return _time.currentTimeMillis - timeLastMovedOrCreated >= _configModelStore.model.opRepoPostCreateDelay
     }
 
     fun isInMissingRetryWindow(key: String): Boolean {

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/operations/OperationRepoTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/operations/OperationRepoTests.kt
@@ -546,31 +546,15 @@ class OperationRepoTests : FunSpec({
         mocks.operationRepo.start()
         mocks.operationRepo.enqueue(operation1)
         val job = launch { mocks.operationRepo.enqueueAndWait(operation2) }.also { yield() }
-        mocks.operationRepo.enqueue(operation3)
+        mocks.operationRepo.enqueueAndWait(operation3)
         job.join()
 
         // Then
         coVerifyOrder {
-            mocks.executor.execute(
-                withArg {
-                    it.count() shouldBe 1
-                    it[0] shouldBe operation1
-                },
-            )
+            mocks.executor.execute(listOf(operation1))
             operation2.translateIds(mapOf("local-id1" to "id2"))
-            mocks.executor.execute(
-                withArg {
-                    it.count() shouldBe 1
-                    it[0] shouldBe operation3
-                },
-            )
-            // Ensure operation2 runs after operation3 as it has to wait for the create delay
-            mocks.executor.execute(
-                withArg {
-                    it.count() shouldBe 1
-                    it[0] shouldBe operation2
-                },
-            )
+            mocks.executor.execute(listOf(operation2))
+            mocks.executor.execute(listOf(operation3))
         }
     }
 
@@ -595,25 +579,9 @@ class OperationRepoTests : FunSpec({
 
         // Then
         coVerifyOrder {
-            mocks.executor.execute(
-                withArg {
-                    it.count() shouldBe 1
-                    it[0] shouldBe operation1
-                },
-            )
+            mocks.executor.execute(listOf(operation1))
             operation2.translateIds(mapOf("local-id1" to "id2"))
-            mocks.executor.execute(
-                withArg {
-                    it.count() shouldBe 1
-                    it[0] shouldBe operation2
-                },
-            )
-            mocks.executor.execute(
-                withArg {
-                    it.count() shouldBe 1
-                    it[0] shouldBe operation3
-                },
-            )
+            mocks.executor.execute(listOf(operation2, operation3))
         }
     }
 


### PR DESCRIPTION
# Description
## One Line Summary
Fix operations being applied out of order when multiple login operations are pending.

## Details
`OperationRepo.getGroupableOperations()` was not respecting `opRepoPostCreateDelay` like `OperationRepo.getNextOps()`, this would lead to some being applied out of order. The only known case is when there is a login in the queue for an Anonymous User crate and also User A and another for User B. The anonymous User create happens first with a push subscription which is correct. Then we have to wait for opRepoPostCreateDelay time after that create before we can attempt to identify it has User A, this is also ok. However we skip to User B and try to create it and transfer the subscription, this isn't correct as we also should wait `opRepoPostCreateDelay` for the new subscription id.

We addressed `getGroupableOperations()` in this PR however it was not enough, the OperationRepo and it's executors still ran into edge cases where ids would get mixed up due to intermixing of operations on different users. So in this PR we consistently stall the whole OperationRepo processing to avoid the issues, until we can make a flow up PR to improve this later.

While this PR fixes the issue noted above there should be another mechanism in place to prevent such an issue. This should be done in a follow up PR.

### Motivation
No matter how quickly or the offline state of the device operations should be applied in the correct order.

### Scope
Corrects `OperationRepo` ordering and makes now consistently delays the OperationRepo after creating records.

### Related
This is a follow up to PR #2059, where that logic created the issue noted above.

# Testing
## Unit testing
* [Failing test proving the issue](https://github.com/OneSignal/OneSignal-Android-SDK/actions/runs/9071886618/job/24926446649?pr=2087#step:6:819).

## Manual testing
Tested on Android 6 with the following scenario:
1. Turned on Airplane mode
2. Opened the app
3. `OneSignal.login("A")`
4. `OneSignal.User.addEmail("a@a.com")`
5. `OneSignal.User.addTag("a", "a")`
3. `OneSignal.login("B")`
4. `OneSignal.User.addEmail("b@b.com")`
5. `OneSignal.User.addTag("b", "b")`
6. Closed app
7. Turned off Airplane mode
8. Opened app again
9. Observed correct REST API calls and checked records on OneSignal dashboard.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [X] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2087)
<!-- Reviewable:end -->
