### PR TITLE
Bump minimum FCM version

### DIFF
--- a/OneSignalSDK/onesignal/notifications/build.gradle
+++ b/OneSignalSDK/onesignal/notifications/build.gradle
@@ -72,12 +72,11 @@ dependencies {
 
     compileOnly('com.amazon.device:amazon-appstore-sdk:[3.0.1, 3.0.99]')
 
-    // firebase-messaging:18.0.0 is the last version before going to AndroidX
-    // firebase-messaging:19.0.0 is the first version using AndroidX
+    // firebase-messaging:21.0.0 introduces FirebaseMessaging.getToken API
     // firebase-messaging:23.0.0 incoporates fix for SecurityException: Not allowed to bind to service
     api('com.google.firebase:firebase-messaging') {
         version {
-            require '[19.0.0, 23.4.99]'
+            require '[21.0.0, 23.4.99]'
             prefer '23.4.0'
         }
     }


### PR DESCRIPTION
Build failed by using FCM version prior to 21.0.0: e:~/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorFCM.kt: (127, 45): Unresolved reference: token

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2102)
<!-- Reviewable:end -->
