### PR TITLE
Fix: Anonymous Login request not cleared if app is forced close within 5 seconds on a new install

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/LoginUserOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/LoginUserOperationExecutor.kt
@@ -66,6 +66,13 @@ internal class LoginUserOperationExecutor(
         loginUserOp: LoginUserOperation,
         operations: List<Operation>,
     ): ExecutionResponse {
+        // Handle a bad state that can happen in User Model 5.1.27 or earlier versions that old Login
+        // request is not removed after processing if app is force-closed within the PostCreateDelay.
+        // Anonymous Login being processed alone will surely be rejected, so we need to drop the request
+        val containsSubscriptionOperation = operations.any { it is CreateSubscriptionOperation || it is TransferSubscriptionOperation }
+        if (!containsSubscriptionOperation && loginUserOp.externalId == null) {
+            return ExecutionResponse(ExecutionResult.FAIL_NORETRY)
+        }
         if (loginUserOp.existingOnesignalId == null || loginUserOp.externalId == null) {
             // When there is no existing user to attempt to associate with the externalId provided, we go right to
             // createUser.  If there is no externalId provided this is an insert, if there is this will be an

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/operations/OperationRepoTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/operations/OperationRepoTests.kt
@@ -215,7 +215,7 @@ class OperationRepoTests : FunSpec({
         // Given
         val mocks = Mocks()
         val opRepo = mocks.operationRepo
-        coEvery { opRepo.delayBeforeNextExecution(any(), any()) } just runs
+        coEvery { opRepo.delayBeforeNextExecution(any(), any(), any()) } just runs
         coEvery {
             mocks.executor.execute(any())
         } returns ExecutionResponse(ExecutionResult.FAIL_RETRY) andThen ExecutionResponse(ExecutionResult.SUCCESS)
@@ -239,7 +239,7 @@ class OperationRepoTests : FunSpec({
                     it[0] shouldBe operation
                 },
             )
-            opRepo.delayBeforeNextExecution(1, null)
+            opRepo.delayBeforeNextExecution(1, null, 0)
             mocks.executor.execute(
                 withArg {
                     it.count() shouldBe 1

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/LoginUserOperationExecutorTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/LoginUserOperationExecutorTests.kt
@@ -39,6 +39,16 @@ class LoginUserOperationExecutorTests : FunSpec({
     val localSubscriptionId2 = "local-subscriptionId2"
     val remoteSubscriptionId1 = "remote-subscriptionId1"
     val remoteSubscriptionId2 = "remote-subscriptionId2"
+    val createSubscriptionOperation =
+        CreateSubscriptionOperation(
+            appId,
+            localOneSignalId,
+            "subscriptionId1",
+            SubscriptionType.PUSH,
+            true,
+            "pushToken1",
+            SubscriptionStatus.SUBSCRIBED,
+        )
 
     test("login anonymous user successfully creates user") {
         // Given
@@ -58,7 +68,7 @@ class LoginUserOperationExecutorTests : FunSpec({
         val loginUserOperationExecutor =
             LoginUserOperationExecutor(
                 mockIdentityOperationExecutor,
-                MockHelper.applicationService(),
+                AndroidMockHelper.applicationService(),
                 MockHelper.deviceService(),
                 mockUserBackendService,
                 mockIdentityModelStore,
@@ -67,7 +77,11 @@ class LoginUserOperationExecutorTests : FunSpec({
                 MockHelper.configModelStore(),
                 MockHelper.languageContext(),
             )
-        val operations = listOf<Operation>(LoginUserOperation(appId, localOneSignalId, null, null))
+        val operations =
+            listOf<Operation>(
+                LoginUserOperation(appId, localOneSignalId, null, null),
+                createSubscriptionOperation,
+            )
 
         // When
         val response = loginUserOperationExecutor.execute(operations)
@@ -98,7 +112,7 @@ class LoginUserOperationExecutorTests : FunSpec({
         val loginUserOperationExecutor =
             LoginUserOperationExecutor(
                 mockIdentityOperationExecutor,
-                MockHelper.applicationService(),
+                AndroidMockHelper.applicationService(),
                 MockHelper.deviceService(),
                 mockUserBackendService,
                 mockIdentityModelStore,
@@ -107,7 +121,11 @@ class LoginUserOperationExecutorTests : FunSpec({
                 MockHelper.configModelStore(),
                 MockHelper.languageContext(),
             )
-        val operations = listOf<Operation>(LoginUserOperation(appId, localOneSignalId, null, null))
+        val operations =
+            listOf<Operation>(
+                LoginUserOperation(appId, localOneSignalId, null, null),
+                createSubscriptionOperation,
+            )
 
         // When
         val response = loginUserOperationExecutor.execute(operations)
@@ -130,8 +148,12 @@ class LoginUserOperationExecutorTests : FunSpec({
         val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
 
         val loginUserOperationExecutor =
-            LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext())
-        val operations = listOf<Operation>(LoginUserOperation(appId, localOneSignalId, null, null))
+            LoginUserOperationExecutor(mockIdentityOperationExecutor, AndroidMockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext())
+        val operations =
+            listOf<Operation>(
+                LoginUserOperation(appId, localOneSignalId, null, null),
+                createSubscriptionOperation,
+            )
 
         // When
         val response = loginUserOperationExecutor.execute(operations)
@@ -678,5 +700,43 @@ class LoginUserOperationExecutorTests : FunSpec({
                 any(),
             )
         }
+    }
+
+    test("ensure anonymous login with no other operations will fail with FAIL_NORETRY") {
+        // Given
+        val mockUserBackendService = mockk<IUserBackendService>()
+        coEvery { mockUserBackendService.createUser(any(), any(), any(), any()) } returns
+            CreateUserResponse(mapOf(IdentityConstants.ONESIGNAL_ID to remoteOneSignalId), PropertiesObject(), listOf())
+
+        val mockIdentityOperationExecutor = mockk<IdentityOperationExecutor>()
+
+        val mockIdentityModelStore = MockHelper.identityModelStore()
+        val mockPropertiesModelStore = MockHelper.propertiesModelStore()
+        val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
+
+        val loginUserOperationExecutor =
+            LoginUserOperationExecutor(
+                mockIdentityOperationExecutor,
+                MockHelper.applicationService(),
+                MockHelper.deviceService(),
+                mockUserBackendService,
+                mockIdentityModelStore,
+                mockPropertiesModelStore,
+                mockSubscriptionsModelStore,
+                MockHelper.configModelStore(),
+                MockHelper.languageContext(),
+            )
+        // anonymous Login request
+        val operations = listOf<Operation>(LoginUserOperation(appId, localOneSignalId, null, null))
+
+        // When
+        val response = loginUserOperationExecutor.execute(operations)
+
+        // Then
+        response.result shouldBe ExecutionResult.FAIL_NORETRY
+        // ensure user is not created by the bad request
+        coVerify(
+            exactly = 0,
+        ) { mockUserBackendService.createUser(appId, any(), any(), any()) }
     }
 })


### PR DESCRIPTION
# Description
## One Line Summary
This PR fixes an issue where subscriptions do not update correctly and results in a 400 error when calling Login. It also handles this bad state when migrating from any previous version.

## Details

### Motivation
There is an edge case where the app successfully creates a user for the first time, but the request remains in the queue due to the `PostCreateDelay`. When this happens, all future Login calls return a 400 error, and any subscription updates fail. This PR prevents this scenario by correctly updating the operation queue and handling the bad state during migration.

### Scope
  * OperationRepo: No longer holds up operation processing before the `PostCreateDelay`. Instead, the waiting time for `PostCreateDelay` is now integrated into `delayBeforeNextExecution` at the end of execution.
  * LoginUserOperationExecutor: Now detects if an anonymous Login request is made without other operations. When this happens, it returns a `FAIL_NORETRY` and drops the duplicated Login request.

# Testing
## Manual testing
###Steps to reproduce
This bug can happen strictly after CreateUser is successful for the first time but the app is force-closed before the 5 seconds `PostCreateDelay` has reached. One way to reproduce this issue is:
  1. Fresh install the app.
  2. Right after the subscription is created or receiving a 200 code from the Create User request, quickly force close the app within 5 seconds.
  3. Re-open the app, observe that a 400 error code is received and any updates like subscribing is not updated in the dashboard.

###New Install
  Step 1-2 same as above
  3. Re-open the app, wait for the server response and observe that Login with the external ID is successful. Confirmed that no error is logged and the fix works.

###Update From the Broken Version
  Step 1-2 same as above
  3. upgrade to this version without uninstalling the previous version or clearing the storage, observe that Login with the externalID is successful without error.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2251)
<!-- Reviewable:end -->
