### PR TITLE
fix(crash): NPE in PermissionsActivity

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/activities/PermissionsActivity.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/activities/PermissionsActivity.kt
@@ -26,6 +26,11 @@ class PermissionsActivity : Activity() {
             return
         }
 
+        if (intent.extras == null) {
+            // This should never happen, but extras is null in rare crash reports
+            return
+        }
+
         requestPermissionService = OneSignal.getService()
         preferenceService = OneSignal.getService()
 


### PR DESCRIPTION
# Description
## One Line Summary
Fix null pointer exception when PermissionsActivity is being created.

## Details
* This should never happen as the SDK does send extras for this Activity, and no other entity should be creating PermissionsActivity.
* However, we have seen crash reports from our users that primarily seems to affect Nexus 5 and Pixel 3, in low numbers.
* One theory is that automatic testing done by the google play store is explicitly driving the PermissionsActivity.

### Motivation
- Address https://github.com/OneSignal/OneSignal-Android-SDK/issues/2215

### Scope
- This appears to be a crash in very low numbers. If we detect `extras` is `null`, then we return early, which is safe to do as it doesn't make sense to show the Activity anyway.

# Testing
## Unit testing
None

## Manual testing
None, unable to repro

**From Josh:**

> The only odd case I can think of is if the end-user backgrounds the app when they see the permission prompt. Then if the app is kicked out of memory and the end-user decides to come back to the app the Activity will be recreated. This is not a flow we normally test, but I just did so now and not seeing any issues.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [ ] I have filled out all **REQUIRED** sections above
   - [ ] PR does one thing
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [ ] Code is as readable as possible.
   - [ ] I have reviewed this PR myself, ensuring it meets each checklist item
