### PR TITLE
Fix: Update onNotificationOpened to process each notification ID

### DIFF
--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/lifecycle/INotificationLifecycleEventHandler.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/lifecycle/INotificationLifecycleEventHandler.kt
@@ -13,6 +13,5 @@ interface INotificationLifecycleEventHandler {
     suspend fun onNotificationOpened(
         activity: Activity,
         data: JSONArray,
-        notificationId: String,
     )
 }

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/lifecycle/INotificationLifecycleService.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/lifecycle/INotificationLifecycleService.kt
@@ -69,6 +69,5 @@ interface INotificationLifecycleService {
     suspend fun notificationOpened(
         activity: Activity,
         data: JSONArray,
-        notificationId: String,
     )
 }

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/lifecycle/impl/NotificationLifecycleService.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/lifecycle/impl/NotificationLifecycleService.kt
@@ -95,7 +95,6 @@ internal class NotificationLifecycleService(
     override suspend fun notificationOpened(
         activity: Activity,
         data: JSONArray,
-        notificationId: String,
     ) {
         intLifecycleHandler.suspendingFire { it.onNotificationOpened(activity, data) }
 

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/lifecycle/impl/NotificationLifecycleService.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/lifecycle/impl/NotificationLifecycleService.kt
@@ -97,7 +97,7 @@ internal class NotificationLifecycleService(
         data: JSONArray,
         notificationId: String,
     ) {
-        intLifecycleHandler.suspendingFire { it.onNotificationOpened(activity, data, notificationId) }
+        intLifecycleHandler.suspendingFire { it.onNotificationOpened(activity, data) }
 
         // queue up the opened notification in case the handler hasn't been set yet. Once set,
         // we will immediately fire the handler.

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/open/impl/NotificationOpenedProcessor.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/open/impl/NotificationOpenedProcessor.kt
@@ -131,7 +131,6 @@ internal class NotificationOpenedProcessor(
                 _lifecycleService.notificationOpened(
                     context,
                     intentExtras!!.dataArray,
-                    NotificationFormatHelper.getOSNotificationIdFromJson(intentExtras.jsonData)!!,
                 )
             }
         }

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/open/impl/NotificationOpenedProcessor.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/open/impl/NotificationOpenedProcessor.kt
@@ -38,7 +38,6 @@ import com.onesignal.core.internal.config.ConfigModelStore
 import com.onesignal.core.internal.database.impl.OneSignalDbContract
 import com.onesignal.debug.internal.logging.Logging
 import com.onesignal.notifications.internal.common.NotificationConstants
-import com.onesignal.notifications.internal.common.NotificationFormatHelper
 import com.onesignal.notifications.internal.common.NotificationHelper
 import com.onesignal.notifications.internal.data.INotificationRepository
 import com.onesignal.notifications.internal.lifecycle.INotificationLifecycleService

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/open/impl/NotificationOpenedProcessorHMS.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/open/impl/NotificationOpenedProcessorHMS.kt
@@ -66,7 +66,6 @@ internal class NotificationOpenedProcessorHMS(
         _lifecycleService.notificationOpened(
             activity,
             JSONUtils.wrapInJsonArray(jsonData),
-            NotificationFormatHelper.getOSNotificationIdFromJson(jsonData)!!,
         )
     }
 }


### PR DESCRIPTION
# Description
## One Line Summary
Update onNotificationOpened to process each notification ID

## Details

### Motivation
After customer reports of dropping CTR following upgrade from v4 to v5, it was discovered that clicking an unexpanded group notification results in only registering the click result for the final notification in the group. This PR restores the SDK behavior back to "default" of registering clicks on a per-notification basis when the entire group is clicked.

# Testing

## Manual testing
Tested on a Pixel 7 (Android 14) emulator that clicking an uncollapsed group notification results in the click being tracked for each notification.

# Affected code checklist
   - [X] Notifications
      - [ ] Display
      - [X] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2111)
<!-- Reviewable:end -->
