### PR TITLE
Window manager BadTokenException / WindowLeaked

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/permissions/AlertDialogPrepromptForAndroidSettings.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/permissions/AlertDialogPrepromptForAndroidSettings.kt
@@ -30,6 +30,8 @@ package com.onesignal.core.internal.permissions
 import android.app.Activity
 import android.app.AlertDialog
 import com.onesignal.core.R
+import com.onesignal.debug.LogLevel
+import com.onesignal.debug.internal.logging.Logging
 
 /**
  * A singleton helper which will display the fallback-to-settings alert dialog.
@@ -56,18 +58,26 @@ object AlertDialogPrepromptForAndroidSettings {
         // simulate showing a dialog in a finishing activity
         activity.finish()
 
-        AlertDialog.Builder(activity)
-            .setTitle(title)
-            .setMessage(message)
-            .setPositiveButton(R.string.permission_not_available_open_settings_option) { dialog, which ->
-                callback.onAccept()
-            }
-            .setNegativeButton(android.R.string.no) { dialog, which ->
-                callback.onDecline()
-            }
-            .setOnCancelListener {
-                callback.onDecline()
-            }
-            .show()
+        // ensure the activity that will be showing the dialog is available
+        if (activity == null || activity.isDestroyed || activity.isFinishing) {
+            Logging.log(LogLevel.ERROR, "Alert dialog for Android settings was skipped because the activity was unavailable to display it.")
+            return
+        }
+
+        if (activity != null && !activity.isFinishing) {
+            AlertDialog.Builder(activity)
+                .setTitle(title)
+                .setMessage(message)
+                .setPositiveButton(R.string.permission_not_available_open_settings_option) { dialog, which ->
+                    callback.onAccept()
+                }
+                .setNegativeButton(android.R.string.no) { dialog, which ->
+                    callback.onDecline()
+                }
+                .setOnCancelListener {
+                    callback.onDecline()
+                }
+                .show()
+        }
     }
 }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/permissions/AlertDialogPrepromptForAndroidSettings.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/permissions/AlertDialogPrepromptForAndroidSettings.kt
@@ -53,6 +53,9 @@ object AlertDialogPrepromptForAndroidSettings {
         val messageTemplate = activity.getString(R.string.permission_not_available_message)
         val message = messageTemplate.format(previouslyDeniedPostfix)
 
+        // simulate showing a dialog in a finishing activity
+        activity.finish()
+
         AlertDialog.Builder(activity)
             .setTitle(title)
             .setMessage(message)

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/permissions/AlertDialogPrepromptForAndroidSettings.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/permissions/AlertDialogPrepromptForAndroidSettings.kt
@@ -55,9 +55,6 @@ object AlertDialogPrepromptForAndroidSettings {
         val messageTemplate = activity.getString(R.string.permission_not_available_message)
         val message = messageTemplate.format(previouslyDeniedPostfix)
 
-        // simulate showing a dialog in a finishing activity
-        activity.finish()
-
         // ensure the activity that will be showing the dialog is available
         if (activity == null || activity.isDestroyed || activity.isFinishing) {
             Logging.log(LogLevel.ERROR, "Alert dialog for Android settings was skipped because the activity was unavailable to display it.")


### PR DESCRIPTION
# Description
## One Line Summary
Fix the BadTokenException and WindowLeaked exception caused by showing a dialog on a finishing or destroyed activity.

## Details

### Motivation
The exception exists since User Model and now becomes the most occurring exception according to the data from Google Play SDK Console. This exception is relatively less impactful to user experience as it normal happens during app closing or backgrounding phrase, but we want to reduce the amount of reported exception as it may potentially affect app's stability rating over the Play Store. 

### Scope
The call to show a permission dialog has no effect if the activity is finishing, backgrounded, or destroyed, and it will not be retried unless user is explicitly asking to do so. There is no behavior change because the current version would just crash and will not retrying showing the dialog upon app restart. 

### OPTIONAL - Other
This PR contains 3 commits: the first commit simulates calling a permission dialog on a finished activity; the second commit shows that the fix is effective in removing the exception in such activity; the third commit cleans up the simulation code and leave the fix code change only. 
Related issue: https://github.com/OneSignal/OneSignal-Android-SDK/issues/2014

# Testing
## Manual testing
By checking out the first commit, I am able to reproduce a WindowLeaked exception by running the sample app. 
<img width="1360" alt="image" src="https://github.com/user-attachments/assets/33fd5115-2420-4a7b-9154-97a722264254">
After the second commit, the exception is no longer reproducible. 
BadTokenException can be caused by showing the dialog in a "finishing" activity but I am unable to simulate the situation other than a "finished" activity. Since this fix checks for both states of the activity, I believe this can fixes both BadTokenException and WindowLeaked exceptions. 

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2208)
<!-- Reviewable:end -->
