### PR TITLE
[Bug] The getter for WorkManager considers the app context

### DIFF
--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/common/OSWorkManagerHelper.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/common/OSWorkManagerHelper.kt
@@ -1,51 +1,57 @@
 package com.onesignal.notifications.internal.common
 
-import android.annotation.SuppressLint
 import android.content.Context
 import androidx.work.Configuration
 import androidx.work.WorkManager
-import androidx.work.impl.WorkManagerImpl
 import com.onesignal.debug.internal.logging.Logging
 
 object OSWorkManagerHelper {
     /**
-     * Helper method to provide a way to check if WorkManager is initialized in this process.
-     * The purpose of this helper is to work around this bug - https://issuetracker.google.com/issues/258176803
-     *
-     * This is effectively the `WorkManager.isInitialized()` public method introduced in androidx.work:work-*:2.8.0-alpha02.
-     * Please see https://android-review.googlesource.com/c/platform/frameworks/support/+/1941186.
-     *
-     * @return `true` if WorkManager has been initialized in this process.
-     */
-    @SuppressWarnings("deprecation")
-    @SuppressLint("RestrictedApi")
-    private fun isInitialized(): Boolean {
-        return WorkManagerImpl.getInstance() != null
-    }
-
-    /**
      * If there is an instance of WorkManager available, use it. Else, in rare cases, initialize it ourselves.
      *
      * Calling `WorkManager.getInstance(context)` directly can cause an exception if it is null.
+     * However, this is the appropriate way to check as the non-throwing `WorkManager.getInstance()`
+     * method does not allow the opportunity for on-demand initialization with custom WorkManager.
+     *
+     * The purpose of this helper is to work around this bug - https://issuetracker.google.com/issues/258176803
      *
      * @return an instance of WorkManager
      */
-    @JvmStatic
     @Synchronized
     fun getInstance(context: Context): WorkManager {
-        if (!isInitialized()) {
-            try {
-                WorkManager.initialize(context, Configuration.Builder().build())
-            } catch (e: IllegalStateException) {
-                /*
-                This catch is meant for the exception -
-                https://android.googlesource.com/platform/frameworks/support/+/60ae0eec2a32396c22ad92502cde952c80d514a0/work/workmanager/src/main/java/androidx/work/impl/WorkManagerImpl.java#177
-                1. We lost the race with another call to  WorkManager.initialize outside of OneSignal.
-                2. It is possible for some other unexpected error is thrown from WorkManager.
-                 */
-                Logging.error("OSWorkManagerHelper initializing WorkManager failed: ", e)
-            }
+        return try {
+            WorkManager.getInstance(context)
+        } catch (e: IllegalStateException) {
+            /*
+            This aims to catch the IllegalStateException "WorkManager is not initialized properly..." -
+            https://androidx.tech/artifacts/work/work-runtime/2.8.1-source/androidx/work/impl/WorkManagerImpl.java.html
+             */
+            Logging.error("OSWorkManagerHelper.getInstance failed, attempting to initialize: ", e)
+            initializeWorkManager(context)
+            WorkManager.getInstance(context)
         }
-        return WorkManager.getInstance(context)
+    }
+
+    /**
+     * This method is called in rare cases to initialize WorkManager ourselves.
+     */
+    private fun initializeWorkManager(context: Context) {
+        try {
+            /*
+            Note: `WorkManager.getInstance(context)` should already initialize WorkManager when the
+            application implements Configuration.Provider. However, as a further safeguard, let's detect
+            for this when we attempt to initialize WorkManager.
+             */
+            val configuration = (context.applicationContext as? Configuration.Provider)?.workManagerConfiguration ?: Configuration.Builder().build()
+            WorkManager.initialize(context, configuration)
+        } catch (e: IllegalStateException) {
+            /*
+            This catch is meant for the exception -
+            https://android.googlesource.com/platform/frameworks/support/+/60ae0eec2a32396c22ad92502cde952c80d514a0/work/workmanager/src/main/java/androidx/work/impl/WorkManagerImpl.java#177
+            1. We lost the race with another call to  WorkManager.initialize outside of OneSignal.
+            2. It is possible for some other unexpected error is thrown from WorkManager.
+             */
+            Logging.error("OSWorkManagerHelper initializing WorkManager failed: ", e)
+        }
     }
 }


### PR DESCRIPTION
# Description
## One Line Summary
Allow custom work manager to be initialized on demand, which resolves Hilt dependency manager conflict.

## Details
* With helpful comments from the community and revisiting WorkManager source code.
* We were mimicking the `isInitialized()` [API](https://android-review.googlesource.com/c/platform/frameworks/support/+/1941186) that checks for a WorkManager instance via `WorkManagerImpl.getInstance()` and initializing it with a blank Configuration when the getter returned null.
* However, we should use `WorkManagerImpl.getInstance(Context)` instead as this getter will allow for on-demand initialization with the app's custom WorkManager.
* Because Hilt dependency manager or other app configurations such as using `lateinit` may not have the WorkManager instance initialized at the time we check.

### Motivation
- Fixes https://github.com/OneSignal/OneSignal-Android-SDK/issues/1748 for user model

### Scope
Work Manager initialization.

# Testing
## Unit testing
- None due to limited ability to reproduce original crashes
- Except to run a bare unit test that experiences the original "not found" crash when given a unit test context.
- Then using the OSWorkManagerHelper's getter instead does not crash and returns a new Work Manager instance.
```kotlin
test("start application service with non-activity shows entry state as closed") {
    // Crashes
    WorkManager.getInstance(ApplicationProvider.getApplicationContext<Context>())

    // Works
    OSWorkManagerHelper.getInstance(ApplicationProvider.getApplicationContext<Context>())
}

```
## Manual testing
Limited ability to test manually due to unable to reproduce **original** crash
- Tested normal app flow in an emulator
- Receiving notifications in background and swiped away state
- Opening app, etc.
- Receive receipt worker runs and succeeds

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2122)
<!-- Reviewable:end -->
