### PR TITLE
Upgrade to Gradle 8.10.2 and AGP 8.8.2

### DIFF
--- a/Examples/OneSignalDemo/app/build.gradle
+++ b/Examples/OneSignalDemo/app/build.gradle
@@ -3,6 +3,7 @@ plugins {
 }
 
 android {
+    namespace 'com.onesignal.sdktest'
     compileSdkVersion 34
     defaultConfig {
         minSdkVersion 21

--- a/Examples/OneSignalDemo/app/build.gradle
+++ b/Examples/OneSignalDemo/app/build.gradle
@@ -62,10 +62,11 @@ android {
     }
 
     task flavorSelection() {
-        if (getGradle().getStartParameter().getTaskRequests().toString().contains("Gms")) {
+        def tasksList = gradle.startParameter.taskRequests.toString()
+        if (tasksList.contains('Gms')) {
             apply plugin: 'com.google.gms.google-services'
             googleServices { disableVersionCheck = true }
-        } else {
+        } else if (tasksList.contains('Huawei')) {
             apply plugin: 'com.huawei.agconnect'
         }
     }

--- a/Examples/OneSignalDemo/app/src/main/AndroidManifest.xml
+++ b/Examples/OneSignalDemo/app/src/main/AndroidManifest.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    xmlns:amazon="http://schemas.amazon.com/apk/res/android"
-    package="com.onesignal.sdktest">
+    xmlns:amazon="http://schemas.amazon.com/apk/res/android">
 
     <uses-permission android:name="com.android.vending.BILLING" />
 

--- a/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/application/MainApplication.java
+++ b/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/application/MainApplication.java
@@ -21,7 +21,6 @@ import com.onesignal.inAppMessages.IInAppMessageWillDisplayEvent;
 import com.onesignal.notifications.IDisplayableNotification;
 import com.onesignal.notifications.INotificationLifecycleListener;
 import com.onesignal.notifications.INotificationWillDisplayEvent;
-import com.onesignal.sdktest.BuildConfig;
 import com.onesignal.sdktest.R;
 import com.onesignal.sdktest.constant.Tag;
 import com.onesignal.sdktest.constant.Text;
@@ -39,9 +38,8 @@ public class MainApplication extends MultiDexApplication {
     private static final int SLEEP_TIME_TO_MIMIC_ASYNC_OPERATION = 2000;
 
     public MainApplication() {
-        // run strict mode default in debug mode to surface any potential issues easier
-        if(BuildConfig.DEBUG)
-            StrictMode.enableDefaults();
+        // run strict mode to surface any potential issues easier
+        StrictMode.enableDefaults();
     }
 
     @SuppressLint("NewApi")

--- a/Examples/OneSignalDemo/build.gradle
+++ b/Examples/OneSignalDemo/build.gradle
@@ -14,7 +14,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.8.2'
         classpath 'com.google.gms:google-services:4.3.10'
-        classpath 'com.huawei.agconnect:agcp:1.6.2.300'
+        classpath 'com.huawei.agconnect:agcp:1.9.1.304'
         
         // TODO: Do not place your application dependencies here; they belong
         //  in the individual module build.gradle files

--- a/Examples/OneSignalDemo/build.gradle
+++ b/Examples/OneSignalDemo/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         maven { url 'https://developer.huawei.com/repo/' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.2'
+        classpath 'com.android.tools.build:gradle:8.8.2'
         classpath 'com.google.gms:google-services:4.3.10'
         classpath 'com.huawei.agconnect:agcp:1.6.2.300'
         

--- a/Examples/OneSignalDemo/gradle/wrapper/gradle-wrapper.properties
+++ b/Examples/OneSignalDemo/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/OneSignalSDK/build.gradle
+++ b/OneSignalSDK/build.gradle
@@ -8,7 +8,7 @@ buildscript {
                 targetSdkVersion: 34,
                 minSdkVersion: 21
         ]
-        androidGradlePluginVersion = '7.2.0'
+        androidGradlePluginVersion = '8.8.2'
         googleServicesGradlePluginVersion = '4.3.10'
         huaweiAgconnectVersion = '1.6.2.300'
         huaweiHMSPushVersion = '6.3.0.304'

--- a/OneSignalSDK/build.gradle
+++ b/OneSignalSDK/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         ]
         androidGradlePluginVersion = '8.8.2'
         googleServicesGradlePluginVersion = '4.3.10'
-        huaweiAgconnectVersion = '1.6.2.300'
+        huaweiAgconnectVersion = '1.9.1.304'
         huaweiHMSPushVersion = '6.3.0.304'
         huaweiHMSLocationVersion = '4.0.0.300'
         kotlinVersion = '1.7.10'

--- a/OneSignalSDK/gradle.properties
+++ b/OneSignalSDK/gradle.properties
@@ -23,9 +23,7 @@
 # Remove when creating an .aar build.
 #android.enableAapt2=false
 
-android.databinding.incremental = false
-kapt.incremental.apt = false
-android.testConfig.useRelativePath = false
+org.gradle.jvmargs=-Xmx1536m
 
 # Enables D8 for all modules.
 android.enableD8 = true

--- a/OneSignalSDK/gradle/wrapper/gradle-wrapper.properties
+++ b/OneSignalSDK/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/OneSignalSDK/onesignal/build.gradle
+++ b/OneSignalSDK/onesignal/build.gradle
@@ -1,5 +1,9 @@
 plugins {
     id 'com.android.library'
+    // There isn't Kotlin or Java code in this top-level project,
+    // however consumers look for an .aar file, which this causes it
+    // to be created.
+    id 'kotlin-android'
 }
 
 android {
@@ -25,6 +29,8 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
     namespace 'com.onesignal'
+
+    kotlinOptions.freeCompilerArgs += ['-module-name', namespace]
 }
 
 ext {

--- a/OneSignalSDK/onesignal/maven-push.gradle
+++ b/OneSignalSDK/onesignal/maven-push.gradle
@@ -66,7 +66,9 @@ afterEvaluate {
 
         publications {
             release(MavenPublication) {
-                from components.release
+                afterEvaluate {
+                    from components.findByName('release')
+                }
 
                 pom {
                     name = projectName

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/display/impl/NotificationDisplayBuilder.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/display/impl/NotificationDisplayBuilder.kt
@@ -12,7 +12,6 @@ import android.net.Uri
 import android.os.Build
 import androidx.core.app.NotificationCompat
 import com.onesignal.common.AndroidUtils
-import com.onesignal.core.R
 import com.onesignal.core.internal.application.IApplicationService
 import com.onesignal.debug.internal.logging.Logging
 import com.onesignal.notifications.internal.bundle.impl.NotificationBundleProcessor
@@ -231,9 +230,9 @@ internal class NotificationDisplayBuilder(
         if (bitmap == null) return null
         try {
             val systemLargeIconHeight =
-                contextResources!!.getDimension(R.dimen.notification_large_icon_height).toInt()
+                contextResources!!.getDimension(android.R.dimen.notification_large_icon_height).toInt()
             val systemLargeIconWidth =
-                contextResources!!.getDimension(R.dimen.notification_large_icon_width).toInt()
+                contextResources!!.getDimension(android.R.dimen.notification_large_icon_width).toInt()
             val bitmapHeight = bitmap.height
             val bitmapWidth = bitmap.width
             if (bitmapWidth > systemLargeIconWidth || bitmapHeight > systemLargeIconHeight) {


### PR DESCRIPTION
# Description
## One Line Summary
Upgrade to latest production AGP and it's supported Gradle version.

## Details

### Motivation
There are two reasons:
* Gradle 7 and APG 7 are legacy, which means they no longer get many updates
* The latest versions of Android Studio come with JDK 21, which doesn't work for Gradle 7 and AGP 7.
   - NOTE: Publishing still need to be done with Java 17 however, explained below.

### Scope
Just updated what is needed to be able build, run, and publish with the newest AGP version.

# Testing
## Unit testing
N/A

## Manual testing
Built SDK with Java 17 (Note: do NOT publish with JDK21 yet) and tested publishing with a staging build with:
 * Java 11
 * Gradle 7.3.3
 * APG 7.2.2
 * Android 5 & 14 Emulator
 * Ensure the example app's Huawei flavor builds and runs.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes
   - [X] Build or Publishing

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
      - The `identity_verification_beta` branch is behind main. Created another branch to prove the tests work after Gradle / AGP upgrade: https://github.com/OneSignal/OneSignal-Android-SDK/pull/2265
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2264)
<!-- Reviewable:end -->
