### PR TITLE
Add option to default to HMS over FCM

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/device/IDeviceService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/device/IDeviceService.kt
@@ -11,6 +11,9 @@ interface IDeviceService {
     val hasAllHMSLibrariesForPushKit: Boolean
     val hasFCMLibrary: Boolean
     val jetpackLibraryStatus: JetpackLibraryStatus
+    val supportsHMS: Boolean
+
+    fun supportsGooglePush(): Boolean
 
     enum class JetpackLibraryStatus {
         MISSING,

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/device/impl/DeviceService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/device/impl/DeviceService.kt
@@ -74,7 +74,7 @@ internal class DeviceService(private val _applicationService: IApplicationServic
             return IDeviceService.JetpackLibraryStatus.OK
         }
 
-    private fun supportsGooglePush(): Boolean {
+    override fun supportsGooglePush(): Boolean {
         // 1. If app does not have the FCM library it won't support Google push
         return if (!hasFCMLibrary) false else isGMSInstalledAndEnabled
 
@@ -116,7 +116,7 @@ internal class DeviceService(private val _applicationService: IApplicationServic
             }
         }
 
-    private val supportsHMS: Boolean
+    override val supportsHMS: Boolean
         get() {
             // 1. App should have the HMSAvailability for best detection and must have PushKit libraries
             return if (!hasHMSAvailabilityLibrary() || !hasAllHMSLibrariesForPushKit) false else isHMSCoreInstalledAndEnabled()

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/device/impl/DeviceService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/device/impl/DeviceService.kt
@@ -40,11 +40,11 @@ internal class DeviceService(private val _applicationService: IApplicationServic
         get() {
             if (supportsADM()) return IDeviceService.DeviceType.Fire
 
-            val supportsHMS: Boolean = supportsHMS
+            val supportsHMS = supportsHMS
             val supportsFCM = supportsGooglePush()
 
             if (supportsFCM && supportsHMS) {
-                val context: Context = _applicationService.appContext
+                val context = _applicationService.appContext
                 val preferHMS = AndroidUtils.getManifestMetaBoolean(context, PREFER_HMS_METADATA_NAME)
                 return if (preferHMS) IDeviceService.DeviceType.Huawei else IDeviceService.DeviceType.Android
             }

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/device/DeviceServiceTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/device/DeviceServiceTests.kt
@@ -1,0 +1,81 @@
+package com.onesignal.core.internal.device
+
+import androidx.test.core.app.ApplicationProvider
+import br.com.colman.kotest.android.extensions.robolectric.RobolectricTest
+import com.onesignal.common.AndroidUtils
+import com.onesignal.core.internal.device.impl.DeviceService
+import com.onesignal.mocks.MockHelper
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.spyk
+
+@RobolectricTest
+class DeviceServiceTests : FunSpec({
+    test("devicetype is Huawei when preferHMS manifest value is true when a device supports HMS and FCM") {
+        // Given
+        val mockApplicationService = MockHelper.applicationService()
+        every { mockApplicationService.appContext } returns ApplicationProvider.getApplicationContext()
+
+        val mockDeviceService =
+            spyk(
+                DeviceService(
+                    mockApplicationService,
+                ),
+            )
+        every { mockDeviceService.supportsHMS } returns true
+        every { mockDeviceService.supportsGooglePush() } returns true
+        mockkObject(AndroidUtils)
+        every { AndroidUtils.getManifestMetaBoolean(ApplicationProvider.getApplicationContext(), "com.onesignal.preferHMS") } returns true
+
+        // When
+        val deviceType = mockDeviceService.deviceType
+
+        // Then
+        deviceType shouldBe IDeviceService.DeviceType.Huawei
+    }
+
+    test("devicetype is FCM when preferHMS manifest value is false when a device supports HMS and FCM") {
+        // Given
+        val mockApplicationService = MockHelper.applicationService()
+        every { mockApplicationService.appContext } returns ApplicationProvider.getApplicationContext()
+
+        val mockDeviceService =
+            spyk(
+                DeviceService(
+                    mockApplicationService,
+                ),
+            )
+        every { mockDeviceService.supportsHMS } returns true
+        every { mockDeviceService.supportsGooglePush() } returns true
+        mockkObject(AndroidUtils)
+        every { AndroidUtils.getManifestMetaBoolean(ApplicationProvider.getApplicationContext(), "com.onesignal.preferHMS") } returns false
+
+        // When
+        val deviceType = mockDeviceService.deviceType
+
+        // Then
+        deviceType shouldBe IDeviceService.DeviceType.Android
+    }
+
+    test("devicetype is FCM when preferHMS manifest value is missing when a device supports HMS and FCM") {
+        // Given
+        val mockApplicationService = MockHelper.applicationService()
+        every { mockApplicationService.appContext } returns ApplicationProvider.getApplicationContext()
+
+        val mockDeviceService =
+            spyk(
+                DeviceService(
+                    mockApplicationService,
+                ),
+            )
+        every { mockDeviceService.supportsHMS } returns true
+        every { mockDeviceService.supportsGooglePush() } returns true
+        // When
+        val deviceType = mockDeviceService.deviceType
+
+        // Then
+        deviceType shouldBe IDeviceService.DeviceType.Android
+    }
+})

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/device/DeviceServiceTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/device/DeviceServiceTests.kt
@@ -15,15 +15,7 @@ import io.mockk.spyk
 class DeviceServiceTests : FunSpec({
     test("devicetype is Huawei when preferHMS manifest value is true when a device supports HMS and FCM") {
         // Given
-        val mockApplicationService = MockHelper.applicationService()
-        every { mockApplicationService.appContext } returns ApplicationProvider.getApplicationContext()
-
-        val mockDeviceService =
-            spyk(
-                DeviceService(
-                    mockApplicationService,
-                ),
-            )
+        val mockDeviceService = Mocks().deviceService
         every { mockDeviceService.supportsHMS } returns true
         every { mockDeviceService.supportsGooglePush() } returns true
         mockkObject(AndroidUtils)
@@ -38,15 +30,7 @@ class DeviceServiceTests : FunSpec({
 
     test("devicetype is FCM when preferHMS manifest value is false when a device supports HMS and FCM") {
         // Given
-        val mockApplicationService = MockHelper.applicationService()
-        every { mockApplicationService.appContext } returns ApplicationProvider.getApplicationContext()
-
-        val mockDeviceService =
-            spyk(
-                DeviceService(
-                    mockApplicationService,
-                ),
-            )
+        val mockDeviceService = Mocks().deviceService
         every { mockDeviceService.supportsHMS } returns true
         every { mockDeviceService.supportsGooglePush() } returns true
         mockkObject(AndroidUtils)
@@ -61,17 +45,10 @@ class DeviceServiceTests : FunSpec({
 
     test("devicetype is FCM when preferHMS manifest value is missing when a device supports HMS and FCM") {
         // Given
-        val mockApplicationService = MockHelper.applicationService()
-        every { mockApplicationService.appContext } returns ApplicationProvider.getApplicationContext()
-
-        val mockDeviceService =
-            spyk(
-                DeviceService(
-                    mockApplicationService,
-                ),
-            )
+        val mockDeviceService = Mocks().deviceService
         every { mockDeviceService.supportsHMS } returns true
         every { mockDeviceService.supportsGooglePush() } returns true
+
         // When
         val deviceType = mockDeviceService.deviceType
 
@@ -79,3 +56,20 @@ class DeviceServiceTests : FunSpec({
         deviceType shouldBe IDeviceService.DeviceType.Android
     }
 })
+
+private class Mocks {
+    val applicationService =
+        run {
+            val mockApplicationService = MockHelper.applicationService()
+            every { mockApplicationService.appContext } returns ApplicationProvider.getApplicationContext()
+            mockApplicationService
+        }
+
+    val deviceService: DeviceService by lazy {
+        spyk(
+            DeviceService(
+                applicationService,
+            ),
+        )
+    }
+}


### PR DESCRIPTION
# Description
## One Line Summary
Read a manifest metadata boolean to allow apps to prefer HMS over FCM for devices that can receive both.

## Details
Apps can add the following to their `AndroidManifest.xml`
`<meta-data android:name="com.onesignal.preferHMS"
            android:value="true"/>`

This setting will allow devices with both HMS and FCM capabilities to use HMS rather than the default of FCM.

**I have left in the testing commits for review, but will rebase prior to merge. The only changed file is `DeviceService.kt`**

### Motivation
Allows apps to message users who move in and out of zones reachable by FCM, but can always receive HMS.

### Scope
subscription type

# Testing
## Unit testing
n/a

## Manual testing
Tested on Huawei device. I have left in 3 testing commits if reviewers would like to test. 

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2163)
<!-- Reviewable:end -->
