### PR TITLE
Make use of `ryw_delay` to minimize retries on IAM fetch

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/consistency/IamFetchReadyCondition.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/consistency/IamFetchReadyCondition.kt
@@ -20,7 +20,7 @@ class IamFetchReadyCondition(
     override val id: String
         get() = ID
 
-    override fun isMet(indexedTokens: Map<String, Map<IConsistencyKeyEnum, String>>): Boolean {
+    override fun isMet(indexedTokens: Map<String, Map<IConsistencyKeyEnum, RywData>>): Boolean {
         val tokenMap = indexedTokens[key] ?: return false
         val userUpdateTokenSet = tokenMap[IamFetchRywTokenKey.USER] != null
 
@@ -33,9 +33,13 @@ class IamFetchReadyCondition(
         return userUpdateTokenSet
     }
 
-    override fun getNewestToken(indexedTokens: Map<String, Map<IConsistencyKeyEnum, String?>>): String? {
+    override fun getNewestToken(indexedTokens: Map<String, Map<IConsistencyKeyEnum, RywData?>>): RywData? {
         val tokenMap = indexedTokens[key] ?: return null
-        // maxOrNull compares lexicographically
-        return listOfNotNull(tokenMap[IamFetchRywTokenKey.USER], tokenMap[IamFetchRywTokenKey.SUBSCRIPTION]).maxOrNull()
+
+        // Collect non-null RywData objects and find the one with the largest rywToken lexicographically
+        return listOfNotNull(
+            tokenMap[IamFetchRywTokenKey.USER],
+            tokenMap[IamFetchRywTokenKey.SUBSCRIPTION],
+        ).maxByOrNull { it.rywToken ?: "" }
     }
 }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/consistency/IamFetchReadyCondition.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/consistency/IamFetchReadyCondition.kt
@@ -36,7 +36,10 @@ class IamFetchReadyCondition(
     override fun getRywData(indexedTokens: Map<String, Map<IConsistencyKeyEnum, RywData?>>): RywData? {
         val tokenMap = indexedTokens[key] ?: return null
 
-        // Collect non-null RywData objects and find the one with the largest rywToken lexicographically
+        /**
+         * Collect non-null RywData objects and find the one with the largest rywToken lexicographically
+         * Note: this works because RYW tokens are always the same length
+         */
         return listOfNotNull(
             tokenMap[IamFetchRywTokenKey.USER],
             tokenMap[IamFetchRywTokenKey.SUBSCRIPTION],

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/consistency/IamFetchReadyCondition.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/consistency/IamFetchReadyCondition.kt
@@ -33,7 +33,7 @@ class IamFetchReadyCondition(
         return userUpdateTokenSet
     }
 
-    override fun getNewestToken(indexedTokens: Map<String, Map<IConsistencyKeyEnum, RywData?>>): RywData? {
+    override fun getRywData(indexedTokens: Map<String, Map<IConsistencyKeyEnum, RywData?>>): RywData? {
         val tokenMap = indexedTokens[key] ?: return null
 
         // Collect non-null RywData objects and find the one with the largest rywToken lexicographically

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/consistency/RywData.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/consistency/RywData.kt
@@ -1,0 +1,3 @@
+package com.onesignal.common.consistency
+
+data class RywData(val rywToken: String, val rywDelay: Long?)

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/consistency/impl/ConsistencyManager.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/consistency/impl/ConsistencyManager.kt
@@ -79,7 +79,7 @@ class ConsistencyManager : IConsistencyManager {
 
         for ((condition, deferred) in conditions) {
             if (condition.isMet(indexedTokens)) {
-                val rywDataForNewestToken = condition.getNewestToken(indexedTokens)
+                val rywDataForNewestToken = condition.getRywData(indexedTokens)
                 if (!deferred.isCompleted) {
                     deferred.complete(rywDataForNewestToken)
                 }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/consistency/impl/ConsistencyManager.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/consistency/impl/ConsistencyManager.kt
@@ -44,7 +44,7 @@ class ConsistencyManager : IConsistencyManager {
     /**
      * Register a condition with its corresponding deferred action. Returns a deferred condition.
      */
-    override suspend fun registerCondition(condition: ICondition): CompletableDeferred<String?> {
+    override suspend fun getRywDataFromAwaitableCondition(condition: ICondition): CompletableDeferred<RywData?> {
         mutex.withLock {
             val deferred = CompletableDeferred<String?>()
             val pair = Pair(condition, deferred)

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/consistency/models/ICondition.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/consistency/models/ICondition.kt
@@ -1,5 +1,7 @@
 package com.onesignal.common.consistency.models
 
+import com.onesignal.common.consistency.RywData
+
 interface ICondition {
     /**
      * Every implementation should define a unique ID & make available via a companion object for
@@ -11,11 +13,11 @@ interface ICondition {
      * Define a condition that "unblocks" execution
      * e.g. we have token (A && B) || A
      */
-    fun isMet(indexedTokens: Map<String, Map<IConsistencyKeyEnum, String>>): Boolean
+    fun isMet(indexedTokens: Map<String, Map<IConsistencyKeyEnum, RywData>>): Boolean
 
     /**
      * Used to process tokens according to their format & return the newest token.
      * e.g. numeric strings would be compared differently from JWT tokens
      */
-    fun getNewestToken(indexedTokens: Map<String, Map<IConsistencyKeyEnum, String?>>): String?
+    fun getNewestToken(indexedTokens: Map<String, Map<IConsistencyKeyEnum, RywData?>>): RywData?
 }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/consistency/models/ICondition.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/consistency/models/ICondition.kt
@@ -19,5 +19,5 @@ interface ICondition {
      * Used to process tokens according to their format & return the newest token.
      * e.g. numeric strings would be compared differently from JWT tokens
      */
-    fun getNewestToken(indexedTokens: Map<String, Map<IConsistencyKeyEnum, RywData?>>): RywData?
+    fun getRywData(indexedTokens: Map<String, Map<IConsistencyKeyEnum, RywData?>>): RywData?
 }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/consistency/models/IConsistencyManager.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/consistency/models/IConsistencyManager.kt
@@ -22,7 +22,7 @@ interface IConsistencyManager {
      *  condition: ICondition - the condition to be registered
      * Returns: CompletableDeferred<String?> - a deferred action that completes when the condition is met
      */
-    suspend fun registerCondition(condition: ICondition): CompletableDeferred<String?>
+    suspend fun getRywDataFromAwaitableCondition(condition: ICondition): CompletableDeferred<String?>
 
     /**
      * Resolve all conditions with a specific ID

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/consistency/models/IConsistencyManager.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/consistency/models/IConsistencyManager.kt
@@ -1,5 +1,6 @@
 package com.onesignal.common.consistency.models
 
+import com.onesignal.common.consistency.RywData
 import kotlinx.coroutines.CompletableDeferred
 
 interface IConsistencyManager {
@@ -10,10 +11,10 @@ interface IConsistencyManager {
      *  key: IConsistencyKeyEnum - corresponds to the operation for which we have a read-your-write token
      *  value: String? - the read-your-write token
      */
-    suspend fun setRywToken(
+    suspend fun setRywData(
         id: String,
         key: IConsistencyKeyEnum,
-        value: String,
+        value: RywData,
     )
 
     /**
@@ -22,7 +23,7 @@ interface IConsistencyManager {
      *  condition: ICondition - the condition to be registered
      * Returns: CompletableDeferred<String?> - a deferred action that completes when the condition is met
      */
-    suspend fun getRywDataFromAwaitableCondition(condition: ICondition): CompletableDeferred<String?>
+    suspend fun getRywDataFromAwaitableCondition(condition: ICondition): CompletableDeferred<RywData?>
 
     /**
      * Resolve all conditions with a specific ID

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/backend/ISubscriptionBackendService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/backend/ISubscriptionBackendService.kt
@@ -1,5 +1,6 @@
 package com.onesignal.user.internal.backend
 
+import com.onesignal.common.consistency.RywData
 import com.onesignal.common.exceptions.BackendException
 
 interface ISubscriptionBackendService {
@@ -21,7 +22,7 @@ interface ISubscriptionBackendService {
         aliasLabel: String,
         aliasValue: String,
         subscription: SubscriptionObject,
-    ): Pair<String, String?>?
+    ): Pair<String, RywData>?
 
     /**
      * Update an existing subscription with the properties provided.
@@ -34,7 +35,7 @@ interface ISubscriptionBackendService {
         appId: String,
         subscriptionId: String,
         subscription: SubscriptionObject,
-    ): String?
+    ): RywData
 
     /**
      * Delete an existing subscription.

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/backend/ISubscriptionBackendService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/backend/ISubscriptionBackendService.kt
@@ -22,7 +22,7 @@ interface ISubscriptionBackendService {
         aliasLabel: String,
         aliasValue: String,
         subscription: SubscriptionObject,
-    ): Pair<String, RywData>?
+    ): Pair<String, RywData?>?
 
     /**
      * Update an existing subscription with the properties provided.
@@ -35,7 +35,7 @@ interface ISubscriptionBackendService {
         appId: String,
         subscriptionId: String,
         subscription: SubscriptionObject,
-    ): RywData
+    ): RywData?
 
     /**
      * Delete an existing subscription.

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/backend/IUserBackendService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/backend/IUserBackendService.kt
@@ -1,5 +1,6 @@
 package com.onesignal.user.internal.backend
 
+import com.onesignal.common.consistency.RywData
 import com.onesignal.common.exceptions.BackendException
 
 interface IUserBackendService {
@@ -47,7 +48,7 @@ interface IUserBackendService {
         properties: PropertiesObject,
         refreshDeviceMetadata: Boolean,
         propertyiesDelta: PropertiesDeltasObject,
-    ): String?
+    ): RywData
 
     /**
      * Retrieve a user from the backend.

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/backend/IUserBackendService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/backend/IUserBackendService.kt
@@ -48,7 +48,7 @@ interface IUserBackendService {
         properties: PropertiesObject,
         refreshDeviceMetadata: Boolean,
         propertyiesDelta: PropertiesDeltasObject,
-    ): RywData
+    ): RywData?
 
     /**
      * Retrieve a user from the backend.

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/backend/impl/UserBackendService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/backend/impl/UserBackendService.kt
@@ -1,5 +1,6 @@
 package com.onesignal.user.internal.backend.impl
 
+import com.onesignal.common.consistency.RywData
 import com.onesignal.common.exceptions.BackendException
 import com.onesignal.common.putMap
 import com.onesignal.core.internal.http.IHttpClient
@@ -52,7 +53,7 @@ internal class UserBackendService(
         properties: PropertiesObject,
         refreshDeviceMetadata: Boolean,
         propertyiesDelta: PropertiesDeltasObject,
-    ): String? {
+    ): RywData {
         val jsonObject =
             JSONObject()
                 .put("refresh_device_metadata", refreshDeviceMetadata)
@@ -71,12 +72,18 @@ internal class UserBackendService(
             throw BackendException(response.statusCode, response.payload, response.retryAfterSeconds)
         }
 
-        val responseBody = JSONObject(response.payload)
-        return if (responseBody.has("ryw_token")) {
-            responseBody.getString("ryw_token")
-        } else {
-            null
+        val responseJSON = JSONObject(response.payload)
+        var rywToken: String? = null
+        if (responseJSON.has("ryw_token")) {
+            rywToken = responseJSON.getString("ryw_token")
         }
+
+        var rywDelay: Long? = null
+        if (responseJSON.has("ryw_delay")) {
+            rywDelay = responseJSON.getLong("ryw_delay")
+        }
+
+        return RywData(rywToken, rywDelay)
     }
 
     override suspend fun getUser(

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/SubscriptionOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/SubscriptionOperationExecutor.kt
@@ -114,10 +114,10 @@ internal class SubscriptionOperationExecutor(
                 ) ?: return ExecutionResponse(ExecutionResult.SUCCESS)
 
             val backendSubscriptionId = result.first
-            val rywToken = result.second
+            val rywData = result.second
 
-            if (rywToken != null) {
-                _consistencyManager.setRywToken(createOperation.onesignalId, IamFetchRywTokenKey.SUBSCRIPTION, rywToken)
+            if (rywData.rywToken != null) {
+                _consistencyManager.setRywData(createOperation.onesignalId, IamFetchRywTokenKey.SUBSCRIPTION, rywData)
             } else {
                 _consistencyManager.resolveConditionsWithID(IamFetchReadyCondition.ID)
             }
@@ -188,10 +188,10 @@ internal class SubscriptionOperationExecutor(
                     AndroidUtils.getAppVersion(_applicationService.appContext),
                 )
 
-            val rywToken = _subscriptionBackend.updateSubscription(lastOperation.appId, lastOperation.subscriptionId, subscription)
+            val rywData = _subscriptionBackend.updateSubscription(lastOperation.appId, lastOperation.subscriptionId, subscription)
 
-            if (rywToken != null) {
-                _consistencyManager.setRywToken(startingOperation.onesignalId, IamFetchRywTokenKey.SUBSCRIPTION, rywToken)
+            if (rywData.rywToken != null) {
+                _consistencyManager.setRywData(startingOperation.onesignalId, IamFetchRywTokenKey.SUBSCRIPTION, rywData)
             } else {
                 _consistencyManager.resolveConditionsWithID(IamFetchReadyCondition.ID)
             }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/SubscriptionOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/SubscriptionOperationExecutor.kt
@@ -116,7 +116,7 @@ internal class SubscriptionOperationExecutor(
             val backendSubscriptionId = result.first
             val rywData = result.second
 
-            if (rywData.rywToken != null) {
+            if (rywData != null) {
                 _consistencyManager.setRywData(createOperation.onesignalId, IamFetchRywTokenKey.SUBSCRIPTION, rywData)
             } else {
                 _consistencyManager.resolveConditionsWithID(IamFetchReadyCondition.ID)
@@ -190,7 +190,7 @@ internal class SubscriptionOperationExecutor(
 
             val rywData = _subscriptionBackend.updateSubscription(lastOperation.appId, lastOperation.subscriptionId, subscription)
 
-            if (rywData.rywToken != null) {
+            if (rywData != null) {
                 _consistencyManager.setRywData(startingOperation.onesignalId, IamFetchRywTokenKey.SUBSCRIPTION, rywData)
             } else {
                 _consistencyManager.resolveConditionsWithID(IamFetchReadyCondition.ID)

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/UpdateUserOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/UpdateUserOperationExecutor.kt
@@ -148,7 +148,7 @@ internal class UpdateUserOperationExecutor(
                         deltasObject,
                     )
 
-                if (rywData.rywToken != null) {
+                if (rywData != null) {
                     _consistencyManager.setRywData(onesignalId, IamFetchRywTokenKey.USER, rywData)
                 } else {
                     _consistencyManager.resolveConditionsWithID(IamFetchReadyCondition.ID)

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/UpdateUserOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/UpdateUserOperationExecutor.kt
@@ -138,7 +138,7 @@ internal class UpdateUserOperationExecutor(
 
         if (appId != null && onesignalId != null) {
             try {
-                val rywToken =
+                val rywData =
                     _userBackend.updateUser(
                         appId,
                         IdentityConstants.ONESIGNAL_ID,
@@ -148,8 +148,8 @@ internal class UpdateUserOperationExecutor(
                         deltasObject,
                     )
 
-                if (rywToken != null) {
-                    _consistencyManager.setRywToken(onesignalId, IamFetchRywTokenKey.USER, rywToken)
+                if (rywData.rywToken != null) {
+                    _consistencyManager.setRywData(onesignalId, IamFetchRywTokenKey.USER, rywData)
                 } else {
                     _consistencyManager.resolveConditionsWithID(IamFetchReadyCondition.ID)
                 }

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/common/consistency/ConsistencyManagerTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/common/consistency/ConsistencyManagerTests.kt
@@ -89,7 +89,7 @@ class ConsistencyManagerTests : FunSpec({
             return false // Always returns false to simulate an unmet condition
         }
 
-        override fun getNewestToken(indexedTokens: Map<String, Map<IConsistencyKeyEnum, RywData?>>): RywData? {
+        override fun getRywData(indexedTokens: Map<String, Map<IConsistencyKeyEnum, RywData?>>): RywData? {
             return null
         }
     }
@@ -109,7 +109,7 @@ class ConsistencyManagerTests : FunSpec({
             return indexedTokens == expectedRywTokens
         }
 
-        override fun getNewestToken(indexedTokens: Map<String, Map<IConsistencyKeyEnum, RywData?>>): RywData? {
+        override fun getRywData(indexedTokens: Map<String, Map<IConsistencyKeyEnum, RywData?>>): RywData? {
             return expectedRywTokens.values.firstOrNull()?.values?.firstOrNull()
         }
     }

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/common/consistency/ConsistencyManagerTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/common/consistency/ConsistencyManagerTests.kt
@@ -1,6 +1,7 @@
-package com.onesignal.common.consistency.impl
+package com.onesignal.common.consistency
 
 import com.onesignal.common.consistency.enums.IamFetchRywTokenKey
+import com.onesignal.common.consistency.impl.ConsistencyManager
 import com.onesignal.common.consistency.models.ICondition
 import com.onesignal.common.consistency.models.IConsistencyKeyEnum
 import io.kotest.core.spec.style.FunSpec
@@ -20,15 +21,17 @@ class ConsistencyManagerTests : FunSpec({
             // Given
             val id = "test_id"
             val key = IamFetchRywTokenKey.USER
-            val value = "123"
+            val token = "123"
+            val delay = 500L
+            val rywData = RywData(token, delay)
 
-            consistencyManager.setRywToken(id, key, value)
+            consistencyManager.setRywData(id, key, rywData)
 
-            val condition = TestMetCondition(mapOf(id to mapOf(key to value)))
+            val condition = TestMetCondition(mapOf(id to mapOf(key to rywData)))
             val deferred = consistencyManager.getRywDataFromAwaitableCondition(condition)
             val result = deferred.await()
 
-            result shouldBe value
+            result shouldBe rywData
         }
     }
 
@@ -37,12 +40,14 @@ class ConsistencyManagerTests : FunSpec({
             // Given
             val id = "test_id"
             val key = IamFetchRywTokenKey.USER
-            val value = "123"
+            val token = "123"
+            val delay = 500L
+            val rywData = RywData(token, delay)
 
             // Set a token to meet the condition
-            consistencyManager.setRywToken(id, key, value)
+            consistencyManager.setRywData(id, key, rywData)
 
-            val condition = TestMetCondition(mapOf(id to mapOf(key to value)))
+            val condition = TestMetCondition(mapOf(id to mapOf(key to rywData)))
             val deferred = consistencyManager.getRywDataFromAwaitableCondition(condition)
 
             deferred.await()
@@ -55,7 +60,7 @@ class ConsistencyManagerTests : FunSpec({
             val condition = TestUnmetCondition()
             val deferred = consistencyManager.getRywDataFromAwaitableCondition(condition)
 
-            consistencyManager.setRywToken("id", IamFetchRywTokenKey.USER, "123")
+            consistencyManager.setRywData("id", IamFetchRywTokenKey.USER, RywData("123", 500L))
             deferred.isCompleted shouldBe false
         }
     }
@@ -80,18 +85,18 @@ class ConsistencyManagerTests : FunSpec({
         override val id: String
             get() = ID
 
-        override fun isMet(indexedTokens: Map<String, Map<IConsistencyKeyEnum, String>>): Boolean {
+        override fun isMet(indexedTokens: Map<String, Map<IConsistencyKeyEnum, RywData>>): Boolean {
             return false // Always returns false to simulate an unmet condition
         }
 
-        override fun getNewestToken(indexedTokens: Map<String, Map<IConsistencyKeyEnum, String?>>): String? {
+        override fun getNewestToken(indexedTokens: Map<String, Map<IConsistencyKeyEnum, RywData?>>): RywData? {
             return null
         }
     }
 
     // Mock implementation of ICondition for cases where the condition is met
     private class TestMetCondition(
-        private val expectedRywTokens: Map<String, Map<IConsistencyKeyEnum, String?>>,
+        private val expectedRywTokens: Map<String, Map<IConsistencyKeyEnum, RywData?>>,
     ) : ICondition {
         companion object {
             const val ID = "TestMetCondition"
@@ -100,11 +105,11 @@ class ConsistencyManagerTests : FunSpec({
         override val id: String
             get() = ID
 
-        override fun isMet(indexedTokens: Map<String, Map<IConsistencyKeyEnum, String>>): Boolean {
+        override fun isMet(indexedTokens: Map<String, Map<IConsistencyKeyEnum, RywData>>): Boolean {
             return indexedTokens == expectedRywTokens
         }
 
-        override fun getNewestToken(indexedTokens: Map<String, Map<IConsistencyKeyEnum, String?>>): String? {
+        override fun getNewestToken(indexedTokens: Map<String, Map<IConsistencyKeyEnum, RywData?>>): RywData? {
             return expectedRywTokens.values.firstOrNull()?.values?.firstOrNull()
         }
     }

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/common/consistency/ConsistencyManagerTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/common/consistency/ConsistencyManagerTests.kt
@@ -25,7 +25,7 @@ class ConsistencyManagerTests : FunSpec({
             consistencyManager.setRywToken(id, key, value)
 
             val condition = TestMetCondition(mapOf(id to mapOf(key to value)))
-            val deferred = consistencyManager.registerCondition(condition)
+            val deferred = consistencyManager.getRywDataFromAwaitableCondition(condition)
             val result = deferred.await()
 
             result shouldBe value
@@ -43,7 +43,7 @@ class ConsistencyManagerTests : FunSpec({
             consistencyManager.setRywToken(id, key, value)
 
             val condition = TestMetCondition(mapOf(id to mapOf(key to value)))
-            val deferred = consistencyManager.registerCondition(condition)
+            val deferred = consistencyManager.getRywDataFromAwaitableCondition(condition)
 
             deferred.await()
             deferred.isCompleted shouldBe true
@@ -53,7 +53,7 @@ class ConsistencyManagerTests : FunSpec({
     test("registerCondition does not complete when condition is not met") {
         runTest {
             val condition = TestUnmetCondition()
-            val deferred = consistencyManager.registerCondition(condition)
+            val deferred = consistencyManager.getRywDataFromAwaitableCondition(condition)
 
             consistencyManager.setRywToken("id", IamFetchRywTokenKey.USER, "123")
             deferred.isCompleted shouldBe false
@@ -63,7 +63,7 @@ class ConsistencyManagerTests : FunSpec({
     test("resolveConditionsWithID resolves conditions based on ID") {
         runTest {
             val condition = TestUnmetCondition()
-            val deferred = consistencyManager.registerCondition(condition)
+            val deferred = consistencyManager.getRywDataFromAwaitableCondition(condition)
             consistencyManager.resolveConditionsWithID(TestUnmetCondition.ID)
             deferred.await()
 

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/backend/SubscriptionBackendServiceTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/backend/SubscriptionBackendServiceTests.kt
@@ -27,7 +27,7 @@ class SubscriptionBackendServiceTests : FunSpec({
         val aliasLabel = "onesignal_id"
         val aliasValue = "11111111-1111-1111-1111-111111111111"
         val spyHttpClient = mockk<IHttpClient>()
-        coEvery { spyHttpClient.post(any(), any()) } returns HttpResponse(202, "{ \"subscription\": { id: \"subscriptionId\" } }")
+        coEvery { spyHttpClient.post(any(), any()) } returns HttpResponse(202, "{ \"subscription\": { id: \"subscriptionId\" }, \"ryw_token\": \"123\"}")
         val subscriptionBackendService = SubscriptionBackendService(spyHttpClient)
 
         // When
@@ -43,7 +43,7 @@ class SubscriptionBackendServiceTests : FunSpec({
         val response = subscriptionBackendService.createSubscription("appId", aliasLabel, aliasValue, subscription)
 
         // Then
-        response shouldBe Pair("subscriptionId", RywData(null, null))
+        response shouldBe Pair("subscriptionId", RywData("123", null))
         coVerify {
             spyHttpClient.post(
                 "apps/appId/users/by/$aliasLabel/$aliasValue/subscriptions",

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/backend/SubscriptionBackendServiceTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/backend/SubscriptionBackendServiceTests.kt
@@ -1,5 +1,6 @@
 package com.onesignal.user.internal.backend
 
+import com.onesignal.common.consistency.RywData
 import com.onesignal.common.exceptions.BackendException
 import com.onesignal.core.internal.http.HttpResponse
 import com.onesignal.core.internal.http.IHttpClient
@@ -42,7 +43,7 @@ class SubscriptionBackendServiceTests : FunSpec({
         val response = subscriptionBackendService.createSubscription("appId", aliasLabel, aliasValue, subscription)
 
         // Then
-        response shouldBe Pair("subscriptionId", null)
+        response shouldBe Pair("subscriptionId", RywData(null, null))
         coVerify {
             spyHttpClient.post(
                 "apps/appId/users/by/$aliasLabel/$aliasValue/subscriptions",

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/SubscriptionOperationExecutorTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/SubscriptionOperationExecutorTests.kt
@@ -1,6 +1,7 @@
 package com.onesignal.user.internal.operations
 
 import br.com.colman.kotest.android.extensions.robolectric.RobolectricTest
+import com.onesignal.common.consistency.RywData
 import com.onesignal.common.consistency.enums.IamFetchRywTokenKey
 import com.onesignal.common.consistency.models.IConsistencyManager
 import com.onesignal.common.exceptions.BackendException
@@ -36,19 +37,19 @@ class SubscriptionOperationExecutorTests :
         val remoteOneSignalId = "remote-onesignalId"
         val localSubscriptionId = "local-subscriptionId1"
         val remoteSubscriptionId = "remote-subscriptionId1"
-        val rywToken = "1"
+        val rywData = RywData("1", 500L)
         val mockConsistencyManager = mockk<IConsistencyManager>()
 
         beforeTest {
             clearMocks(mockConsistencyManager)
-            coEvery { mockConsistencyManager.setRywToken(any(), any(), any()) } just runs
+            coEvery { mockConsistencyManager.setRywData(any(), any(), any()) } just runs
         }
 
         test("create subscription successfully creates subscription") {
             // Given
             val mockSubscriptionBackendService = mockk<ISubscriptionBackendService>()
             coEvery { mockSubscriptionBackendService.createSubscription(any(), any(), any(), any()) } returns
-                Pair(remoteSubscriptionId, rywToken)
+                Pair(remoteSubscriptionId, rywData)
 
             val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
             val subscriptionModel1 = SubscriptionModel()
@@ -302,7 +303,7 @@ class SubscriptionOperationExecutorTests :
             // Given
             val mockSubscriptionBackendService = mockk<ISubscriptionBackendService>()
             coEvery { mockSubscriptionBackendService.createSubscription(any(), any(), any(), any()) } returns
-                Pair(remoteSubscriptionId, rywToken)
+                Pair(remoteSubscriptionId, rywData)
 
             val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
             val subscriptionModel1 = SubscriptionModel()
@@ -369,7 +370,7 @@ class SubscriptionOperationExecutorTests :
         test("update subscription successfully updates subscription") {
             // Given
             val mockSubscriptionBackendService = mockk<ISubscriptionBackendService>()
-            coEvery { mockSubscriptionBackendService.updateSubscription(any(), any(), any()) } returns rywToken
+            coEvery { mockSubscriptionBackendService.updateSubscription(any(), any(), any()) } returns rywData
 
             val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
             val subscriptionModel1 =
@@ -723,7 +724,7 @@ class SubscriptionOperationExecutorTests :
             val mockSubscriptionBackendService = mockk<ISubscriptionBackendService>()
             coEvery {
                 mockSubscriptionBackendService.updateSubscription(any(), any(), any())
-            } returns rywToken
+            } returns rywData
 
             val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
             val subscriptionModel1 =
@@ -764,7 +765,7 @@ class SubscriptionOperationExecutorTests :
 
             // Then
             coVerify(exactly = 1) {
-                mockConsistencyManager.setRywToken(remoteOneSignalId, IamFetchRywTokenKey.SUBSCRIPTION, rywToken)
+                mockConsistencyManager.setRywData(remoteOneSignalId, IamFetchRywTokenKey.SUBSCRIPTION, rywData)
             }
         }
     })

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/UpdateUserOperationExecutorTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/UpdateUserOperationExecutorTests.kt
@@ -1,5 +1,6 @@
 package com.onesignal.user.internal.operations
 
+import com.onesignal.common.consistency.RywData
 import com.onesignal.common.consistency.enums.IamFetchRywTokenKey
 import com.onesignal.common.consistency.models.IConsistencyManager
 import com.onesignal.common.exceptions.BackendException
@@ -29,18 +30,18 @@ class UpdateUserOperationExecutorTests :
         val appId = "appId"
         val localOneSignalId = "local-onesignalId"
         val remoteOneSignalId = "remote-onesignalId"
-        val rywToken = "1"
+        val rywData = RywData("1", 500L)
         val mockConsistencyManager = mockk<IConsistencyManager>()
 
         beforeTest {
             clearMocks(mockConsistencyManager)
-            coEvery { mockConsistencyManager.setRywToken(any(), any(), any()) } just runs
+            coEvery { mockConsistencyManager.setRywData(any(), any(), any()) } just runs
         }
 
         test("update user single operation is successful") {
             // Given
             val mockUserBackendService = mockk<IUserBackendService>()
-            coEvery { mockUserBackendService.updateUser(any(), any(), any(), any(), any(), any()) } returns rywToken
+            coEvery { mockUserBackendService.updateUser(any(), any(), any(), any(), any(), any()) } returns rywData
 
             // Given
             val mockIdentityModelStore = MockHelper.identityModelStore()
@@ -80,7 +81,7 @@ class UpdateUserOperationExecutorTests :
         test("update user multiple property operations are successful") {
             // Given
             val mockUserBackendService = mockk<IUserBackendService>()
-            coEvery { mockUserBackendService.updateUser(any(), any(), any(), any(), any(), any()) } returns rywToken
+            coEvery { mockUserBackendService.updateUser(any(), any(), any(), any(), any(), any()) } returns rywData
 
             // Given
             val mockIdentityModelStore = MockHelper.identityModelStore()
@@ -142,7 +143,7 @@ class UpdateUserOperationExecutorTests :
         test("update user single property delta operations is successful") {
             // Given
             val mockUserBackendService = mockk<IUserBackendService>()
-            coEvery { mockUserBackendService.updateUser(any(), any(), any(), any(), any(), any()) } returns rywToken
+            coEvery { mockUserBackendService.updateUser(any(), any(), any(), any(), any(), any()) } returns rywData
 
             // Given
             val mockIdentityModelStore = MockHelper.identityModelStore()
@@ -187,7 +188,7 @@ class UpdateUserOperationExecutorTests :
         test("update user multiple property delta operations are successful") {
             // Given
             val mockUserBackendService = mockk<IUserBackendService>()
-            coEvery { mockUserBackendService.updateUser(any(), any(), any(), any(), any(), any()) } returns rywToken
+            coEvery { mockUserBackendService.updateUser(any(), any(), any(), any(), any(), any()) } returns rywData
 
             // Given
             val mockIdentityModelStore = MockHelper.identityModelStore()
@@ -252,7 +253,7 @@ class UpdateUserOperationExecutorTests :
         test("update user with both property and property delta operations are successful") {
             // Given
             val mockUserBackendService = mockk<IUserBackendService>()
-            coEvery { mockUserBackendService.updateUser(any(), any(), any(), any(), any(), any()) } returns rywToken
+            coEvery { mockUserBackendService.updateUser(any(), any(), any(), any(), any(), any()) } returns rywData
 
             // Given
             val mockIdentityModelStore = MockHelper.identityModelStore()
@@ -364,7 +365,7 @@ class UpdateUserOperationExecutorTests :
             val mockUserBackendService = mockk<IUserBackendService>()
             coEvery {
                 mockUserBackendService.updateUser(any(), any(), any(), any(), any(), any())
-            } returns rywToken
+            } returns rywData
 
             val mockIdentityModelStore = MockHelper.identityModelStore()
             val mockPropertiesModelStore = MockHelper.propertiesModelStore()
@@ -390,7 +391,7 @@ class UpdateUserOperationExecutorTests :
 
             // Then
             coVerify(exactly = 1) {
-                mockConsistencyManager.setRywToken(remoteOneSignalId, IamFetchRywTokenKey.USER, rywToken)
+                mockConsistencyManager.setRywData(remoteOneSignalId, IamFetchRywTokenKey.USER, rywData)
             }
         }
     })

--- a/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/InAppMessagesManager.kt
+++ b/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/InAppMessagesManager.kt
@@ -164,7 +164,7 @@ internal class InAppMessagesManager(
             // attempt to fetch messages from the backend (if we have the pre-requisite data already)
             val onesignalId = _userManager.onesignalId
             val updateConditionDeferred =
-                _consistencyManager.registerCondition(IamFetchReadyCondition(onesignalId))
+                _consistencyManager.getRywDataFromAwaitableCondition(IamFetchReadyCondition(onesignalId))
             val rywToken = updateConditionDeferred.await()
             if (rywToken != null) {
                 fetchMessages(rywToken)
@@ -241,7 +241,7 @@ internal class InAppMessagesManager(
         suspendifyOnThread {
             val onesignalId = _userManager.onesignalId
             val iamFetchCondition =
-                _consistencyManager.registerCondition(IamFetchReadyCondition(onesignalId))
+                _consistencyManager.getRywDataFromAwaitableCondition(IamFetchReadyCondition(onesignalId))
             val rywToken = iamFetchCondition.await()
 
             if (rywToken != null) {

--- a/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/backend/IInAppBackendService.kt
+++ b/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/backend/IInAppBackendService.kt
@@ -1,5 +1,6 @@
 package com.onesignal.inAppMessages.internal.backend
 
+import com.onesignal.common.consistency.RywData
 import com.onesignal.common.exceptions.BackendException
 import com.onesignal.inAppMessages.internal.InAppMessage
 import com.onesignal.inAppMessages.internal.InAppMessageContent
@@ -21,7 +22,7 @@ internal interface IInAppBackendService {
     suspend fun listInAppMessages(
         appId: String,
         subscriptionId: String,
-        rywToken: String?,
+        rywData: RywData,
         sessionDurationProvider: () -> Long,
     ): List<InAppMessage>?
 

--- a/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/backend/impl/InAppBackendService.kt
+++ b/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/backend/impl/InAppBackendService.kt
@@ -1,6 +1,7 @@
 package com.onesignal.inAppMessages.internal.backend.impl
 
 import com.onesignal.common.NetworkUtils
+import com.onesignal.common.consistency.RywData
 import com.onesignal.common.exceptions.BackendException
 import com.onesignal.core.internal.device.IDeviceService
 import com.onesignal.core.internal.http.IHttpClient
@@ -26,14 +27,14 @@ internal class InAppBackendService(
     override suspend fun listInAppMessages(
         appId: String,
         subscriptionId: String,
-        rywToken: String?,
+        rywData: RywData,
         sessionDurationProvider: () -> Long,
     ): List<InAppMessage>? {
         val rywDelay = rywData.rywDelay ?: DEFAULT_RYW_DELAY_MS
         delay(rywDelay) // Delay by the specified amount
 
         val baseUrl = "apps/$appId/subscriptions/$subscriptionId/iams"
-        return attemptFetchWithRetries(baseUrl, rywToken, sessionDurationProvider)
+        return attemptFetchWithRetries(baseUrl, rywData, sessionDurationProvider)
     }
 
     override suspend fun getIAMData(
@@ -206,7 +207,7 @@ internal class InAppBackendService(
 
     private suspend fun attemptFetchWithRetries(
         baseUrl: String,
-        rywToken: String?,
+        rywData: RywData,
         sessionDurationProvider: () -> Long,
     ): List<InAppMessage>? {
         var attempts = 0
@@ -216,7 +217,7 @@ internal class InAppBackendService(
             val retryCount = if (attempts > 0) attempts else null
             val values =
                 OptionalHeaders(
-                    rywToken = rywToken,
+                    rywToken = rywData.rywToken,
                     sessionDuration = sessionDurationProvider(),
                     retryCount = retryCount,
                 )

--- a/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/backend/impl/InAppBackendService.kt
+++ b/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/backend/impl/InAppBackendService.kt
@@ -14,6 +14,8 @@ import com.onesignal.inAppMessages.internal.hydrators.InAppHydrator
 import kotlinx.coroutines.delay
 import org.json.JSONObject
 
+private const val DEFAULT_RYW_DELAY_MS = 500L
+
 internal class InAppBackendService(
     private val _httpClient: IHttpClient,
     private val _deviceService: IDeviceService,
@@ -27,6 +29,9 @@ internal class InAppBackendService(
         rywToken: String?,
         sessionDurationProvider: () -> Long,
     ): List<InAppMessage>? {
+        val rywDelay = rywData.rywDelay ?: DEFAULT_RYW_DELAY_MS
+        delay(rywDelay) // Delay by the specified amount
+
         val baseUrl = "apps/$appId/subscriptions/$subscriptionId/iams"
         return attemptFetchWithRetries(baseUrl, rywToken, sessionDurationProvider)
     }

--- a/OneSignalSDK/onesignal/in-app-messages/src/test/java/com/onesignal/inAppMessages/internal/backend/InAppBackendServiceTests.kt
+++ b/OneSignalSDK/onesignal/in-app-messages/src/test/java/com/onesignal/inAppMessages/internal/backend/InAppBackendServiceTests.kt
@@ -1,5 +1,6 @@
 package com.onesignal.inAppMessages.internal.backend
 
+import com.onesignal.common.consistency.RywData
 import com.onesignal.common.exceptions.BackendException
 import com.onesignal.common.safeBool
 import com.onesignal.common.safeInt
@@ -39,7 +40,7 @@ class InAppBackendServiceTests :
             val inAppBackendService = InAppBackendService(mockHttpClient, MockHelper.deviceService(), mockHydrator)
 
             // When
-            val response = inAppBackendService.listInAppMessages("appId", "subscriptionId", "123", mockSessionDurationProvider)
+            val response = inAppBackendService.listInAppMessages("appId", "subscriptionId", RywData("123", 500L), mockSessionDurationProvider)
 
             // Then
             response shouldNotBe null
@@ -62,7 +63,7 @@ class InAppBackendServiceTests :
             val inAppBackendService = InAppBackendService(mockHttpClient, MockHelper.deviceService(), mockHydrator)
 
             // When
-            val response = inAppBackendService.listInAppMessages("appId", "subscriptionId", "123", mockSessionDurationProvider)
+            val response = inAppBackendService.listInAppMessages("appId", "subscriptionId", RywData("123", 500L), mockSessionDurationProvider)
 
             // Then
             response shouldNotBe null
@@ -95,7 +96,7 @@ class InAppBackendServiceTests :
             val inAppBackendService = InAppBackendService(mockHttpClient, MockHelper.deviceService(), mockHydrator)
 
             // When
-            val response = inAppBackendService.listInAppMessages("appId", "subscriptionId", "123", mockSessionDurationProvider)
+            val response = inAppBackendService.listInAppMessages("appId", "subscriptionId", RywData("123", 500L), mockSessionDurationProvider)
 
             // Then
             response shouldBe null
@@ -124,7 +125,7 @@ class InAppBackendServiceTests :
             val inAppBackendService = InAppBackendService(mockHttpClient, MockHelper.deviceService(), mockHydrator)
 
             // When
-            val response = inAppBackendService.listInAppMessages("appId", "subscriptionId", "1234", mockSessionDurationProvider)
+            val response = inAppBackendService.listInAppMessages("appId", "subscriptionId", RywData("1234", 500L), mockSessionDurationProvider)
 
             // Then
             response shouldNotBe null


### PR DESCRIPTION
# Description
## One Line Summary
Encapsulate `rywToken` and `rywDelay` into a `RywData` class and update usage throughout the codebase including delaying IAM fetch by the specified delay.

## Details

### Motivation
This update introduces the **RywData** class to group `rywToken` and `rywDelay` into a single data object. This ensures both values are handled together, allowing for accurate delay management based on the most recent `rywToken`.

Along with `ryw_token`, `ryw_delay` is returned by user & subscription create & update endpoints. It essentially says "this is about when we expect the change will be ready". The goal is to minimize retries.

### Scope
- **Encapsulated `rywToken` and `rywDelay`** into the new `RywData` class to centralize their usage.  
- **Updated method signatures**: All previous usages of `String` (`rywToken`) are replaced with the new `RywData` object.  
  - Renamed `setRywToken` method to **`setRywData`** to reflect this change.
- **IAM fetch logic adjusted**: The delay for IAM fetch now leverages the `rywDelay` value from `RywData`. A fallback mechanism ensures minimal retries to the backend.
- **Renamed methods for clarity**, ensuring method names convey when a value is expected to be returned.

# Testing
## Unit testing
Tests were updated & passed.

## Manual testing
Tested accurate segment membership calculation & display of IAMs. e.g:
1. Create two IAMs targeting segments with version 1, & another targeting version 2 of the app
2. Set the IAMs to display every time conditions are met
3. Switch back & forth between versions in the example app
4. See that you get the correct IAM

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [x] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2207)
<!-- Reviewable:end -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208624001324438