### PR TITLE
Maintain: fix flaky tests in operationRepoTests

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/threading/OSPrimaryCoroutineScope.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/threading/OSPrimaryCoroutineScope.kt
@@ -16,4 +16,6 @@ object OSPrimaryCoroutineScope {
             block()
         }
     }
+
+    suspend fun waitForIdle() = mainScope.launch { }.join()
 }

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/operations/OperationRepoTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/operations/OperationRepoTests.kt
@@ -1,5 +1,6 @@
 package com.onesignal.core.internal.operations
 
+import com.onesignal.common.threading.OSPrimaryCoroutineScope
 import com.onesignal.common.threading.Waiter
 import com.onesignal.common.threading.WaiterWithValue
 import com.onesignal.core.internal.operations.impl.OperationModelStore
@@ -100,6 +101,7 @@ class OperationRepoTests : FunSpec({
                     listOf(mocks.executor),
                     operationModelStore,
                     mocks.configModelStore,
+                    mocks.identityModelStore,
                     Time(),
                     getNewRecordState(mocks.configModelStore),
                 ),
@@ -165,6 +167,7 @@ class OperationRepoTests : FunSpec({
         // When
         operationRepo.start()
         operationRepo.enqueue(MyOperation())
+        OSPrimaryCoroutineScope.waitForIdle()
 
         // Then
         operationRepo.containsInstanceOf<MyOperation>() shouldBe true
@@ -269,6 +272,7 @@ class OperationRepoTests : FunSpec({
         // When
         opRepo.start()
         opRepo.enqueue(mockOperation())
+        OSPrimaryCoroutineScope.waitForIdle()
         val response1 =
             withTimeoutOrNull(999) {
                 opRepo.enqueueAndWait(mockOperation())
@@ -647,6 +651,7 @@ class OperationRepoTests : FunSpec({
         mocks.operationRepo.start()
         mocks.operationRepo.enqueue(operation1)
         mocks.operationRepo.enqueue(operation2)
+        OSPrimaryCoroutineScope.waitForIdle()
         mocks.operationRepo.enqueueAndWait(operation3)
 
         // Then
@@ -727,6 +732,7 @@ class OperationRepoTests : FunSpec({
         val mocks = Mocks()
         val op = mockOperation()
         mocks.operationRepo.enqueue(op)
+        OSPrimaryCoroutineScope.waitForIdle()
 
         // When
         mocks.operationRepo.loadSavedOperations()
@@ -767,6 +773,7 @@ class OperationRepoTests : FunSpec({
         // When
         opRepo.start()
         opRepo.enqueue(mockOperation())
+        OSPrimaryCoroutineScope.waitForIdle()
         val response1 =
             withTimeoutOrNull(999) {
                 opRepo.enqueueAndWait(mockOperation())


### PR DESCRIPTION
# Description
## One Line Summary
Fixed some flaky test units in operationRepoTests due to previous commits

## Details

### Motivation
Fix the flaky test units that have been blocking the runner to complete successfully

## Other
This PR also added a waitForIdle() method for testing in OSPrimaryCoroutineScope to allow thread to wait for the completion of operation enqueue. 

# Testing
## Unit testing
The test units are fixed and passed.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [ ] I have filled out all **REQUIRED** sections above
   - [ ] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [ ] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [ ] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2318)
<!-- Reviewable:end -->
