### PR TITLE
Fix: IAM now showing after switching to 3-button-navigation mode

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/DeviceUtils.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/DeviceUtils.kt
@@ -4,9 +4,11 @@ import android.app.Activity
 import android.content.Context
 import android.graphics.Rect
 import android.net.ConnectivityManager
+import android.os.Build
 import android.telephony.TelephonyManager
 import android.util.DisplayMetrics
 import android.view.View
+import androidx.core.view.WindowInsetsCompat
 import java.lang.ref.WeakReference
 
 object DeviceUtils {
@@ -14,7 +16,6 @@ object DeviceUtils {
 
     /**
      * Check if the keyboard is currently being shown.
-     * Does not work for cases when keyboard is full screen.
      */
     fun isKeyboardUp(activityWeakReference: WeakReference<Activity?>): Boolean {
         val metrics = DisplayMetrics()
@@ -28,8 +29,15 @@ object DeviceUtils {
             window.windowManager.defaultDisplay.getMetrics(metrics)
         }
         if (view != null) {
-            val heightDiff = metrics.heightPixels - visibleBounds.bottom
-            isOpen = heightDiff > MARGIN_ERROR_PX_SIZE
+            isOpen =
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                    val imeInsets = view.rootWindowInsets
+                    imeInsets.isVisible(WindowInsetsCompat.Type.ime())
+                } else {
+                    // Does not work for cases when keyboard is full screen for Android 9 and below
+                    val heightDiff = metrics.heightPixels - visibleBounds.bottom
+                    heightDiff > MARGIN_ERROR_PX_SIZE
+                }
         }
         return isOpen
     }


### PR DESCRIPTION
# Description
## One Line Summary
Fix some IAMs being suppressed under some specific view layouts with the 3 button navigation mode

## Details

### Motivation
Fix the bug that causes IAM not shown when user is on the 3 button navigation mode.

### Scope
The PR changes how we determine if keyboard is currently open by using WindowInsets instead of using a fixed value for the offset of current view height and the screen height. This change will only be available for devices running on Android 11 and up. 

# Testing
## Manual testing
I was unable to reproduce the scenario that prevent IAM from showing. Instead, I tested whether isKeyboardUp returns the correct value with the soft keyboard being open and close. 

Devices I tested:
  - Pixel 9 API 35: used imeInsets logic and returned the correct output
  - Pixel 2 API 29: used visible bound height diff and returned the correct output

Both 

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [ ] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [ ] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2284)
<!-- Reviewable:end -->
