### PR TITLE
Fix: incorrect activity path for NotificationOpenedActivityHMS

### DIFF
--- a/OneSignalSDK/onesignal/notifications/src/main/AndroidManifest.xml
+++ b/OneSignalSDK/onesignal/notifications/src/main/AndroidManifest.xml
@@ -65,8 +65,9 @@
             </intent-filter>
         </service>
 
+        <!-- CAUTION: OneSignal backend includes the activity name in the payload, modifying the name without sync may result in notification click not firing -->
         <activity
-            android:name="com.onesignal.notifications.activities.NotificationOpenedActivityHMS"
+            android:name="com.onesignal.NotificationOpenedActivityHMS"
             android:noHistory="true"
             android:theme="@android:style/Theme.Translucent.NoTitleBar"
             android:exported="true">

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/NotificationOpenedActivityHMS.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/NotificationOpenedActivityHMS.kt
@@ -24,12 +24,12 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package com.onesignal.notifications.activities
+package com.onesignal
+// OneSignal backend includes the activity name in the payload, modifying the namespace may result in notification click not firing
 
 import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
-import com.onesignal.OneSignal
 import com.onesignal.common.threading.suspendifyBlocking
 import com.onesignal.notifications.internal.open.INotificationOpenedProcessorHMS
 

--- a/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/ClassPathTests.kt
+++ b/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/ClassPathTests.kt
@@ -1,0 +1,15 @@
+package com.onesignal.notifications
+
+import io.kotest.core.spec.style.FunSpec
+import org.junit.jupiter.api.assertDoesNotThrow
+
+class ClassPathTests : FunSpec({
+    test("ensure the class path for NotificationOpenedActivityHMS.kt is in consistent with that returned by the backend service") {
+        // The test will fail if the classpath is changed by accident.
+        // If the change is intentional and corresponds with the backend update, modify or remove this test accordingly.
+        val fullClassName = "com.onesignal.NotificationOpenedActivityHMS"
+        assertDoesNotThrow {
+            Class.forName(fullClassName)
+        }
+    }
+})


### PR DESCRIPTION
# Description
## One Line Summary
Fix the class path of NotificationOpenedActivityHMS so it can be consistent with the path returned by the backend service.

## Details

### Motivation
NotificationOpenedActivityHMS is currently broken for all Huawei devices on V5 because the class path is currently under com.onesignal.notifications.activities instead of com.onesignal used in our backend service. This PR moves the class so the path is in consistent with that used by the backend service.

### Scope
**RECOMMEND - OPTIONAL -** What is intended to be effected. What is known not to change. Example: Notifications are grouped when parameter X is set, not enabled by default.

# Testing
## Manual testing
  1. Place a breakpoint inside processOpen().
  2. Send a HMS notification and click it.
  3. Observe that the breakpoint is never reached.
  4. Apply the fix and repeat the steps above. Observe that the breakpoint has reached and the intent includes some custom data.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2243)
<!-- Reviewable:end -->
