### PR TITLE
consentGiven true forces wake when delaying for retry

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/IOperationRepo.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/IOperationRepo.kt
@@ -41,7 +41,7 @@ interface IOperationRepo {
 
     suspend fun awaitInitialized()
 
-    fun forceProcessDeltas()
+    fun forceExecuteOperations()
 }
 
 // Extension function so the syntax containsInstanceOf<Operation>() can be used over

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/IOperationRepo.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/IOperationRepo.kt
@@ -40,6 +40,8 @@ interface IOperationRepo {
     fun <T : Operation> containsInstanceOf(type: KClass<T>): Boolean
 
     suspend fun awaitInitialized()
+
+    fun forceProcessDeltas()
 }
 
 // Extension function so the syntax containsInstanceOf<Operation>() can be used over

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
@@ -67,8 +67,12 @@ internal class OneSignalImp : IOneSignal, IServiceProvider {
     override var consentGiven: Boolean
         get() = configModel?.consentGiven ?: (_consentGiven == true)
         set(value) {
+            val oldValue = _consentGiven
             _consentGiven = value
             configModel?.consentGiven = value
+            if (oldValue != value && value) {
+                operationRepo?.forceProcessDeltas()
+            }
         }
 
     override var disableGMSMissingPrompt: Boolean

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
@@ -71,7 +71,7 @@ internal class OneSignalImp : IOneSignal, IServiceProvider {
             _consentGiven = value
             configModel?.consentGiven = value
             if (oldValue != value && value) {
-                operationRepo?.forceProcessDeltas()
+                operationRepo?.forceExecuteOperations()
             }
         }
 


### PR DESCRIPTION
# Description
## One Line Summary
Retriable errors now use waiter instead of delay and it can only be interrupted by force calls to waiter.wake or waiting the 

## Details
We were previously using delay() to wait to retry failed server requests. This included privacy consent not given. This PR adds a way to interrupt that delay when privacy consent goes from false to true.

We cannot use delay() for this so it uses the waiter instead. This has the side effect of making all retry-able errors use the waiter.


### Motivation
We want a way to immediately process deltas when privacy consent goes from false to true.

### Scope
Retry-able operations and privacy consent given

# Testing
## Unit testing
**OPTIONAL -**  Explain unit tests added, if not clear in the code.

## Manual testing
Tested not giving privacy consent to ensure we were properly delaying retries. Then tested providing privacy consent and ensured that the operations were sent immediately.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [x] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2109)
<!-- Reviewable:end -->
