### PR TITLE
Player model - Add log listener debug feature

### DIFF
--- a/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/application/MainApplication.java
+++ b/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/application/MainApplication.java
@@ -8,6 +8,8 @@ import com.onesignal.OSInAppMessage;
 import com.onesignal.OSNotification;
 import com.onesignal.OSInAppMessageLifecycleHandler;
 import com.onesignal.OneSignal;
+import com.onesignal.debug.OneSignalLogEvent;
+import com.onesignal.debug.OneSignalLogListener;
 import com.onesignal.sdktest.R;
 import com.onesignal.sdktest.constant.Tag;
 import com.onesignal.sdktest.constant.Text;
@@ -72,6 +74,21 @@ public class MainApplication extends MultiDexApplication {
         OneSignal.setLocationShared(false);
 
         Log.d(Tag.DEBUG, Text.ONESIGNAL_SDK_INIT);
+    }
+
+    private void setupLogListener() {
+        OneSignalLogListener logListener = new OneSignalLogListener() {
+            @Override
+            public void onLogEvent(OneSignalLogEvent event) {
+                // App developer can send these logs to their backend, the
+                // println code here is just to show it works.
+                System.out.println(event.getEntry());
+            }
+        };
+
+        OneSignal.addLogListener(logListener);
+        // Remove can be called if you need to stop collecting logs.
+        // OneSignal.removeLogListener(logListener);
     }
 
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -45,6 +45,8 @@ import androidx.annotation.Nullable;
 import androidx.annotation.WorkerThread;
 import androidx.core.app.NotificationCompat;
 
+import com.onesignal.debug.OneSignalLogEvent;
+import com.onesignal.debug.OneSignalLogListener;
 import com.onesignal.influence.data.OSTrackerFactory;
 import com.onesignal.influence.domain.OSInfluence;
 import com.onesignal.language.LanguageContext;
@@ -1332,6 +1334,28 @@ public class OneSignal {
             Log.e(TAG, "Error showing logging message.", t);
          }
       }
+
+      callLogListeners(level, message, throwable);
+   }
+
+   private static void callLogListeners(@NonNull final LOG_LEVEL level, @NonNull String message, @Nullable Throwable throwable) {
+      String logEntry = message;
+      if (throwable != null) {
+         logEntry += "\n" + Log.getStackTraceString(throwable);
+      }
+      for (OneSignalLogListener listener : logListeners) {
+         listener.onLogEvent(new OneSignalLogEvent(level, logEntry));
+      }
+   }
+
+   private static final List<OneSignalLogListener> logListeners = new ArrayList<>();
+
+   public static void addLogListener(@NonNull OneSignalLogListener listener) {
+      logListeners.add(listener);
+   }
+
+   public static void removeLogListener(@NonNull OneSignalLogListener listener) {
+      logListeners.remove(listener);
    }
 
    static void logHttpError(String errorString, int statusCode, Throwable throwable, String errorResponse) {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/debug/OneSignalLogEvent.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/debug/OneSignalLogEvent.kt
@@ -1,0 +1,8 @@
+package com.onesignal.debug
+
+import com.onesignal.OneSignal
+
+data class OneSignalLogEvent(
+    val level: OneSignal.LOG_LEVEL,
+    val entry: String,
+)

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/debug/OneSignalLogListener.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/debug/OneSignalLogListener.kt
@@ -1,0 +1,5 @@
+package com.onesignal.debug
+
+interface OneSignalLogListener {
+    fun onLogEvent(event: OneSignalLogEvent)
+}


### PR DESCRIPTION
# Description
## One Line Summary
Add log listener debug feature, so it's possible for app developers to use this to send OneSignal device logs to their backend.

## Details

### Motivation
There was no way for app developer to capture logs from the OneSignal SDK, as you can't intercept Android's Log methods.

### Scope
Only adds new functionally to get log entries from OneSignal. 

# Testing

## Manual testing
Tested on an Android 15 Emulator, ensured log entries can be printed. Also tested throwables print correctly, with their full stack trace.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [X] Public API changes
      - OneSignal.addLogListener(OneSignalLogEvent)
      - OneSignal.removeLogListener(OneSignalLogEvent)

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
      - player-model-main CI is broken currently
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2260)
<!-- Reviewable:end -->
