### PR TITLE
JWT: Resolve IAM conditions after user create to allow fetching of IAMs

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/backend/IUserBackendService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/backend/IUserBackendService.kt
@@ -84,4 +84,9 @@ class CreateUserResponse(
      * The subscriptions for the user.
      */
     val subscriptions: List<SubscriptionObject>,
+    /**
+     * The RYW data returned by the server.
+     * This is expected for the response to CreateUser only, not UpdateUser.
+     */
+    val rywData: RywData?,
 )

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/backend/impl/JSONConverter.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/backend/impl/JSONConverter.kt
@@ -1,5 +1,6 @@
 package com.onesignal.user.internal.backend.impl
 
+import com.onesignal.common.consistency.RywData
 import com.onesignal.common.expandJSONArray
 import com.onesignal.common.putJSONArray
 import com.onesignal.common.putMap
@@ -8,6 +9,7 @@ import com.onesignal.common.safeBool
 import com.onesignal.common.safeDouble
 import com.onesignal.common.safeInt
 import com.onesignal.common.safeJSONObject
+import com.onesignal.common.safeLong
 import com.onesignal.common.safeString
 import com.onesignal.common.toMap
 import com.onesignal.user.internal.backend.CreateUserResponse
@@ -55,7 +57,15 @@ object JSONConverter {
                 return@expandJSONArray null
             }
 
