### PR TITLE
Release 5.1.35

### DIFF
--- a/Examples/OneSignalDemo/app/build.gradle
+++ b/Examples/OneSignalDemo/app/build.gradle
@@ -85,12 +85,12 @@ dependencies {
     implementation 'com.github.bumptech.glide:glide:4.12.0'
 
     /** START - Google Play Builds **/
-    gmsImplementation('com.onesignal:OneSignal:5.1.34')
+    gmsImplementation('com.onesignal:OneSignal:5.1.35')
     /** END - Google Play Builds **/
 
     /** START - Huawei Builds **/
     // Omit Google / Firebase libraries for Huawei builds.
-    huaweiImplementation('com.onesignal:OneSignal:5.1.34') {
+    huaweiImplementation('com.onesignal:OneSignal:5.1.35') {
         exclude group: 'com.google.android.gms', module: 'play-services-gcm'
         exclude group: 'com.google.android.gms', module: 'play-services-analytics'
         exclude group: 'com.google.android.gms', module: 'play-services-location'

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/OneSignalUtils.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/OneSignalUtils.kt
@@ -6,7 +6,7 @@ object OneSignalUtils {
     /**
      * The version of this SDK.
      */
-    const val SDK_VERSION: String = "050134"
+    const val SDK_VERSION: String = "050135"
 
     fun isValidEmail(email: String): Boolean {
         if (email.isEmpty()) {

--- a/OneSignalSDK/settings.gradle
+++ b/OneSignalSDK/settings.gradle
@@ -3,7 +3,7 @@
 gradle.rootProject {
     allprojects {
         group = 'com.onesignal'
-        version = '5.1.34'
+        version = '5.1.35'
         configurations.all {
             resolutionStrategy.dependencySubstitution {
                 substitute(module('com.onesignal:OneSignal')).using(project(':OneSignal'))


### PR DESCRIPTION
🐛 Bug Fixes
* Fix crashes with Amazon IAP tracking by dropping support for this (#2333)
* Fix push subscription observers not firing (#2330)
* Properly handle in-app messages dismissed by back press (#2328)
* Fix Android 7 and lower crashes with getParameterCount calls, when the app is built with AGP 7 or older (#2329)
* Fix logout incorrectly uses the old subscription ID (#2327)

✨ Improvements
* Clean up logging from ServiceProvider (#2332)
* Migrated build to Gradle/AGP 8 & Changes to publish to the Central Portal. (#2331)
   * No project changes are required, you may still used Gradle / AGP 7.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2334)
<!-- Reviewable:end -->
