### PR TITLE
Release 5.1.18

### DIFF
--- a/Examples/OneSignalDemo/app/build.gradle
+++ b/Examples/OneSignalDemo/app/build.gradle
@@ -83,12 +83,12 @@ dependencies {
     implementation 'com.github.bumptech.glide:glide:4.12.0'
 
     /** START - Google Play Builds **/
-    gmsImplementation('com.onesignal:OneSignal:5.1.17')
+    gmsImplementation('com.onesignal:OneSignal:5.1.18')
     /** END - Google Play Builds **/
 
     /** START - Huawei Builds **/
     // Omit Google / Firebase libraries for Huawei builds.
-    huaweiImplementation('com.onesignal:OneSignal:5.1.17') {
+    huaweiImplementation('com.onesignal:OneSignal:5.1.18') {
         exclude group: 'com.google.android.gms', module: 'play-services-gcm'
         exclude group: 'com.google.android.gms', module: 'play-services-analytics'
         exclude group: 'com.google.android.gms', module: 'play-services-location'

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/OneSignalUtils.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/OneSignalUtils.kt
@@ -6,7 +6,7 @@ object OneSignalUtils {
     /**
      * The version of this SDK.
      */
-    const val SDK_VERSION: String = "050117"
+    const val SDK_VERSION: String = "050118"
 
     fun isValidEmail(email: String): Boolean {
         if (email.isEmpty()) {

--- a/OneSignalSDK/settings.gradle
+++ b/OneSignalSDK/settings.gradle
@@ -3,7 +3,7 @@
 gradle.rootProject {
     allprojects {
         group = 'com.onesignal'
-        version = '5.1.17'
+        version = '5.1.18'
         configurations.all {
             resolutionStrategy.dependencySubstitution {
                 substitute(module('com.onesignal:OneSignal')).using(project(':OneSignal'))


### PR DESCRIPTION
🐛 Bug Fixes
- IAM with dynamic trigger showing forever (https://github.com/OneSignal/OneSignal-Android-SDK/pull/2137)
- Allow preventDefault to be fired up to two times (https://github.com/OneSignal/OneSignal-Android-SDK/pull/2138)

✨ Improvements
- Remove fallback code for FCM pre-21.0.0 (https://github.com/OneSignal/OneSignal-Android-SDK/pull/2148)
- Clean up Android Support Library references, drop dependency on androidx.legacy, & Android 4.4 and older code (https://github.com/OneSignal/OneSignal-Android-SDK/pull/2147)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2156)
<!-- Reviewable:end -->
