### PR TITLE
[Fix] "could not be instantiated" exception when; some modules are omitted AND android.enableR8.fullMode=true

### DIFF
--- a/OneSignalSDK/onesignal/core/consumer-rules.pro
+++ b/OneSignalSDK/onesignal/core/consumer-rules.pro
@@ -14,4 +14,6 @@
 
 -keepclassmembers class com.onesignal.common.** { *; }
 
+-keepclassmembers @com.onesignal.core.internal.minification.KeepStub class * { <init>(...); }
+
 -keep class ** implements com.onesignal.common.modules.IModule { *; }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/minification/KeepStub.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/minification/KeepStub.kt
@@ -1,0 +1,8 @@
+package com.onesignal.core.internal.minification
+
+/**
+ * Purpose: Use on stub classes that are expected to always exists when
+ * aggressive minification is enabled on the app.
+ *     - Such as android.enableR8.fullMode.
+ */
+annotation class KeepStub

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/inAppMessages/internal/MisconfiguredIAMManager.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/inAppMessages/internal/MisconfiguredIAMManager.kt
@@ -37,7 +37,7 @@ internal class MisconfiguredIAMManager : IInAppMessagesManager {
     override fun removeClickListener(listener: IInAppMessageClickListener) = throw EXCEPTION
 
     companion object {
-        private val EXCEPTION: Throwable get() =
+        private val EXCEPTION get() =
             Exception(
                 "Must include gradle module com.onesignal:InAppMessages in order to use this functionality!",
             )

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/inAppMessages/internal/MisconfiguredIAMManager.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/inAppMessages/internal/MisconfiguredIAMManager.kt
@@ -1,13 +1,15 @@
 package com.onesignal.inAppMessages.internal
 
+import com.onesignal.core.internal.minification.KeepStub
 import com.onesignal.inAppMessages.IInAppMessageClickListener
 import com.onesignal.inAppMessages.IInAppMessageLifecycleListener
 import com.onesignal.inAppMessages.IInAppMessagesManager
 
 /**
- * The misconfigured IAMManager is an implementation of [IInAppMessagesManager] that warns the user they
- * have not included the appropriate IAM module.
+ * The misconfigured IAMManager is an implementation of [IInAppMessagesManager]
+ * that warns the dev they have not included the appropriate IAM module.
  */
+@KeepStub
 internal class MisconfiguredIAMManager : IInAppMessagesManager {
     override var paused: Boolean
         get() = throw EXCEPTION

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/location/internal/MisconfiguredLocationManager.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/location/internal/MisconfiguredLocationManager.kt
@@ -16,6 +16,6 @@ internal class MisconfiguredLocationManager : ILocationManager {
     override suspend fun requestPermission(): Boolean = throw EXCEPTION
 
     companion object {
-        private val EXCEPTION = Exception("Must include gradle module com.onesignal:Location in order to use this functionality!")
+        private val EXCEPTION get() = Exception("Must include gradle module com.onesignal:Location in order to use this functionality!")
     }
 }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/location/internal/MisconfiguredLocationManager.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/location/internal/MisconfiguredLocationManager.kt
@@ -1,11 +1,13 @@
 package com.onesignal.location.internal
 
+import com.onesignal.core.internal.minification.KeepStub
 import com.onesignal.location.ILocationManager
 
 /**
- * The misconfigured IAMManager is an implementation of [ILocationManager] that warns the user they
+ * The misconfigured IAMManager is an implementation of [ILocationManager] that warns the dev they
  * have not included the appropriate location module.
  */
+@KeepStub
 internal class MisconfiguredLocationManager : ILocationManager {
     override var isShared: Boolean
         get() = throw EXCEPTION

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/location/internal/MisconfiguredLocationManager.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/location/internal/MisconfiguredLocationManager.kt
@@ -13,7 +13,7 @@ internal class MisconfiguredLocationManager : ILocationManager {
         get() = throw EXCEPTION
         set(value) = throw EXCEPTION
 
-    override suspend fun requestPermission(): Boolean = throw EXCEPTION
+    override suspend fun requestPermission() = throw EXCEPTION
 
     companion object {
         private val EXCEPTION get() = Exception("Must include gradle module com.onesignal:Location in order to use this functionality!")

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/notifications/internal/MisconfiguredNotificationsManager.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/notifications/internal/MisconfiguredNotificationsManager.kt
@@ -13,12 +13,12 @@ import com.onesignal.notifications.IPermissionObserver
  */
 @KeepStub
 internal class MisconfiguredNotificationsManager : INotificationsManager {
-    override val permission: Boolean
+    override val permission
         get() = throw EXCEPTION
-    override val canRequestPermission: Boolean
+    override val canRequestPermission
         get() = throw EXCEPTION
 
-    override suspend fun requestPermission(fallbackToSettings: Boolean): Boolean = throw EXCEPTION
+    override suspend fun requestPermission(fallbackToSettings: Boolean) = throw EXCEPTION
 
     override fun removeNotification(id: Int) = throw EXCEPTION
 

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/notifications/internal/MisconfiguredNotificationsManager.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/notifications/internal/MisconfiguredNotificationsManager.kt
@@ -39,6 +39,6 @@ internal class MisconfiguredNotificationsManager : INotificationsManager {
     override fun removeClickListener(listener: INotificationClickListener) = throw EXCEPTION
 
     companion object {
-        private val EXCEPTION = Exception("Must include gradle module com.onesignal:Notification in order to use this functionality!")
+        private val EXCEPTION get() = Exception("Must include gradle module com.onesignal:Notification in order to use this functionality!")
     }
 }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/notifications/internal/MisconfiguredNotificationsManager.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/notifications/internal/MisconfiguredNotificationsManager.kt
@@ -1,14 +1,17 @@
 package com.onesignal.notifications.internal
 
+import com.onesignal.core.internal.minification.KeepStub
 import com.onesignal.notifications.INotificationClickListener
 import com.onesignal.notifications.INotificationLifecycleListener
 import com.onesignal.notifications.INotificationsManager
 import com.onesignal.notifications.IPermissionObserver
 
 /**
- * The misconfigured NotificationsManager is an implementation of [INotificationsManager] that warns the user they
- * have not included the appropriate notifications module.
+ * The misconfigured NotificationsManager is an implementation of
+ * [INotificationsManager] that warns the dev they have not included the
+ * appropriate notifications module.
  */
+@KeepStub
 internal class MisconfiguredNotificationsManager : INotificationsManager {
     override val permission: Boolean
         get() = throw EXCEPTION


### PR DESCRIPTION
# Description
## One Line Summary
Fix "could not be instantiated" exception when; some modules are omitted AND `android.enableR8.fullMode` is enabled.

## Details
This also fixes the stack traces reported when attempting to use a module that wasn't included 2b2e76ae403a3910073d087aad9b8a48ca36490f

### Motivation
This results in crashes when these two conditions are meet. SDK should include all Proguard rules so app developers don't have to manually add them to avoid issues like this.

### Scope
Only effects keeping a bit more code when minification is enabled.

# Testing
## Manual testing
Tested with the included example app with the following modifications:
* Added `android.enableR8.fullMode=true` to `Examples/OneSignalDemo/gradle.properties`
* Replaced `com.onesignal:OneSignal:5.1.15` with `com.onesignal:core:5.1.15` in `Examples/OneSignalDemo/app/buidle.gradle`
* Modified OneSignalDemo's code no longer call things that require modules;

Reproduced the crash reported in issue #1969 and ensured it no longer happens after the change. Tested on an Android 6.0 emulator.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
         - CI doesn't currently build or run the demo app.
   - [x] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2136)
<!-- Reviewable:end -->
