### PR TITLE
Release 5.1.14

### DIFF
--- a/Examples/OneSignalDemo/app/build.gradle
+++ b/Examples/OneSignalDemo/app/build.gradle
@@ -84,12 +84,12 @@ dependencies {
     implementation 'com.github.bumptech.glide:glide:4.12.0'
 
     /** START - Google Play Builds **/
-    gmsImplementation('com.onesignal:OneSignal:5.1.13')
+    gmsImplementation('com.onesignal:OneSignal:5.1.14')
     /** END - Google Play Builds **/
 
     /** START - Huawei Builds **/
     // Omit Google / Firebase libraries for Huawei builds.
-    huaweiImplementation('com.onesignal:OneSignal:5.1.13') {
+    huaweiImplementation('com.onesignal:OneSignal:5.1.14') {
         exclude group: 'com.google.android.gms', module: 'play-services-gcm'
         exclude group: 'com.google.android.gms', module: 'play-services-analytics'
         exclude group: 'com.google.android.gms', module: 'play-services-location'

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/OneSignalUtils.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/OneSignalUtils.kt
@@ -6,7 +6,7 @@ object OneSignalUtils {
     /**
      * The version of this SDK.
      */
-    const val SDK_VERSION: String = "050113"
+    const val SDK_VERSION: String = "050114"
 
     fun isValidEmail(email: String): Boolean {
         if (email.isEmpty()) {

--- a/OneSignalSDK/settings.gradle
+++ b/OneSignalSDK/settings.gradle
@@ -3,7 +3,7 @@
 gradle.rootProject {
     allprojects {
         group = 'com.onesignal'
-        version = '5.1.13'
+        version = '5.1.14'
         configurations.all {
             resolutionStrategy.dependencySubstitution {
                 substitute(module('com.onesignal:OneSignal')).using(project(':OneSignal'))


### PR DESCRIPTION
### 🔧 Maintenance
* Add the ability to immediately discard a notification by calling preventDefault(discard: true) (https://github.com/OneSignal/OneSignal-Android-SDK/pull/2094)
* Bump minimum FCM version to 21.0.0. (https://github.com/OneSignal/OneSignal-Android-SDK/pull/2102)
* Add a way to immediately process deltas when privacy consent goes from false to true. (https://github.com/OneSignal/OneSignal-Android-SDK/pull/2109)

### 🐛 Bug Fixes
* Fix a bug causing OneSignal.getNotifications().requestPermission with continuation not firing when permission is granted. (https://github.com/OneSignal/OneSignal-Android-SDK/pull/2093)
* Fix Operation Model Store adding duplicate operations when the same ones that were previously added to the store and persisted, are re-read from cache. (https://github.com/OneSignal/OneSignal-Android-SDK/pull/2099)
* Fix a bug causing clicking an unexpanded group notification results in only registering the click result for the final notification in the group. (https://github.com/OneSignal/OneSignal-Android-SDK/pull/2111)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2117)
<!-- Reviewable:end -->
