### PR TITLE
fix: NPE when accessing WindowInsets used in isKeyboardUp()

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/DeviceUtils.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/DeviceUtils.kt
@@ -32,7 +32,7 @@ object DeviceUtils {
             isOpen =
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
                     val imeInsets = view.rootWindowInsets
-                    imeInsets.isVisible(WindowInsetsCompat.Type.ime())
+                    imeInsets?.isVisible(WindowInsetsCompat.Type.ime()) ?: false
                 } else {
                     // Does not work for cases when keyboard is full screen for Android 9 and below
                     val heightDiff = metrics.heightPixels - visibleBounds.bottom


### PR DESCRIPTION
# Description
## One Line Summary
Check whether the WindowInsets is null before calling its method.

## Details

### Motivation
Fix a NPE crash when a view is detached while evaluating IAMs. 

# Testing
## Unit testing
No unit test is added; test not needed

## Manual testing
Tested on a Pixel 9 API 35 emulator only with basic functionalities. I am not able to reproduce the scenario when WindowInsets is null. The code will return false when that happens.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [x] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [ ] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [ ] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2305)
<!-- Reviewable:end -->
