### PR TITLE
Fix: NotificationOpenedActivity "freeze" when a large amount of notification is clicked

### DIFF
--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/lifecycle/impl/NotificationLifecycleService.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/lifecycle/impl/NotificationLifecycleService.kt
@@ -7,6 +7,7 @@ import com.onesignal.common.JSONUtils
 import com.onesignal.common.events.CallbackProducer
 import com.onesignal.common.events.EventProducer
 import com.onesignal.common.exceptions.BackendException
+import com.onesignal.common.threading.OSPrimaryCoroutineScope
 import com.onesignal.core.internal.application.AppEntryAction
 import com.onesignal.core.internal.application.IApplicationService
 import com.onesignal.core.internal.config.ConfigModelStore
@@ -138,15 +139,17 @@ internal class NotificationLifecycleService(
 
             postedOpenedNotifIds.add(notificationId)
 
-            try {
-                _backend.updateNotificationAsOpened(
-                    appId,
-                    notificationId,
-                    subscriptionId,
-                    deviceType,
-                )
-            } catch (ex: BackendException) {
-                Logging.error("Notification opened confirmation failed with statusCode: ${ex.statusCode} response: ${ex.response}")
+            OSPrimaryCoroutineScope.execute {
+                try {
+                    _backend.updateNotificationAsOpened(
+                        appId,
+                        notificationId,
+                        subscriptionId,
+                        deviceType,
+                    )
+                } catch (ex: BackendException) {
+                    Logging.error("Notification opened confirmation failed with statusCode: ${ex.statusCode} response: ${ex.response}")
+                }
             }
         }
 


### PR DESCRIPTION
# Description
## One Line Summary
Move the backend call `updateNotificationsAsOpened` to a background thread to prevent blocking the next activity from opening when many notifications are clicked.

## Details

### Motivation
Fix a frozen screen issue that occurs when a large number of notifications are clicked simultaneously.

### Scope
- The `updateNotificationsAsOpened` operation is now performed silently in the background. This means we no longer wait for its response before opening the destination activity upon a notification click. As a result, the order of this operation relative to other operations is no longer guaranteed. A potential risk is that IDs may change before `updateNotificationsAsOpened` completes on the backend. However, since all data is finalized at the time the requests are created, data integrity is maintained without blocking the UI.
- OSPrimaryCoroutineScope is also used by other backend operations like `createUser` and `updateSubscription`. As a result, these operations could potentially be delayed if too many `updateNotificationsAsOpened` calls are made.
One possible improvement would be to introduce a `SecondaryCoroutineScope` to handle lower-priority updates, but since they’re all backend calls, the overall time required to complete them remains roughly the same.
- ⚠️ Important: If the app is force-closed shortly after a notification click, some `updateNotificationsAsOpened` calls may be interrupted, and those clicks might not be updated on the backend.

# Testing
## Unit testing
A new unit test ensures that `openDestinationActivity` is not blocked when clicking on a large number of notifications.

## Manual testing
Tested on a Pixel 9 (API 35) emulator. Clicking a summary notification that groups 50+ individual notifications opens the app seamlessly. The `updateNotificationsAsOpened` calls are successfully processed in the background after the app is opened.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [x] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2304)
<!-- Reviewable:end -->
