### PR TITLE
fix: push subscription observers not firing

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/subscriptions/impl/SubscriptionManager.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/subscriptions/impl/SubscriptionManager.kt
@@ -190,6 +190,14 @@ internal class SubscriptionManager(
         model: SubscriptionModel,
         tag: String,
     ) {
+        // Do not remove the push subscription: we need to keep the existing push subscription and its observers
+        // This push subscription will immediately be replaced by the new one in the [onModelAdded] event
+        // The [onModelRemoved] event for a push subscription model should always be followed by a [onModelAdded]
+        // event with a new push subscription model. On 404s, no push subscription models are removed.
+        if (model.type == SubscriptionType.PUSH) {
+            return
+        }
+
         val subscription = subscriptions.collection.firstOrNull { it.id == model.id }
 
         if (subscription != null) {


### PR DESCRIPTION
# Description
## One Line Summary
Fix push subscription observers not firing by preventing manual removal of a PushSubscription which allows correct transfer of existing observers.

## Details
* When the SDK hydrates users or changes users, it will trigger the subscription model store's `replaceAll` method. This will remove the current push subscription model and immediately add a new push subscription model. The Subscription Manager was removing the current push subscription and then adding a new push subscription that it manages. When the new one is added, the old one is removed and any observers are transferred over.
* However, because the old one was already removed by the time the new one is added, observers are lost. The [onModelAdded] already triggers an add and remove, so we should not remove in the preceding [onModelRemoved] event.
* These 2 events of [onModelAdded] and [onModelRemoved] are always together as they are always triggered via `replaceAll`. There is no current usage where only [onModelRemoved] is called for a push subscription model. 
* Even on 404s, push subscription models are not removed.

### Motivation
Clients reported their push observers not firing in certain circumstances, and I was able to reproduce more generally as well.

### Scope
* Don't manually remove a `PushSubscription` instance managed by `SubscriptionManager`, it will be removed by an expected immediate call to remove and add a new `PushSubscription` instance.
* There will only be 1 instance so the "add" call will do the replacement, which also transfers any observers.

# Testing
## Unit testing
**OPTIONAL -**  Explain unit tests added, if not clear in the code.

## Manual testing
Android emulator API 33
* Tested to reproduce this issue easily: Add a push observer in Application `onCreate` and wait for the refresh-user call to complete. Toggle `optIn` and `optOut` and see your observer fires before the `refresh-user` returns and no longer fire after the call returns.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [x] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2330)
<!-- Reviewable:end -->
