### PR TITLE
Player Model - Fix concurrency with modifying log listeners

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -73,6 +73,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import static com.onesignal.GenerateNotification.BUNDLE_KEY_ACTION_ID;
 import static com.onesignal.GenerateNotification.BUNDLE_KEY_ANDROID_NOTIFICATION_ID;
@@ -1348,7 +1349,7 @@ public class OneSignal {
       }
    }
 
-   private static final List<OneSignalLogListener> logListeners = new ArrayList<>();
+   private static final List<OneSignalLogListener> logListeners = new CopyOnWriteArrayList<>();
 
    public static void addLogListener(@NonNull OneSignalLogListener listener) {
       logListeners.add(listener);

--- a/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
+++ b/OneSignalSDK/unittest/src/test/java/com/onesignal/OneSignalPackagePrivateHelper.java
@@ -328,6 +328,10 @@ public class OneSignalPackagePrivateHelper {
       return OneSignal.isInForeground();
    }
 
+   public static void OneSignal_Log(@NonNull OneSignal.LOG_LEVEL level, @NonNull String message) {
+      OneSignal.Log(level,message);
+   }
+
    static public class OSSharedPreferencesWrapper extends com.onesignal.OSSharedPreferencesWrapper {}
 
    static public class RemoteOutcomeParams extends OneSignalRemoteParams.InfluenceParams {

--- a/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
+++ b/OneSignalSDK/unittest/src/test/java/com/test/onesignal/MainOneSignalClassRunner.java
@@ -91,6 +91,8 @@ import com.onesignal.ShadowRoboNotificationManager;
 import com.onesignal.StaticResetHelper;
 import com.onesignal.SyncJobService;
 import com.onesignal.SyncService;
+import com.onesignal.debug.OneSignalLogEvent;
+import com.onesignal.debug.OneSignalLogListener;
 import com.onesignal.example.BlankActivity;
 import com.onesignal.example.MainActivity;
 import com.onesignal.influence.data.OSTrackerFactory;
@@ -133,6 +135,7 @@ import java.util.regex.Pattern;
 import static com.onesignal.OneSignalPackagePrivateHelper.FCMBroadcastReceiver_processBundle;
 import static com.onesignal.OneSignalPackagePrivateHelper.NotificationBundleProcessor_Process;
 import static com.onesignal.OneSignalPackagePrivateHelper.NotificationOpenedProcessor_processFromContext;
+import static com.onesignal.OneSignalPackagePrivateHelper.OneSignal_Log;
 import static com.onesignal.OneSignalPackagePrivateHelper.OneSignal_getSessionListener;
 import static com.onesignal.OneSignalPackagePrivateHelper.OneSignal_handleNotificationOpen;
 import static com.onesignal.OneSignalPackagePrivateHelper.OneSignal_isInForeground;
@@ -4165,6 +4168,46 @@ public class MainOneSignalClassRunner {
       // Verify MainActivity has no orientation flag
       boolean mainHasFlag = OneSignalPackagePrivateHelper.hasConfigChangeFlag(mainActivity, ActivityInfo.CONFIG_ORIENTATION);
       assertFalse(mainHasFlag);
+   }
+
+   // ####### Unit test log listener ########
+   @Test
+   public void testAddLogListener() {
+      final String[] lastMessage = new String[1];
+      OneSignal.addLogListener(event -> lastMessage[0] = event.getEntry());
+
+      OneSignal_Log(OneSignal.LOG_LEVEL.DEBUG, "test");
+      assertEquals(lastMessage[0], "test");
+   }
+
+   @Test
+   public void testRemoveLogListener() {
+      final String[] lastMessage = new String[1];
+      OneSignalLogListener listener = event -> lastMessage[0] = event.getEntry();
+      OneSignal.addLogListener(listener);
+
+      OneSignal.removeLogListener(listener);
+      OneSignal_Log(OneSignal.LOG_LEVEL.DEBUG, "test");
+      assertNull(lastMessage[0]);
+   }
+
+   @Test
+   public void testNestedAddLogListenerDoesNotThrow() {
+      OneSignalLogListener listener = event -> OneSignal.addLogListener(event2 -> {});
+
+      OneSignal.addLogListener(listener);
+
+      OneSignal_Log(OneSignal.LOG_LEVEL.DEBUG, "test");
+   }
+
+   @Test
+   public void testNestedRemoveLogListenerDoesNotThrow() {
+      final OneSignalLogListener[] listener = new OneSignalLogListener[1];
+
+      listener[0] = event -> OneSignal.removeLogListener(listener[0]);
+      OneSignal.addLogListener(listener[0]);
+
+      OneSignal_Log(OneSignal.LOG_LEVEL.DEBUG, "test");
    }
 
    // ####### Unit test helper methods ########


### PR DESCRIPTION
# Description
## One Line Summary
Avoid `ConcurrentModificationException` when someone adds or removes a log listener while the stack is still inside the `onLogEvent` method.

## Details
Addressed by switching from an `ArrayList` to `CopyOnWriteArrayList`. This is a good fit as the listener list will rarely be modified, but will have a ton of reads.

### Motivation
All public SDK methods should be thread safe.

### Scope
Only effects the log listener feature originally added in PR #2260.

# Testing
## Unit testing
Added tests to prove and ensure this issue is now avoided.

## Manual testing
Tested on an Android 14 emulator.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
       - Number of issues with CI on the 4.x.x where they are no long running, but the new tests added in the PR pass locally.
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2293)
<!-- Reviewable:end -->
