### PR TITLE
Properly handle in-app messages dismissed by back press

### DIFF
--- a/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/display/impl/OSPopupWindow.kt
+++ b/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/display/impl/OSPopupWindow.kt
@@ -1,0 +1,32 @@
+package com.onesignal.inAppMessages.internal.display.impl
+
+import android.view.View
+import android.widget.PopupWindow
+
+/**
+ * Custom PopupWindow to listen to dismiss event
+ */
+internal class OSPopupWindow(
+    contentView: View?,
+    width: Int,
+    height: Int,
+    focusable: Boolean,
+    private val listener: PopupWindowListener,
+) : PopupWindow(contentView, width, height, focusable) {
+    /**
+     * Used to differentiate when this popup window has been dismissed programmatically by OneSignal vs by the system.
+     * When the back button is pressed while an IAM is displaying, the system will dismiss the popup window
+     * without the SDK's awareness. We need to know of this event and run the post-dismissal flows.
+     * Using this flag will prevent duplicate flows from triggering.
+     */
+    var wasDismissedManually: Boolean? = null
+
+    internal interface PopupWindowListener {
+        fun onDismiss(wasDismissedManually: Boolean?)
+    }
+
+    override fun dismiss() {
+        super.dismiss()
+        listener.onDismiss(wasDismissedManually)
+    }
+}


### PR DESCRIPTION
# Description
## One Line Summary
Properly handle and dismiss in-app messages that are dismissed by back press.

## Details

### Motivation
**Fixes poor behavior:** When back button is pressed, the system automatically dismisses the in-app message, without the SDK's awareness. This leads to poor user experience as the SDK does not know of this message's dismissal and will inappropriately redisplay it.

### Scope
- Create new OSPopupWindow class extending PopupWindow
- Adds additional code to trigger post-dismissal flows when we believe the system dismissed the IAM without our awareness
- All new logic lives in `InAppMessageView`. A single instance of `InAppMessageView` can have multiple popupWindow instances such as when orientation changes. So, we need to hook into individual popup windows instead of the View. We mark the popup window as manually dismissed in the method `removeAllViews()`. This is sufficient as this method is called by every flow in the SDK that dismisses an IAM (clicking to close, activity change, drag to dismiss, etc). In our listener, if we believe the popup window was dismissed by the system bypassing OneSignal, we trigger `messageController?.onMessageWasDismissed()`. This call is appropriate as this is the root method that triggers the post-dismissal flows for an IAM. We considered doing more logic in the dismiss event but we cannot generalize here as some dismiss events should not trigger the post-dismissal flow, such as on orientation changes. 

### Example of system triggering popup window dismissal
```
 java.lang.Thread.State: RUNNABLE
	  at com.onesignal.inAppMessages.internal.display.impl.InAppMessageView$popupWindowListener$1.onDismiss(InAppMessageView.kt:91)
	  at com.onesignal.inAppMessages.internal.display.impl.OSPopupWindow.dismiss(OSPopupWindow.kt:32)
	  at android.widget.PopupWindow$PopupDecorView.dispatchKeyEvent(PopupWindow.java:2555)
	  at android.view.ViewRootImpl$ViewPostImeInputStage.processKeyEvent(ViewRootImpl.java:6584)
	  at android.view.ViewRootImpl$ViewPostImeInputStage.onProcess(ViewRootImpl.java:6450)
	  at android.view.ViewRootImpl$InputStage.deliver(ViewRootImpl.java:5910)
	  at android.view.ViewRootImpl$InputStage.onDeliverToNext(ViewRootImpl.java:5967)
	  at android.view.ViewRootImpl$InputStage.forward(ViewRootImpl.java:5933)
	  at android.view.ViewRootImpl$AsyncInputStage.forward(ViewRootImpl.java:6098)
	  at android.view.ViewRootImpl$InputStage.apply(ViewRootImpl.java:5941)
	  at android.view.ViewRootImpl$AsyncInputStage.apply(ViewRootImpl.java:6155)
	  at android.view.ViewRootImpl$InputStage.deliver(ViewRootImpl.java:5914)
	  at android.view.ViewRootImpl$InputStage.onDeliverToNext(ViewRootImpl.java:5967)
	  at android.view.ViewRootImpl$InputStage.forward(ViewRootImpl.java:5933)
	  at android.view.ViewRootImpl$InputStage.apply(ViewRootImpl.java:5941)
	  at android.view.ViewRootImpl$InputStage.deliver(ViewRootImpl.java:5914)
	  at android.view.ViewRootImpl$InputStage.onDeliverToNext(ViewRootImpl.java:5967)
	  at android.view.ViewRootImpl$InputStage.forward(ViewRootImpl.java:5933)
	  at android.view.ViewRootImpl$AsyncInputStage.forward(ViewRootImpl.java:6131)
	  at android.view.ViewRootImpl$ImeInputStage.onFinishedInputEvent(ViewRootImpl.java:6311)
	  at android.view.inputmethod.InputMethodManager$PendingEvent.run(InputMethodManager.java:3649)
	  at android.view.inputmethod.InputMethodManager.invokeFinishedInputEventCallback(InputMethodManager.java:3169)
	  at android.view.inputmethod.InputMethodManager.finishedInputEvent(InputMethodManager.java:3160)
	  at android.view.inputmethod.InputMethodManager$ImeInputEventSender.onInputEventFinished(InputMethodManager.java:3626)
	  at android.view.InputEventSender.dispatchInputEventFinished(InputEventSender.java:154)
	  at android.os.MessageQueue.nativePollOnce(MessageQueue.java:-1)
	  at android.os.MessageQueue.next(MessageQueue.java:335)
	  at android.os.Looper.loopOnce(Looper.java:161)
	  at android.os.Looper.loop(Looper.java:288)
	  at android.app.ActivityThread.main(ActivityThread.java:7872)
	  at java.lang.reflect.Method.invoke(Method.java:-1)
	  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
	  at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:936)
```

# Testing
## Unit testing
None

## Manual testing
Android emulator API 33

**Types of IAMs tested:**
   - [x] Standard modals
   - [x] Full screen
   - [x] Banner _(note banners are not dismissed by the system on back press and remain on screen)_

**Scenarios tested:**
   - [x] Device orientation change _(correctly does **not** trigger our listener)_
   - [x] Backgrounding and foregrounding app _(correctly does **not** trigger our listener)_
   - [x] Click on buttons in IAM _(correctly does **not** trigger our listener)_
   - [x] Drag to dismiss _(correctly does **not** trigger our listener)_
   - [x] Click on button with URL _(correctly does **not** trigger our listener)_
   - [x] Click on button that triggers a push prompt _(correctly does **not** trigger our listener)_
   - [x] Back button press _(correctly **does** trigger our listener)_

Devices tested:
   - [ ] Android 5.1 (API level 22) - the SDK isn't fetching IAMs, no call to `GET /iams` made after user is created
   - [ ] Android 6.0 (API level 23) - the SDK isn't displaying IAMs, logs "InAppMessagesManager.attemptToShowInAppMessage: There is an IAM currently showing!" but none are
   - [x] Android 7.0 (API level 24)
   - [x] Android 9 (API level 28)
   - [x] Android 11 (API level 30)
   - [x] Android 13 (API level 33)
   - [x] Android 15 (API level 35)
   - [x] Android 16 (API level 36)

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [x] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2328)
<!-- Reviewable:end -->
