### PR TITLE
[fix] NotificationPermissionController fix an override method signature

### DIFF
--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/permissions/impl/NotificationPermissionController.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/permissions/impl/NotificationPermissionController.kt
@@ -87,8 +87,8 @@ internal class NotificationPermissionController(
     private fun registerPollingLifecycleListener() {
         _applicationService.addApplicationLifecycleHandler(
             object : ApplicationLifecycleHandlerBase() {
-                override fun onFocus() {
-                    super.onFocus()
+                override fun onFocus(firedOnSubscribe: Boolean) {
+                    super.onFocus(firedOnSubscribe)
                     pollingWaitInterval = _configModelStore.model.foregroundFetchNotificationPermissionInterval
                     pollingWaiter.wake()
                 }

--- a/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/permission/NotificationPermissionControllerTests.kt
+++ b/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/permission/NotificationPermissionControllerTests.kt
@@ -61,7 +61,7 @@ class NotificationPermissionControllerTests : FunSpec({
         // call onFocus to set the proper polling interval.
         // This happens when registering the lifecycle handler
         for (focusHandler in focusHandlerList) {
-            focusHandler.onFocus()
+            focusHandler.onFocus(false)
         }
 
         // When
@@ -99,7 +99,7 @@ class NotificationPermissionControllerTests : FunSpec({
         // call onFocus to set the proper polling interval.
         // This happens when registering the lifecycle handler
         for (focusHandler in handlerList) {
-            focusHandler.onFocus()
+            focusHandler.onFocus(false)
         }
 
         // When
@@ -142,7 +142,7 @@ class NotificationPermissionControllerTests : FunSpec({
         // call onFocus to set the proper polling interval.
         // This happens when registering the lifecycle handler
         for (focusHandler in handlerList) {
-            focusHandler.onFocus()
+            focusHandler.onFocus(false)
         }
 
         // When
@@ -156,7 +156,7 @@ class NotificationPermissionControllerTests : FunSpec({
         delay(100)
         // the app regains focus
         for (handler in handlerList) {
-            handler.onFocus()
+            handler.onFocus(false)
         }
         delay(5)
 


### PR DESCRIPTION
- This code was originally created in https://github.com/OneSignal/OneSignal-Android-SDK/pull/2112
- But another parallel PR https://github.com/OneSignal/OneSignal-Android-SDK/pull/2113 modified the method signature

```
> Task :OneSignal:notifications:compileReleaseKotlin FAILED
w: Argument -module-name is passed multiple times. Only the last value will be used: com.onesignal.notifications
e: /Users/nanli/Documents/GitHub/OneSignal-Android-SDK/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/permissions/impl/NotificationPermissionController.kt: (90, 17): 'onFocus' overrides nothing
e: /Users/nanli/Documents/GitHub/OneSignal-Android-SDK/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/permissions/impl/NotificationPermissionController.kt: (91, 35): No value passed for parameter 'firedOnSubscribe'

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':OneSignal:notifications:compileReleaseKotlin'.
> A failure occurred while executing org.jetbrains.kotlin.compilerRunner.GradleCompilerRunnerWithWorkers$GradleKotlinCompilerWorkAction
   > Compilation error. See log for more details
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2132)
<!-- Reviewable:end -->
