### PR TITLE
[Fix] Xiaomi notification click not foregrounding

### DIFF
--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/activities/NotificationOpenedActivityBase.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/activities/NotificationOpenedActivityBase.kt
@@ -36,32 +36,26 @@ import com.onesignal.notifications.internal.open.INotificationOpenedProcessor
 abstract class NotificationOpenedActivityBase : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        if (!OneSignal.initWithContext(applicationContext)) {
-            return
-        }
-
-        var self = this
-
-        suspendifyOnThread {
-            var openedProcessor = OneSignal.getService<INotificationOpenedProcessor>()
-            openedProcessor.processFromContext(self, intent)
-        }
-
-        finish()
+        processIntent()
     }
 
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
+        processIntent()
+    }
+
+    private fun processIntent() {
         if (!OneSignal.initWithContext(applicationContext)) {
             return
         }
-
-        var self = this
         suspendifyOnThread {
-            var openedProcessor = OneSignal.getService<INotificationOpenedProcessor>()
-            openedProcessor.processFromContext(self, getIntent())
+            val openedProcessor = OneSignal.getService<INotificationOpenedProcessor>()
+            openedProcessor.processFromContext(this, intent)
+            // KEEP: Xiaomi Compatibility:
+            // Must keep this Activity alive while trampolining, that is
+            // startActivity() must be called BEFORE finish(), otherwise
+            // the app is never foregrounded.
+            finish()
         }
-
-        finish()
     }
 }


### PR DESCRIPTION
# Description
## One Line Summary
This fixes a bug where tapping on a OneSignal notification on a Xiaomi device doesn't bring the app to the foreground.

## Details
Xiaomi has very strict activity trampolining rules on notification open. We have to start the next activity before the current activity is finished.

### Motivation
Xiaomi are commonly used so it is important notifications open behaves correctly. 

### Scope
Delays when the invisible activity is closed.

### Background
Xiaomi's rules were originally discovered and documented in the Player Model PR #1581.

# Testing
## Manual testing
Tested on Xiaomi Redmi 6A device with MIUI 11.0.8 (Android 9) as well as an Android 14 emulator with the following scenarios:
1. Background the app and tap on a notification
2. Swipe away the app and tap on a notification.
3. When the app is in the foreground tap on a notification
4. While the app is closed and the device is offline tap on a notification.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [X] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
      - Automatized test for this is tricky, it needs more of an integration style test due to how far apart logic.
   - [ ] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item
