### PR TITLE
Feat: add public log listener methods

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/debug/IDebugManager.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/debug/IDebugManager.kt
@@ -3,17 +3,29 @@ package com.onesignal.debug
 /**
  * Access to debug the SDK in the event additional information is required to diagnose any
  * SDK-related issues.
- *
- * WARNING: This should not be used in a production setting.
  */
 interface IDebugManager {
     /**
      * The log level the OneSignal SDK should be writing to the Android log. Defaults to [LogLevel.WARN].
+     * WARNING: This should not be set higher than LogLevel.WARN in a production setting.
      */
     var logLevel: LogLevel
 
     /**
      * The log level the OneSignal SDK should be showing as a modal. Defaults to [LogLevel.NONE].
+     * WARNING: This should not be used in a production setting.
      */
     var alertLevel: LogLevel
+
+    /**
+     * Add a listener to receive all logging messages the SDK produces.
+     * Useful to capture and send logs to your server.
+     * NOTE: All log messages are always passed, logLevel has no effect on this.
+     */
+    fun addLogListener(listener: ILogListener)
+
+    /**
+     * Removes a listener added by addLogListener
+     */
+    fun removeLogListener(listener: ILogListener)
 }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/debug/ILogListener.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/debug/ILogListener.kt
@@ -1,0 +1,5 @@
+package com.onesignal.debug
+
+fun interface ILogListener {
+    fun onLogEvent(event: OneSignalLogEvent)
+}

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/debug/OneSignalLogEvent.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/debug/OneSignalLogEvent.kt
@@ -1,0 +1,6 @@
+package com.onesignal.debug
+
+data class OneSignalLogEvent(
+    val level: LogLevel,
+    val entry: String,
+)

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/debug/internal/DebugManager.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/debug/internal/DebugManager.kt
@@ -1,6 +1,7 @@
 package com.onesignal.debug.internal
 
 import com.onesignal.debug.IDebugManager
+import com.onesignal.debug.ILogListener
 import com.onesignal.debug.LogLevel
 import com.onesignal.debug.internal.logging.Logging
 
