### PR TITLE
[Fix] Model store saving to and loading from prefs, and remove duplicates

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/modeling/ModelStore.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/modeling/ModelStore.kt
@@ -5,6 +5,7 @@ import com.onesignal.common.events.IEventNotifier
 import com.onesignal.core.internal.preferences.IPreferencesService
 import com.onesignal.core.internal.preferences.PreferenceOneSignalKeys
 import com.onesignal.core.internal.preferences.PreferenceStores
+import com.onesignal.debug.internal.logging.Logging
 import org.json.JSONArray
 
 /**
@@ -172,6 +173,20 @@ abstract class ModelStore<TModel>(
             val shouldRePersist = models.isNotEmpty()
             for (index in jsonArray.length() - 1 downTo 0) {
                 val newModel = create(jsonArray.getJSONObject(index)) ?: continue
+
+                /*
+                 * NOTE: Migration fix for bug introduced in 5.1.12
+                 * The following check is intended for the operation model store.
+                 * When the call to this method moved out of the operation model store's initializer,
+                 * duplicate operations could be cached.
+                 * See https://github.com/OneSignal/OneSignal-Android-SDK/pull/2099
+                 */
+                val hasExisting = models.any { it.id == newModel.id }
+                if (hasExisting) {
+                    Logging.debug("ModelStore<$name>: load - operation.id: ${newModel.id} already exists in the store.")
+                    continue
+                }
+
                 models.add(0, newModel)
                 // listen for changes to this model
                 newModel.subscribe(this)


### PR DESCRIPTION
# Description
## One Line Summary
Don't overwrite operation model store cache before it as been loaded, and avoid duplicates when loading them.

## Details
**Bug Fix**
* This is to remedy the Operation Model Store adding duplicate operations when the same ones that were previously added to the store and persisted, are re-read from cache
* Though the duplicate would not get enqueued to the Operation Repo, the duplicate was still persisted. When the operations are successful, only one of the duplicates will be removed from cache as the Model Store's removal logic utilizes a `firstOrNull` search for the operation. Then, on the next cold start, the remaining operation will load from cache and become enqueued to the OperationRepo
* Bug introduced in 5.1.12 with the Operation-loading changes to prevent ANRs
* See manual testing below for more information

**Solution**
* Fix model store to not overwrite cache. Don't persist models before load is called. This is safe because the time gap between any models being added and load being called should be very small.
* When load is called, the cached models are added to the front. Then the models get persisted altogether again if necessary.
* Add check for duplicate operations when loading model store

### Motivation
Bug fix

# Testing
## Unit testing
Added test that saves duplicates to Prefs, enqueues a model, then loads from cache.

## Manual testing
Android emulator on API 33
**Reproduce Bug Before PR**
1. New app install
2. A `login-user` and a `create-subscription` are quickly enqueued and persisted
3. The Operation Model Store then loads from cache and reads the 2 operations above
4. They get added to the store
5. The store now has 4 operations (2 of each)
6. The operations enqueue to the Operation Repo but it does prevents the duplicates from enqueueing
7. The Operation Repo flushes the `login-user` and `create-subscription` 
8. On success, they are removed from the model store via `firstOrNull`
9. The Operation Model Store now has 2 operations left
10. On the next cold start, the `login-user` and the `create-subscription` are read from cache and added to the Operation Repo

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2099)
<!-- Reviewable:end -->
