### PR TITLE
[Fix] NPE by getScheduleBackgroundRunIn

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/session/SessionModule.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/session/SessionModule.kt
@@ -3,6 +3,7 @@ package com.onesignal.session
 import com.onesignal.common.modules.IModule
 import com.onesignal.common.services.ServiceBuilder
 import com.onesignal.core.internal.background.IBackgroundService
+import com.onesignal.core.internal.startup.IBootstrapService
 import com.onesignal.core.internal.startup.IStartableService
 import com.onesignal.session.internal.SessionManager
 import com.onesignal.session.internal.influence.IInfluenceManager
@@ -39,6 +40,7 @@ internal class SessionModule : IModule {
             .provides<ISessionService>()
             .provides<IStartableService>()
             .provides<IBackgroundService>()
+            .provides<IBootstrapService>()
         builder.register<SessionListener>().provides<IStartableService>()
         builder.register<SessionManager>().provides<ISessionManager>()
     }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/session/internal/session/impl/SessionService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/session/internal/session/impl/SessionService.kt
@@ -6,6 +6,7 @@ import com.onesignal.core.internal.application.IApplicationService
 import com.onesignal.core.internal.background.IBackgroundService
 import com.onesignal.core.internal.config.ConfigModel
 import com.onesignal.core.internal.config.ConfigModelStore
+import com.onesignal.core.internal.startup.IBootstrapService
 import com.onesignal.core.internal.startup.IStartableService
 import com.onesignal.core.internal.time.ITime
 import com.onesignal.debug.LogLevel
@@ -32,7 +33,7 @@ internal class SessionService(
     private val _configModelStore: ConfigModelStore,
     private val _sessionModelStore: SessionModelStore,
     private val _time: ITime,
-) : ISessionService, IStartableService, IBackgroundService, IApplicationLifecycleHandler {
+) : ISessionService, IBootstrapService, IStartableService, IBackgroundService, IApplicationLifecycleHandler {
     override val startTime: Long
         get() = session!!.startTime
 
@@ -50,9 +51,12 @@ internal class SessionService(
     // True if app has been foregrounded at least once since the app started
     private var hasFocused = false
 
-    override fun start() {
+    override fun bootstrap() {
         session = _sessionModelStore.model
         config = _configModelStore.model
+    }
+
+    override fun start() {
         _applicationService.addApplicationLifecycleHandler(this)
     }
 

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/session/internal/session/SessionServiceTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/session/internal/session/SessionServiceTests.kt
@@ -18,7 +18,8 @@ private class Mocks {
         return mockSessionModelStore
     }
 
-    val sessionService = SessionService(MockHelper.applicationService(), MockHelper.configModelStore(), mockSessionModelStore, MockHelper.time(currentTime))
+    val sessionService =
+        SessionService(MockHelper.applicationService(), MockHelper.configModelStore(), mockSessionModelStore, MockHelper.time(currentTime))
 
     val spyCallback = spyk<ISessionLifecycleHandler>()
 }
@@ -29,6 +30,7 @@ class SessionServiceTests : FunSpec({
         val mocks = Mocks()
         val sessionService = mocks.sessionService
 
+        sessionService.bootstrap()
         sessionService.start()
         val sessionModelStore = mocks.sessionModelStore { it.isValid = false }
         sessionService.subscribe(mocks.spyCallback)
@@ -50,6 +52,7 @@ class SessionServiceTests : FunSpec({
         val sessionModelStore = mocks.sessionModelStore()
 
         // When
+        sessionService.bootstrap()
         sessionService.start()
         sessionService.onFocus(true)
         sessionService.subscribe(mocks.spyCallback)
@@ -73,6 +76,7 @@ class SessionServiceTests : FunSpec({
         val mocks = Mocks()
         val sessionService = mocks.sessionService
 
+        sessionService.bootstrap()
         sessionService.start()
         val sessionModelStore =
             mocks.sessionModelStore {
@@ -101,6 +105,7 @@ class SessionServiceTests : FunSpec({
         val mocks = Mocks()
         val sessionService = mocks.sessionService
 
+        sessionService.bootstrap()
         sessionService.start()
         val sessionModelStore =
             mocks.sessionModelStore {
@@ -125,6 +130,7 @@ class SessionServiceTests : FunSpec({
         val mocks = Mocks()
         val sessionService = mocks.sessionService
 
+        sessionService.bootstrap()
         sessionService.start()
         val sessionModelStore =
             mocks.sessionModelStore {
@@ -147,6 +153,7 @@ class SessionServiceTests : FunSpec({
         mocks.sessionModelStore { it.isValid = false }
         val sessionService = mocks.sessionService
         sessionService.subscribe(mocks.spyCallback)
+        sessionService.bootstrap()
         sessionService.start()
 
         // When


### PR DESCRIPTION
# Description
## One Line Summary
Fixes a NullPointerException issue thrown by SessionService.getScheduleBackgroundRunIn.

## Details

### Motivation
With the optimization introduced to `initWithContext`, part of the initialization is now performed in the background after `initWithContext` is called. This change created a rare race condition where services are accessed shortly after startup, but initialization hasn’t completed. In one scenario, when the app goes into the background before SessionService finishes initializing, a lifecycle callback fires to notify the "unfocus" event, attempting to access `SessionService`, whose component is null at that time. This error can crash the app and disrupt background services. This PR prevents the crash by ensuring that all major components of `SessionService` are available during the `initWithContext` phase.

### Scope
This PR moves part of `SessionService` initialization from `start()` (which was previously running in the background after `initWithContext`) to `bootstrap()`, which is called and completed during the `initWithContext` phase.

## Manual testing
I used a manual approach to reproduce the crash and verify the fix is working for the crash. 

Step to reproduce: 
1. Pull the first commit and run the demo app. During initialization, swipe the app into the background. (Note: This commit includes an arbitrary 10-second delay to the session service start time for testing purposes.)
2. Wait a few seconds and observe the crash in the background.
<img width="1118" alt="image" src="https://github.com/user-attachments/assets/1673222d-e89d-4007-8c04-d911ba92c3a1">

After the fix:
Following the same reproduction steps, the error no longer appears, and the session service functions as expected.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [x] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2212)
<!-- Reviewable:end -->
