### PR TITLE
Added activity lifecycle handler to safe call android settings dialog

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/permissions/AlertDialogPrepromptForAndroidSettings.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/permissions/AlertDialogPrepromptForAndroidSettings.kt
@@ -31,7 +31,6 @@ import android.app.Activity
 import android.app.AlertDialog
 import com.onesignal.common.AndroidUtils
 import com.onesignal.core.R
-import com.onesignal.core.activities.PermissionsActivity
 import com.onesignal.core.internal.application.IActivityLifecycleHandler
 import com.onesignal.core.internal.application.IApplicationService
 
@@ -83,6 +82,7 @@ object AlertDialogPrepromptForAndroidSettings {
 
                 override fun onActivityStopped(activity: Activity) {
                 }
-            })
+            },
+        )
     }
 }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/permissions/AlertDialogPrepromptForAndroidSettings.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/permissions/AlertDialogPrepromptForAndroidSettings.kt
@@ -29,7 +29,7 @@ package com.onesignal.core.internal.permissions
 
 import android.app.Activity
 import android.app.AlertDialog
-import com.onesignal.common.AndroidUtils
+import com.onesignal.common.threading.suspendifyOnThread
 import com.onesignal.core.R
 import com.onesignal.core.internal.application.IActivityLifecycleHandler
 import com.onesignal.core.internal.application.IApplicationService
@@ -54,7 +54,8 @@ object AlertDialogPrepromptForAndroidSettings {
         application.addActivityLifecycleHandler(
             object : IActivityLifecycleHandler {
                 override fun onActivityAvailable(activity: Activity) {
-                    if (AndroidUtils.isActivityFullyReady(activity)) {
+                    suspendifyOnThread {
+                        application.waitUntilActivityReady()
                         val titleTemplate =
                             activity.getString(R.string.permission_not_available_title)
                         val title = titleTemplate.format(titlePrefix)

--- a/OneSignalSDK/onesignal/location/src/main/java/com/onesignal/location/internal/permissions/LocationPermissionController.kt
+++ b/OneSignalSDK/onesignal/location/src/main/java/com/onesignal/location/internal/permissions/LocationPermissionController.kt
@@ -99,7 +99,7 @@ internal class LocationPermissionController(
     private fun showFallbackAlertDialog(): Boolean {
         val activity = _applicationService.current ?: return false
         AlertDialogPrepromptForAndroidSettings.show(
-            activity,
+            _applicationService,
             activity.getString(R.string.location_permission_name_for_title),
             activity.getString(R.string.location_permission_settings_message),
             object : AlertDialogPrepromptForAndroidSettings.Callback {

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/permissions/impl/NotificationPermissionController.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/permissions/impl/NotificationPermissionController.kt
@@ -137,7 +137,7 @@ internal class NotificationPermissionController(
         val activity = _application.current ?: return false
 
         AlertDialogPrepromptForAndroidSettings.show(
-            activity,
+            _application,
             activity.getString(R.string.notification_permission_name_for_title),
             activity.getString(R.string.notification_permission_settings_message),
             object : AlertDialogPrepromptForAndroidSettings.Callback {


### PR DESCRIPTION
# Description
## One Line Summary
Added a safe call for `AlertDialogPrepromptForAndroidSettings.show()` using an activity lifecycle handler

## Details

### Motivation
This is a fix for #2014. 

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2088)
<!-- Reviewable:end -->
