### PR TITLE
Recover null onesignal ID crashes for Operations

### DIFF
--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/common/ModelingTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/common/ModelingTests.kt
@@ -9,8 +9,8 @@ import com.onesignal.core.internal.preferences.PreferenceOneSignalKeys
 import com.onesignal.core.internal.preferences.PreferenceStores
 import com.onesignal.mocks.MockHelper
 import com.onesignal.mocks.MockPreferencesService
-import com.onesignal.user.internal.operations.SetPropertyOperation
-import com.onesignal.user.internal.operations.SetTagOperation
+import com.onesignal.user.internal.operations.LoginUserFromSubscriptionOperation
+import com.onesignal.user.internal.operations.LoginUserOperation
 import com.onesignal.user.internal.subscriptions.SubscriptionModel
 import com.onesignal.user.internal.subscriptions.SubscriptionModelStore
 import io.kotest.core.spec.style.FunSpec
@@ -150,7 +150,7 @@ class ModelingTests : FunSpec({
         val operationModelStore = OperationModelStore(prefs)
         val jsonArray = JSONArray()
 
-        val cachedOperation = SetTagOperation()
+        val cachedOperation = LoginUserFromSubscriptionOperation()
         cachedOperation.id = UUID.randomUUID().toString()
         // Add duplicate operations to the cache
         jsonArray.put(cachedOperation.toJSON())
@@ -158,7 +158,7 @@ class ModelingTests : FunSpec({
         prefs.saveString(PreferenceStores.ONESIGNAL, PreferenceOneSignalKeys.MODEL_STORE_PREFIX + "operations", jsonArray.toString())
 
         // When - adding an operation first and then loading from cache
-        val newOperation = SetPropertyOperation()
+        val newOperation = LoginUserOperation()
         newOperation.id = UUID.randomUUID().toString()
         operationModelStore.add(newOperation)
         operationModelStore.loadOperations()

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/operations/OperationModelStoreTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/operations/OperationModelStoreTests.kt
@@ -1,0 +1,66 @@
+package com.onesignal.core.internal.operations
+
+import com.onesignal.core.internal.operations.impl.OperationModelStore
+import com.onesignal.core.internal.preferences.PreferenceOneSignalKeys
+import com.onesignal.core.internal.preferences.PreferenceStores
+import com.onesignal.debug.LogLevel
+import com.onesignal.debug.internal.logging.Logging
+import com.onesignal.mocks.MockPreferencesService
+import com.onesignal.user.internal.operations.LoginUserOperation
+import com.onesignal.user.internal.operations.SetPropertyOperation
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import org.json.JSONArray
+import org.json.JSONObject
+import java.util.UUID
+
+class OperationModelStoreTests : FunSpec({
+
+    beforeAny {
+        Logging.logLevel = LogLevel.NONE
+    }
+
+    test("does not load invalid cached operations") {
+        // Given
+        val prefs = MockPreferencesService()
+        val operationModelStore = OperationModelStore(prefs)
+        val jsonArray = JSONArray()
+
+        // 1. Create a VALID Operation with onesignalId
+        val validOperation = SetPropertyOperation(UUID.randomUUID().toString(), UUID.randomUUID().toString(), "property", "value")
+        validOperation.id = UUID.randomUUID().toString()
+
+        // 2. Create a VALID operation missing onesignalId
+        val validOperationMissingOnesignalId = LoginUserOperation()
+        validOperationMissingOnesignalId.id = UUID.randomUUID().toString()
+
+        // 3. Create an INVALID Operation missing onesignalId
+        val invalidOperationMissingOnesignalId = SetPropertyOperation()
+        invalidOperationMissingOnesignalId.id = UUID.randomUUID().toString()
+
+        // 4. Create an INVALID Operation missing operation name
+        val invalidOperationMissingName =
+            JSONObject()
+                .put("app_id", UUID.randomUUID().toString())
+                .put("onesignalId", UUID.randomUUID().toString())
+                .put("id", UUID.randomUUID().toString())
+
+        // Add the Operations to the cache
+        jsonArray.put(validOperation.toJSON())
+        jsonArray.put(validOperationMissingOnesignalId.toJSON())
+        jsonArray.put(invalidOperationMissingOnesignalId.toJSON())
+        jsonArray.put(invalidOperationMissingName)
+        prefs.saveString(PreferenceStores.ONESIGNAL, PreferenceOneSignalKeys.MODEL_STORE_PREFIX + "operations", jsonArray.toString())
+
+        // When
+        operationModelStore.loadOperations()
+
+        // Then
+        operationModelStore.list().count() shouldBe 2
+        operationModelStore.get(validOperation.id) shouldNotBe null
+        operationModelStore.get(validOperationMissingOnesignalId.id) shouldNotBe null
+        operationModelStore.get(invalidOperationMissingOnesignalId.id) shouldBe null
+        operationModelStore.get(invalidOperationMissingName["id"] as String) shouldBe null
+    }
+})


### PR DESCRIPTION
# Description
## One Line Summary
Don't uncache invalid Operations that are missing onesignalId in order to prevent repetitive crashes when they go on to be processed.

## Details

### Motivation
Crash report showing high-volume repetitive crashes happening for a low volume of users.
- Crash report shows `onesignalId` is `null` for an UpdateSubscriptionOperation
- Recovers those users
- Does _not_ prevent the first crash. This is rare and only reported by one app, so we don't want to hide any issues if we start receiving increased reports of this crash. This fix will prevent the repetitive nature of the crash and allow recovery.
- **Note:** this repetitive crash should not typically happen as this Operation should not be instantiated in the first place due to null checks, but this appears to have happened for the reporting app due to more aggressive minification that removes all Kotlin enforced null checks

```
Fatal Exception: java.lang.NullPointerException: Attempt to invoke virtual method 'boolean java.lang.String.startsWith(java.lang.String)' on a null object reference
       at kotlin.text.StringsKt__StringsJVMKt.startsWith(StringsJVM.kt:421)
       at kotlin.text.StringsKt__StringsJVMKt.startsWith$default(StringsJVM.kt:419)
       at com.onesignal.common.IDManager.isLocalId(IDManager.kt:28)
       at com.onesignal.user.internal.operations.UpdateSubscriptionOperation.getCanStartExecute(UpdateSubscriptionOperation.kt:87)
        ...
```

### Investigation
- Not able to reproduce a scenario where `UpdateSubscriptionOperation` would get created without a `onesignalId`
- This could mean a subscription property was changed before `initWithContext` finishes setting the local onesignalId
- This could also mean the identity model's onesignalId is set to from nonnull to null at the moment this operation is created
- This could also be the identity model in the store is overwritten with an identity model that is missing onesignalId or by a blank Identity Model
- I was not able to recreate any of the above scenarios naturally

### Scope
Basically drop any Operation that is invalid and would not be sendable.

# Testing
## Unit testing
- Add new unit test that uncaches valid and invalid Operations

## Manual testing
**Device: Emulator Pixel 3 API 33**
- Limited ability to test manually due to inability to reproduce
- Attempted multiple paths of reproduction naturally
- Force reproduction by instantiating blank `UpdateSubscriptionOperation` directly

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2157)
<!-- Reviewable:end -->
