### PR TITLE
Release 5.1.17

### DIFF
--- a/Examples/OneSignalDemo/app/build.gradle
+++ b/Examples/OneSignalDemo/app/build.gradle
@@ -84,12 +84,12 @@ dependencies {
     implementation 'com.github.bumptech.glide:glide:4.12.0'
 
     /** START - Google Play Builds **/
-    gmsImplementation('com.onesignal:OneSignal:5.1.16')
+    gmsImplementation('com.onesignal:OneSignal:5.1.17')
     /** END - Google Play Builds **/
 
     /** START - Huawei Builds **/
     // Omit Google / Firebase libraries for Huawei builds.
-    huaweiImplementation('com.onesignal:OneSignal:5.1.16') {
+    huaweiImplementation('com.onesignal:OneSignal:5.1.17') {
         exclude group: 'com.google.android.gms', module: 'play-services-gcm'
         exclude group: 'com.google.android.gms', module: 'play-services-analytics'
         exclude group: 'com.google.android.gms', module: 'play-services-location'

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/OneSignalUtils.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/OneSignalUtils.kt
@@ -6,7 +6,7 @@ object OneSignalUtils {
     /**
      * The version of this SDK.
      */
-    const val SDK_VERSION: String = "050116"
+    const val SDK_VERSION: String = "050117"
 
     fun isValidEmail(email: String): Boolean {
         if (email.isEmpty()) {

--- a/OneSignalSDK/settings.gradle
+++ b/OneSignalSDK/settings.gradle
@@ -3,7 +3,7 @@
 gradle.rootProject {
     allprojects {
         group = 'com.onesignal'
-        version = '5.1.16'
+        version = '5.1.17'
         configurations.all {
             resolutionStrategy.dependencySubstitution {
                 substitute(module('com.onesignal:OneSignal')).using(project(':OneSignal'))


### PR DESCRIPTION
🐛 Bug Fixes
- Revert a breaking change that causes a crash when calling requestPermission in a separate thread right after initWithContext. (https://github.com/OneSignal/OneSignal-Android-SDK/pull/2141)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2142)
<!-- Reviewable:end -->
