### PR TITLE
Release 5.1.37

### DIFF
--- a/Examples/OneSignalDemo/app/build.gradle
+++ b/Examples/OneSignalDemo/app/build.gradle
@@ -85,12 +85,12 @@ dependencies {
     implementation 'com.github.bumptech.glide:glide:4.12.0'
 
     /** START - Google Play Builds **/
-    gmsImplementation('com.onesignal:OneSignal:5.1.36')
+    gmsImplementation('com.onesignal:OneSignal:5.1.37')
     /** END - Google Play Builds **/
 
     /** START - Huawei Builds **/
     // Omit Google / Firebase libraries for Huawei builds.
-    huaweiImplementation('com.onesignal:OneSignal:5.1.36') {
+    huaweiImplementation('com.onesignal:OneSignal:5.1.37') {
         exclude group: 'com.google.android.gms', module: 'play-services-gcm'
         exclude group: 'com.google.android.gms', module: 'play-services-analytics'
         exclude group: 'com.google.android.gms', module: 'play-services-location'

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/OneSignalUtils.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/OneSignalUtils.kt
@@ -6,7 +6,7 @@ object OneSignalUtils {
     /**
      * The version of this SDK.
      */
-    const val SDK_VERSION: String = "050136"
+    const val SDK_VERSION: String = "050137"
 
     fun isValidEmail(email: String): Boolean {
         if (email.isEmpty()) {

--- a/OneSignalSDK/settings.gradle
+++ b/OneSignalSDK/settings.gradle
@@ -3,7 +3,7 @@
 gradle.rootProject {
     allprojects {
         group = 'com.onesignal'
-        version = '5.1.36'
+        version = '5.1.37'
         configurations.all {
             resolutionStrategy.dependencySubstitution {
                 substitute(module('com.onesignal:OneSignal')).using(project(':OneSignal'))


### PR DESCRIPTION
🐛 Bug Fixes

* If the existing push subscription ID is non-local, send it in the create subscription call. If this subscription has since been deleted, a new ID will be returned and the SDK will correctly hydrate (https://github.com/OneSignal/OneSignal-Android-SDK/pull/2354).

* Finishing the activity on main thread when a notification is opened(https://github.com/OneSignal/OneSignal-Android-SDK/pull/2353)