### PR TITLE
[Main] Cherry picks from 5.2.x - Migrate to Gradle/AGP 8 & Changes to publish to the Central Portal.

### DIFF
--- a/Examples/OneSignalDemo/app/build.gradle
+++ b/Examples/OneSignalDemo/app/build.gradle
@@ -3,6 +3,7 @@ plugins {
 }
 
 android {
+    namespace 'com.onesignal.sdktest'
     compileSdkVersion 34
     defaultConfig {
         minSdkVersion 21

--- a/Examples/OneSignalDemo/app/build.gradle
+++ b/Examples/OneSignalDemo/app/build.gradle
@@ -62,10 +62,11 @@ android {
     }
 
     task flavorSelection() {
-        if (getGradle().getStartParameter().getTaskRequests().toString().contains("Gms")) {
+        def tasksList = gradle.startParameter.taskRequests.toString()
+        if (tasksList.contains('Gms')) {
             apply plugin: 'com.google.gms.google-services'
             googleServices { disableVersionCheck = true }
-        } else {
+        } else if (tasksList.contains('Huawei')) {
             apply plugin: 'com.huawei.agconnect'
         }
     }

--- a/Examples/OneSignalDemo/app/src/main/AndroidManifest.xml
+++ b/Examples/OneSignalDemo/app/src/main/AndroidManifest.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    xmlns:amazon="http://schemas.amazon.com/apk/res/android"
-    package="com.onesignal.sdktest">
+    xmlns:amazon="http://schemas.amazon.com/apk/res/android">
 
     <uses-permission android:name="com.android.vending.BILLING" />
 

--- a/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/application/MainApplication.java
+++ b/Examples/OneSignalDemo/app/src/main/java/com/onesignal/sdktest/application/MainApplication.java
@@ -20,7 +20,6 @@ import com.onesignal.inAppMessages.IInAppMessageWillDisplayEvent;
 import com.onesignal.notifications.IDisplayableNotification;
 import com.onesignal.notifications.INotificationLifecycleListener;
 import com.onesignal.notifications.INotificationWillDisplayEvent;
-import com.onesignal.sdktest.BuildConfig;
 import com.onesignal.sdktest.R;
 import com.onesignal.sdktest.constant.Tag;
 import com.onesignal.sdktest.constant.Text;
@@ -38,9 +37,8 @@ public class MainApplication extends MultiDexApplication {
     private static final int SLEEP_TIME_TO_MIMIC_ASYNC_OPERATION = 2000;
 
     public MainApplication() {
-        // run strict mode default in debug mode to surface any potential issues easier
-        if(BuildConfig.DEBUG)
-            StrictMode.enableDefaults();
+        // run strict mode to surface any potential issues easier
+        StrictMode.enableDefaults();
     }
 
     @SuppressLint("NewApi")

--- a/Examples/OneSignalDemo/build.gradle
+++ b/Examples/OneSignalDemo/build.gradle
@@ -14,7 +14,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.8.2'
         classpath 'com.google.gms:google-services:4.3.10'
-        classpath 'com.huawei.agconnect:agcp:1.6.2.300'
+        classpath 'com.huawei.agconnect:agcp:1.9.1.304'
         
         // TODO: Do not place your application dependencies here; they belong
         //  in the individual module build.gradle files

--- a/Examples/OneSignalDemo/build.gradle
+++ b/Examples/OneSignalDemo/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         maven { url 'https://developer.huawei.com/repo/' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.2'
+        classpath 'com.android.tools.build:gradle:8.8.2'
         classpath 'com.google.gms:google-services:4.3.10'
         classpath 'com.huawei.agconnect:agcp:1.6.2.300'
         

--- a/Examples/OneSignalDemo/gradle/wrapper/gradle-wrapper.properties
+++ b/Examples/OneSignalDemo/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/OneSignalSDK/build.gradle
+++ b/OneSignalSDK/build.gradle
@@ -8,7 +8,7 @@ buildscript {
                 targetSdkVersion: 34,
                 minSdkVersion: 21
         ]
-        androidGradlePluginVersion = '7.2.0'
+        androidGradlePluginVersion = '8.8.2'
         googleServicesGradlePluginVersion = '4.3.10'
         huaweiAgconnectVersion = '1.6.2.300'
         huaweiHMSPushVersion = '6.3.0.304'

--- a/OneSignalSDK/build.gradle
+++ b/OneSignalSDK/build.gradle
@@ -19,21 +19,29 @@ buildscript {
         ktlintVersion = '1.0.1'
         // DO NOT upgrade for tests, using an old version so it matches AOSP
         tdunningJsonForTest = '1.0'
+
+        sharedRepos = {
+            google()
+            mavenCentral()
+            gradlePluginPortal()
+            // Huawei maven
+            maven { url 'https://developer.huawei.com/repo/' }
+        }
+        sharedDeps = [
+            "com.android.tools.build:gradle:$androidGradlePluginVersion",
+            "com.google.gms:google-services:$googleServicesGradlePluginVersion",
+            "com.huawei.agconnect:agcp:$huaweiAgconnectVersion",
+            "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion",
+            "org.jlleitschuh.gradle:ktlint-gradle:$ktlintPluginVersion",
+            "com.vanniktech.maven.publish:com.vanniktech.maven.publish.gradle.plugin:0.32.0"
+        ]
     }
 
-    repositories {
-        google()
-        mavenCentral()
-        gradlePluginPortal()
-        // Huawei maven
-        maven { url 'https://developer.huawei.com/repo/' }
-    }
-    dependencies {
-        classpath "com.android.tools.build:gradle:$androidGradlePluginVersion"
-        classpath "com.google.gms:google-services:$googleServicesGradlePluginVersion"
-        classpath "com.huawei.agconnect:agcp:$huaweiAgconnectVersion"
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
-        classpath "org.jlleitschuh.gradle:ktlint-gradle:$ktlintPluginVersion"
+    buildscript {
+        repositories sharedRepos
+        dependencies {
+            classpath sharedDeps
+        }
     }
 }
 

--- a/OneSignalSDK/build.gradle
+++ b/OneSignalSDK/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         ]
         androidGradlePluginVersion = '8.8.2'
         googleServicesGradlePluginVersion = '4.3.10'
-        huaweiAgconnectVersion = '1.6.2.300'
+        huaweiAgconnectVersion = '1.9.1.304'
         huaweiHMSPushVersion = '6.3.0.304'
         huaweiHMSLocationVersion = '4.0.0.300'
         kotlinVersion = '1.7.10'

--- a/OneSignalSDK/gradle.properties
+++ b/OneSignalSDK/gradle.properties
@@ -23,9 +23,7 @@
 # Remove when creating an .aar build.
 #android.enableAapt2=false
 
-android.databinding.incremental = false
-kapt.incremental.apt = false
-android.testConfig.useRelativePath = false
+org.gradle.jvmargs=-Xmx1536m
 
 # Enables D8 for all modules.
 android.enableD8 = true

--- a/OneSignalSDK/gradle/wrapper/gradle-wrapper.properties
+++ b/OneSignalSDK/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/OneSignalSDK/onesignal/build.gradle
+++ b/OneSignalSDK/onesignal/build.gradle
@@ -1,5 +1,9 @@
 plugins {
     id 'com.android.library'
+    // There isn't Kotlin or Java code in this top-level project,
+    // however consumers look for an .aar file, which this causes it
+    // to be created.
+    id 'kotlin-android'
 }
 
 android {
@@ -25,6 +29,8 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
     namespace 'com.onesignal'
+
+    kotlinOptions.freeCompilerArgs += ['-module-name', namespace]
 }
 
 ext {

--- a/OneSignalSDK/onesignal/build.gradle
+++ b/OneSignalSDK/onesignal/build.gradle
@@ -4,6 +4,7 @@ plugins {
     // however consumers look for an .aar file, which this causes it
     // to be created.
     id 'kotlin-android'
+    id 'com.vanniktech.maven.publish'
 }
 
 android {

--- a/OneSignalSDK/onesignal/core/build.gradle
+++ b/OneSignalSDK/onesignal/core/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'org.jlleitschuh.gradle.ktlint'
+    id 'com.vanniktech.maven.publish'
 }
 
 android {

--- a/OneSignalSDK/onesignal/in-app-messages/build.gradle
+++ b/OneSignalSDK/onesignal/in-app-messages/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'org.jlleitschuh.gradle.ktlint'
+    id 'com.vanniktech.maven.publish'
 }
 
 android {

--- a/OneSignalSDK/onesignal/location/build.gradle
+++ b/OneSignalSDK/onesignal/location/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'org.jlleitschuh.gradle.ktlint'
+    id 'com.vanniktech.maven.publish'
 }
 
 android {

--- a/OneSignalSDK/onesignal/maven-push.gradle
+++ b/OneSignalSDK/onesignal/maven-push.gradle
@@ -66,7 +66,9 @@ afterEvaluate {
 
         publications {
             release(MavenPublication) {
-                from components.release
+                afterEvaluate {
+                    from components.findByName('release')
+                }
 
                 pom {
                     name = projectName

--- a/OneSignalSDK/onesignal/maven-push.gradle
+++ b/OneSignalSDK/onesignal/maven-push.gradle
@@ -1,108 +1,44 @@
-/**
- * Modified MIT License
- *
- * Copyright 2021 OneSignal
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * 1. The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * 2. All copies of substantial portions of the Software may only be used in connection
- * with services provided by OneSignal.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
- */
-
-apply plugin: 'maven-publish'
-apply plugin: 'signing'
-
-class Global {
-    static def POM_PACKAGING = 'aar'
-
-    static def POM_URL = 'https://github.com/onesignal/onesignal-android-sdk'
-    static def POM_SCM_URL = 'https://github.com/onesignal/onesignal-android-sdk'
-    static def POM_SCM_CONNECTION = 'scm:git:https://github.com/onesignal/onesignal-android-sdk'
-    static def POM_SCM_DEV_CONNECTION = 'scm:git:https://github.com/onesignal/onesignal-android-sdk'
-    static def POM_LICENCE_NAME = 'MIT License'
-    static def POM_LICENCE_URL = 'https://raw.githubusercontent.com/onesignal/onesignal-android-sdk/master/LICENSE'
-    static def POM_LICENCE_DIST = 'repo'
-    static def POM_DEVELOPER_ID = 'OneSignal'
-    static def POM_DEVELOPER_NAME = 'Josh Kasten'
-    static def SNAPSHOT_REPOSITORY_URL = 'https://oss.sonatype.org/content/repositories/snapshots'
-    static def RELEASE_REPOSITORY_URL = 'https://oss.sonatype.org/service/local/staging/deploy/maven2'
-}
-
-def getRepositoryUsername() {
-    return hasProperty('NEXUS_USERNAME') ? NEXUS_USERNAME : ""
-}
-
-def getRepositoryPassword() {
-    return hasProperty('NEXUS_PASSWORD') ? NEXUS_PASSWORD : ""
-}
-
-afterEvaluate {
-    publishing {
-        repositories {
-            maven {
-                url = Global.RELEASE_REPOSITORY_URL
-                credentials {
-                    username = getRepositoryUsername()
-                    password = getRepositoryPassword()
-                }
-            }
-        }
-
-        publications {
-            release(MavenPublication) {
-                afterEvaluate {
-                    from components.findByName('release')
-                }
-
-                pom {
-                    name = projectName
-                    description = projectDescription
-                    packaging = Global.POM_PACKAGING
-                    url = Global.POM_URL
-
-                    scm {
-                        url = Global.POM_SCM_URL
-                        connection = Global.POM_SCM_CONNECTION
-                        developerConnection = Global.POM_SCM_DEV_CONNECTION
-                    }
-
-                    licenses {
-                        license {
-                            name = Global.POM_LICENCE_NAME
-                            url = Global.POM_LICENCE_URL
-                            distribution = Global.POM_LICENCE_DIST
-                        }
-                    }
-
-                    developers {
-                        developer {
-                            id = Global.POM_DEVELOPER_ID
-                            name = Global.POM_DEVELOPER_NAME
-                        }
-                    }
-                }
-            }
-        }
+buildscript {
+    repositories sharedRepos
+    dependencies {
+        classpath sharedDeps
     }
+}
 
-    signing {
-        required { true }
-        sign publishing.publications.release
+import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
+import com.vanniktech.maven.publish.SonatypeHost
+
+mavenPublishing {
+    configure(new AndroidSingleVariantLibrary("release", true, true))
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+
+    signAllPublications()
+
+    coordinates(project.group, project.name, project.version)
+
+    pom {
+        name = "OneSignal Android SDK"
+        description = "OneSignal is a free email, sms, push notification, and in-app message service for mobile apps. This plugin makes it easy to integrate your native Android or Amazon app with OneSignal."
+        inceptionYear = "2015"
+        url = "https://github.com/onesignal/onesignal-android-sdk/"
+        licenses {
+            license {
+                name = "Modified MIT License"
+                url = "https://raw.githubusercontent.com/onesignal/onesignal-android-sdk/main/LICENSE"
+                distribution = "repo"
+            }
+        }
+        developers {
+            developer {
+                id = "OneSignal"
+                name = "OneSignal"
+                url = "https://github.com/OneSignal/"
+            }
+        }
+        scm {
+            url = "https://github.com/onesignal/onesignal-android-sdk"
+            connection = "scm:git:git://github.com/onesignal/onesignal-android-sdk.git"
+            developerConnection = "scm:git:ssh://git@github.com/onesignal/onesignal-android-sdk.git"
+        }
     }
 }

--- a/OneSignalSDK/onesignal/notifications/build.gradle
+++ b/OneSignalSDK/onesignal/notifications/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'org.jlleitschuh.gradle.ktlint'
+    id 'com.vanniktech.maven.publish'
 }
 
 android {

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/display/impl/NotificationDisplayBuilder.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/display/impl/NotificationDisplayBuilder.kt
@@ -12,7 +12,6 @@ import android.net.Uri
 import android.os.Build
 import androidx.core.app.NotificationCompat
 import com.onesignal.common.AndroidUtils
-import com.onesignal.core.R
 import com.onesignal.core.internal.application.IApplicationService
 import com.onesignal.debug.internal.logging.Logging
 import com.onesignal.notifications.internal.bundle.impl.NotificationBundleProcessor
@@ -231,9 +230,9 @@ internal class NotificationDisplayBuilder(
         if (bitmap == null) return null
         try {
             val systemLargeIconHeight =
-                contextResources!!.getDimension(R.dimen.notification_large_icon_height).toInt()
+                contextResources!!.getDimension(android.R.dimen.notification_large_icon_height).toInt()
             val systemLargeIconWidth =
-                contextResources!!.getDimension(R.dimen.notification_large_icon_width).toInt()
+                contextResources!!.getDimension(android.R.dimen.notification_large_icon_width).toInt()
             val bitmapHeight = bitmap.height
             val bitmapWidth = bitmap.width
             if (bitmapWidth > systemLargeIconWidth || bitmapHeight > systemLargeIconHeight) {


### PR DESCRIPTION
Cherry picks PR #2264 and PR #2317 from 5.2.x into main.

Cherry picks were clean; no manual changes or extra commits.

The reason is we need both these PRs to publish new versions to maven central, as noted in PR #2317.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2331)
<!-- Reviewable:end -->
