### PR TITLE
Fix/fcm push token bug

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/RefreshUserOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/RefreshUserOperationExecutor.kt
@@ -117,9 +117,22 @@ internal class RefreshUserOperationExecutor(
                 subscriptionModel.carrier = subscription.carrier ?: ""
                 subscriptionModel.appVersion = subscription.appVersion ?: ""
 
-                // We only add a push subscription if it is this device's push subscription.
-                if (subscriptionModel.type != SubscriptionType.PUSH || subscriptionModel.id == _configModelStore.model.pushSubscriptionId) {
+                // We only add a non-push subscriptions. For push, the device is the source of truth
+                // so we don't want to cache these subscriptions from the backend.
+                if (subscriptionModel.type != SubscriptionType.PUSH) {
                     subscriptionModels.add(subscriptionModel)
+                }
+            }
+            // Retrieve the push subscription ID from the backend configuration model store
+            val pushSubscriptionIdFromConfig = _configModelStore.model.pushSubscriptionId
+
+            if (pushSubscriptionIdFromConfig != null) {
+                // Retrieve the push subscription model from the model store
+                val cachedPushSubscriptionModel = _subscriptionsModelStore.get(pushSubscriptionIdFromConfig)
+
+                // If non-null, the cached push subscription matches the ID coming from backend config
+                if (cachedPushSubscriptionModel != null) {
+                    subscriptionModels.add(cachedPushSubscriptionModel)
                 }
             }
 

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/listeners/DeviceRegistrationListener.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/listeners/DeviceRegistrationListener.kt
@@ -37,8 +37,6 @@ internal class DeviceRegistrationListener(
         _configModelStore.subscribe(this)
         _notificationsManager.addPermissionObserver(this)
         _subscriptionManager.subscribe(this)
-
-        retrievePushTokenAndUpdateSubscription()
     }
 
     override fun onModelReplaced(


### PR DESCRIPTION
<!-- START -->

# Description
**One line summary:** Remove redundant `retrievePushToken` call and refine local model replacement logic.

## Details

### Motivation
### Remove Unnecessary `retrievePushToken` Call
The `retrievePushToken` call in the `start` function has been removed. Since the config model is replaced every time, this call is redundant.

### Replace Local Models with Non-Push Subscriptions
Local models are now only replaced with non-push subscriptions. The backend should sync its push token state with the client state, as the client directly obtains the token during subscription.

# Testing
## Manual testing
Tested locally.
- Change project number
- Send push - failed
- Open app
- Send push - success

# Affected code checklist
   - [x] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2125)
<!-- Reviewable:end -->
