### PR TITLE
Fix: IAM not shown when calling login immediately after init

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/consistency/IamFetchReadyCondition.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/consistency/IamFetchReadyCondition.kt
@@ -20,8 +20,10 @@ class IamFetchReadyCondition(
     override val id: String
         get() = ID
 
+    private var translateKey: String = key
+
     override fun isMet(indexedTokens: Map<String, Map<IConsistencyKeyEnum, RywData>>): Boolean {
-        val tokenMap = indexedTokens[key] ?: return false
+        val tokenMap = indexedTokens[key] ?: indexedTokens[translateKey] ?: return false
         val userUpdateTokenSet = tokenMap[IamFetchRywTokenKey.USER] != null
 
         /**
@@ -34,7 +36,7 @@ class IamFetchReadyCondition(
     }
 
     override fun getRywData(indexedTokens: Map<String, Map<IConsistencyKeyEnum, RywData?>>): RywData? {
-        val tokenMap = indexedTokens[key] ?: return null
+        val tokenMap = indexedTokens[key] ?: indexedTokens[translateKey] ?: return null
 
         /**
          * Collect non-null RywData objects and find the one with the largest rywToken lexicographically
@@ -44,5 +46,14 @@ class IamFetchReadyCondition(
             tokenMap[IamFetchRywTokenKey.USER],
             tokenMap[IamFetchRywTokenKey.SUBSCRIPTION],
         ).maxByOrNull { it.rywToken ?: "" }
+    }
+
+    override fun translateKey(
+        oldKey: String,
+        newKey: String,
+    ) {
+        if (key == oldKey) {
+            translateKey = newKey
+        }
     }
 }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/consistency/impl/ConsistencyManager.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/consistency/impl/ConsistencyManager.kt
@@ -71,6 +71,18 @@ class ConsistencyManager : IConsistencyManager {
         conditions.removeAll(completedConditions)
     }
 
+    override fun translateConditionKeyWithID(
+        id: String,
+        oldKey: String,
+        newKey: String,
+    ) {
+        for ((condition, _) in conditions) {
+            if (condition.id == id) {
+                condition.translateKey(oldKey, newKey)
+            }
+        }
+    }
+
     /**
      * IMPORTANT: calling code should be protected by mutex to avoid potential inconsistencies
      */

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/consistency/models/ICondition.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/consistency/models/ICondition.kt
@@ -20,4 +20,12 @@ interface ICondition {
      * e.g. numeric strings would be compared differently from JWT tokens
      */
     fun getRywData(indexedTokens: Map<String, Map<IConsistencyKeyEnum, RywData?>>): RywData?
+
+    /**
+     * Used to update condition when the key (i.e. onesignalId) can be translated into a new key
+     */
+    fun translateKey(
+        oldKey: String,
+        newKey: String,
+    )
 }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/consistency/models/IConsistencyManager.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/consistency/models/IConsistencyManager.kt
@@ -29,4 +29,13 @@ interface IConsistencyManager {
      * Resolve all conditions with a specific ID
      */
     suspend fun resolveConditionsWithID(id: String)
+
+    /**
+     * Update the key used by the condition
+     */
+    fun translateConditionKeyWithID(
+        id: String,
+        oldKey: String,
+        newKey: String,
+    )
 }

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/common/consistency/ConsistencyManagerTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/common/consistency/ConsistencyManagerTests.kt
@@ -75,6 +75,24 @@ class ConsistencyManagerTests : FunSpec({
             deferred.isCompleted shouldBe true
         }
     }
+
+    test("translateConditionKeyWithID translates keys with corresponding ID") {
+        runTest {
+            // Given
+            val oldOnesignalId = "123"
+            val newOnesignalId = "456"
+            val condition = IamFetchReadyCondition(oldOnesignalId)
+            val deferred = consistencyManager.getRywDataFromAwaitableCondition(condition)
+
+            // a new onesignal ID has been received
+            consistencyManager.translateConditionKeyWithID(condition.id, oldOnesignalId, newOnesignalId)
+            consistencyManager.setRywData(newOnesignalId, IamFetchRywTokenKey.USER, RywData("token", 500L))
+
+            deferred.await()
+            // setRywData with new onesignal ID completes the condition that was created with old onesignalID
+            deferred.isCompleted shouldBe true
+        }
+    }
 }) {
     // Mock implementation of ICondition that simulates a condition that isn't met
     private class TestUnmetCondition : ICondition {
@@ -91,6 +109,13 @@ class ConsistencyManagerTests : FunSpec({
 
         override fun getRywData(indexedTokens: Map<String, Map<IConsistencyKeyEnum, RywData?>>): RywData? {
             return null
+        }
+
+        override fun translateKey(
+            oldKey: String,
+            newKey: String,
+        ) {
+            // not used
         }
     }
 
@@ -111,6 +136,13 @@ class ConsistencyManagerTests : FunSpec({
 
         override fun getRywData(indexedTokens: Map<String, Map<IConsistencyKeyEnum, RywData?>>): RywData? {
             return expectedRywTokens.values.firstOrNull()?.values?.firstOrNull()
+        }
+
+        override fun translateKey(
+            oldKey: String,
+            newKey: String,
+        ) {
+            // not used
         }
     }
 }

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/LoginUserOperationExecutorTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/LoginUserOperationExecutorTests.kt
@@ -1,6 +1,7 @@
 package com.onesignal.user.internal.operations
 
 import br.com.colman.kotest.android.extensions.robolectric.RobolectricTest
+import com.onesignal.common.consistency.models.IConsistencyManager
 import com.onesignal.common.exceptions.BackendException
 import com.onesignal.core.internal.operations.ExecutionResponse
 import com.onesignal.core.internal.operations.ExecutionResult
@@ -76,6 +77,7 @@ class LoginUserOperationExecutorTests : FunSpec({
                 mockSubscriptionsModelStore,
                 MockHelper.configModelStore(),
                 MockHelper.languageContext(),
+                mockk<IConsistencyManager>(),
             )
         val operations =
             listOf<Operation>(
@@ -120,6 +122,7 @@ class LoginUserOperationExecutorTests : FunSpec({
                 mockSubscriptionsModelStore,
                 MockHelper.configModelStore(),
                 MockHelper.languageContext(),
+                mockk<IConsistencyManager>(),
             )
         val operations =
             listOf<Operation>(
@@ -148,7 +151,7 @@ class LoginUserOperationExecutorTests : FunSpec({
         val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
 
         val loginUserOperationExecutor =
-            LoginUserOperationExecutor(mockIdentityOperationExecutor, AndroidMockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext())
+            LoginUserOperationExecutor(mockIdentityOperationExecutor, AndroidMockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext(), mockk<IConsistencyManager>())
         val operations =
             listOf<Operation>(
                 LoginUserOperation(appId, localOneSignalId, null, null),
@@ -176,7 +179,7 @@ class LoginUserOperationExecutorTests : FunSpec({
         val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
 
         val loginUserOperationExecutor =
-            LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext())
+            LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext(), mockk<IConsistencyManager>())
         val operations = listOf<Operation>(LoginUserOperation(appId, localOneSignalId, "externalId", null))
 
         // When
@@ -214,6 +217,7 @@ class LoginUserOperationExecutorTests : FunSpec({
                 mockSubscriptionsModelStore,
                 MockHelper.configModelStore(),
                 MockHelper.languageContext(),
+                mockk<IConsistencyManager>(),
             )
         val operations = listOf<Operation>(LoginUserOperation(appId, localOneSignalId, "externalId", null))
 
@@ -242,7 +246,7 @@ class LoginUserOperationExecutorTests : FunSpec({
         val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
 
         val loginUserOperationExecutor =
-            LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext())
+            LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext(), mockk<IConsistencyManager>())
         val operations = listOf<Operation>(LoginUserOperation(appId, localOneSignalId, "externalId", "existingOneSignalId"))
 
         // When
@@ -278,7 +282,7 @@ class LoginUserOperationExecutorTests : FunSpec({
         val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
 
         val loginUserOperationExecutor =
-            LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext())
+            LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext(), mockk<IConsistencyManager>())
         val operations = listOf<Operation>(LoginUserOperation(appId, localOneSignalId, "externalId", "existingOneSignalId"))
 
         // When
@@ -314,7 +318,7 @@ class LoginUserOperationExecutorTests : FunSpec({
         val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
 
         val loginUserOperationExecutor =
-            LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext())
+            LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext(), mockk<IConsistencyManager>())
         val operations = listOf<Operation>(LoginUserOperation(appId, localOneSignalId, "externalId", "existingOneSignalId"))
 
         // When
@@ -352,7 +356,7 @@ class LoginUserOperationExecutorTests : FunSpec({
         val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
 
         val loginUserOperationExecutor =
-            LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext())
+            LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext(), mockk<IConsistencyManager>())
         val operations = listOf<Operation>(LoginUserOperation(appId, localOneSignalId, "externalId", "existingOneSignalId"))
 
         // When
@@ -403,6 +407,7 @@ class LoginUserOperationExecutorTests : FunSpec({
                 mockSubscriptionsModelStore,
                 MockHelper.configModelStore(),
                 MockHelper.languageContext(),
+                mockk<IConsistencyManager>(),
             )
         val operations =
             listOf<Operation>(
@@ -504,6 +509,7 @@ class LoginUserOperationExecutorTests : FunSpec({
                 mockSubscriptionsModelStore,
                 MockHelper.configModelStore(),
                 MockHelper.languageContext(),
+                mockk<IConsistencyManager>(),
             )
         val operations =
             listOf<Operation>(
@@ -590,6 +596,7 @@ class LoginUserOperationExecutorTests : FunSpec({
                 mockSubscriptionsModelStore,
                 MockHelper.configModelStore(),
                 MockHelper.languageContext(),
+                mockk<IConsistencyManager>(),
             )
         val operations =
             listOf<Operation>(
@@ -662,6 +669,7 @@ class LoginUserOperationExecutorTests : FunSpec({
                 mockSubscriptionsModelStore,
                 MockHelper.configModelStore(),
                 MockHelper.languageContext(),
+                mockk<IConsistencyManager>(),
             )
         val operations =
             listOf<Operation>(
@@ -725,6 +733,7 @@ class LoginUserOperationExecutorTests : FunSpec({
                 mockSubscriptionsModelStore,
                 MockHelper.configModelStore(),
                 MockHelper.languageContext(),
+                mockk<IConsistencyManager>(),
             )
         // anonymous Login request
         val operations = listOf<Operation>(LoginUserOperation(appId, localOneSignalId, null, null))

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/LoginUserOperationExecutorTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/LoginUserOperationExecutorTests.kt
@@ -1,7 +1,6 @@
 package com.onesignal.user.internal.operations
 
 import br.com.colman.kotest.android.extensions.robolectric.RobolectricTest
-import com.onesignal.common.consistency.models.IConsistencyManager
 import com.onesignal.common.exceptions.BackendException
 import com.onesignal.core.internal.operations.ExecutionResponse
 import com.onesignal.core.internal.operations.ExecutionResult
@@ -77,7 +76,7 @@ class LoginUserOperationExecutorTests : FunSpec({
                 mockSubscriptionsModelStore,
                 MockHelper.configModelStore(),
                 MockHelper.languageContext(),
-                mockk<IConsistencyManager>(),
+                MockHelper.consistencyManager(),
             )
         val operations =
             listOf<Operation>(
@@ -122,7 +121,7 @@ class LoginUserOperationExecutorTests : FunSpec({
                 mockSubscriptionsModelStore,
                 MockHelper.configModelStore(),
                 MockHelper.languageContext(),
-                mockk<IConsistencyManager>(),
+                MockHelper.consistencyManager(),
             )
         val operations =
             listOf<Operation>(
@@ -151,7 +150,7 @@ class LoginUserOperationExecutorTests : FunSpec({
         val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
 
         val loginUserOperationExecutor =
-            LoginUserOperationExecutor(mockIdentityOperationExecutor, AndroidMockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext(), mockk<IConsistencyManager>())
+            LoginUserOperationExecutor(mockIdentityOperationExecutor, AndroidMockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext(), MockHelper.consistencyManager())
         val operations =
             listOf<Operation>(
                 LoginUserOperation(appId, localOneSignalId, null, null),
@@ -179,7 +178,7 @@ class LoginUserOperationExecutorTests : FunSpec({
         val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
 
         val loginUserOperationExecutor =
-            LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext(), mockk<IConsistencyManager>())
+            LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext(), MockHelper.consistencyManager())
         val operations = listOf<Operation>(LoginUserOperation(appId, localOneSignalId, "externalId", null))
 
         // When
@@ -217,7 +216,7 @@ class LoginUserOperationExecutorTests : FunSpec({
                 mockSubscriptionsModelStore,
                 MockHelper.configModelStore(),
                 MockHelper.languageContext(),
-                mockk<IConsistencyManager>(),
+                MockHelper.consistencyManager(),
             )
         val operations = listOf<Operation>(LoginUserOperation(appId, localOneSignalId, "externalId", null))
 
@@ -246,7 +245,7 @@ class LoginUserOperationExecutorTests : FunSpec({
         val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
 
         val loginUserOperationExecutor =
-            LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext(), mockk<IConsistencyManager>())
+            LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext(), MockHelper.consistencyManager())
         val operations = listOf<Operation>(LoginUserOperation(appId, localOneSignalId, "externalId", "existingOneSignalId"))
 
         // When
@@ -282,7 +281,7 @@ class LoginUserOperationExecutorTests : FunSpec({
         val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
 
         val loginUserOperationExecutor =
-            LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext(), mockk<IConsistencyManager>())
+            LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext(), MockHelper.consistencyManager())
         val operations = listOf<Operation>(LoginUserOperation(appId, localOneSignalId, "externalId", "existingOneSignalId"))
 
         // When
@@ -318,7 +317,7 @@ class LoginUserOperationExecutorTests : FunSpec({
         val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
 
         val loginUserOperationExecutor =
-            LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext(), mockk<IConsistencyManager>())
+            LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext(), MockHelper.consistencyManager())
         val operations = listOf<Operation>(LoginUserOperation(appId, localOneSignalId, "externalId", "existingOneSignalId"))
 
         // When
@@ -356,7 +355,7 @@ class LoginUserOperationExecutorTests : FunSpec({
         val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
 
         val loginUserOperationExecutor =
-            LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext(), mockk<IConsistencyManager>())
+            LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext(), MockHelper.consistencyManager())
         val operations = listOf<Operation>(LoginUserOperation(appId, localOneSignalId, "externalId", "existingOneSignalId"))
 
         // When
@@ -407,7 +406,7 @@ class LoginUserOperationExecutorTests : FunSpec({
                 mockSubscriptionsModelStore,
                 MockHelper.configModelStore(),
                 MockHelper.languageContext(),
-                mockk<IConsistencyManager>(),
+                MockHelper.consistencyManager(),
             )
         val operations =
             listOf<Operation>(
@@ -509,7 +508,7 @@ class LoginUserOperationExecutorTests : FunSpec({
                 mockSubscriptionsModelStore,
                 MockHelper.configModelStore(),
                 MockHelper.languageContext(),
-                mockk<IConsistencyManager>(),
+                MockHelper.consistencyManager(),
             )
         val operations =
             listOf<Operation>(
@@ -596,7 +595,7 @@ class LoginUserOperationExecutorTests : FunSpec({
                 mockSubscriptionsModelStore,
                 MockHelper.configModelStore(),
                 MockHelper.languageContext(),
-                mockk<IConsistencyManager>(),
+                MockHelper.consistencyManager(),
             )
         val operations =
             listOf<Operation>(
@@ -669,7 +668,7 @@ class LoginUserOperationExecutorTests : FunSpec({
                 mockSubscriptionsModelStore,
                 MockHelper.configModelStore(),
                 MockHelper.languageContext(),
-                mockk<IConsistencyManager>(),
+                MockHelper.consistencyManager(),
             )
         val operations =
             listOf<Operation>(
@@ -733,7 +732,7 @@ class LoginUserOperationExecutorTests : FunSpec({
                 mockSubscriptionsModelStore,
                 MockHelper.configModelStore(),
                 MockHelper.languageContext(),
-                mockk<IConsistencyManager>(),
+                MockHelper.consistencyManager(),
             )
         // anonymous Login request
         val operations = listOf<Operation>(LoginUserOperation(appId, localOneSignalId, null, null))

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/SubscriptionOperationExecutorTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/SubscriptionOperationExecutorTests.kt
@@ -3,7 +3,6 @@ package com.onesignal.user.internal.operations
 import br.com.colman.kotest.android.extensions.robolectric.RobolectricTest
 import com.onesignal.common.consistency.RywData
 import com.onesignal.common.consistency.enums.IamFetchRywTokenKey
-import com.onesignal.common.consistency.models.IConsistencyManager
 import com.onesignal.common.exceptions.BackendException
 import com.onesignal.core.internal.operations.ExecutionResult
 import com.onesignal.core.internal.operations.Operation
@@ -38,7 +37,7 @@ class SubscriptionOperationExecutorTests :
         val localSubscriptionId = "local-subscriptionId1"
         val remoteSubscriptionId = "remote-subscriptionId1"
         val rywData = RywData("1", 500L)
-        val mockConsistencyManager = mockk<IConsistencyManager>()
+        val mockConsistencyManager = MockHelper.consistencyManager()
 
         beforeTest {
             clearMocks(mockConsistencyManager)

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/UpdateUserOperationExecutorTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/UpdateUserOperationExecutorTests.kt
@@ -2,7 +2,6 @@ package com.onesignal.user.internal.operations
 
 import com.onesignal.common.consistency.RywData
 import com.onesignal.common.consistency.enums.IamFetchRywTokenKey
-import com.onesignal.common.consistency.models.IConsistencyManager
 import com.onesignal.common.exceptions.BackendException
 import com.onesignal.core.internal.operations.ExecutionResult
 import com.onesignal.core.internal.operations.Operation
@@ -31,7 +30,7 @@ class UpdateUserOperationExecutorTests :
         val localOneSignalId = "local-onesignalId"
         val remoteOneSignalId = "remote-onesignalId"
         val rywData = RywData("1", 500L)
-        val mockConsistencyManager = mockk<IConsistencyManager>()
+        val mockConsistencyManager = MockHelper.consistencyManager()
 
         beforeTest {
             clearMocks(mockConsistencyManager)

--- a/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/InAppMessagesManager.kt
+++ b/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/InAppMessagesManager.kt
@@ -43,6 +43,7 @@ import com.onesignal.session.internal.outcomes.IOutcomeEventsController
 import com.onesignal.session.internal.session.ISessionLifecycleHandler
 import com.onesignal.session.internal.session.ISessionService
 import com.onesignal.user.IUserManager
+import com.onesignal.user.internal.identity.IdentityModelStore
 import com.onesignal.user.internal.subscriptions.ISubscriptionChangedHandler
 import com.onesignal.user.internal.subscriptions.ISubscriptionManager
 import com.onesignal.user.internal.subscriptions.SubscriptionModel
@@ -59,6 +60,7 @@ internal class InAppMessagesManager(
     private val _sessionService: ISessionService,
     private val _influenceManager: IInfluenceManager,
     private val _configModelStore: ConfigModelStore,
+    private val _identityModelStore: IdentityModelStore,
     private val _userManager: IUserManager,
     private val _subscriptionManager: ISubscriptionManager,
     private val _outcomeEventsController: IOutcomeEventsController,
@@ -163,7 +165,7 @@ internal class InAppMessagesManager(
             }
 
             // attempt to fetch messages from the backend (if we have the pre-requisite data already)
-            val onesignalId = _userManager.onesignalId
+            val onesignalId = _identityModelStore.model.onesignalId
             val updateConditionDeferred =
                 _consistencyManager.getRywDataFromAwaitableCondition(IamFetchReadyCondition(onesignalId))
             val rywToken = updateConditionDeferred.await()
@@ -240,7 +242,7 @@ internal class InAppMessagesManager(
 
     private fun fetchMessagesWhenConditionIsMet() {
         suspendifyOnThread {
-            val onesignalId = _userManager.onesignalId
+            val onesignalId = _identityModelStore.model.onesignalId
             val iamFetchCondition =
                 _consistencyManager.getRywDataFromAwaitableCondition(IamFetchReadyCondition(onesignalId))
             val rywData = iamFetchCondition.await()

--- a/OneSignalSDK/onesignal/in-app-messages/src/test/java/com/onesignal/inAppMessages/internal/InAppMessagesManagerTests.kt
+++ b/OneSignalSDK/onesignal/in-app-messages/src/test/java/com/onesignal/inAppMessages/internal/InAppMessagesManagerTests.kt
@@ -1,6 +1,5 @@
 package com.onesignal.inAppMessages.internal
 
-import com.onesignal.common.consistency.models.IConsistencyManager
 import com.onesignal.core.internal.config.ConfigModelStore
 import com.onesignal.inAppMessages.internal.backend.IInAppBackendService
 import com.onesignal.inAppMessages.internal.display.IInAppDisplayer
@@ -14,6 +13,7 @@ import com.onesignal.session.internal.influence.IInfluenceManager
 import com.onesignal.session.internal.outcomes.IOutcomeEventsController
 import com.onesignal.session.internal.session.ISessionService
 import com.onesignal.user.IUserManager
+import com.onesignal.user.internal.identity.IdentityModelStore
 import com.onesignal.user.internal.subscriptions.ISubscriptionManager
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
@@ -40,6 +40,7 @@ class InAppMessagesManagerTests : FunSpec({
                 mockk<ISessionService>(),
                 mockk<IInfluenceManager>(),
                 mockk<ConfigModelStore>(),
+                mockk<IdentityModelStore>(),
                 mockk<IUserManager>(),
                 mockk<ISubscriptionManager>(),
                 mockk<IOutcomeEventsController>(),
@@ -53,7 +54,7 @@ class InAppMessagesManagerTests : FunSpec({
                 mockk<IInAppLifecycleService>(),
                 MockHelper.languageContext(),
                 MockHelper.time(1000),
-                mockk<IConsistencyManager>(),
+                MockHelper.consistencyManager(),
             )
 
         // When

--- a/OneSignalSDK/onesignal/testhelpers/src/main/java/com/onesignal/mocks/MockHelper.kt
+++ b/OneSignalSDK/onesignal/testhelpers/src/main/java/com/onesignal/mocks/MockHelper.kt
@@ -1,5 +1,7 @@
 package com.onesignal.mocks
 
+import com.onesignal.common.consistency.impl.ConsistencyManager
+import com.onesignal.common.consistency.models.IConsistencyManager
 import com.onesignal.core.internal.application.IApplicationService
 import com.onesignal.core.internal.config.ConfigModel
 import com.onesignal.core.internal.config.ConfigModelStore
@@ -125,5 +127,11 @@ object MockHelper {
         val deviceService = mockk<IDeviceService>()
         every { deviceService.deviceType } returns IDeviceService.DeviceType.Android
         return deviceService
+    }
+
+    fun consistencyManager(): IConsistencyManager {
+        val consistencyManager = mockk<ConsistencyManager>()
+        every { consistencyManager.translateConditionKeyWithID(any(), any(), any()) } just runs
+        return consistencyManager
     }
 }


### PR DESCRIPTION
# Description
## One Line Summary
Fix ConsistencyManager so it can translate IAM conditions with old OneSignalID.

## Details

### Motivation
Fix the issue when IAM is not showing on fresh install if Login is called immediately after initWithContext. This is caused by ConsistencyManager not translating the condition key after a user is created. The PR works around ConsistencyManager to add a functionality that can correctly update the conditions with correct keys.

### Scope
Condition now has a new method translateKey(), which allows to translate its previous key to be updated to be able to meet condition in the event of ID translation. LoginUserOperationExecutor will translate all conditions through ConsistencyManager when a user is successfully created.

# Testing
## Unit testing
- ConsistencyManagerTests.kt: created a new test unit to test whether translateKey() makes a condition met after the key has been updated.
- Update all tests with LoginUserOperation to pass in a ConsistencyManager as parameter.

## Manual testing
Issue reproducible by a fresh install that is calling Login immediately after initWithContext. We could observe that IAM does not show on the first startup. After the fix, IAM shows successfully.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [ ] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2286)
<!-- Reviewable:end -->
