### PR TITLE
[ci] update `actions` to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,9 @@ jobs:
   build:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: "[Setup] Java"
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -29,7 +29,7 @@ jobs:
           ./gradlew testReleaseUnitTest --console=plain --continue
       - name: Unit tests results
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: unit-tests-results
           path: OneSignalSDK/unittest/build


### PR DESCRIPTION
# Description
Upgrade `actions` for CI due to deprecation.

## Details
* Let's update all `actions` packages to v4. It looks like there is no other changes needed after bumping the version, as we have little additional configurations.
* The `android-actions/setup-android` is still on release v3 so keep the same

### Motivation
Motivated by CI breaking, seen in the [failure of this PR run](https://github.com/OneSignal/OneSignal-Android-SDK/actions/runs/13061969287/job/36446831167?pr=2244)
Also: See deprecation notice: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

### Scope
CI

# Testing
CI now success: https://github.com/OneSignal/OneSignal-Android-SDK/actions/runs/13062566604/job/36448678877?pr=2250

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2250)
<!-- Reviewable:end -->