-        return CreateUserResponse(respIdentities, respProperties, respSubscriptions)
+        val rywToken = jsonObject.safeString("ryw_token")
+        val rywDelay = jsonObject.safeLong("ryw_delay")
+        var rywData: RywData? = null
+
+        if (rywToken != null) {
+            rywData = RywData(rywToken, rywDelay)
+        }
+
+        return CreateUserResponse(respIdentities, respProperties, respSubscriptions, rywData)
     }
 
     fun convertToJSON(properties: PropertiesObject): JSONObject {

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/LoginUserOperationExecutorTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/LoginUserOperationExecutorTests.kt
@@ -1,6 +1,8 @@
 package com.onesignal.user.internal.operations
 
 import br.com.colman.kotest.android.extensions.robolectric.RobolectricTest
+import com.onesignal.common.consistency.RywData
+import com.onesignal.common.consistency.models.IConsistencyManager
 import com.onesignal.common.exceptions.BackendException
 import com.onesignal.core.internal.operations.ExecutionResponse
 import com.onesignal.core.internal.operations.ExecutionResult
@@ -25,10 +27,13 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldBeOneOf
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.clearMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.runs
 
 @RobolectricTest
 class LoginUserOperationExecutorTests : FunSpec({
@@ -39,6 +44,8 @@ class LoginUserOperationExecutorTests : FunSpec({
     val localSubscriptionId2 = "local-subscriptionId2"
     val remoteSubscriptionId1 = "remote-subscriptionId1"
     val remoteSubscriptionId2 = "remote-subscriptionId2"
+    val rywData = RywData("1", 500L)
+    val mockConsistencyManager = mockk<IConsistencyManager>()
     val createSubscriptionOperation =
         CreateSubscriptionOperation(
             appId,
@@ -50,6 +57,11 @@ class LoginUserOperationExecutorTests : FunSpec({
             SubscriptionStatus.SUBSCRIBED,
         )
 
+    beforeTest {
+        clearMocks(mockConsistencyManager)
+        coEvery { mockConsistencyManager.setRywData(any(), any(), any()) } just runs
+    }
+
     test("login anonymous user successfully creates user") {
         // Given
         val mockUserBackendService = mockk<IUserBackendService>()
@@ -58,6 +70,7 @@ class LoginUserOperationExecutorTests : FunSpec({
                 mapOf(IdentityConstants.ONESIGNAL_ID to remoteOneSignalId),
                 PropertiesObject(),
                 listOf(),
+                rywData,
             )
         // Given
         val mockIdentityOperationExecutor = mockk<IdentityOperationExecutor>()
@@ -76,6 +89,7 @@ class LoginUserOperationExecutorTests : FunSpec({
                 mockSubscriptionsModelStore,
                 MockHelper.configModelStore(),
                 MockHelper.languageContext(),
+                mockConsistencyManager,
             )
         val operations =
             listOf<Operation>(
@@ -120,6 +134,7 @@ class LoginUserOperationExecutorTests : FunSpec({
                 mockSubscriptionsModelStore,
                 MockHelper.configModelStore(),
                 MockHelper.languageContext(),
+                mockConsistencyManager,
             )
         val operations =
             listOf<Operation>(
@@ -148,7 +163,7 @@ class LoginUserOperationExecutorTests : FunSpec({
         val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
 
         val loginUserOperationExecutor =
-            LoginUserOperationExecutor(mockIdentityOperationExecutor, AndroidMockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext())
+            LoginUserOperationExecutor(mockIdentityOperationExecutor, AndroidMockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext(), mockConsistencyManager)
         val operations =
             listOf<Operation>(
                 LoginUserOperation(appId, localOneSignalId, null, null),
@@ -167,7 +182,7 @@ class LoginUserOperationExecutorTests : FunSpec({
         // Given
         val mockUserBackendService = mockk<IUserBackendService>()
         coEvery { mockUserBackendService.createUser(any(), any(), any(), any()) } returns
-            CreateUserResponse(mapOf(IdentityConstants.ONESIGNAL_ID to remoteOneSignalId), PropertiesObject(), listOf())
+            CreateUserResponse(mapOf(IdentityConstants.ONESIGNAL_ID to remoteOneSignalId), PropertiesObject(), listOf(), rywData)
 
         val mockIdentityOperationExecutor = mockk<IdentityOperationExecutor>()
 
@@ -176,7 +191,7 @@ class LoginUserOperationExecutorTests : FunSpec({
         val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
 
         val loginUserOperationExecutor =
-            LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext())
+            LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext(), mockConsistencyManager)
         val operations = listOf<Operation>(LoginUserOperation(appId, localOneSignalId, "externalId", null))
 
         // When
@@ -195,7 +210,7 @@ class LoginUserOperationExecutorTests : FunSpec({
         // Given
         val mockUserBackendService = mockk<IUserBackendService>()
         coEvery { mockUserBackendService.createUser(any(), any(), any(), any()) } returns
-            CreateUserResponse(mapOf(IdentityConstants.ONESIGNAL_ID to remoteOneSignalId), PropertiesObject(), listOf())
+            CreateUserResponse(mapOf(IdentityConstants.ONESIGNAL_ID to remoteOneSignalId), PropertiesObject(), listOf(), rywData)
 
         val mockIdentityOperationExecutor = mockk<IdentityOperationExecutor>()
 
@@ -214,6 +229,7 @@ class LoginUserOperationExecutorTests : FunSpec({
                 mockSubscriptionsModelStore,
                 MockHelper.configModelStore(),
                 MockHelper.languageContext(),
+                mockConsistencyManager,
             )
         val operations = listOf<Operation>(LoginUserOperation(appId, localOneSignalId, "externalId", null))
 
@@ -242,7 +258,7 @@ class LoginUserOperationExecutorTests : FunSpec({
         val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
 
         val loginUserOperationExecutor =
-            LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext())
+            LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext(), mockConsistencyManager)
         val operations = listOf<Operation>(LoginUserOperation(appId, localOneSignalId, "externalId", "existingOneSignalId"))
 
         // When
@@ -268,7 +284,7 @@ class LoginUserOperationExecutorTests : FunSpec({
         // Given
         val mockUserBackendService = mockk<IUserBackendService>()
         coEvery { mockUserBackendService.createUser(any(), any(), any(), any()) } returns
-            CreateUserResponse(mapOf(IdentityConstants.ONESIGNAL_ID to remoteOneSignalId), PropertiesObject(), listOf())
+            CreateUserResponse(mapOf(IdentityConstants.ONESIGNAL_ID to remoteOneSignalId), PropertiesObject(), listOf(), rywData)
 
         val mockIdentityOperationExecutor = mockk<IdentityOperationExecutor>()
         coEvery { mockIdentityOperationExecutor.execute(any()) } returns ExecutionResponse(ExecutionResult.FAIL_RETRY)
@@ -278,7 +294,7 @@ class LoginUserOperationExecutorTests : FunSpec({
         val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
 
         val loginUserOperationExecutor =
-            LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext())
+            LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext(), mockConsistencyManager)
         val operations = listOf<Operation>(LoginUserOperation(appId, localOneSignalId, "externalId", "existingOneSignalId"))
 
         // When
@@ -304,7 +320,7 @@ class LoginUserOperationExecutorTests : FunSpec({
         // Given
         val mockUserBackendService = mockk<IUserBackendService>()
         coEvery { mockUserBackendService.createUser(any(), any(), any(), any()) } returns
-            CreateUserResponse(mapOf(IdentityConstants.ONESIGNAL_ID to remoteOneSignalId), PropertiesObject(), listOf())
+            CreateUserResponse(mapOf(IdentityConstants.ONESIGNAL_ID to remoteOneSignalId), PropertiesObject(), listOf(), rywData)
 
         val mockIdentityOperationExecutor = mockk<IdentityOperationExecutor>()
         coEvery { mockIdentityOperationExecutor.execute(any()) } returns ExecutionResponse(ExecutionResult.FAIL_NORETRY)
@@ -314,7 +330,7 @@ class LoginUserOperationExecutorTests : FunSpec({
         val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
 
         val loginUserOperationExecutor =
-            LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext())
+            LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext(), mockConsistencyManager)
         val operations = listOf<Operation>(LoginUserOperation(appId, localOneSignalId, "externalId", "existingOneSignalId"))
 
         // When
@@ -352,7 +368,7 @@ class LoginUserOperationExecutorTests : FunSpec({
         val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
 
         val loginUserOperationExecutor =
-            LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext())
+            LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext(), mockConsistencyManager)
         val operations = listOf<Operation>(LoginUserOperation(appId, localOneSignalId, "externalId", "existingOneSignalId"))
 
         // When
@@ -385,6 +401,7 @@ class LoginUserOperationExecutorTests : FunSpec({
                 mapOf(IdentityConstants.ONESIGNAL_ID to remoteOneSignalId),
                 PropertiesObject(),
                 listOf(),
+                rywData,
             )
         // Given
         val mockIdentityOperationExecutor = mockk<IdentityOperationExecutor>()
@@ -403,6 +420,7 @@ class LoginUserOperationExecutorTests : FunSpec({
                 mockSubscriptionsModelStore,
                 MockHelper.configModelStore(),
                 MockHelper.languageContext(),
+                mockConsistencyManager,
             )
         val operations =
             listOf<Operation>(
@@ -471,6 +489,7 @@ class LoginUserOperationExecutorTests : FunSpec({
                 mapOf(IdentityConstants.ONESIGNAL_ID to remoteOneSignalId),
                 PropertiesObject(),
                 listOf(SubscriptionObject(remoteSubscriptionId1, SubscriptionObjectType.ANDROID_PUSH), SubscriptionObject(remoteSubscriptionId2, SubscriptionObjectType.EMAIL)),
+                rywData,
             )
         // Given
         val mockIdentityOperationExecutor = mockk<IdentityOperationExecutor>()
@@ -504,6 +523,7 @@ class LoginUserOperationExecutorTests : FunSpec({
                 mockSubscriptionsModelStore,
                 MockHelper.configModelStore(),
                 MockHelper.languageContext(),
+                mockConsistencyManager,
             )
         val operations =
             listOf<Operation>(
@@ -557,6 +577,7 @@ class LoginUserOperationExecutorTests : FunSpec({
                 mapOf(IdentityConstants.ONESIGNAL_ID to remoteOneSignalId),
                 PropertiesObject(),
                 listOf(SubscriptionObject(remoteSubscriptionId1, SubscriptionObjectType.ANDROID_PUSH), SubscriptionObject(remoteSubscriptionId2, SubscriptionObjectType.EMAIL)),
+                rywData,
             )
         // Given
         val mockIdentityOperationExecutor = mockk<IdentityOperationExecutor>()
@@ -590,6 +611,7 @@ class LoginUserOperationExecutorTests : FunSpec({
                 mockSubscriptionsModelStore,
                 MockHelper.configModelStore(),
                 MockHelper.languageContext(),
+                mockConsistencyManager,
             )
         val operations =
             listOf<Operation>(
@@ -643,6 +665,7 @@ class LoginUserOperationExecutorTests : FunSpec({
                 mapOf(IdentityConstants.ONESIGNAL_ID to remoteOneSignalId),
                 PropertiesObject(),
                 listOf(SubscriptionObject(remoteSubscriptionId1, SubscriptionObjectType.ANDROID_PUSH), SubscriptionObject(remoteSubscriptionId2, SubscriptionObjectType.EMAIL)),
+                rywData,
             )
         // Given
         val mockIdentityOperationExecutor = mockk<IdentityOperationExecutor>()
@@ -662,6 +685,7 @@ class LoginUserOperationExecutorTests : FunSpec({
                 mockSubscriptionsModelStore,
                 MockHelper.configModelStore(),
                 MockHelper.languageContext(),
+                mockConsistencyManager,
             )
         val operations =
             listOf<Operation>(
@@ -706,7 +730,7 @@ class LoginUserOperationExecutorTests : FunSpec({
         // Given
         val mockUserBackendService = mockk<IUserBackendService>()
         coEvery { mockUserBackendService.createUser(any(), any(), any(), any()) } returns
-            CreateUserResponse(mapOf(IdentityConstants.ONESIGNAL_ID to remoteOneSignalId), PropertiesObject(), listOf())
+            CreateUserResponse(mapOf(IdentityConstants.ONESIGNAL_ID to remoteOneSignalId), PropertiesObject(), listOf(), rywData)
 
         val mockIdentityOperationExecutor = mockk<IdentityOperationExecutor>()
 
@@ -725,6 +749,7 @@ class LoginUserOperationExecutorTests : FunSpec({
                 mockSubscriptionsModelStore,
                 MockHelper.configModelStore(),
                 MockHelper.languageContext(),
+                mockConsistencyManager,
             )
         // anonymous Login request
         val operations = listOf<Operation>(LoginUserOperation(appId, localOneSignalId, null, null))

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/RefreshUserOperationExecutorTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/RefreshUserOperationExecutorTests.kt
@@ -49,6 +49,7 @@ class RefreshUserOperationExecutorTests : FunSpec({
                     SubscriptionObject(remoteSubscriptionId1, SubscriptionObjectType.ANDROID_PUSH, enabled = true, token = "pushToken2"),
                     SubscriptionObject(remoteSubscriptionId2, SubscriptionObjectType.EMAIL, token = "name@company.com"),
                 ),
+                null,
             )
 
         // Given
@@ -142,6 +143,7 @@ class RefreshUserOperationExecutorTests : FunSpec({
                 mapOf(IdentityConstants.ONESIGNAL_ID to remoteOneSignalId),
                 PropertiesObject(),
                 listOf(),
+                null,
             )
 
         // Given

--- a/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/InAppMessagesManager.kt
+++ b/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/InAppMessagesManager.kt
@@ -196,15 +196,6 @@ internal class InAppMessagesManager(
             for (redisplayInAppMessage in redisplayedInAppMessages) {
                 redisplayInAppMessage.isDisplayedInSession = false
             }
-
-            // attempt to fetch messages from the backend (if we have the pre-requisite data already)
-            val onesignalId = _userManager.onesignalId
-            val updateConditionDeferred =
-                _consistencyManager.getRywDataFromAwaitableCondition(IamFetchReadyCondition(onesignalId))
-            val rywToken = updateConditionDeferred.await()
-            if (rywToken != null) {
-                fetchMessages(rywToken)
-            }
         }
     }
 


### PR DESCRIPTION
# Description
## One Line Summary
Resolve fetch IAM conditions after the user create call, not just in user update call, in order to allow fetching IAMs after the first usage of `login`.

## Details
When Identity Verification is enabled, the initial anonymous user create is dropped. As a result, we will never make this call. Then, when `login` is invoked, we send a create user request with no subsequent update user calls to be made. Thus, the fetch IAM condition was never resolving. Since create user returns ryw data from the server, we can safely resolve the condition with this data when the create user returns successfully. Additionally, this is appropriate and safe to do so as a create user call effectively serves the same role as a user update call for purposes of read-your-write consistency.

### Motivation
- Reported in #2336 and reproducible 

### Scope
- Add resolving fetch IAM conditions after user create
- **Behavior change:** Does result in a behavior change when combined with https://github.com/OneSignal/OneSignal-Android-SDK/pull/2287. When a new user logs in, IAMs may be fetched again if enough time has passed since the initial fetch at app start.
- remove a chunk of code leftover from #2287 that was left over after rebase

# Testing
## Unit testing
Unit tests are updated only

## Manual testing
Android emulator on API 35
Reproduced the issue that IAMs are not fetched after the first `login` call. After fix, IAMs are fetched.

**Testing with identity verification enabled:**
1. New install, then login, iams fetched
2. Quit and reopen app, patch user call is made for new session, iams fetched
3. Now login to another user, iams are fetched again if enough time has passed since the last fetch

**Testing with identity verification disabled:**
1. New install, iams are fetched for the anonymous user
2. Now login to another user, iams are fetched again if enough tie has passed since the last fetch
3. Now logout (blocked: logout appears broken when identity verification is disabled)

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [x] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2337)
<!-- Reviewable:end -->
