### PR TITLE
WIP: Fix ANR caused by operationRepo.enqueue while loading is in progress

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/impl/OperationModelStore.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/impl/OperationModelStore.kt
@@ -30,7 +30,6 @@ import org.json.JSONObject
 internal class OperationModelStore(prefs: IPreferencesService) : ModelStore<Operation>("operations", prefs) {
     fun loadOperations() {
         load()
-        Logging.debug("OperationModelStore finished loading.")
     }
 
     override fun create(jsonObject: JSONObject?): Operation? {
@@ -64,7 +63,6 @@ internal class OperationModelStore(prefs: IPreferencesService) : ModelStore<Oper
                 else -> throw Exception("Unrecognized operation: $operationName")
             }
 
-        Thread.sleep(5000)
         // populate the operation with the data.
         operation.initializeFromJson(jsonObject)
 

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/impl/OperationModelStore.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/impl/OperationModelStore.kt
@@ -30,6 +30,7 @@ import org.json.JSONObject
 internal class OperationModelStore(prefs: IPreferencesService) : ModelStore<Operation>("operations", prefs) {
     fun loadOperations() {
         load()
+        Logging.debug("OperationModelStore finished loading.")
     }
 
     override fun create(jsonObject: JSONObject?): Operation? {
@@ -63,6 +64,7 @@ internal class OperationModelStore(prefs: IPreferencesService) : ModelStore<Oper
                 else -> throw Exception("Unrecognized operation: $operationName")
             }
 
+        Thread.sleep(5000)
         // populate the operation with the data.
         operation.initializeFromJson(jsonObject)
 


### PR DESCRIPTION
# Description
## One Line Summary
This PR will fix ANR caused by model store insertion while model store loading is stuck with some prolonged process.

## Details

### Motivation
Multiple users have reported that ANRs related to OneSignal have shown up in their analytics. We want to eliminate these ANRs to ensure smooth app start up. 

### Scope
This PR will alter the loading behavior for all models so that model insertion in the main thread becomes possible before loading is completed. The order will be correct because load() will insert cached items in the beginning of the list. However, it is possible for model to process the newly added item before loading is completed. 

### Others
This PR contains 4 commits. 
  * The 1st commit forces a prolonged loading process for OperationModelStore and will cause an ANR during app startup.
  * The 2nd commit adds a test unit that will fail because of the long loading time added by the first commit. 
  * The 3rd commit applies the fix and we should no longer observe the ANR and the test fail.
  * The 4th commit clears up the code that manually forces the loading process to take 5 seconds.

# Testing
## Unit testing
I have included a test unit to simulate a model insertion while loading is blocked by a lengthy process. THE UNIT TEST HAS ONE PENDING TODO.

## Manual testing
The first commit manually force the loading of operationRepo to take at least 5 seconds in order to simulate the issue. The second commit applies the fix and we can observe that ANR can no long occur. 

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [ ] I have filled out all **REQUIRED** sections above
   - [ ] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [ ] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [ ] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2231)
<!-- Reviewable:end -->
