### PR TITLE
Fix setting consentGiven throwing if called before initWithContext

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
@@ -126,8 +126,9 @@ internal class OneSignalImp : IOneSignal, IServiceProvider {
         }
 
     // Services required by this class
-    private val operationRepo: IOperationRepo
-        get() = services.getService()
+    // WARNING: OperationRepo depends on OperationModelStore which in-turn depends
+    // on ApplicationService.appContext being non-null.
+    private var operationRepo: IOperationRepo? = null
     private val identityModelStore: IdentityModelStore
         get() = services.getService()
     private val propertiesModelStore: PropertiesModelStore
@@ -208,6 +209,7 @@ internal class OneSignalImp : IOneSignal, IServiceProvider {
             // get the current config model, if there is one
             configModel = services.getService<ConfigModelStore>().model
             sessionModel = services.getService<SessionModelStore>().model
+            operationRepo = services.getService<IOperationRepo>()
 
             // initWithContext is called by our internal services/receivers/activites but they do not provide
             // an appId (they don't know it).  If the app has never called the external initWithContext

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/internal/OneSignalImpTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/internal/OneSignalImpTests.kt
@@ -38,4 +38,52 @@ class OneSignalImpTests : FunSpec({
         // Then
         exception.message shouldBe "Must call 'initWithContext' before 'logout'"
     }
+
+    // consentRequired probably should have thrown like the other OneSignal methods in 5.0.0,
+    // but we can't make a breaking change to an existing API.
+    context("consentRequired") {
+        context("before initWithContext") {
+            test("set should not throw") {
+                // Given
+                val os = OneSignalImp()
+                // When
+                os.consentRequired = false
+                os.consentRequired = true
+                // Then
+                // Test fails if the above throws
+            }
+            test("get should not throw") {
+                // Given
+                val os = OneSignalImp()
+                // When
+                println(os.consentRequired)
+                // Then
+                // Test fails if the above throws
+            }
+        }
+    }
+
+    // consentGiven probably should have thrown like the other OneSignal methods in 5.0.0,
+    // but we can't make a breaking change to an existing API.
+    context("consentGiven") {
+        context("before initWithContext") {
+            test("set should not throw") {
+                // Given
+                val os = OneSignalImp()
+                // When
+                os.consentGiven = true
+                os.consentGiven = false
+                // Then
+                // Test fails if the above throws
+            }
+            test("get should not throw") {
+                // Given
+                val os = OneSignalImp()
+                // When
+                println(os.consentGiven)
+                // Then
+                // Test fails if the above throws
+            }
+        }
+    }
 })


### PR DESCRIPTION
# Description
## One Line Summary
Prevent throwing if `consentGiven` is set before calling `initWithContext`.

## Details
Since `consentGiven` accesses `operationRepo` which requires `ApplicationService.appContext `to be non-null we stopped using the lazy-loading pattern for `operationRepo`. We put the assignment into `initWithContext` to make this more clear.

### Motivation
While most SDK methods throw if accessed before init the consent methods were an exception from the beginning. We need to restore the orignal behavior so apps do not break unexpectedly.

### Scope
Only affects OneSignalImp access to `operationRepo`, which should only have an effect on  `consentGiven` and `consentRequired`.

# Testing
## Unit testing
Added new tests for `consentRequired` & `consentGiven`.

## Manual testing
1. Called `OneSignal.setConsentGiven(true)` before `OneSignal.initWithContext`, observed crash.
2. Made fix
3. Ensured crash no longer happens.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2200)
<!-- Reviewable:end -->
