### PR TITLE
fix(webview): force IAM render on android 5 and 6

### DIFF
--- a/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/display/impl/WebViewManager.kt
+++ b/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/display/impl/WebViewManager.kt
@@ -314,6 +314,22 @@ internal class WebViewManager(
 
         // Setup receiver for page events / data from JS
         webView!!.addJavascriptInterface(OSJavaScriptInterface(), JS_OBJ_NAME)
+
+        webView!!.webViewClient = object : android.webkit.WebViewClient() {
+            override fun onPageFinished(view: android.webkit.WebView?, url: String?) {
+                android.os.Handler(android.os.Looper.getMainLooper()).postDelayed({
+                    val mockRenderingComplete = """{"type":"rendering_complete"}"""
+                    try {
+                        val jsInterface = OSJavaScriptInterface()
+                        jsInterface.postMessage(mockRenderingComplete)
+                    } catch (e: Exception) {
+                        Logging.error("Issue when forcing rendering_complete: ", e)
+                    }
+                }, 3000)
+
+                super.onPageFinished(view, url)
+            }
+        }
         if (isFullScreen) {
             webView!!.systemUiVisibility = View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN or
                 View.SYSTEM_UI_FLAG_IMMERSIVE or


### PR DESCRIPTION
# Description
## One Line Summary

### WIP - seeking high-level feedback
Fixes an issue where IAM are received, but not rendered, in Android versions 5 and 6.

## Details

After debugging, it looks like there is a JavaScript issue within WebView, resulting in the `rendering_complete` event to not fire. Therefore, the SDK will indefinitely wait for this event before showing the IAM. At this point, it is not clear what the specific issue could be that causes this to happen.

The current approach creates a time-based (3 seconds) fallback which will manually send the `rendering_complete` event if it one is not automatically sent as expected. This is not an ideal solution, so I am currently **seeking feedback on a more idiomatic approach**.

### Motivation
Following up on this [action item](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2328#pullrequestreview-2972266872) from a previous PR: this change addresses an issue where an IAM is not shown on older Android versions.

# Testing
## Unit testing
None added, seeking feedback here as well.

## Manual testing

Tested on Android emulator for both API versions 23 and 22 (Android 6 and 5, respectively)

Create a segment on your app via dashboard.onesignal.com. Have the segment target users with a tag similar to `{'user': '1'}`. Finally, create and publish an In-App Message that targets this segment.

### Build and run a new install of the app on either Android 6 or 5

1. Open the app, accept push permissions
2. Login user and add the tag mentioned above, e.g. `{'user': '1'}`
3. Completely close the app, reopen and wait

**Before this change**: no IAM would appear
**After this change**: the IAM appears after 3 seconds

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [x] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [ ] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2345)
<!-- Reviewable:end -->
