### PR TITLE
WiP Add discard parameter to preventDefault() 

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/notifications/INotificationWillDisplayEvent.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/notifications/INotificationWillDisplayEvent.kt
@@ -38,4 +38,11 @@ interface INotificationWillDisplayEvent {
      * caller still has the option to display the notification by calling `notification.display()`.
      */
     fun preventDefault()
+
+    /**
+     * Call this to prevent OneSignal from displaying the notification automatically.
+     * @param discard an [preventDefault] set to true to dismiss the notification with no
+     * possibility of displaying it in the future.
+     */
+    fun preventDefault(discard: Boolean)
 }

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/NotificationWillDisplayEvent.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/NotificationWillDisplayEvent.kt
@@ -7,9 +7,15 @@ internal class NotificationWillDisplayEvent(
     override val notification: Notification,
 ) : INotificationWillDisplayEvent {
     var isPreventDefault: Boolean = false
+    var discard: Boolean = false
 
     override fun preventDefault() {
+        preventDefault(false)
+    }
+
+    override fun preventDefault(discard: Boolean) {
         Logging.debug("NotificationWillDisplayEvent.preventDefault()")
         isPreventDefault = true
+        this.discard = discard
     }
 }

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/generation/impl/NotificationGenerationProcessor.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/generation/impl/NotificationGenerationProcessor.kt
@@ -105,7 +105,9 @@ internal class NotificationGenerationProcessor(
                         GlobalScope.launch(Dispatchers.IO) {
                             _lifecycleService.externalNotificationWillShowInForeground(notificationWillDisplayEvent)
 
-                            if (notificationWillDisplayEvent.isPreventDefault) {
+                            if (notificationWillDisplayEvent.discard) {
+                                wantsToDisplay = false;
+                            } else if (notificationWillDisplayEvent.isPreventDefault) {
                                 // wait on display waiter. If the caller calls `display` on the notification,
                                 // we will exit `waitForWake` and set `wantsToDisplay` to true. If the callback
                                 // never calls `display` we will timeout and never set `wantsToDisplay` to true.


### PR DESCRIPTION
# Description
## One Line Summary
Add the ability to immediately discard a notification by calling preventDefault(discard: true)

## Details
This fixes a bug where if the app is closed before the preventDefault waiter times out, the notification is not removed from the local database and will be displayed when the app is opened next. 

### Motivation
**REQUIRED -** Why is this code change being made? Or what is the goal of this PR? Examples: Fixes a specific bug, provides additional logging to debug future issues, feature to allow X.

### Scope
**RECOMMEND - OPTIONAL -** What is intended to be effected. What is known not to change. Example: Notifications are grouped when parameter X is set, not enabled by default.

### OPTIONAL - Other
**OPTIONAL -** Feel free to add any other sections or sub-sections that can explain your PR better.

# Testing
## Unit testing
**OPTIONAL -**  Explain unit tests added, if not clear in the code.

## Manual testing
**RECOMMEND - OPTIONAL -** Explain what scenarios were tested and the environment.
Example: Tested opening a notification while the app was foregrounded, app build with Android Studio 2020.3 with a fresh install of the OneSignal example app on a Pixel 6 with Android 12.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [ ] I have filled out all **REQUIRED** sections above
   - [ ] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [ ] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [ ] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.
