### PR TITLE
Poll for notification permission changes

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/config/ConfigModel.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/config/ConfigModel.kt
@@ -193,9 +193,18 @@ class ConfigModel : Model() {
      * The minimum number of milliseconds required to pass to allow the fetching of IAM to occur.
      */
     var fetchIAMMinInterval: Long
-        get() = getLongProperty(::fetchIAMMinInterval.name) { 30000 }
+        get() = getLongProperty(::fetchIAMMinInterval.name) { 30_000 }
         set(value) {
             setLongProperty(::fetchIAMMinInterval.name, value)
+        }
+
+    /**
+     * The number of milliseconds between fetching the current notification permission value
+     */
+    var fetchNotificationPermissionInterval: Long
+        get() = getLongProperty(::fetchNotificationPermissionInterval.name) { 1_000 }
+        set(value) {
+            setLongProperty(::fetchNotificationPermissionInterval.name, value)
         }
 
     /**

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/config/ConfigModel.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/config/ConfigModel.kt
@@ -199,12 +199,21 @@ class ConfigModel : Model() {
         }
 
     /**
-     * The number of milliseconds between fetching the current notification permission value
+     * The number of milliseconds between fetching the current notification permission value when the app is in focus
      */
-    var fetchNotificationPermissionInterval: Long
-        get() = getLongProperty(::fetchNotificationPermissionInterval.name) { 1_000 }
+    var foregroundFetchNotificationPermissionInterval: Long
+        get() = getLongProperty(::foregroundFetchNotificationPermissionInterval.name) { 1_000 }
         set(value) {
-            setLongProperty(::fetchNotificationPermissionInterval.name, value)
+            setLongProperty(::foregroundFetchNotificationPermissionInterval.name, value)
+        }
+
+    /**
+     * The number of milliseconds between fetching the current notification permission value when the app is out of focus
+     */
+    var backgroundFetchNotificationPermissionInterval: Long
+        get() = getLongProperty(::backgroundFetchNotificationPermissionInterval.name) { 1_800_000 }
+        set(value) {
+            setLongProperty(::backgroundFetchNotificationPermissionInterval.name, value)
         }
 
     /**

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/config/ConfigModel.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/config/ConfigModel.kt
@@ -209,9 +209,10 @@ class ConfigModel : Model() {
 
     /**
      * The number of milliseconds between fetching the current notification permission value when the app is out of focus
+     * We want this value to be very large to effectively stop polling in the background
      */
     var backgroundFetchNotificationPermissionInterval: Long
-        get() = getLongProperty(::backgroundFetchNotificationPermissionInterval.name) { 1_800_000 }
+        get() = getLongProperty(::backgroundFetchNotificationPermissionInterval.name) { 86_400_000 }
         set(value) {
             setLongProperty(::backgroundFetchNotificationPermissionInterval.name, value)
         }

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/permissions/impl/NotificationPermissionController.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/permissions/impl/NotificationPermissionController.kt
@@ -77,7 +77,7 @@ internal class NotificationPermissionController(
     init {
         this.enabled = notificationsEnabled()
         _requestPermission.registerAsCallback(PERMISSION_TYPE, this)
-        pollingWaitInterval = _configModelStore.model.foregroundFetchNotificationPermissionInterval
+        pollingWaitInterval = _configModelStore.model.backgroundFetchNotificationPermissionInterval
         registerPollingLifecycleListener()
         coroutineScope.launch {
             pollForPermission()

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/permissions/impl/NotificationPermissionController.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/permissions/impl/NotificationPermissionController.kt
@@ -31,6 +31,7 @@ import android.os.Build
 import androidx.annotation.ChecksSdkIntAtLeast
 import com.onesignal.common.AndroidUtils
 import com.onesignal.common.events.EventProducer
+import com.onesignal.common.threading.Waiter
 import com.onesignal.common.threading.WaiterWithValue
 import com.onesignal.core.internal.application.ApplicationLifecycleHandlerBase
 import com.onesignal.core.internal.application.IApplicationService
@@ -59,7 +60,7 @@ internal class NotificationPermissionController(
 ) : IRequestPermissionService.PermissionCallback,
     INotificationPermissionController {
     private val waiter = WaiterWithValue<Boolean>()
-    private val pollingWaiter = WaiterWithValue<Boolean>()
+    private val pollingWaiter = Waiter()
     private var pollingWaitInterval: Long
     private val events = EventProducer<INotificationPermissionChangedHandler>()
     private var enabled: Boolean
@@ -89,11 +90,12 @@ internal class NotificationPermissionController(
                 override fun onFocus() {
                     super.onFocus()
                     pollingWaitInterval = _configModelStore.model.foregroundFetchNotificationPermissionInterval
-                    pollingWaiter.wake(true)
+                    pollingWaiter.wake()
                 }
 
                 override fun onUnfocused() {
                     super.onUnfocused()
+                    // Changing the polling interval to 1 day to effectively pause polling
                     pollingWaitInterval = _configModelStore.model.backgroundFetchNotificationPermissionInterval
                 }
             },

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/permissions/impl/NotificationPermissionController.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/permissions/impl/NotificationPermissionController.kt
@@ -45,9 +45,9 @@ import com.onesignal.notifications.internal.common.NotificationHelper
 import com.onesignal.notifications.internal.permissions.INotificationPermissionChangedHandler
 import com.onesignal.notifications.internal.permissions.INotificationPermissionController
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.newSingleThreadContext
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.coroutines.yield
 
 internal class NotificationPermissionController(
@@ -59,6 +59,8 @@ internal class NotificationPermissionController(
 ) : IRequestPermissionService.PermissionCallback,
     INotificationPermissionController {
     private val waiter = WaiterWithValue<Boolean>()
+    private val pollingWaiter = WaiterWithValue<Boolean>()
+    private var pollingWaitInterval: Long
     private val events = EventProducer<INotificationPermissionChangedHandler>()
     private var enabled: Boolean
     private val coroutineScope = CoroutineScope(newSingleThreadContext(name = "NotificationPermissionController"))
@@ -74,9 +76,28 @@ internal class NotificationPermissionController(
     init {
         this.enabled = notificationsEnabled()
         _requestPermission.registerAsCallback(PERMISSION_TYPE, this)
+        pollingWaitInterval = _configModelStore.model.foregroundFetchNotificationPermissionInterval
+        registerPollingLifecycleListener()
         coroutineScope.launch {
             pollForPermission()
         }
+    }
+
+    private fun registerPollingLifecycleListener() {
+        _applicationService.addApplicationLifecycleHandler(
+            object : ApplicationLifecycleHandlerBase() {
+                override fun onFocus() {
+                    super.onFocus()
+                    pollingWaitInterval = _configModelStore.model.foregroundFetchNotificationPermissionInterval
+                    pollingWaiter.wake(true)
+                }
+
+                override fun onUnfocused() {
+                    super.onUnfocused()
+                    pollingWaitInterval = _configModelStore.model.backgroundFetchNotificationPermissionInterval
+                }
+            },
+        )
     }
 
     private suspend fun pollForPermission() {
@@ -86,7 +107,9 @@ internal class NotificationPermissionController(
                 this.enabled = enabled
                 events.fire { it.onNotificationPermissionChanged(enabled) }
             }
-            delay(_configModelStore.model.fetchNotificationPermissionInterval)
+            withTimeoutOrNull(pollingWaitInterval) {
+                pollingWaiter.waitForWake()
+            }
         }
     }
 

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/permissions/impl/NotificationPermissionController.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/permissions/impl/NotificationPermissionController.kt
@@ -34,6 +34,7 @@ import com.onesignal.common.events.EventProducer
 import com.onesignal.common.threading.WaiterWithValue
 import com.onesignal.core.internal.application.ApplicationLifecycleHandlerBase
 import com.onesignal.core.internal.application.IApplicationService
+import com.onesignal.core.internal.config.ConfigModelStore
 import com.onesignal.core.internal.permissions.AlertDialogPrepromptForAndroidSettings
 import com.onesignal.core.internal.permissions.IRequestPermissionService
 import com.onesignal.core.internal.preferences.IPreferencesService
@@ -43,6 +44,10 @@ import com.onesignal.notifications.R
 import com.onesignal.notifications.internal.common.NotificationHelper
 import com.onesignal.notifications.internal.permissions.INotificationPermissionChangedHandler
 import com.onesignal.notifications.internal.permissions.INotificationPermissionController
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.newSingleThreadContext
 import kotlinx.coroutines.yield
 
 internal class NotificationPermissionController(
@@ -50,10 +55,13 @@ internal class NotificationPermissionController(
     private val _requestPermission: IRequestPermissionService,
     private val _applicationService: IApplicationService,
     private val _preferenceService: IPreferencesService,
+    private val _configModelStore: ConfigModelStore,
 ) : IRequestPermissionService.PermissionCallback,
     INotificationPermissionController {
     private val waiter = WaiterWithValue<Boolean>()
     private val events = EventProducer<INotificationPermissionChangedHandler>()
+    private var enabled: Boolean
+    private val coroutineScope = CoroutineScope(newSingleThreadContext(name = "NotificationPermissionController"))
 
     override val canRequestPermission: Boolean
         get() =
@@ -64,13 +72,34 @@ internal class NotificationPermissionController(
             )!!
 
     init {
+        this.enabled = notificationsEnabled()
         _requestPermission.registerAsCallback(PERMISSION_TYPE, this)
+        coroutineScope.launch {
+            pollForPermission()
+        }
+    }
+
+    private suspend fun pollForPermission() {
+        while (true) {
+            val enabled = this.notificationsEnabled()
+            if (this.enabled != enabled) { // If the permission has changed without prompting through OneSignal
+                this.enabled = enabled
+                events.fire { it.onNotificationPermissionChanged(enabled) }
+            }
+            delay(_configModelStore.model.fetchNotificationPermissionInterval)
+        }
     }
 
     @ChecksSdkIntAtLeast(api = 33)
     val supportsNativePrompt =
         Build.VERSION.SDK_INT > 32 &&
             AndroidUtils.getTargetSdkVersion(_application.appContext) > 32
+
+    private fun permissionPromptCompleted(enabled: Boolean) {
+        this.enabled = enabled
+        waiter.wake(enabled)
+        events.fire { it.onNotificationPermissionChanged(enabled) }
+    }
 
     /**
      * Prompt the user for notification permission.  Note it is possible the application
@@ -119,8 +148,7 @@ internal class NotificationPermissionController(
         get() = events.hasSubscribers
 
     override fun onAccept() {
-        waiter.wake(true)
-        events.fire { it.onNotificationPermissionChanged(true) }
+        permissionPromptCompleted(true)
     }
 
     override fun onReject(fallbackToSettings: Boolean) {
@@ -132,8 +160,7 @@ internal class NotificationPermissionController(
             }
 
         if (!fallbackShown) {
-            waiter.wake(false)
-            events.fire { it.onNotificationPermissionChanged(false) }
+            permissionPromptCompleted(false)
         }
     }
 
@@ -154,8 +181,7 @@ internal class NotificationPermissionController(
                                 super.onFocus()
                                 _applicationService.removeApplicationLifecycleHandler(this)
                                 val hasPermission = AndroidUtils.hasPermission(ANDROID_PERMISSION_STRING, true, _applicationService)
-                                waiter.wake(hasPermission)
-                                events.fire { it.onNotificationPermissionChanged(hasPermission) }
+                                permissionPromptCompleted(hasPermission)
                             }
                         },
                     )
@@ -163,8 +189,7 @@ internal class NotificationPermissionController(
                 }
 
                 override fun onDecline() {
-                    waiter.wake(false)
-                    events.fire { it.onNotificationPermissionChanged(false) }
+                    permissionPromptCompleted(false)
                 }
             },
         )

--- a/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/permission/NotificationPermissionControllerTests.kt
+++ b/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/permission/NotificationPermissionControllerTests.kt
@@ -33,6 +33,10 @@ class NotificationPermissionControllerTests : FunSpec({
         ShadowRoboNotificationManager.reset()
     }
 
+    beforeEach {
+        ShadowRoboNotificationManager.reset()
+    }
+
     test("NotificationPermissionController permission polling fires permission changed event") {
         // Given
         val mockRequestPermissionService = mockk<IRequestPermissionService>()
@@ -62,8 +66,8 @@ class NotificationPermissionControllerTests : FunSpec({
 
         // When
         // permission changes
-        ShadowRoboNotificationManager.setNotificationsEnabled(false)
-        delay(5)
+        ShadowRoboNotificationManager.setShadowNotificationsEnabled(false)
+        delay(100)
 
         // Then
         // permissionChanged Event should fire
@@ -103,10 +107,10 @@ class NotificationPermissionControllerTests : FunSpec({
         for (handler in handlerList) {
             handler.onUnfocused()
         }
-        delay(5)
+        delay(100)
         // the permission changes
-        ShadowRoboNotificationManager.setNotificationsEnabled(false)
-        delay(5)
+        ShadowRoboNotificationManager.setShadowNotificationsEnabled(false)
+        delay(100)
 
         // Then
         // permissionChanged Event should not fire
@@ -146,10 +150,10 @@ class NotificationPermissionControllerTests : FunSpec({
         for (handler in handlerList) {
             handler.onUnfocused()
         }
-        delay(5)
+        delay(100)
         // the permission changes
-        ShadowRoboNotificationManager.setNotificationsEnabled(false)
-        delay(5)
+        ShadowRoboNotificationManager.setShadowNotificationsEnabled(false)
+        delay(100)
         // the app regains focus
         for (handler in handlerList) {
             handler.onFocus()

--- a/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/permission/NotificationPermissionControllerTests.kt
+++ b/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/permission/NotificationPermissionControllerTests.kt
@@ -1,0 +1,60 @@
+package com.onesignal.notifications.internal.permission
+
+import br.com.colman.kotest.android.extensions.robolectric.RobolectricTest
+import com.onesignal.core.internal.permissions.IRequestPermissionService
+import com.onesignal.core.internal.preferences.IPreferencesService
+import com.onesignal.debug.LogLevel
+import com.onesignal.debug.internal.logging.Logging
+import com.onesignal.mocks.AndroidMockHelper
+import com.onesignal.mocks.MockHelper
+import com.onesignal.notifications.internal.permissions.INotificationPermissionChangedHandler
+import com.onesignal.notifications.internal.permissions.impl.NotificationPermissionController
+import com.onesignal.notifications.shadows.ShadowRoboNotificationManager
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import kotlinx.coroutines.delay
+import org.robolectric.annotation.Config
+
+@Config(
+    packageName = "com.onesignal.example",
+    shadows = [ShadowRoboNotificationManager::class],
+    sdk = [33],
+)
+@RobolectricTest
+class NotificationPermissionControllerTests : FunSpec({
+    beforeAny {
+        Logging.logLevel = LogLevel.NONE
+        ShadowRoboNotificationManager.reset()
+    }
+
+    test("NotificationPermissionController permission polling fires permission changed event") {
+        // Given
+        val mockRequestPermissionService = mockk<IRequestPermissionService>()
+        every { mockRequestPermissionService.registerAsCallback(any(), any()) } just runs
+        val mockPreferenceService = mockk<IPreferencesService>()
+
+        var handlerFired = false
+        val notificationPermissionController = NotificationPermissionController(AndroidMockHelper.applicationService(), mockRequestPermissionService, AndroidMockHelper.applicationService(), mockPreferenceService, MockHelper.configModelStore())
+
+        notificationPermissionController.subscribe(
+            object : INotificationPermissionChangedHandler {
+                override fun onNotificationPermissionChanged(enabled: Boolean) {
+                    handlerFired = true
+                }
+            },
+        )
+
+        // When
+        // permission changes
+        ShadowRoboNotificationManager.setNotificationsEnabled(false)
+        delay(5)
+
+        // Then
+        // permissionChanged Event should fire
+        handlerFired shouldBe true
+    }
+})

--- a/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/shadows/ShadowRoboNotificationManager.kt
+++ b/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/shadows/ShadowRoboNotificationManager.kt
@@ -79,6 +79,14 @@ class ShadowRoboNotificationManager : ShadowNotificationManager() {
         super.notify(tag, id, notification)
     }
 
+    override fun setNotificationsEnabled(areNotificationsEnabled: Boolean) {
+        notificationsEnabled = areNotificationsEnabled
+    }
+
+    override fun areNotificationsEnabled(): Boolean {
+        return notificationsEnabled
+    }
+
     fun createNotificationChannel(channel: NotificationChannel?) {
         lastChannel = channel
         super.createNotificationChannel(channel as Any?)
@@ -97,12 +105,14 @@ class ShadowRoboNotificationManager : ShadowNotificationManager() {
         var lastNotifId = 0
         val notifications = LinkedHashMap<Int, PostedNotification>()
         val cancelledNotifications = mutableListOf<Int>()
+        var notificationsEnabled = true
 
         fun reset() {
             notifications.clear()
             cancelledNotifications.clear()
             lastNotif = null
             lastNotifId = 0
+            notificationsEnabled = true
         }
 
         private lateinit var mInstance: ShadowRoboNotificationManager
@@ -117,7 +127,7 @@ class ShadowRoboNotificationManager : ShadowNotificationManager() {
             return notifications
         }
 
-        fun setNotificationsEnabled(enabled: Boolean) {
+        fun setShadowNotificationsEnabled(enabled: Boolean) {
             mInstance.setNotificationsEnabled(enabled)
         }
 

--- a/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/shadows/ShadowRoboNotificationManager.kt
+++ b/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/shadows/ShadowRoboNotificationManager.kt
@@ -117,6 +117,10 @@ class ShadowRoboNotificationManager : ShadowNotificationManager() {
             return notifications
         }
 
+        fun setNotificationsEnabled(enabled: Boolean) {
+            mInstance.setNotificationsEnabled(enabled)
+        }
+
         var lastChannel: NotificationChannel? = null
         var lastChannelGroup: NotificationChannelGroup? = null
     }

--- a/OneSignalSDK/onesignal/testhelpers/src/main/java/com/onesignal/mocks/MockHelper.kt
+++ b/OneSignalSDK/onesignal/testhelpers/src/main/java/com/onesignal/mocks/MockHelper.kt
@@ -49,6 +49,7 @@ object MockHelper {
         configModel.opRepoPostCreateDelay = 1
         configModel.opRepoPostCreateRetryUpTo = 1
         configModel.opRepoDefaultFailRetryBackoff = 1
+        configModel.foregroundFetchNotificationPermissionInterval = 1
 
         configModel.appId = DEFAULT_APP_ID
 


### PR DESCRIPTION
# Description
## One Line Summary
This PR adds polling for notification permission changes so that we can detect changes that happen from outside of the SDK in the current session.

## Details
Spawn a new thread where we check notification permission every second. If the permission has changed we fire the permission observer.
This means that we need to track the permission value to know if it has changed. 

This is done using an `_enabled` boolean that gets set when using OneSignal's prompting or when the polling detects a change. 

When the app loses focus we change the polling interval to 1 day to have the thread sleep until the app is brought into focus. 

### Motivation
Currently if an app prompts for permissions without using OneSignal or if the user changes permissions without closing the app (notification center long press on notification), we don't detect those permission changes until the next session begins.

### Scope
notification permission prompting

# Testing
## Unit testing
Added a unit testing file for the PermissionController. Currently has 3 tests around the new polling behavior.

## Manual testing
Tested by prompting directly through Android native APIs to test that the SDK detects the change.
Tested that backgrounding that properly sleeps the thread to ensure we aren't polling while the app is not in focus.

# Affected code checklist
   - [x] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2112)
<!-- Reviewable:end -->
