### PR TITLE
Fix subscription/IAM not updated after upgrading from 5.2.0-beta or between 5.1.9 to 5.1.27

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/UserModule.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/UserModule.kt
@@ -17,6 +17,7 @@ import com.onesignal.user.internal.backend.impl.UserBackendService
 import com.onesignal.user.internal.builduser.IRebuildUserService
 import com.onesignal.user.internal.builduser.impl.RebuildUserService
 import com.onesignal.user.internal.identity.IdentityModelStore
+import com.onesignal.user.internal.migrations.RecoverConfigPushSubscription
 import com.onesignal.user.internal.migrations.RecoverFromDroppedLoginBug
 import com.onesignal.user.internal.operations.impl.executors.IdentityOperationExecutor
 import com.onesignal.user.internal.operations.impl.executors.LoginUserFromSubscriptionOperationExecutor
@@ -74,6 +75,7 @@ internal class UserModule : IModule {
         builder.register<UserRefreshService>().provides<IStartableService>()
 
         builder.register<RecoverFromDroppedLoginBug>().provides<IStartableService>()
+        builder.register<RecoverConfigPushSubscription>().provides<IStartableService>()
 
         // Shared state between Executors
         builder.register<NewRecordsState>().provides<NewRecordsState>()

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/migrations/IMigrationRecovery.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/migrations/IMigrationRecovery.kt
@@ -1,0 +1,19 @@
+package com.onesignal.user.internal.migrations
+
+import com.onesignal.core.internal.startup.IStartableService
+
+/**
+ * Purpose: allow to identify and take corrective action for some specific bad states during migration
+ *
+ * Implement these properties to:
+ *  - isInBadState(): return true the condition for the bad state has met
+ *  - recover(): take a recovery action if the bad state has been identified
+ *  - recoveryMessage: log a message after the bad state is found and the corrective action is taken
+ */
+interface IMigrationRecovery : IStartableService {
+    fun isInBadState(): Boolean
+
+    fun recover()
+
+    fun recoveryMessage(): String
+}

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/migrations/MigrationRecovery.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/migrations/MigrationRecovery.kt
@@ -1,0 +1,13 @@
+package com.onesignal.user.internal.migrations
+
+import com.onesignal.debug.internal.logging.Logging
+
+abstract class MigrationRecovery : IMigrationRecovery {
+    override fun start() {
+        // log a message and take the corrective action if it is determined that app is in a bad state
+        if (isInBadState()) {
+            Logging.warn(recoveryMessage())
+            recover()
+        }
+    }
+}

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/migrations/RecoverConfigPushSubscription.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/migrations/RecoverConfigPushSubscription.kt
@@ -1,0 +1,29 @@
+package com.onesignal.user.internal.migrations
+
+import com.onesignal.core.internal.config.ConfigModelStore
+import com.onesignal.user.internal.subscriptions.SubscriptionModelStore
+import com.onesignal.user.internal.subscriptions.SubscriptionType
+
+/**
+ * Purpose: Automatically recovers a missing push sub ID in the config model store due
+ * to a bug migrating from the SDK 5.2.0-beta
+ */
+class RecoverConfigPushSubscription(
+    private val _configModelStore: ConfigModelStore,
+    private val _subscriptionModelStore: SubscriptionModelStore,
+) : MigrationRecovery() {
+    val activePushSubscription by lazy { _subscriptionModelStore.list().firstOrNull { it.type == SubscriptionType.PUSH } }
+
+    override fun isInBadState(): Boolean {
+        val isPushSubIdMissing = _configModelStore.model.pushSubscriptionId == null
+        return isPushSubIdMissing && activePushSubscription != null
+    }
+
+    override fun recover() {
+        _configModelStore.model.pushSubscriptionId = activePushSubscription?.id
+    }
+
+    override fun recoveryMessage(): String {
+        return "Recovering missing push subscription ID in the config model store."
+    }
+}

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/migrations/MigrationRecoveryTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/migrations/MigrationRecoveryTests.kt
@@ -1,0 +1,41 @@
+package com.onesignal.user.internal.migrations
+
+import com.onesignal.debug.LogLevel
+import com.onesignal.debug.internal.logging.Logging
+import com.onesignal.mocks.MockHelper
+import com.onesignal.user.internal.subscriptions.SubscriptionModel
+import com.onesignal.user.internal.subscriptions.SubscriptionModelStore
+import com.onesignal.user.internal.subscriptions.SubscriptionType
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+
+class MigrationRecoveryTests : FunSpec({
+    beforeAny {
+        Logging.logLevel = LogLevel.NONE
+    }
+
+    test("ensure RecoverConfigPushSubscription adds the missing push sub ID") {
+        // Given
+        val configModelStore = MockHelper.configModelStore()
+        val mockSubscriptionModelStore = mockk<SubscriptionModelStore>()
+        val recovery = RecoverConfigPushSubscription(configModelStore, mockSubscriptionModelStore)
+
+        // Set up config model store with null push subscription ID
+        val configModel = configModelStore.model
+        configModel.pushSubscriptionId = null
+
+        // Add a push subscription
+        val pushSubscription = SubscriptionModel()
+        pushSubscription.type = SubscriptionType.PUSH
+        pushSubscription.id = "0"
+        every { mockSubscriptionModelStore.list() } returns listOf(pushSubscription)
+
+        // When
+        recovery.start()
+
+        // Then
+        configModelStore.model.pushSubscriptionId shouldBe "0"
+    }
+})


### PR DESCRIPTION
# Description
## One Line Summary
Added a MigrationRecovery that detects and recovers a bad state that push sub ID is missing in the config store, caused by a bug in 5.2.0-beta or any version between 5.1.9-5.1.27.

## Details

### Motivation
5.2.0-beta and all versions between 5.1.9-5.1.27 have a specific logic for push subscription that depends on the result of a remote params fetch. It may cause the push sub ID to be missing from the config model if a postCreateDelay bug also happens that the app is closed within 5 seconds of first start.

### Scope
A new MigrationRecovery that will check the status of the config model store and the subscription model store at the start() level. 

### OPTIONAL - Other
Interface IMigrationRecovery and a base class MigrationRecovery are added for the ease of creating more recovery in the future.

# Testing
## Unit testing
**OPTIONAL -**  Explain unit tests added, if not clear in the code.

## Manual testing

Step to reproduce:
1. Check out the commit that release 5.2.0-beta that is specifically based on 5.1.25. Beta rebased to 5.1.27 will not have this issue.
2. close the app within 5 seconds, and reopen it. A 400 error occurs.
3. Downgrade to 5.1.29. After setting setPaused(false), no IAMs are displayed, and the push subscription is not updated.

Expected Behavior After the Fix:
After downgrade, the push subscription ID is correctly updated. All IAMs are displayed as expected.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [ ] PR does one thing
     - PR also includes a new interface IMigrationRecovery and a base class MigrationRecovery for the ease of creating new recovery if needed in the future.
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2271)
<!-- Reviewable:end -->
