### PR TITLE
Fix ending an already ended session

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/background/IBackgroundService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/background/IBackgroundService.kt
@@ -4,9 +4,9 @@ import androidx.annotation.WorkerThread
 
 /**
  * Implement and provide this interface as part of service registration to indicate the service
- * wants to be instantiated and its [backgroundRun] function called when the app is in the background.  The
- * background process is initiated when the application is no longer in focus.  Each background
- * service's [scheduleBackgroundRunIn] will be analyzed to determine when [backgroundRun] should be called.
+ * wants to be instantiated and its [backgroundRun] function called when the app is in the background.
+ * Each background service's [scheduleBackgroundRunIn] will be analyzed to determine when
+ * [backgroundRun] should be called.
  */
 interface IBackgroundService {
     /**
@@ -16,7 +16,12 @@ interface IBackgroundService {
     val scheduleBackgroundRunIn: Long?
 
     /**
-     * Run the background service
+     * Run the background service.
+     * WARNING: This may not follow your scheduleBackgroundRunIn schedule:
+     *       1. May run more often as the lowest scheduleBackgroundRunIn
+     *       value is used across the SDK.
+     *       2. Android doesn't guarantee exact timing on when the job is run,
+     *       so it's possible for it to be delayed by a few minutes.
      */
     @WorkerThread
     suspend fun backgroundRun()

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/session/internal/outcomes/impl/OutcomeEventsRepository.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/session/internal/outcomes/impl/OutcomeEventsRepository.kt
@@ -8,6 +8,7 @@ import com.onesignal.session.internal.influence.Influence
 import com.onesignal.session.internal.influence.InfluenceChannel
 import com.onesignal.session.internal.influence.InfluenceType
 import com.onesignal.session.internal.influence.InfluenceType.Companion.fromString
+import com.onesignal.session.internal.outcomes.migrations.RemoveZeroSessionTimeRecords
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.json.JSONArray
@@ -101,6 +102,7 @@ internal class OutcomeEventsRepository(
     override suspend fun getAllEventsToSend(): List<OutcomeEventParams> {
         val events: MutableList<OutcomeEventParams> = ArrayList()
         withContext(Dispatchers.IO) {
+            RemoveZeroSessionTimeRecords.run(_databaseProvider)
             _databaseProvider.os.query(OutcomeEventsTable.TABLE_NAME) { cursor ->
                 if (cursor.moveToFirst()) {
                     do {

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/session/internal/outcomes/migrations/RemoveZeroSessionTimeRecords.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/session/internal/outcomes/migrations/RemoveZeroSessionTimeRecords.kt
@@ -1,0 +1,24 @@
+package com.onesignal.session.internal.outcomes.migrations
+
+import com.onesignal.core.internal.database.IDatabaseProvider
+import com.onesignal.session.internal.outcomes.impl.OutcomeEventsTable
+
+/**
+ * Purpose: Clean up invalid cached os__session_duration outcome records
+ * with zero session_time produced in SDK versions 5.1.15 to 5.1.20 so we stop
+ * sending these requests to the backend.
+ *
+ * Issue: SessionService.backgroundRun() didn't account for it being run more
+ * than one time in the background, when this happened it would create a
+ * outcome record with zero time which is invalid.
+ */
+object RemoveZeroSessionTimeRecords {
+    fun run(databaseProvider: IDatabaseProvider) {
+        databaseProvider.os.delete(
+            OutcomeEventsTable.TABLE_NAME,
+            OutcomeEventsTable.COLUMN_NAME_NAME + " = \"os__session_duration\"" +
+                " AND " + OutcomeEventsTable.COLUMN_NAME_SESSION_TIME + " = 0",
+            null,
+        )
+    }
+}

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/session/internal/session/SessionModel.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/session/internal/session/SessionModel.kt
@@ -16,7 +16,10 @@ class SessionModel : Model() {
         }
 
     /**
-     * Whether the session is valid.
+     * Indicates if there is an active session.
+     * True when app is in the foreground.
+     * Also true in the background for a short period of time (default 30s)
+     * as a debouncing mechanism.
      */
     var isValid: Boolean
         get() = getBooleanProperty(::isValid.name) { false }

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/session/internal/session/SessionServiceTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/session/internal/session/SessionServiceTests.kt
@@ -86,10 +86,10 @@ class SessionServiceTests : FunSpec({
 
         // Then
         sessionModelStore.model.isValid shouldBe true
-        sessionModelStore.model.startTime shouldBe startTime
+        sessionModelStore.model.startTime shouldBe mocks.currentTime
         sessionModelStore.model.focusTime shouldBe mocks.currentTime
-        verify(exactly = 1) { mocks.spyCallback.onSessionActive() }
-        verify(exactly = 0) { mocks.spyCallback.onSessionStarted() }
+        verify(exactly = 0) { mocks.spyCallback.onSessionActive() }
+        verify(exactly = 1) { mocks.spyCallback.onSessionStarted() }
     }
 
     test("session active duration updated when unfocused") {
@@ -139,5 +139,20 @@ class SessionServiceTests : FunSpec({
         // Then
         sessionModelStore.model.isValid shouldBe false
         verify(exactly = 1) { mocks.spyCallback.onSessionEnded(activeDuration) }
+    }
+
+    test("do not trigger onSessionEnd if session is not active") {
+        // Given
+        val mocks = Mocks()
+        mocks.sessionModelStore { it.isValid = false }
+        val sessionService = mocks.sessionService
+        sessionService.subscribe(mocks.spyCallback)
+        sessionService.start()
+
+        // When
+        sessionService.backgroundRun()
+
+        // Then
+        verify(exactly = 0) { mocks.spyCallback.onSessionEnded(any()) }
     }
 })

--- a/OneSignalSDK/onesignal/location/src/main/java/com/onesignal/location/internal/background/LocationBackgroundService.kt
+++ b/OneSignalSDK/onesignal/location/src/main/java/com/onesignal/location/internal/background/LocationBackgroundService.kt
@@ -35,6 +35,10 @@ internal class LocationBackgroundService(
             return scheduleTime
         }
 
+    /** NOTE: This triggers more often than scheduleBackgroundRunIn defined above,
+     * as it runs on the lowest IBackgroundService.scheduleBackgroundRunIn across
+     * the SDK.
+     */
     override suspend fun backgroundRun() {
         _capturer.captureLastLocation()
     }


### PR DESCRIPTION
# Description
## One Line Summary
Fixes invalid REST API requests, when location is on, to both outcomes/measure and User updates with `session_time` being zero/missing in the background.

## Details
This is only present when location sharing is enabled in the SDK (in addition to the app and end-user allowing it) and the end-user opens the app at any point after receiving a notification. This resulted in 400 errors in the outcomes/measure case and no-op User updates that wasting resources, the later doesn't depend on receiving notifications. The outcomes/measure is also additive as the bad requests are cached and retried on app open.

### Motivation
These invalid and no op request put a lot of extra load on both the device and the OneSignal backend.

### Scope
Session tracking only.

# Testing
## Unit testing
Added a new session test and update an existing one.

## Manual testing
Tested on an Android 14 emulator with our example app.

Reproducing the issue:
1. Allowed location
3. Sent a notification to the device
4. Wait until background location update fired.
   * Modified SDK to a lower time so this takes far less than 10 minutes
5. Observed the invalid request of `os__session_duration` with no session_time sent and the 400 response.

Reproducing repeating bad cached values:
1. Reproduce the root issue noted above.
2. Cold restart the app
3. Observer the missing `session_time ` being relayed.
4. Added migration logic and observed these requests are no longer replied.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [X] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2185)
<!-- Reviewable:end -->
