### PR TITLE
[Fix] Continuation called with OneSignal.getNotifications().requestPermission does not fire when permission is already granted

### DIFF
--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/permissions/impl/NotificationPermissionController.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/permissions/impl/NotificationPermissionController.kt
@@ -43,6 +43,7 @@ import com.onesignal.notifications.R
 import com.onesignal.notifications.internal.common.NotificationHelper
 import com.onesignal.notifications.internal.permissions.INotificationPermissionChangedHandler
 import com.onesignal.notifications.internal.permissions.INotificationPermissionController
+import kotlinx.coroutines.yield
 
 internal class NotificationPermissionController(
     private val _application: IApplicationService,
@@ -84,6 +85,10 @@ internal class NotificationPermissionController(
      * to notify of the status.
      */
     override suspend fun prompt(fallbackToSettings: Boolean): Boolean {
+        // Calling yield() to force a suspension point because Kotlin Continuation won't work
+        // properly from java caller if a suspend function does not actually suspend
+        yield()
+
         if (notificationsEnabled()) {
             return true
         }


### PR DESCRIPTION
# Description
## One Line Summary
Fix a bug causing OneSignal.getNotifications().requestPermission with continuation not firing when permission is granted.

## Details

### Motivation
This will fix some wrappers that utilize a Java bridge (like Unity and Flutter) and await forever and never resolve.

# Testing
## Manual testing
Scenarios that I manually tested:
  a. Notification permission is off:
      1. prompt for permission and allow
      2. request again and observe that no prompt shows up and the continuation is fired with permissionResult = true
  b.  Notification permission is off:
      1. prompt for permission and dismiss both dialogs
      2. observe that the continuation is fired with permissionResult = false
  c. Notification permission is on:
      1. request permission and observe that no prompt shows up and the continuation is fired with permissionResult = true

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2093)
<!-- Reviewable:end -->
