### PR TITLE
Clean up logging from ServiceProvider

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/services/ServiceProvider.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/services/ServiceProvider.kt
@@ -1,7 +1,5 @@
 package com.onesignal.common.services
 
-import com.onesignal.debug.internal.logging.Logging
-
 /**
  * A service provider gives access to the implementations of a service.
  */
@@ -66,7 +64,6 @@ class ServiceProvider(
     override fun <T> getService(c: Class<T>): T {
         val service = getServiceOrNull(c)
         if (service == null) {
-            Logging.warn("Service not found: $c")
             throw Exception("Service $c could not be instantiated")
         }
 
@@ -75,7 +72,6 @@ class ServiceProvider(
 
     override fun <T> getServiceOrNull(c: Class<T>): T? {
         synchronized(serviceMap) {
-            Logging.debug("${indent}Retrieving service $c")
             return serviceMap[c]?.last()?.resolve(this) as T?
         }
     }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/services/ServiceRegistration.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/services/ServiceRegistration.kt
@@ -11,9 +11,7 @@ import java.lang.reflect.WildcardType
 abstract class ServiceRegistration<T> {
     val services: MutableSet<Class<*>> = mutableSetOf()
 
-    inline fun <reified TService : Any> provides(): ServiceRegistration<T> {
-        return provides(TService::class.java)
-    }
+    inline fun <reified TService : Any> provides(): ServiceRegistration<T> = provides(TService::class.java)
 
     /**
      * Indicate this registration wants to provide the provided class as
@@ -53,14 +51,12 @@ class ServiceRegistrationReflection<T>(
 
     override fun resolve(provider: IServiceProvider): Any? {
         if (obj != null) {
-            Logging.debug("${ServiceProvider.indent}Already instantiated: $obj")
             return obj
         }
 
         // use reflection to try to instantiate the thing
         for (constructor in clazz.constructors) {
             if (doesHaveAllParameters(constructor, provider)) {
-                Logging.debug("${ServiceProvider.indent}Found constructor: $constructor")
                 var paramList: MutableList<Any?> = mutableListOf()
 
                 for (param in constructor.genericParameterTypes) {
@@ -106,13 +102,13 @@ class ServiceRegistrationReflection<T>(
                     val clazz = argType.upperBounds.first()
                     if (clazz is Class<*>) {
                         if (!provider.hasService(clazz)) {
-                            Logging.debug("Constructor $constructor could not find service: $clazz")
+                            Logging.error("Constructor $constructor could not find service: $clazz")
                             return false
                         }
                     }
                 } else if (argType is Class<*>) {
                     if (!provider.hasService(argType)) {
-                        Logging.debug("Constructor $constructor could not find service: $argType")
+                        Logging.error("Constructor $constructor could not find service: $argType")
                         return false
                     }
                 } else {
@@ -120,11 +116,11 @@ class ServiceRegistrationReflection<T>(
                 }
             } else if (param is Class<*>) {
                 if (!provider.hasService(param)) {
-                    Logging.debug("Constructor $constructor could not find service: $param")
+                    Logging.error("Constructor $constructor could not find service: $param")
                     return false
                 }
             } else {
-                Logging.debug("Constructor $constructor could not identify param type: $param")
+                Logging.error("Constructor $constructor could not identify param type: $param")
                 return false
             }
         }


### PR DESCRIPTION
# Description
## One Line Summary
Removed noisy logging "Already instantiated" and "Found constructor" that has never been useful.

## Details
Also corrected "Constructor X could not find service" to be errors instead of debug.


### Motivation
These extra logs always got in the way with 100s of entries and we never ever used them. This is also expected to give a very small, but still probably measurable, initialization performance improvement. 

### Scope
No logic changes, only effects logging of the ServiceProvider

# Testing
## Unit testing
No tests covering these logs to remove.

## Manual testing
Tested on a Android 9 emulator. 

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2332)
<!-- Reviewable:end -->
