### PR TITLE
Remove fallback code for FCM pre-21.0.0

### DIFF
--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorFCM.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorFCM.kt
@@ -8,13 +8,6 @@ import com.google.firebase.messaging.FirebaseMessaging
 import com.onesignal.core.internal.application.IApplicationService
 import com.onesignal.core.internal.config.ConfigModelStore
 import com.onesignal.core.internal.device.IDeviceService
-import com.onesignal.debug.internal.logging.Logging
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
-import java.io.IOException
-import java.lang.reflect.InvocationTargetException
 import java.util.concurrent.ExecutionException
 
 internal class PushRegistratorFCM(
@@ -53,92 +46,32 @@ internal class PushRegistratorFCM(
         this.apiKey = fcpParams.apiKey ?: defaultApiKey
     }
 
-    @Throws(ExecutionException::class, InterruptedException::class, IOException::class)
+    @Throws(ExecutionException::class, InterruptedException::class)
     override suspend fun getToken(senderId: String): String {
         initFirebaseApp(senderId)
-        try {
-            return getTokenWithClassFirebaseMessaging()
-        } catch (e: NoClassDefFoundError) {
-            // Class or method wil be missing at runtime if firebase-message older than 21.0.0 is used.
-            Logging.info("FirebaseMessaging.getToken not found, attempting to use FirebaseInstanceId.getToken")
-        } catch (e: NoSuchMethodError) {
-            Logging.info("FirebaseMessaging.getToken not found, attempting to use FirebaseInstanceId.getToken")
-        }
-
-        // Fallback for firebase-message versions older than 21.0.0
-        return getTokenWithClassFirebaseInstanceId(senderId)
+        return getTokenWithClassFirebaseMessaging()
     }
 
-    // This method is only used if firebase-message older than 21.0.0 is in the app
-    // We are using reflection here so we can compile with firebase-message:22.0.0 and newer
-    //   - This version of Firebase has completely removed FirebaseInstanceId
-    @Deprecated("")
-    @Throws(IOException::class)
-    private suspend fun getTokenWithClassFirebaseInstanceId(senderId: String): String =
-        coroutineScope {
-            var token: String = ""
-            // The following code is equivalent to:
-            //   FirebaseInstanceId instanceId = FirebaseInstanceId.getInstance(firebaseApp);
-            //   return instanceId.getToken(senderId, FirebaseMessaging.INSTANCE_ID_SCOPE);
-            val exception: Exception =
-                try {
-                    val firebaseInstanceIdClass = Class.forName("com.google.firebase.iid.FirebaseInstanceId")
-                    val getInstanceMethod = firebaseInstanceIdClass.getMethod("getInstance", FirebaseApp::class.java)
-                    val instanceId = getInstanceMethod.invoke(null, firebaseApp)
-                    val getTokenMethod = instanceId.javaClass.getMethod("getToken", String::class.java, String::class.java)
-
-                    launch(Dispatchers.Default) {
-                        val tkn = getTokenMethod.invoke(instanceId, senderId, "FCM")
-                        token = tkn as String
-                    }
-
-                    return@coroutineScope token
-                } catch (e: ClassNotFoundException) {
-                    e
-                } catch (e: NoSuchMethodException) {
-                    e
-                } catch (e: IllegalAccessException) {
-                    e
-                } catch (e: InvocationTargetException) {
-                    e
-                }
-
-            throw Error(
-                "Reflection error on FirebaseInstanceId.getInstance(firebaseApp).getToken(senderId, FirebaseMessaging.INSTANCE_ID_SCOPE)",
-                exception,
-            )
-        }
-
-    // We use firebaseApp.get(FirebaseMessaging.class) instead of FirebaseMessaging.getInstance()
-    //   as the latter uses the default Firebase app. We need to use a custom Firebase app as
-    //   the senderId is provided at runtime.
     @Throws(ExecutionException::class, InterruptedException::class)
-    private suspend fun getTokenWithClassFirebaseMessaging(): String =
-        coroutineScope {
-            var token: String = ""
-
-            withContext(Dispatchers.Default) {
-                // FirebaseMessaging.getToken API was introduced in firebase-messaging:21.0.0
-                // We use firebaseApp.get(FirebaseMessaging.class) instead of FirebaseMessaging.getInstance()
-                //   as the latter uses the default Firebase app. We need to use a custom Firebase app as
-                //   the senderId is provided at runtime.
-                val fcmInstance = firebaseApp!!.get(FirebaseMessaging::class.java)
-                // FirebaseMessaging.getToken API was introduced in firebase-messaging:21.0.0
-                val tokenTask = fcmInstance.token
-                try {
-                    token = Tasks.await(tokenTask)
-                } catch (e: ExecutionException) {
-                    throw tokenTask.exception ?: e
-                }
-            }
-
-            return@coroutineScope token
+    private fun getTokenWithClassFirebaseMessaging(): String {
+        // We use firebaseApp.get(FirebaseMessaging.class) instead of FirebaseMessaging.getInstance()
+        //   as the latter uses the default Firebase app. We need to use a custom Firebase app as
+        //   the senderId is provided at runtime.
+        val fcmInstance = firebaseApp!!.get(FirebaseMessaging::class.java)
+        // FirebaseMessaging.getToken API was introduced in firebase-messaging:21.0.0
+        val tokenTask = fcmInstance.token
+        try {
+            return Tasks.await(tokenTask)
+        } catch (e: ExecutionException) {
+            throw tokenTask.exception ?: e
         }
+    }
 
     private fun initFirebaseApp(senderId: String) {
         if (firebaseApp != null) return
         val firebaseOptions =
-            FirebaseOptions.Builder()
+            FirebaseOptions
+                .Builder()
                 .setGcmSenderId(senderId)
                 .setApplicationId(appId)
                 .setApiKey(apiKey)


### PR DESCRIPTION
# Description
## One Line Summary
We bumped the minimum `firebase-messaging` version to `21.0.0` in the `build.gradle` a while ago but never cleaned up the old per-21.0.0 fallback code.

## Details
### Motivation
Cleaning up dead code to make the SDK a bit smaller and easier to read.

### Scope
Only effects FCM push token registration.

# Testing
## Manual testing
Tested on an Android 14 emulator.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2148)
<!-- Reviewable:end -->