@@ -20,5 +21,13 @@ internal class DebugManager() : IDebugManager {
     init {
         logLevel = LogLevel.WARN
         alertLevel = LogLevel.NONE
+    }
+
+    override fun addLogListener(listener: ILogListener) {
+        Logging.addListener(listener)
+    }
+
+    override fun removeLogListener(listener: ILogListener) {
+        Logging.removeListener(listener)
     }
 }

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/debug/internal/LoggingTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/debug/internal/LoggingTests.kt
@@ -6,6 +6,7 @@ import com.onesignal.debug.OneSignalLogEvent
 import com.onesignal.debug.internal.logging.Logging
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldEndWith
 
 class TestLogLister : ILogListener {
     val calls = ArrayList<String>()
@@ -13,6 +14,11 @@ class TestLogLister : ILogListener {
     override fun onLogEvent(event: OneSignalLogEvent) {
         calls += event.entry
     }
+}
+
+infix fun <T : Collection<String>> T.shouldHaveEachItemEndWith(expected: Array<String>): T {
+    this.forEachIndexed { index, it -> it shouldEndWith expected[index] }
+    return this
 }
 
 class LoggingTests : FunSpec({
@@ -29,7 +35,7 @@ class LoggingTests : FunSpec({
         Logging.debug("test")
 
         // Then
-        listener.calls shouldBe arrayOf("test")
+        listener.calls shouldHaveEachItemEndWith arrayOf("test")
     }
 
     test("addListener twice") {
@@ -42,7 +48,7 @@ class LoggingTests : FunSpec({
         Logging.debug("test")
 
         // Then
-        listener.calls shouldBe arrayOf("test")
+        listener.calls shouldHaveEachItemEndWith arrayOf("test")
     }
 
     test("removeListener") {
@@ -83,7 +89,7 @@ class LoggingTests : FunSpec({
         Logging.debug("test3")
 
         // Then
-        nestedListener.calls shouldBe arrayOf("test2", "test3")
+        nestedListener.calls shouldHaveEachItemEndWith arrayOf("test2", "test3")
     }
 
     test("removeListener nested") {
@@ -102,6 +108,6 @@ class LoggingTests : FunSpec({
         Logging.debug("test2")
 
         // Then
-        calls shouldBe arrayOf("test")
+        calls shouldHaveEachItemEndWith arrayOf("test")
     }
 })

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/debug/internal/LoggingTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/debug/internal/LoggingTests.kt
@@ -1,0 +1,107 @@
+package com.onesignal.debug.internal
+
+import com.onesignal.debug.ILogListener
+import com.onesignal.debug.LogLevel
+import com.onesignal.debug.OneSignalLogEvent
+import com.onesignal.debug.internal.logging.Logging
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class TestLogLister : ILogListener {
+    val calls = ArrayList<String>()
+
+    override fun onLogEvent(event: OneSignalLogEvent) {
+        calls += event.entry
+    }
+}
+
+class LoggingTests : FunSpec({
+    beforeAny {
+        Logging.logLevel = LogLevel.NONE
+    }
+
+    test("addListener") {
+        // Given
+        val listener = TestLogLister()
+        Logging.addListener(listener)
+
+        // When
+        Logging.debug("test")
+
+        // Then
+        listener.calls shouldBe arrayOf("test")
+    }
+
+    test("addListener twice") {
+        // Given
+        val listener = TestLogLister()
+        Logging.addListener(listener)
+        Logging.addListener(listener)
+
+        // When
+        Logging.debug("test")
+
+        // Then
+        listener.calls shouldBe arrayOf("test")
+    }
+
+    test("removeListener") {
+        // Given
+        val listener = TestLogLister()
+        Logging.addListener(listener)
+        Logging.removeListener(listener)
+
+        // When
+        Logging.debug("test")
+
+        // Then
+        listener.calls shouldBe arrayOf<String>()
+    }
+
+    test("removeListener twice") {
+        // Given
+        val listener = TestLogLister()
+        Logging.addListener(listener)
+        Logging.removeListener(listener)
+        Logging.removeListener(listener)
+
+        // When
+        Logging.debug("test")
+
+        // Then
+        listener.calls shouldBe arrayOf<String>()
+    }
+
+    test("addListener nested") {
+        // Given
+        val nestedListener = TestLogLister()
+        Logging.addListener { Logging.addListener(nestedListener) }
+
+        // When
+        Logging.debug("test")
+        Logging.debug("test2")
+        Logging.debug("test3")
+
+        // Then
+        nestedListener.calls shouldBe arrayOf("test2", "test3")
+    }
+
+    test("removeListener nested") {
+        // Given
+        val calls = ArrayList<String>()
+        var listener: ILogListener? = null
+        listener =
+            ILogListener {
+                calls += it.entry
+                Logging.removeListener(listener!!)
+            }
+        Logging.addListener(listener!!)
+
+        // When
+        Logging.debug("test")
+        Logging.debug("test2")
+
+        // Then
+        calls shouldBe arrayOf("test")
+    }
+})


### PR DESCRIPTION
# Description
## One Line Summary
Adds the following new public methods to allow an app developer to capture logs as strings at runtime.

## Details
Adds the following new public methods:
* `OneSignal.Debug.addLogListener`
* `OneSignal.Debug.removeLogListener`

These new methods provide a way to capture all SDK log entires at runtime, allowing the app developer to store these and/or send them to their server.

The log listener is independent of logLevel, all message are always sent to listeners.

### Motivation
App developers want a way to capture all SDK logs and send them to their server to debug issues in production.

### Scope
Only add new methods to OneSignal.Debug to allow of capturing logs at runtime.

# Testing
## Unit testing
Added a new `LoggingTests` class to cover the new public methods.

## Manual testing
Tested on an Android 15 emulator.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [X] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
       - Failing due to unrelated flaky OperationRepoTests test.
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2311)
<!-- Reviewable:end -->
