### PR TITLE
[Optimization] Init with context in background

### DIFF
--- a/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/application/MainApplication.java
+++ b/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/application/MainApplication.java
@@ -1,12 +1,13 @@
 package com.onesignal.sdktest.application;
 
+import android.annotation.SuppressLint;
 import android.os.StrictMode;
 import android.util.Log;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.multidex.MultiDexApplication;
 
+import com.onesignal.Continue;
 import com.onesignal.OneSignal;
 import com.onesignal.inAppMessages.IInAppMessageClickListener;
 import com.onesignal.inAppMessages.IInAppMessageClickEvent;
@@ -28,8 +29,10 @@ import com.onesignal.sdktest.util.SharedPreferenceUtil;
 import com.onesignal.user.state.IUserStateObserver;
 import com.onesignal.user.state.UserChangedState;
 import com.onesignal.user.state.UserState;
-
 import org.json.JSONObject;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 public class MainApplication extends MultiDexApplication {
     private static final int SLEEP_TIME_TO_MIMIC_ASYNC_OPERATION = 2000;
@@ -40,6 +43,7 @@ public class MainApplication extends MultiDexApplication {
             StrictMode.enableDefaults();
     }
 
+    @SuppressLint("NewApi")
     @Override
     public void onCreate() {
         super.onCreate();
@@ -54,7 +58,17 @@ public class MainApplication extends MultiDexApplication {
         }
 
         OneSignalNotificationSender.setAppId(appId);
+
         OneSignal.initWithContext(this, appId);
+
+        // Ensure calling requestPermission in a thread right after initWithContext does not crash
+        // This will reproduce result similar to Kotlin CouroutineScope.launch{}, which may potentially crash the app
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        @SuppressLint({"NewApi", "LocalSuppress"}) CompletableFuture<Void> future = CompletableFuture.runAsync(() -> {
+            OneSignal.getNotifications().requestPermission(true, Continue.none());
+        }, executor);
+        future.join(); // Waits for the task to complete
+        executor.shutdown();
 
         OneSignal.getInAppMessages().addLifecycleListener(new IInAppMessageLifecycleListener() {
             @Override

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/CoreModule.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/CoreModule.kt
@@ -32,7 +32,6 @@ import com.onesignal.core.internal.preferences.impl.PreferencesService
 import com.onesignal.core.internal.purchases.impl.TrackAmazonPurchase
 import com.onesignal.core.internal.purchases.impl.TrackGooglePurchase
 import com.onesignal.core.internal.startup.IStartableService
-import com.onesignal.core.internal.startup.StartupService
 import com.onesignal.core.internal.time.ITime
 import com.onesignal.core.internal.time.impl.Time
 import com.onesignal.inAppMessages.IInAppMessagesManager
@@ -54,7 +53,6 @@ internal class CoreModule : IModule {
         builder.register<DeviceService>().provides<IDeviceService>()
         builder.register<Time>().provides<ITime>()
         builder.register<DatabaseProvider>().provides<IDatabaseProvider>()
-        builder.register<StartupService>().provides<StartupService>()
         builder.register<InstallIdService>().provides<IInstallIdService>()
 
         // Params (Config)

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/permissions/impl/RequestPermissionService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/permissions/impl/RequestPermissionService.kt
@@ -10,7 +10,7 @@ import com.onesignal.core.internal.permissions.IRequestPermissionService
 
 internal class RequestPermissionService(
     private val _application: IApplicationService,
-) : Activity(), IRequestPermissionService {
+) : IRequestPermissionService {
     var waiting = false
     var fallbackToSettings = false
     var shouldShowRequestPermissionRationaleBeforeRequest = false

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/startup/StartupService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/startup/StartupService.kt
@@ -1,18 +1,18 @@
 package com.onesignal.core.internal.startup
 
+import com.onesignal.common.services.ServiceProvider
+
 internal class StartupService(
-    private val _bootstrapServices: List<IBootstrapService>,
-    private val _startableServices: List<IStartableService>,
+    private val services: ServiceProvider,
 ) {
     fun bootstrap() {
-        // now that we have the params initialized, start everything else up
-        for (bootstrapService in _bootstrapServices)
-            bootstrapService.bootstrap()
+        services.getAllServices<IBootstrapService>().forEach { it.bootstrap() }
     }
 
-    fun start() {
-        // now that we have the params initialized, start everything else up
-        for (startableService in _startableServices)
-            startableService.start()
+    // schedule to start all startable services in a separate thread
+    fun scheduleStart() {
+        Thread {
+            services.getAllServices<IStartableService>().forEach { it.start() }
+        }.start()
     }
 }

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/startup/StartupServiceTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/startup/StartupServiceTests.kt
@@ -1,16 +1,30 @@
 package com.onesignal.core.internal.startup
 
+import com.onesignal.common.services.ServiceBuilder
+import com.onesignal.common.services.ServiceProvider
 import com.onesignal.debug.LogLevel
 import com.onesignal.debug.internal.logging.Logging
 import io.kotest.assertions.throwables.shouldThrowUnit
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import io.mockk.coVerifyOrder
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.verify
 
 class StartupServiceTests : FunSpec({
+    fun setupServiceProvider(
+        bootstrapServices: List<IBootstrapService>,
+        startableServices: List<IStartableService>,
+    ): ServiceProvider {
+        val serviceBuilder = ServiceBuilder()
+        for (reg in bootstrapServices)
+            serviceBuilder.register(reg).provides<IBootstrapService>()
+        for (reg in startableServices)
+            serviceBuilder.register(reg).provides<IStartableService>()
+        return serviceBuilder.build()
+    }
 
     beforeAny {
         Logging.logLevel = LogLevel.NONE
@@ -18,7 +32,7 @@ class StartupServiceTests : FunSpec({
 
     test("bootstrap with no IBootstrapService dependencies is a no-op") {
         // Given
-        val startupService = StartupService(listOf(), listOf())
+        val startupService = StartupService(setupServiceProvider(listOf(), listOf()))
 
         // When
         startupService.bootstrap()
@@ -31,7 +45,7 @@ class StartupServiceTests : FunSpec({
         val mockBootstrapService1 = spyk<IBootstrapService>()
         val mockBootstrapService2 = spyk<IBootstrapService>()
 
-        val startupService = StartupService(listOf(mockBootstrapService1, mockBootstrapService2), listOf())
+        val startupService = StartupService(setupServiceProvider(listOf(mockBootstrapService1, mockBootstrapService2), listOf()))
 
         // When
         startupService.bootstrap()
@@ -49,7 +63,7 @@ class StartupServiceTests : FunSpec({
         every { mockBootstrapService1.bootstrap() } throws exception
         val mockBootstrapService2 = spyk<IBootstrapService>()
 
-        val startupService = StartupService(listOf(mockBootstrapService1, mockBootstrapService2), listOf())
+        val startupService = StartupService(setupServiceProvider(listOf(mockBootstrapService1, mockBootstrapService2), listOf()))
 
         // When
         val actualException =
@@ -63,40 +77,41 @@ class StartupServiceTests : FunSpec({
         verify(exactly = 0) { mockBootstrapService2.bootstrap() }
     }
 
-    test("startup will call all IStartableService dependencies successfully") {
+    test("startup will call all IStartableService dependencies successfully after a short delay") {
         // Given
         val mockStartupService1 = spyk<IStartableService>()
         val mockStartupService2 = spyk<IStartableService>()
 
-        val startupService = StartupService(listOf(), listOf(mockStartupService1, mockStartupService2))
+        val startupService = StartupService(setupServiceProvider(listOf(), listOf(mockStartupService1, mockStartupService2)))
 
         // When
-        startupService.start()
+        startupService.scheduleStart()
 
         // Then
+        Thread.sleep(10)
         verify(exactly = 1) { mockStartupService1.start() }
         verify(exactly = 1) { mockStartupService2.start() }
     }
 
-    test("startup will propagate exception when an IStartableService throws an exception") {
+    test("scheduleStart does not block main thread") {
         // Given
-        val exception = Exception("SOMETHING BAD")
-
-        val mockStartableService1 = mockk<IStartableService>()
-        every { mockStartableService1.start() } throws exception
+        val mockStartableService1 = spyk<IStartableService>()
         val mockStartableService2 = spyk<IStartableService>()
+        val mockStartableService3 = spyk<IStartableService>()
 
-        val startupService = StartupService(listOf(), listOf(mockStartableService1, mockStartableService2))
+        val startupService = StartupService(setupServiceProvider(listOf(), listOf(mockStartableService1, mockStartableService2)))
 
         // When
-        val actualException =
-            shouldThrowUnit<Exception> {
-                startupService.start()
-            }
+        startupService.scheduleStart()
+        mockStartableService3.start()
 
         // Then
-        actualException shouldBe exception
-        verify(exactly = 1) { mockStartableService1.start() }
-        verify(exactly = 0) { mockStartableService2.start() }
+        Thread.sleep(10)
+        coVerifyOrder {
+            // service3 will call start() first even though service1 and service2 are scheduled first
+            mockStartableService3.start()
+            mockStartableService1.start()
+            mockStartableService2.start()
+        }
     }
 })


### PR DESCRIPTION
# Description
## One Line Summary
Move start call of unused services off the main thread to make the initWithContext more efficient.

## Details

### Motivation
Our SDK initialization is currently taking longer to finish compare to some other SDKs. One of the reason is we construct service components like Location Manager or IAM Manager during the initialization phrase when they are not really needed until later. This PR aims to move the initialization of these services to background thread so they don't slow down the overall SDK initialization.

### Scope
The retrieval of services that were changed to initialize in background is not longer from a saved instance in OneSignalImp.kt. Instead, each of these components has a getter that retrieve its instance from the service provider. 

# Testing
## Manual testing
* Bench mark tests: I measure how long the initialization takes by tracking the start and finish time when 'initWithContext' is called. In my testing in a pixel 3a API 34 emulator, it took an average of 600 ms to complete initialization before the change and around 300 ms after the change, which is around ~50% faster. 
* Normal SDK behavior test: Send notification, add tags, and outcome work.
* Calling 'initWithContext' in a background thread: no error and the demo app works as normal. Other OneSignal calls can only work if they are called after 'initWithContext' and in the same thread.
* Calling 'requestPermission' in a background thread: a test case is added in MainApplication to ensure the app won't crash by calling requestPermission in a thread right after initWithContext.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2151)
<!-- Reviewable:end -->
