### PR TITLE
Release 5.1.15

### DIFF
--- a/Examples/OneSignalDemo/app/build.gradle
+++ b/Examples/OneSignalDemo/app/build.gradle
@@ -84,12 +84,12 @@ dependencies {
     implementation 'com.github.bumptech.glide:glide:4.12.0'
 
     /** START - Google Play Builds **/
-    gmsImplementation('com.onesignal:OneSignal:5.1.14')
+    gmsImplementation('com.onesignal:OneSignal:5.1.15')
     /** END - Google Play Builds **/
 
     /** START - Huawei Builds **/
     // Omit Google / Firebase libraries for Huawei builds.
-    huaweiImplementation('com.onesignal:OneSignal:5.1.14') {
+    huaweiImplementation('com.onesignal:OneSignal:5.1.15') {
         exclude group: 'com.google.android.gms', module: 'play-services-gcm'
         exclude group: 'com.google.android.gms', module: 'play-services-analytics'
         exclude group: 'com.google.android.gms', module: 'play-services-location'

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/OneSignalUtils.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/OneSignalUtils.kt
@@ -6,7 +6,7 @@ object OneSignalUtils {
     /**
      * The version of this SDK.
      */
-    const val SDK_VERSION: String = "050114"
+    const val SDK_VERSION: String = "050115"
 
     fun isValidEmail(email: String): Boolean {
         if (email.isEmpty()) {

--- a/OneSignalSDK/settings.gradle
+++ b/OneSignalSDK/settings.gradle
@@ -3,7 +3,7 @@
 gradle.rootProject {
     allprojects {
         group = 'com.onesignal'
-        version = '5.1.14'
+        version = '5.1.15'
         configurations.all {
             resolutionStrategy.dependencySubstitution {
                 substitute(module('com.onesignal:OneSignal')).using(project(':OneSignal'))


### PR DESCRIPTION
**🐛 Bug Fixes**

- Xiaomi notification click was not foregrounding app [#2129](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2129)
- Fixes related to FCM push token (https://github.com/OneSignal/OneSignal-Android-SDK/pull/2125, https://github.com/OneSignal/OneSignal-Android-SDK/pull/2118)
- Poll for notification permission changes to detect permission change when prompting outside of OneSignal [#2112](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2112)
- `WorkManager` fixes when the app uses a custom WorkManager [#2122](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2122)

**✨ Improvements**
- Cold start creates new session and refreshes the user from the server [#2113](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2113)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2131)
<!-- Reviewable:end -->
