### PR TITLE
[Feat] Application service focus update, cold start creates new session and drives user refresh

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/application/IApplicationLifecycleHandler.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/application/IApplicationLifecycleHandler.kt
@@ -10,8 +10,13 @@ import android.app.Application.ActivityLifecycleCallbacks
 interface IApplicationLifecycleHandler {
     /**
      * Called when the application is brought into the foreground.
+     * This callback can be fired immediately on subscribing to the IApplicationService (when the
+     * IApplicationService itself is started too late to capture the application's early lifecycle events),
+     * or through natural application lifecycle callbacks.
+     *
+     * @param firedOnSubscribe Method is fired from subscribing or from application lifecycle callbacks
      */
-    fun onFocus()
+    fun onFocus(firedOnSubscribe: Boolean)
 
     /**
      * Called when the application has been brought out of the foreground, to the background.
@@ -24,7 +29,7 @@ interface IApplicationLifecycleHandler {
  * can use this if they only want to override a subset of the callbacks that make up this interface.
  */
 open class ApplicationLifecycleHandlerBase : IApplicationLifecycleHandler {
-    override fun onFocus() {}
+    override fun onFocus(firedOnSubscribe: Boolean) {}
 
     override fun onUnfocused() {}
 }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/application/impl/ApplicationService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/application/impl/ApplicationService.kt
@@ -67,6 +67,9 @@ class ApplicationService() : IApplicationService, ActivityLifecycleCallbacks, On
     private var activityReferences = 0
     private var isActivityChangingConfigurations = false
 
+    private val wasInBackground: Boolean
+        get() = !isInForeground || nextResumeIsFirstActivity
+
     /**
      * Call to "start" this service, expected to be called during initialization of the SDK.
      *
@@ -150,7 +153,7 @@ class ApplicationService() : IApplicationService, ActivityLifecycleCallbacks, On
 
         current = activity
 
-        if ((!isInForeground || nextResumeIsFirstActivity) && !isActivityChangingConfigurations) {
+        if (wasInBackground && !isActivityChangingConfigurations) {
             activityReferences = 1
             handleFocus()
         } else {
@@ -170,7 +173,7 @@ class ApplicationService() : IApplicationService, ActivityLifecycleCallbacks, On
             current = activity
         }
 
-        if ((!isInForeground || nextResumeIsFirstActivity) && !isActivityChangingConfigurations) {
+        if (wasInBackground && !isActivityChangingConfigurations) {
             activityReferences = 1
             handleFocus()
         }
@@ -373,7 +376,7 @@ class ApplicationService() : IApplicationService, ActivityLifecycleCallbacks, On
     }
 
     private fun handleFocus() {
-        if (!isInForeground || nextResumeIsFirstActivity) {
+        if (wasInBackground) {
             Logging.debug(
                 "ApplicationService.handleFocus: application is now in focus, nextResumeIsFirstActivity=$nextResumeIsFirstActivity",
             )

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/background/impl/BackgroundManager.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/background/impl/BackgroundManager.kt
@@ -79,7 +79,7 @@ internal class BackgroundManager(
         _applicationService.addApplicationLifecycleHandler(this)
     }
 
-    override fun onFocus() {
+    override fun onFocus(firedOnSubscribe: Boolean) {
         cancelSyncTask()
     }
 

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/purchases/impl/TrackAmazonPurchase.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/purchases/impl/TrackAmazonPurchase.kt
@@ -115,7 +115,7 @@ internal class TrackAmazonPurchase(
         e.printStackTrace()
     }
 
-    override fun onFocus() { }
+    override fun onFocus(firedOnSubscribe: Boolean) { }
 
     override fun onUnfocused() {
         if (!canTrack) return

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/purchases/impl/TrackGooglePurchase.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/purchases/impl/TrackGooglePurchase.kt
@@ -98,7 +98,7 @@ internal class TrackGooglePurchase(
         trackIAP()
     }
 
-    override fun onFocus() {
+    override fun onFocus(firedOnSubscribe: Boolean) {
         trackIAP()
     }
 

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/session/internal/session/SessionModel.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/session/internal/session/SessionModel.kt
@@ -38,7 +38,7 @@ class SessionModel : Model() {
      * When this app was last focused, in Unix time milliseconds.
      */
     var focusTime: Long
-        get() = getLongProperty(::focusTime.name) { 0 }
+        get() = getLongProperty(::focusTime.name) { System.currentTimeMillis() }
         set(value) {
             setLongProperty(::focusTime.name, value)
         }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/session/internal/session/SessionModel.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/session/internal/session/SessionModel.kt
@@ -19,13 +19,14 @@ class SessionModel : Model() {
      * Whether the session is valid.
      */
     var isValid: Boolean
-        get() = getBooleanProperty(::isValid.name) { true }
+        get() = getBooleanProperty(::isValid.name) { false }
         set(value) {
             setBooleanProperty(::isValid.name, value)
         }
 
     /**
      * When this session started, in Unix time milliseconds.
+     * This is used by In-App Message triggers, and not used in detecting session time.
      */
     var startTime: Long
         get() = getLongProperty(::startTime.name) { System.currentTimeMillis() }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/session/internal/session/impl/SessionListener.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/session/internal/session/impl/SessionListener.kt
@@ -4,6 +4,7 @@ import com.onesignal.common.threading.suspendifyOnThread
 import com.onesignal.core.internal.config.ConfigModelStore
 import com.onesignal.core.internal.operations.IOperationRepo
 import com.onesignal.core.internal.startup.IStartableService
+import com.onesignal.debug.internal.logging.Logging
 import com.onesignal.session.internal.outcomes.IOutcomeEventsController
 import com.onesignal.session.internal.session.ISessionLifecycleHandler
 import com.onesignal.session.internal.session.ISessionService
@@ -48,9 +49,9 @@ internal class SessionListener(
     override fun onSessionEnded(duration: Long) {
         val durationInSeconds = duration / 1000
 
-        // Time is invalid if below 1 second or over a day
+        // Time is erroneous if below 1 second or over a day
         if (durationInSeconds < 1L || durationInSeconds > SECONDS_IN_A_DAY) {
-            return
+            Logging.error("SessionListener.onSessionEnded sending duration of $durationInSeconds seconds")
         }
 
         _operationRepo.enqueue(

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/session/internal/session/impl/SessionListener.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/session/internal/session/impl/SessionListener.kt
@@ -47,6 +47,12 @@ internal class SessionListener(
 
     override fun onSessionEnded(duration: Long) {
         val durationInSeconds = duration / 1000
+
+        // Time is invalid if below 1 second or over a day
+        if (durationInSeconds < 1L || durationInSeconds > SECONDS_IN_A_DAY) {
+            return
+        }
+
         _operationRepo.enqueue(
             TrackSessionEndOperation(_configModelStore.model.appId, _identityModelStore.model.onesignalId, durationInSeconds),
         )
@@ -54,5 +60,9 @@ internal class SessionListener(
         suspendifyOnThread {
             _outcomeEventsController.sendSessionEndOutcomeEvent(durationInSeconds)
         }
+    }
+
+    companion object {
+        const val SECONDS_IN_A_DAY = 86_400L
     }
 }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/session/internal/session/impl/SessionService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/session/internal/session/impl/SessionService.kt
@@ -56,16 +56,12 @@ internal class SessionService(
     }
 
     override suspend fun backgroundRun() {
-        Logging.log(LogLevel.DEBUG, "SessionService.backgroundRun()")
-
-        if (!session!!.isValid) {
-            return
-        }
-
+        val activeDuration = session!!.activeDuration
         // end the session
-        Logging.debug("SessionService: Session ended. activeDuration: ${session!!.activeDuration}")
+        Logging.debug("SessionService.backgroundRun: Session ended. activeDuration: $activeDuration")
         session!!.isValid = false
-        sessionLifeCycleNotifier.fire { it.onSessionEnded(session!!.activeDuration) }
+        sessionLifeCycleNotifier.fire { it.onSessionEnded(activeDuration) }
+        session!!.activeDuration = 0L
     }
 
     /**
@@ -85,7 +81,6 @@ internal class SessionService(
             session!!.sessionId = UUID.randomUUID().toString()
             session!!.startTime = _time.currentTimeMillis
             session!!.focusTime = session!!.startTime
-            session!!.activeDuration = 0L
             session!!.isValid = true
 
             Logging.debug("SessionService: New session started at ${session!!.startTime}")

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/application/ApplicationServiceTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/application/ApplicationServiceTests.kt
@@ -175,7 +175,27 @@ class ApplicationServiceTests : FunSpec({
         // Then
         currentActivity shouldBe activity2
         verify(exactly = 1) { mockApplicationLifecycleHandler.onUnfocused() }
-        verify(exactly = 1) { mockApplicationLifecycleHandler.onFocus() }
+        verify(exactly = 1) { mockApplicationLifecycleHandler.onFocus(false) }
+    }
+
+    test("focus will occur on subscribe when activity is already started") {
+        // Given
+        val activity: Activity
+
+        Robolectric.buildActivity(Activity::class.java).use { controller ->
+            controller.setup() // Moves Activity to RESUMED state
+            activity = controller.get()
+        }
+
+        val applicationService = ApplicationService()
+        val mockApplicationLifecycleHandler = spyk<IApplicationLifecycleHandler>()
+
+        // When
+        applicationService.start(activity)
+        applicationService.addApplicationLifecycleHandler(mockApplicationLifecycleHandler)
+
+        // Then
+        verify(exactly = 1) { mockApplicationLifecycleHandler.onFocus(true) }
     }
 
     test("wait until system condition returns false when there is no activity") {

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/session/internal/session/SessionServiceTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/session/internal/session/SessionServiceTests.kt
@@ -7,60 +7,89 @@ import io.kotest.matchers.shouldBe
 import io.mockk.spyk
 import io.mockk.verify
 
-class SessionServiceTests : FunSpec({
+// Mocks used by every test in this file
+private class Mocks {
+    val currentTime = 1111L
 
+    private val mockSessionModelStore = MockHelper.sessionModelStore()
+
+    fun sessionModelStore(action: ((SessionModel) -> Unit)? = null): SessionModelStore {
+        if (action != null) action(mockSessionModelStore.model)
+        return mockSessionModelStore
+    }
+
+    val sessionService = SessionService(MockHelper.applicationService(), MockHelper.configModelStore(), mockSessionModelStore, MockHelper.time(currentTime))
+
+    val spyCallback = spyk<ISessionLifecycleHandler>()
+}
+
+class SessionServiceTests : FunSpec({
     test("session created on focus when current session invalid") {
         // Given
-        val currentTime = 1111L
+        val mocks = Mocks()
+        val sessionService = mocks.sessionService
 
-        val configModelStoreMock = MockHelper.configModelStore()
-        val sessionModelStoreMock =
-            MockHelper.sessionModelStore {
-                it.isValid = false
-            }
-        val spyCallback = spyk<ISessionLifecycleHandler>()
-
-        val sessionService =
-            SessionService(MockHelper.applicationService(), configModelStoreMock, sessionModelStoreMock, MockHelper.time(currentTime))
         sessionService.start()
-        sessionService.subscribe(spyCallback)
+        val sessionModelStore = mocks.sessionModelStore { it.isValid = false }
+        sessionService.subscribe(mocks.spyCallback)
 
         // When
-        sessionService.onFocus()
+        sessionService.onFocus(false)
 
         // Then
-        sessionModelStoreMock.model.isValid shouldBe true
-        sessionModelStoreMock.model.startTime shouldBe currentTime
-        sessionModelStoreMock.model.focusTime shouldBe currentTime
-        verify(exactly = 1) { spyCallback.onSessionStarted() }
+        sessionModelStore.model.isValid shouldBe true
+        sessionModelStore.model.startTime shouldBe mocks.currentTime
+        sessionModelStore.model.focusTime shouldBe mocks.currentTime
+        verify(exactly = 1) { mocks.spyCallback.onSessionStarted() }
+    }
+
+    test("session created in start when application is in the foreground") {
+        // Given
+        val mocks = Mocks()
+        val sessionService = mocks.sessionService
+        val sessionModelStore = mocks.sessionModelStore()
+
+        // When
+        sessionService.start()
+        sessionService.onFocus(true)
+        sessionService.subscribe(mocks.spyCallback)
+
+        // Then
+        sessionModelStore.model.isValid shouldBe true
+        sessionModelStore.model.startTime shouldBe mocks.currentTime
+        sessionModelStore.model.focusTime shouldBe mocks.currentTime
+        verify(exactly = 1) { mocks.spyCallback.onSessionStarted() }
+
+        // When
+        sessionService.onFocus(false) // Should not trigger a second session
+
+        // Then
+        verify(exactly = 1) { mocks.spyCallback.onSessionStarted() }
     }
 
     test("session focus time updated when current session valid") {
         // Given
-        val currentTime = 1111L
         val startTime = 555L
+        val mocks = Mocks()
+        val sessionService = mocks.sessionService
 
-        val configModelStoreMock = MockHelper.configModelStore()
-        val sessionModelStoreMock =
-            MockHelper.sessionModelStore {
-                it.isValid = true
-                it.startTime = startTime
-            }
-        val spyCallback = spyk<ISessionLifecycleHandler>()
-
-        val sessionService =
-            SessionService(MockHelper.applicationService(), configModelStoreMock, sessionModelStoreMock, MockHelper.time(currentTime))
         sessionService.start()
-        sessionService.subscribe(spyCallback)
+        val sessionModelStore =
+            mocks.sessionModelStore {
+                it.startTime = startTime
+                it.isValid = true
+            }
+        sessionService.subscribe(mocks.spyCallback)
 
         // When
-        sessionService.onFocus()
+        sessionService.onFocus(false)
 
         // Then
-        sessionModelStoreMock.model.isValid shouldBe true
-        sessionModelStoreMock.model.startTime shouldBe startTime
-        sessionModelStoreMock.model.focusTime shouldBe currentTime
-        verify(exactly = 1) { spyCallback.onSessionActive() }
+        sessionModelStore.model.isValid shouldBe true
+        sessionModelStore.model.startTime shouldBe startTime
+        sessionModelStore.model.focusTime shouldBe mocks.currentTime
+        verify(exactly = 1) { mocks.spyCallback.onSessionActive() }
+        verify(exactly = 0) { mocks.spyCallback.onSessionStarted() }
     }
 
     test("session active duration updated when unfocused") {
@@ -68,53 +97,47 @@ class SessionServiceTests : FunSpec({
         val startTime = 555L
         val focusTime = 666L
         val startingDuration = 1000L
-        val currentTime = 1111L
 
-        val configModelStoreMock = MockHelper.configModelStore()
-        val sessionModelStoreMock =
-            MockHelper.sessionModelStore {
+        val mocks = Mocks()
+        val sessionService = mocks.sessionService
+
+        sessionService.start()
+        val sessionModelStore =
+            mocks.sessionModelStore {
                 it.isValid = true
                 it.startTime = startTime
                 it.focusTime = focusTime
                 it.activeDuration = startingDuration
             }
 
-        val sessionService =
-            SessionService(MockHelper.applicationService(), configModelStoreMock, sessionModelStoreMock, MockHelper.time(currentTime))
-        sessionService.start()
-
         // When
         sessionService.onUnfocused()
 
         // Then
-        sessionModelStoreMock.model.isValid shouldBe true
-        sessionModelStoreMock.model.startTime shouldBe startTime
-        sessionModelStoreMock.model.activeDuration shouldBe startingDuration + (currentTime - focusTime)
+        sessionModelStore.model.isValid shouldBe true
+        sessionModelStore.model.startTime shouldBe startTime
+        sessionModelStore.model.activeDuration shouldBe startingDuration + (mocks.currentTime - focusTime)
     }
 
     test("session ended when background run") {
         // Given
         val activeDuration = 555L
-        val currentTime = 1111L
+        val mocks = Mocks()
+        val sessionService = mocks.sessionService
 
-        val configModelStoreMock = MockHelper.configModelStore()
-        val sessionModelStoreMock =
-            MockHelper.sessionModelStore {
+        sessionService.start()
+        val sessionModelStore =
+            mocks.sessionModelStore {
                 it.isValid = true
                 it.activeDuration = activeDuration
             }
-        val spyCallback = spyk<ISessionLifecycleHandler>()
-
-        val sessionService =
-            SessionService(MockHelper.applicationService(), configModelStoreMock, sessionModelStoreMock, MockHelper.time(currentTime))
-        sessionService.start()
-        sessionService.subscribe(spyCallback)
+        sessionService.subscribe(mocks.spyCallback)
 
         // When
         sessionService.backgroundRun()
 
         // Then
-        sessionModelStoreMock.model.isValid shouldBe false
-        verify(exactly = 1) { spyCallback.onSessionEnded(activeDuration) }
+        sessionModelStore.model.isValid shouldBe false
+        verify(exactly = 1) { mocks.spyCallback.onSessionEnded(activeDuration) }
     }
 })

--- a/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/InAppMessagesManager.kt
+++ b/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/InAppMessagesManager.kt
@@ -881,15 +881,7 @@ internal class InAppMessagesManager(
             .show()
     }
 
-    private var onFocusCalled: Boolean = false
-
-    override fun onFocus(firedOnSubscribe: Boolean) {
-        if (onFocusCalled) return
-        onFocusCalled = true
-        suspendifyOnThread {
-            fetchMessages()
-        }
-    }
+    override fun onFocus(firedOnSubscribe: Boolean) { }
 
     override fun onUnfocused() { }
 }

--- a/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/InAppMessagesManager.kt
+++ b/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/InAppMessagesManager.kt
@@ -883,7 +883,7 @@ internal class InAppMessagesManager(
 
     private var onFocusCalled: Boolean = false
 
-    override fun onFocus() {
+    override fun onFocus(firedOnSubscribe: Boolean) {
         if (onFocusCalled) return
         onFocusCalled = true
         suspendifyOnThread {

--- a/OneSignalSDK/onesignal/location/src/main/java/com/onesignal/location/internal/controller/impl/GmsLocationController.kt
+++ b/OneSignalSDK/onesignal/location/src/main/java/com/onesignal/location/internal/controller/impl/GmsLocationController.kt
@@ -175,7 +175,7 @@ internal class GmsLocationController(
             refreshRequest()
         }
 
-        override fun onFocus() {
+        override fun onFocus(firedOnSubscribe: Boolean) {
             Logging.log(LogLevel.DEBUG, "LocationUpdateListener.onFocus()")
             refreshRequest()
         }

--- a/OneSignalSDK/onesignal/location/src/main/java/com/onesignal/location/internal/controller/impl/HmsLocationController.kt
+++ b/OneSignalSDK/onesignal/location/src/main/java/com/onesignal/location/internal/controller/impl/HmsLocationController.kt
@@ -161,7 +161,7 @@ internal class HmsLocationController(
             refreshRequest()
         }
 
-        override fun onFocus() {
+        override fun onFocus(firedOnSubscribe: Boolean) {
             Logging.log(LogLevel.DEBUG, "LocationUpdateListener.onFocus()")
             refreshRequest()
         }

--- a/OneSignalSDK/onesignal/location/src/main/java/com/onesignal/location/internal/permissions/LocationPermissionController.kt
+++ b/OneSignalSDK/onesignal/location/src/main/java/com/onesignal/location/internal/permissions/LocationPermissionController.kt
@@ -107,8 +107,12 @@ internal class LocationPermissionController(
                     // wait for focus to be regained, and check the current permission status.
                     _applicationService.addApplicationLifecycleHandler(
                         object : ApplicationLifecycleHandlerBase() {
-                            override fun onFocus() {
-                                super.onFocus()
+                            override fun onFocus(firedOnSubscribe: Boolean) {
+                                // Triggered by subscribing, wait for lifecycle callback
+                                if (firedOnSubscribe) {
+                                    return
+                                }
+                                super.onFocus(false)
                                 _applicationService.removeApplicationLifecycleHandler(this)
                                 val hasPermission = AndroidUtils.hasPermission(currPermission, true, _applicationService)
                                 waiter.wake(hasPermission)

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/NotificationsManager.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/NotificationsManager.kt
@@ -61,7 +61,7 @@ internal class NotificationsManager(
         }
     }
 
-    override fun onFocus() {
+    override fun onFocus(firedOnSubscribe: Boolean) {
         refreshNotificationState()
     }
 

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/permissions/impl/NotificationPermissionController.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/permissions/impl/NotificationPermissionController.kt
@@ -150,8 +150,12 @@ internal class NotificationPermissionController(
                     // wait for focus to be regained, and check the current permission status.
                     _applicationService.addApplicationLifecycleHandler(
                         object : ApplicationLifecycleHandlerBase() {
-                            override fun onFocus() {
-                                super.onFocus()
+                            override fun onFocus(firedOnSubscribe: Boolean) {
+                                // Triggered by subscribing, wait for lifecycle callback
+                                if (firedOnSubscribe) {
+                                    return
+                                }
+                                super.onFocus(false)
                                 _applicationService.removeApplicationLifecycleHandler(this)
                                 val hasPermission = AndroidUtils.hasPermission(ANDROID_PERMISSION_STRING, true, _applicationService)
                                 waiter.wake(hasPermission)


### PR DESCRIPTION
# Description
## One Line Summary
(1) All cold starts create new sessions, (2) refresh user on all new sessions, (3) Application Service fills in gaps where it did not fire `onFocus` for awaiting subscribers.

## Details
❓ Is my interpretation of this commit[ ApplicationService: Clarify a condition by naming it](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2113/commits/58df743e9eb9b2d474c6ebbbd24d47a292337fb0) accurate?

❓ Now that "refresh-user" and "track-session-start" always enqueue at the same time, the `UserRefreshService` could be removed and its task could move to the `SessionListener`.

**Application Service will fire `onFocus` even when it is too late**
* Typically, the app foregrounding will trigger the ApplicationService to fire `onFocus` to its subscribers.
* However, it is possible for OneSignal to initialize too late, so the ApplicationService itself is started too late to capture the application's early lifecycle events.
* In this case, the app is already foregrounded, so fire a subscriber's `onFocus` callback immediately upon it subscribing, as many services have logic to run in the **first** `onFocus` call of a cold start, and pass a parameter so the subscriber knows if the callback is fired from subscribing or from natural application lifecycle callbacks. Some subscribers such as permission controllers do not want the callback when it is fired from just subscribing.
* This may fix some other bugs commonly seen on wrappers such as permission not being detected and updated between cold starts, or background runnables not being cancelled.

**Session service creates new session on cold start**
* Also fix a bug where a cold start may not detect the start of a session correctly. On wrappers, it is common for OneSignal to initialize too late for the `ApplicationService` to `start()` and capture the Android `onActivityStarted` or `onActivityResumed` lifecycle callbacks, which was the primary way of session detection.
* **Player model reference**: In player model, we addressed this by triggering the `FocusTimeController` in the `init(context)` method when the ActivityLifecycleHandler is added AND the application is already in the foreground: [link](https://github.com/OneSignal/OneSignal-Android-SDK/blob/8a36a3238e7cbe07ddf26494a8916bbbdcce9cc4/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java#L976).

**Session service updates tracking active duration with cold starts**
* Additionally, the background task to send the session time **will be triggered by the existence of an active duration of 1 second or more and under 1 day, instead of whether the session is valid**. This is in line with player model logic.

**Refresh user on new sessions (not just cold start)**
* New sessions can happen when the app is backgrounded over 30 seconds. Let's refresh the user then, not just when the app is cold started.
* The user will still be refreshed only when the app is in the foreground.

### Motivation

- Align behavior with expectation
- Update last active always when cold started
- Fix some other bugs commonly found on wrappers due to OneSignal initializing later after activity already started

### Scope
**New session creation and when users are refreshed**
* Users are now refreshed on every new session triggered by backgrounding the app, **whereas they were previously only refreshed on a cold start**
* All cold starts will create new sessions, instead of also relying on 30 seconds backgrounded time

**Application Service will always fire `onFocus` when services are started up**
* Previously the SDK had to be initialized in the Applications `onCreate` call to capture and fire the early `onFocus` callback
* Now if the SDK is initialized later, the Application Service will still fire that callback when handlers subscribe to it

# Testing
## Unit testing
**Update Session Service and Application Service Tests**
* Extract helper methods them into a helper class for reuse
* `SessionServiceTests` - Add test `"session created in start when application is in the foreground"`
* `ApplicationServiceTests` - Add test `"focus will occur on subscribe when activity is already started"`

## Manual testing
Tested these primary scenarios
1. SDK initialized in Application `onCreate`
2. SDK initialized after activity is already running
3. Background app for under 30 seconds and over 30 seconds
4. Swipe away app and re-open in under 30 seconds and over 30 seconds

Checked for:
- [x]  Last active is updated (`track-session-start` operation)
- [x]  Refresh user (`refresh-user` operation )
- [x]  Session time accumulated correctly still
- [x]  Fetch IAMs correct

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2113)
<!-- Reviewable:end -->
