### PR TITLE
[FIX] IAM with dynamic trigger showing forever

### DIFF
--- a/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/InAppMessagesManager.kt
+++ b/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/InAppMessagesManager.kt
@@ -458,13 +458,10 @@ internal class InAppMessagesManager(
         isNewTriggerAdded: Boolean,
     ) {
         for (message in messages) {
-            if (!message.isTriggerChanged &&
-                redisplayedInAppMessages.contains(message) &&
-                (
-                    _triggerController.isTriggerOnMessage(message, newTriggersKeys) ||
-                        isNewTriggerAdded && _triggerController.messageHasOnlyDynamicTriggers(message)
-                )
-            ) {
+            val isMessageDisplayed = redisplayedInAppMessages.contains(message)
+            val isTriggerOnMessage = _triggerController.isTriggerOnMessage(message, newTriggersKeys)
+            val isOnlyDynamicTriggers = _triggerController.messageHasOnlyDynamicTriggers(message)
+            if (!message.isTriggerChanged && isMessageDisplayed && (isTriggerOnMessage || isNewTriggerAdded && isOnlyDynamicTriggers)) {
                 Logging.debug("InAppMessagesManager.makeRedisplayMessagesAvailableWithTriggers: Trigger changed for message: $message")
                 message.isTriggerChanged = true
             }

--- a/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/InAppMessagesManager.kt
+++ b/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/InAppMessagesManager.kt
@@ -451,7 +451,7 @@ internal class InAppMessagesManager(
      *
      * Make all messages with redisplay available if:
      * - Already displayed
-     * - At least one existing Trigger has changed OR a new trigger is added
+     * - At least one existing Trigger has changed OR a new trigger is added when there is only dynamic trigger
      */
     private fun makeRedisplayMessagesAvailableWithTriggers(
         newTriggersKeys: Collection<String>,
@@ -460,7 +460,10 @@ internal class InAppMessagesManager(
         for (message in messages) {
             if (!message.isTriggerChanged &&
                 redisplayedInAppMessages.contains(message) &&
-                (_triggerController.isTriggerOnMessage(message, newTriggersKeys) || isNewTriggerAdded)
+                (
+                    _triggerController.isTriggerOnMessage(message, newTriggersKeys) ||
+                        isNewTriggerAdded && _triggerController.messageHasOnlyDynamicTriggers(message)
+                )
             ) {
                 Logging.debug("InAppMessagesManager.makeRedisplayMessagesAvailableWithTriggers: Trigger changed for message: $message")
                 message.isTriggerChanged = true

--- a/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/triggers/ITriggerHandler.kt
+++ b/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/triggers/ITriggerHandler.kt
@@ -16,7 +16,7 @@ internal interface ITriggerHandler {
     /**
      * Called when a time-based trigger (dynamic trigger) will now evaluate to true.
      */
-    fun onTriggerConditionChanged()
+    fun onTriggerConditionChanged(triggerId: String)
 
     /**
      * Called when a new trigger has been added, or an existing trigger's value has been

--- a/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/triggers/impl/DynamicTriggerController.kt
+++ b/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/triggers/impl/DynamicTriggerController.kt
@@ -89,7 +89,7 @@ internal class DynamicTriggerController(
                 object : TimerTask() {
                     override fun run() {
                         scheduledMessages.remove(triggerId)
-                        events.fire { it.onTriggerConditionChanged() }
+                        events.fire { it.onTriggerConditionChanged(triggerId) }
                     }
                 },
                 triggerId,


### PR DESCRIPTION
# Description
## One Line Summary
Fix an issue with IAM with dynamic triggers like "SESSION_TIME" showing up repetitively after being dismissed.

## Details

### Motivation
Fix the incorrect app behavior when IAM with both custom trigger and session_time trigger continues to show up even it was dismissed.

### Scope
- This issue happens strictly when both a time based trigger like Session_Time and an in-app trigger of "IS NOT EQUAL" exist with AND. The first time both triggers evaluated to true, IAM shows up, gets dismissed, and will reevaluate the triggers again. In the reevaluation, the system first determines if there is only dynamic trigger. If there is, it forces evaluate to false to suppress the IAM from showing up again. But in this case, another in-app trigger exists and will always evaluate to true due to the IS NOT EQUAL characteristics we currently have, thus a repeating IAM occurs.
- This PR alters the logic on when to redisplay message so that we no longer make redisplay messages available to avoid duplicate redisplay of a same message. A message can be redisplayed if at least one trigger has changed or a new trigger is added when a dynamic trigger exists.

## Manual testing
Before the fix:
IAM setting to reproduce the issue:
![image](https://github.com/OneSignal/OneSignal-Android-SDK/assets/14221056/4c5c4272-3d8a-4bd8-a09d-81aa593d4b1d)
This IAM would show up 5 seconds after app start up and continue to show up after being dismissed.

After the fix:
1. IAM with whatever IS NOT 5 AND Session_Time > 5 with Every time trigger conditions are satisfied checked:
    - Result: This IAM will show up 5 seconds after app start up and will not show up again once dismissed. Whenever I add a new trigger, the IAM shows up again.
2. IAM with whatever = true AND Session_Time > 5 with Every time trigger conditions are satisfied checked:
    - Result: This IAM will not show up initially, but will show up if I add a trigger whatever = true EVERY TIME after 5 seconds of startup. If I add a trigger with an unrelated key, the IAM will not show.
3. IAM with a single trigger whatever2 = 2
    - Result: This IAM will not show up unless a trigger whatever2 = 2 is added. Any value for the same key that is not equals to 2 will not show the IAM. 
4. IAM with a single dynamic trigger Session_Time > 5
    - Result: This IAM will only show once 5 seconds after startup.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [x] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2137)
<!-- Reviewable:end -->
