### PR TITLE
Fix: Don't retry IAM display if 410 is received from backend

### DIFF
--- a/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/InAppMessagesManager.kt
+++ b/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/InAppMessagesManager.kt
@@ -106,8 +106,6 @@ internal class InAppMessagesManager(
     private val fetchIAMMutex = Mutex()
     private var lastTimeFetchedIAMs: Long? = null
 
-    private val lock = Any()
-
     override var paused: Boolean
         get() = _state.paused
         set(value) {
@@ -269,7 +267,7 @@ internal class InAppMessagesManager(
         Logging.debug("InAppMessagesManager.evaluateInAppMessages()")
         val messagesToQueue = mutableListOf<InAppMessage>()
 
-        synchronized(lock) {
+        synchronized(messages) {
             for (message in messages) {
                 if (_triggerController.evaluateMessageTriggers(message)) {
                     setDataForRedisplay(message)
@@ -466,7 +464,7 @@ internal class InAppMessagesManager(
         newTriggersKeys: Collection<String>,
         isNewTriggerAdded: Boolean,
     ) {
-        synchronized(lock) {
+        synchronized(messages) {
             for (message in messages) {
                 val isMessageDisplayed = redisplayedInAppMessages.contains(message)
                 val isTriggerOnMessage =

--- a/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/InAppMessagesManager.kt
+++ b/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/InAppMessagesManager.kt
@@ -79,7 +79,7 @@ internal class InAppMessagesManager(
 
     // IAMs loaded remotely from on_session
     //   If on_session won't be called this will be loaded from cache
-    private var messages: List<InAppMessage> = listOf()
+    private var messages: MutableList<InAppMessage> = mutableListOf()
 
     // IAMs that have been dismissed by the user
     //   This mean they have already displayed to the user
@@ -255,7 +255,7 @@ internal class InAppMessagesManager(
         val newMessages = _backend.listInAppMessages(appId, subscriptionId)
 
         if (newMessages != null) {
-            this.messages = newMessages
+            this.messages = newMessages as MutableList<InAppMessage>
             evaluateInAppMessages()
         }
     }
@@ -390,6 +390,7 @@ internal class InAppMessagesManager(
                 queueMessageForDisplay(messageToDisplay!!)
             } else if (result == false) {
                 _state.inAppMessageIdShowing = null
+                messages.remove(messageToDisplay)
                 messageWasDismissed(messageToDisplay!!, true)
             }
         }


### PR DESCRIPTION
# Description
## One Line Summary
Don't retry IAM display if 410 is received from backend

## Details

### Motivation
In instances where an IAM is disabled mid-session, a 410 is received and is caught in a retrying loop. This change will prevent the retry and just not display the IAM, since it just become disabled.

### Scope
Changes to `InAppMessagesManager` only.

Since this change involves changing the `messages` list, synchronization was added to `makeRedisplayMessagesAvailableWithTriggers` and `attemptToShowInAppMessage` to prevent concurrent modification issues. `evaluateInAppMessages` was further updated to collect messages for display inside a synchronized block and process them outside to avoid suspension points within critical sections.

# Testing

## Manual testing
Forced reproduction by setting breakpoint right before IAM is set to display, pausing the IAM from the dashboard, then resuming app flow. A 410 will result.

After updating the code, tested on an Android 14 emulator to see that app resumes normally after IAM is paused in the dashboard. Subsequent 410s are not received and app resumes as expected.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [X] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2158)
<!-- Reviewable:end -->
