### PR TITLE
V4 to v5 upgrade will migrate app ID for wrapper SDKs

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/preferences/IPreferencesService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/preferences/IPreferencesService.kt
@@ -178,6 +178,11 @@ object PreferenceOneSignalKeys {
     // Legacy
 
     /**
+     * (String) The legacy app ID from SDKs prior to 5.
+     */
+    const val PREFS_LEGACY_APP_ID = "GT_APP_ID"
+
+    /**
      * (String) The legacy player ID from SDKs prior to 5.
      */
     const val PREFS_LEGACY_PLAYER_ID = "GT_PLAYER_ID"

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
@@ -211,15 +211,23 @@ internal class OneSignalImp : IOneSignal, IServiceProvider {
             sessionModel = services.getService<SessionModelStore>().model
             operationRepo = services.getService<IOperationRepo>()
 
-            // initWithContext is called by our internal services/receivers/activites but they do not provide
+            var forceCreateUser = false
+
+            // initWithContext is called by our internal services/receivers/activities but they do not provide
             // an appId (they don't know it).  If the app has never called the external initWithContext
             // prior to our services/receivers/activities we will blow up, as no appId has been established.
             if (appId == null && !configModel!!.hasProperty(ConfigModel::appId.name)) {
-                Logging.warn("initWithContext called without providing appId, and no appId has been established!")
-                return false
+                val legacyAppId = getLegacyAppId()
+                if (legacyAppId == null) {
+                    Logging.warn("initWithContext called without providing appId, and no appId has been established!")
+                    return false
+                } else {
+                    Logging.debug("initWithContext: using cached legacy appId $legacyAppId")
+                    forceCreateUser = true
+                    configModel!!.appId = legacyAppId
+                }
             }
 
-            var forceCreateUser = false
             // if the app id was specified as input, update the config model with it
             if (appId != null) {
                 if (!configModel!!.hasProperty(ConfigModel::appId.name) || configModel!!.appId != appId) {
@@ -416,6 +424,16 @@ internal class OneSignalImp : IOneSignal, IServiceProvider {
 
             // TODO: remove JWT Token for all future requests.
         }
+    }
+
+    /**
+     * Returns the cached app ID from v4 of the SDK, if available.
+     */
+    private fun getLegacyAppId(): String? {
+        return preferencesService.getString(
+            PreferenceStores.ONESIGNAL,
+            PreferenceOneSignalKeys.PREFS_LEGACY_APP_ID,
+        )
     }
 
     private fun createAndSwitchToNewUser(


### PR DESCRIPTION
# Description
## One Line Summary
(Resolves an issue that only affects wrappers) When migrating from v4 to v5, check for a cached app ID from v4 if none are available on v5.

## Details

### Motivation
* In wrappers, after an app upgrades from player to user model... if the app is not opened yet and a notification is received, there was no app ID detected and `initWithContext` returns early.
* Now, check for the cached app ID from v4 and use that to continue the init process. This mimics what should happen when using the native SDK directly.
* The reason this is an issue on wrappers is because when an app upgrades, the Application `onCreate` is automatically called, without needing to open the app. In native SDK clients, their OneSignal initialization code will run here and populate the app ID, setup the user, etc. However, in wrappers, clients don't modify the native code so the `onCreate` does not set app ID.

### Scope

- Using cached app ID from v4 if the app ID has not been set yet after migration
- Affects wrappers
- I aimed to mimic the same behavior as an upgrade using the native SDK, what would happen before the application is opened.

# Testing
## Unit testing

## Manual testing

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [ ] I have filled out all **REQUIRED** sections above
   - [ ] PR does one thing
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [ ] Code is as readable as possible.
   - [ ] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2244)
<!-- Reviewable:end -->
