### PR TITLE
Maintain: fix flaky test unit caused by enqueue not complete instantly

### DIFF
--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/operations/OperationRepoTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/operations/OperationRepoTests.kt
@@ -157,6 +157,12 @@ class OperationRepoTests : FunSpec({
         // When
         operationRepo.start()
         operationRepo.enqueue(MyOperation())
+        // Wait for the background coroutine to complete enqueue
+        withTimeout(1000) {
+            while (operationRepo.queue.size == 0) {
+                delay(10)
+            }
+        }
 
         // Then
         operationRepo.containsInstanceOf<MyOperation>() shouldBe true
@@ -609,6 +615,12 @@ class OperationRepoTests : FunSpec({
         // When
         mocks.operationRepo.start()
         mocks.operationRepo.enqueue(operation1)
+        // Wait for the background coroutine to complete enqueue
+        withTimeout(1000) {
+            while (mocks.operationRepo.queue.size == 0) {
+                delay(10)
+            }
+        }
         val job = launch { mocks.operationRepo.enqueueAndWait(operation2) }.also { yield() }
         mocks.operationRepo.enqueueAndWait(operation3)
         job.join()
@@ -639,6 +651,12 @@ class OperationRepoTests : FunSpec({
         mocks.operationRepo.start()
         mocks.operationRepo.enqueue(operation1)
         mocks.operationRepo.enqueue(operation2)
+        // Wait for the background coroutine to complete enqueue
+        withTimeout(1000) {
+            while (mocks.operationRepo.queue.size < 2) {
+                delay(10)
+            }
+        }
         mocks.operationRepo.enqueueAndWait(operation3)
 
         // Then


### PR DESCRIPTION
Since OperationRepo.enqueue() was changed to internal enqueue in a separate coroutine scope, we can no longer expect calling OperationRepo.enqueue() can instantly insert the operation. Adding a delay after each enqueue call in the unit test to give time for the internal enqueuing to actually complete.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2290)
<!-- Reviewable:end -->
