### PR TITLE
Allow `preventDefault` to be fired up to two times

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/notifications/INotificationReceivedEvent.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/notifications/INotificationReceivedEvent.kt
@@ -53,6 +53,9 @@ interface INotificationReceivedEvent {
 
     /**
      * Call this to prevent OneSignal from displaying the notification automatically.
+     * This method can be called up to two times with false and then true, if processing time is needed.
+     * Typically this is only possible within a short
+     * time-frame (~30 seconds) after the notification is received on the device.
      * @param discard an [preventDefault] set to true to dismiss the notification with no
      * possibility of displaying it in the future.
      */

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/notifications/INotificationWillDisplayEvent.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/notifications/INotificationWillDisplayEvent.kt
@@ -41,6 +41,9 @@ interface INotificationWillDisplayEvent {
 
     /**
      * Call this to prevent OneSignal from displaying the notification automatically.
+     * This method can be called up to two times with false and then true, if processing time is needed.
+     * Typically this is only possible within a short
+     * time-frame (~30 seconds) after the notification is received on the device.
      * @param discard an [preventDefault] set to true to dismiss the notification with no
      * possibility of displaying it in the future.
      */

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/Notification.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/Notification.kt
@@ -3,7 +3,7 @@ package com.onesignal.notifications.internal
 import androidx.core.app.NotificationCompat
 import com.onesignal.common.safeJSONObject
 import com.onesignal.common.safeString
-import com.onesignal.common.threading.Waiter
+import com.onesignal.common.threading.WaiterWithValue
 import com.onesignal.core.internal.time.ITime
 import com.onesignal.debug.internal.logging.Logging
 import com.onesignal.notifications.BackgroundImageLayout
@@ -24,7 +24,11 @@ import org.json.JSONObject
  */
 class Notification : IDisplayableMutableNotification {
     var notificationExtender: NotificationCompat.Extender? = null
-    val displayWaiter: Waiter = Waiter()
+
+    /**
+     * Wake with true to display the notification, or false to discard it permanently.
+     */
+    val displayWaiter = WaiterWithValue<Boolean>()
 
     override var groupedNotifications: List<Notification>? = null
     override var androidNotificationId = 0
@@ -251,7 +255,7 @@ class Notification : IDisplayableMutableNotification {
     }
 
     override fun display() {
-        displayWaiter.wake()
+        displayWaiter.wake(true)
     }
 
     /**

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/NotificationReceivedEvent.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/NotificationReceivedEvent.kt
@@ -16,7 +16,14 @@ internal class NotificationReceivedEvent(
     }
 
     override fun preventDefault(discard: Boolean) {
-        Logging.debug("NotificationReceivedEvent.preventDefault()")
+        Logging.debug("NotificationReceivedEvent.preventDefault($discard)")
+
+        // If preventDefault(false) has already been called and it is now called again with
+        // preventDefault(true), the waiter is fired to discard this notification.
+        // This is necessary for wrapper SDKs that can call preventDefault(discard) twice.
+        if (isPreventDefault && discard) {
+            notification.displayWaiter.wake(false)
+        }
         isPreventDefault = true
         this.discard = discard
     }

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/NotificationWillDisplayEvent.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/NotificationWillDisplayEvent.kt
@@ -14,7 +14,14 @@ internal class NotificationWillDisplayEvent(
     }
 
     override fun preventDefault(discard: Boolean) {
-        Logging.debug("NotificationWillDisplayEvent.preventDefault()")
+        Logging.debug("NotificationWillDisplayEvent.preventDefault($discard)")
+
+        // If preventDefault(false) has already been called and it is now called again with
+        // preventDefault(true), the waiter is fired to discard this notification.
+        // This is necessary for wrapper SDKs that can call preventDefault(discard) twice.
+        if (isPreventDefault && discard) {
+            notification.displayWaiter.wake(false)
+        }
         isPreventDefault = true
         this.discard = discard
     }

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/generation/impl/NotificationGenerationProcessor.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/generation/impl/NotificationGenerationProcessor.kt
@@ -76,12 +76,11 @@ internal class NotificationGenerationProcessor(
                     if (notificationReceivedEvent.discard) {
                         wantsToDisplay = false
                     } else if (notificationReceivedEvent.isPreventDefault) {
-                        // wait on display waiter. If the caller calls `display` on the notification,
-                        // we will exit `waitForWake` and set `wantsToDisplay` to true. If the callback
-                        // never calls `display` we will timeout and never set `wantsToDisplay` to true.
                         wantsToDisplay = false
-                        notification.displayWaiter.waitForWake()
-                        wantsToDisplay = true
+                        // wait on display waiter. If the caller calls `display` or `preventDefault(true)` on the notification,
+                        // we will exit `waitForWake` and set `wantsToDisplay` to true or false respectively. If the callback
+                        // never calls `display` or `preventDefault(true)`, we will timeout and never update `wantsToDisplay`.
+                        wantsToDisplay = notification.displayWaiter.waitForWake()
                     }
                 }.join()
             }
@@ -110,12 +109,11 @@ internal class NotificationGenerationProcessor(
                             if (notificationWillDisplayEvent.discard) {
                                 wantsToDisplay = false
                             } else if (notificationWillDisplayEvent.isPreventDefault) {
-                                // wait on display waiter. If the caller calls `display` on the notification,
-                                // we will exit `waitForWake` and set `wantsToDisplay` to true. If the callback
-                                // never calls `display` we will timeout and never set `wantsToDisplay` to true.
                                 wantsToDisplay = false
-                                notification.displayWaiter.waitForWake()
-                                wantsToDisplay = true
+                                // wait on display waiter. If the caller calls `display` or `preventDefault(true)` on the notification,
+                                // we will exit `waitForWake` and set `wantsToDisplay` to true or false respectively. If the callback
+                                // never calls `display` or `preventDefault(true)`, we will timeout and never update `wantsToDisplay`.
+                                wantsToDisplay = notification.displayWaiter.waitForWake()
                             }
                         }.join()
                     }


### PR DESCRIPTION
# Description
## One Line Summary
Allow `preventDefault` to be fired up to two times with the `discard` parameter of `false` and then `true`, for the Received Event and the Display Event.

## Details
* The issue was that the event is passed to the developer's callback and the `discard` parameter is read when the callback returns. Then the logic continues on with that state.
* So, a second call to `preventDefault(true)` had no effect.
* Modify the notification display waiter to accept this second prevent default call.
* This is necessary for wrappers which may need to call this twice, once to capture the event internally and once from the developer's intent.
* `preventDefault(false)` can be called multiple times and has no effects due to no state change.


### Motivation
To allow https://github.com/OneSignal/OneSignal-Android-SDK/pull/2094 to work for wrappers.

### Scope
Calling preventDefault twice where the first does not discard and the second discards.

# Testing
## Unit testing

- Cleaned up NotificationGenerationProcessorTests helper methods
- Added 2 tests

## Manual testing

1. Test with `NotificationLifecycleListener` for the will display event.
2. Call `preventDefault()`
3. Delay 3 seconds and call `preventDefault(true)`
5. Delay 3 seconds and call `display()`
6. See that the notification will **not** display.
7. Do the same manual test with `NotificationServiceExtension` for the received event.

Also test there is no breaking of current behavior when preventDefault(discard: false) is called followed by display, will display the notification.

```java
@Override
public void onWillDisplay(@NonNull INotificationWillDisplayEvent event) {
    Log.v(Tag.LOG_TAG, "APP onWillDisplay fired with event: " + event);

    IDisplayableNotification notification = event.getNotification();
    JSONObject data = notification.getAdditionalData();

    event.preventDefault();

    Runnable preventDefaultAgain = () -> {
        try {
            Thread.sleep(3000);
        } catch (InterruptedException ignored) { }
        Log.v(Tag.LOG_TAG, "Dev App INotificationLifecycleListener calling prevent default: discard = true" );
        event.preventDefault(true);
    };

    Runnable callDisplay = () -> {
        try {
            Thread.sleep(6000);
        } catch (InterruptedException ignored) { }
        Log.v(Tag.LOG_TAG, "Dev App INotificationLifecycleListener calling DISPLAY");
        notification.display();
    };

    Thread t1 = new Thread(preventDefaultAgain);
    t1.start();
    Thread t2 = new Thread(callDisplay);
    t2.start();
}
```

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2138)
<!-- Reviewable:end -->
