### PR TITLE
Refactor: move part of initWithContext off main thread

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/IOneSignal.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/IOneSignal.kt
@@ -85,8 +85,15 @@ interface IOneSignal {
      */
     fun initWithContext(
         context: Context,
-        appId: String?,
+        appId: String,
     ): Boolean
+
+    /**
+     * Initialize the OneSignal SDK, suspend until initialization is completed
+     *
+     * @param context The Android context the SDK should use.
+     */
+    suspend fun initWithContext(context: Context): Boolean
 
     /**
      * Login to OneSignal under the user identified by the [externalId] provided. The act of

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/OneSignal.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/OneSignal.kt
@@ -204,8 +204,8 @@ object OneSignal {
      * THIS IS AN INTERNAL INTERFACE AND SHOULD NOT BE USED DIRECTLY.
      */
     @JvmStatic
-    fun initWithContext(context: Context): Boolean {
-        return oneSignal.initWithContext(context, null)
+    suspend fun initWithContext(context: Context): Boolean {
+        return oneSignal.initWithContext(context)
     }
 
     /**

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/threading/LatchAwaiter.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/threading/LatchAwaiter.kt
@@ -1,0 +1,82 @@
+package com.onesignal.common.threading
+
+import com.onesignal.common.AndroidUtils
+import com.onesignal.debug.internal.logging.Logging
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+/**
+ * This class allows blocking execution until asynchronous initialization or completion is signaled, with support for configurable timeouts and detailed logging for troubleshooting.
+ * It is designed for scenarios where certain tasks, such as SDK initialization, must finish before continuing.
+ * When used on the main/UI thread, it applies a shorter timeout and logs a thread stack trace to warn developers, helping to prevent Application Not Responding (ANR) errors caused by blocking the UI thread.
+ *
+ * Usage:
+ *   val awaiter = LatchAwaiter("OneSignal SDK Init")
+ *   awaiter.release() // when done
+ */
+class LatchAwaiter(
+    private val componentName: String = "Component",
+) {
+    companion object {
+        const val DEFAULT_TIMEOUT_MS = 30_000L // 30 seconds
+        const val ANDROID_ANR_TIMEOUT_MS = 4_800L // Conservative ANR threshold
+    }
+
+    private val latch = CountDownLatch(1)
+
+    /**
+     * Releases the latch to unblock any waiting threads.
+     */
+    fun release() {
+        latch.countDown()
+    }
+
+    /**
+     * Wait for the latch to be released with an optional timeout.
+     *
+     * @return true if latch was released before timeout, false otherwise.
+     */
+    fun await(timeoutMs: Long = getDefaultTimeout()): Boolean {
+        val completed =
+            try {
+                latch.await(timeoutMs, TimeUnit.MILLISECONDS)
+            } catch (e: InterruptedException) {
+                Logging.warn("Interrupted while waiting for $componentName", e)
+                logAllThreads()
+                false
+            }
+
+        if (!completed) {
+            val message = createTimeoutMessage(timeoutMs)
+            Logging.warn(message)
+        }
+
+        return completed
+    }
+
+    private fun getDefaultTimeout(): Long {
+        return if (AndroidUtils.isRunningOnMainThread()) ANDROID_ANR_TIMEOUT_MS else DEFAULT_TIMEOUT_MS
+    }
+
+    private fun createTimeoutMessage(timeoutMs: Long): String {
+        return if (AndroidUtils.isRunningOnMainThread()) {
+            "Timeout waiting for $componentName after ${timeoutMs}ms on the main thread. " +
+                "This can cause ANRs. Consider calling from a background thread."
+        } else {
+            "Timeout waiting for $componentName after ${timeoutMs}ms."
+        }
+    }
+
+    private fun logAllThreads(): String {
+        val allThreads = Thread.getAllStackTraces()
+        val sb = StringBuilder()
+        for ((thread, stack) in allThreads) {
+            sb.append("ThreadDump Thread: ${thread.name} [${thread.state}]\n")
+            for (element in stack) {
+                sb.append("\tat $element\n")
+            }
+        }
+
+        return sb.toString()
+    }
+}

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/activities/PermissionsActivity.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/activities/PermissionsActivity.kt
@@ -8,11 +8,14 @@ import android.os.Bundle
 import android.os.Handler
 import androidx.core.app.ActivityCompat
 import com.onesignal.OneSignal
+import com.onesignal.common.threading.suspendifyOnThread
 import com.onesignal.core.R
 import com.onesignal.core.internal.permissions.impl.RequestPermissionService
 import com.onesignal.core.internal.preferences.IPreferencesService
 import com.onesignal.core.internal.preferences.PreferenceOneSignalKeys
 import com.onesignal.core.internal.preferences.PreferenceStores
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 class PermissionsActivity : Activity() {
     private var requestPermissionService: RequestPermissionService? = null
@@ -22,21 +25,29 @@ class PermissionsActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        if (!OneSignal.initWithContext(this)) {
-            finishActivity()
-            return
-        }
-
         if (intent.extras == null) {
             // This should never happen, but extras is null in rare crash reports
             finishActivity()
             return
         }
 
-        requestPermissionService = OneSignal.getService()
-        preferenceService = OneSignal.getService()
+        // init in background
+        suspendifyOnThread {
+            val initialized = OneSignal.initWithContext(this)
 
-        handleBundleParams(intent.extras)
+            // finishActivity() and handleBundleParams must be called from main
+            withContext(Dispatchers.Main) {
+                if (!initialized) {
+                    finishActivity()
+                    return@withContext
+                }
+
+                requestPermissionService = OneSignal.getService()
+                preferenceService = OneSignal.getService()
+
+                handleBundleParams(intent.extras)
+            }
+        }
     }
 
     override fun onNewIntent(intent: Intent) {

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/services/SyncJobService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/services/SyncJobService.kt
@@ -35,13 +35,14 @@ import com.onesignal.debug.internal.logging.Logging
 
 class SyncJobService : JobService() {
     override fun onStartJob(jobParameters: JobParameters): Boolean {
-        if (!OneSignal.initWithContext(this)) {
-            return false
-        }
-
-        var backgroundService = OneSignal.getService<IBackgroundManager>()
-
         suspendifyOnThread {
+            // init OneSignal in background
+            if (!OneSignal.initWithContext(this)) {
+                jobFinished(jobParameters, false)
+                return@suspendifyOnThread
+            }
+
+            val backgroundService = OneSignal.getService<IBackgroundManager>()
             backgroundService.runBackgroundServices()
 
             Logging.debug("LollipopSyncRunnable:JobFinished needsJobReschedule: " + backgroundService.needsJobReschedule)
@@ -49,7 +50,6 @@ class SyncJobService : JobService() {
             // Reschedule if needed
             val reschedule = backgroundService.needsJobReschedule
             backgroundService.needsJobReschedule = false
-
             jobFinished(jobParameters, reschedule)
         }
 

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/InitState.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/InitState.kt
@@ -1,0 +1,39 @@
+package com.onesignal.internal
+
+/**
+ * Represents the current initialization state of the OneSignal SDK.
+ *
+ * This enum is used to track the lifecycle of SDK initialization, ensuring that operations like `login`,
+ * `logout`, or accessing services are only allowed when the SDK is fully initialized.
+ */
+internal enum class InitState {
+    /**
+     * SDK initialization has not yet started.
+     * Calling SDK-dependent methods in this state will throw an exception.
+     */
+    NOT_STARTED,
+
+    /**
+     * SDK initialization is currently in progress.
+     * Calls that require initialization will block (via a latch) until this completes.
+     */
+    IN_PROGRESS,
+
+    /**
+     * SDK initialization completed successfully.
+     * All SDK-dependent operations can proceed safely.
+     */
+    SUCCESS,
+
+    /**
+     * SDK initialization has failed due to an unrecoverable error (e.g., missing app ID).
+     * All dependent operations should fail fast or throw until re-initialized.
+     */
+    FAILED,
+
+    ;
+
+    fun isSDKAccessible(): Boolean {
+        return this == IN_PROGRESS || this == SUCCESS
+    }
+}

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/common/threading/LatchAwaiterTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/common/threading/LatchAwaiterTests.kt
@@ -1,0 +1,88 @@
+package com.onesignal.common.threading
+
+import com.onesignal.common.AndroidUtils
+import com.onesignal.debug.LogLevel
+import com.onesignal.debug.internal.logging.Logging
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.longs.shouldBeGreaterThan
+import io.kotest.matchers.longs.shouldBeLessThan
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockkObject
+import kotlinx.coroutines.delay
+
+class LatchAwaiterTests : FunSpec({
+
+    lateinit var awaiter: LatchAwaiter
+
+    beforeEach {
+        Logging.logLevel = LogLevel.NONE
+        awaiter = LatchAwaiter("TestComponent")
+    }
+
+    context("successful initialization") {
+
+        test("completes immediately when already successful") {
+            // Given
+            awaiter.release()
+
+            // When
+            val completed = awaiter.await(0)
+
+            // Then
+            completed shouldBe true
+        }
+    }
+
+    context("waiting behavior - holds until completion") {
+
+        test("waits for delayed completion") {
+            val completionDelay = 300L
+            val timeoutMs = 2000L
+
+            val startTime = System.currentTimeMillis()
+
+            // Simulate delayed success from another thread
+            suspendifyOnThread {
+                delay(completionDelay)
+                awaiter.release()
+            }
+
+            val result = awaiter.await(timeoutMs)
+            val duration = System.currentTimeMillis() - startTime
+
+            result shouldBe true
+            duration shouldBeGreaterThan (completionDelay - 50)
+            duration shouldBeLessThan (completionDelay + 150) // buffer
+        }
+    }
+
+    context("timeout scenarios") {
+
+        beforeEach {
+            mockkObject(AndroidUtils)
+            every { AndroidUtils.isRunningOnMainThread() } returns true
+        }
+
+        test("await returns false when timeout expires") {
+            val timeoutMs = 200L
+            val startTime = System.currentTimeMillis()
+
+            val completed = awaiter.await(timeoutMs)
+            val duration = System.currentTimeMillis() - startTime
+
+            completed shouldBe false
+            duration shouldBeGreaterThan (timeoutMs - 50)
+            duration shouldBeLessThan (timeoutMs + 150)
+        }
+
+        test("timeout of 0 returns false immediately") {
+            val startTime = System.currentTimeMillis()
+            val completed = awaiter.await(0)
+            val duration = System.currentTimeMillis() - startTime
+
+            completed shouldBe false
+            duration shouldBeLessThan 20L
+        }
+    }
+})

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/application/SDKInitTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/application/SDKInitTests.kt
@@ -1,0 +1,281 @@
+package com.onesignal.core.internal.application
+
+import android.content.Context
+import android.content.ContextWrapper
+import android.content.SharedPreferences
+import androidx.test.core.app.ApplicationProvider.getApplicationContext
+import br.com.colman.kotest.android.extensions.robolectric.RobolectricTest
+import com.onesignal.common.threading.LatchAwaiter
+import com.onesignal.debug.LogLevel
+import com.onesignal.debug.internal.logging.Logging
+import com.onesignal.internal.OneSignalImp
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.maps.shouldContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.runBlocking
+
+@RobolectricTest
+class SDKInitTests : FunSpec({
+
+    beforeAny {
+        Logging.logLevel = LogLevel.NONE
+    }
+
+    afterAny {
+        val context = getApplicationContext<Context>()
+        val prefs = context.getSharedPreferences("OneSignal", Context.MODE_PRIVATE)
+        prefs.edit().clear().commit()
+    }
+
+    test("OneSignal accessors throw before calling initWithContext") {
+        val os = OneSignalImp()
+
+        shouldThrow<IllegalStateException> {
+            os.user
+        }
+        shouldThrow<IllegalStateException> {
+            os.inAppMessages
+        }
+        shouldThrow<IllegalStateException> {
+            os.session
+        }
+        shouldThrow<IllegalStateException> {
+            os.notifications
+        }
+        shouldThrow<IllegalStateException> {
+            os.location
+        }
+    }
+
+    test("initWithContext with no appId blocks and will return false") {
+        // Given
+        // block SharedPreference before calling init
+        val trigger = LatchAwaiter("Test")
+        val context = getApplicationContext<Context>()
+        val blockingPrefContext = BlockingPrefsContext(context, trigger, 2000)
+        val os = OneSignalImp()
+        var initSuccess = true
+
+        // When
+        val accessorThread =
+            Thread {
+                // this will block until after SharedPreferences is released
+                runBlocking {
+                    initSuccess = os.initWithContext(blockingPrefContext)
+                }
+            }
+
+        accessorThread.start()
+        accessorThread.join(500)
+
+        accessorThread.isAlive shouldBe true
+
+        // release SharedPreferences
+        trigger.release()
+
+        accessorThread.join(500)
+        accessorThread.isAlive shouldBe false
+
+        // always return false because appId is missing
+        initSuccess shouldBe false
+        os.isInitialized shouldBe false
+    }
+
+    test("initWithContext with appId does not block") {
+        // Given
+        // block SharedPreference before calling init
+        val trigger = LatchAwaiter("Test")
+        val context = getApplicationContext<Context>()
+        val blockingPrefContext = BlockingPrefsContext(context, trigger, 1000)
+        val os = OneSignalImp()
+
+        // When
+        val accessorThread =
+            Thread {
+                os.initWithContext(blockingPrefContext, "appId")
+            }
+
+        accessorThread.start()
+        accessorThread.join(500)
+
+        // Then
+        // should complete even SharedPreferences is unavailable
+        accessorThread.isAlive shouldBe false
+        os.isInitialized shouldBe true
+    }
+
+    test("accessors will be blocked if call too early after initWithContext with appId") {
+        // Given
+        // block SharedPreference before calling init
+        val trigger = LatchAwaiter("Test")
+        val context = getApplicationContext<Context>()
+        val blockingPrefContext = BlockingPrefsContext(context, trigger, 2000)
+        val os = OneSignalImp()
+
+        val accessorThread =
+            Thread {
+                os.initWithContext(blockingPrefContext, "appId")
+                os.user // This should block until either trigger is released or timed out
+            }
+
+        accessorThread.start()
+        accessorThread.join(500)
+
+        accessorThread.isAlive shouldBe true
+
+        // release the lock on SharedPreferences
+        trigger.release()
+
+        accessorThread.join(1000)
+        accessorThread.isAlive shouldBe false
+        os.isInitialized shouldBe true
+    }
+
+    test("ensure adding tags right after initWithContext with appId is successful") {
+        // Given
+        val context = getApplicationContext<Context>()
+        val os = OneSignalImp()
+        val tagKey = "tagKey"
+        val tagValue = "tagValue"
+        val testTags = mapOf(tagKey to tagValue)
+
+        // When
+        os.initWithContext(context, "appId")
+        os.user.addTags(testTags)
+
+        // Then
+        val tags = os.user.getTags()
+        tags shouldContain (tagKey to tagValue)
+    }
+
+    test("ensure login called right after initWithContext can set externalId correctly") {
+        // Given
+        // block SharedPreference before calling init
+        val trigger = LatchAwaiter("Test")
+        val context = getApplicationContext<Context>()
+        val blockingPrefContext = BlockingPrefsContext(context, trigger, 2000)
+        val os = OneSignalImp()
+        val externalId = "testUser"
+
+        val accessorThread =
+            Thread {
+                os.initWithContext(blockingPrefContext, "appId")
+                os.login(externalId)
+            }
+
+        accessorThread.start()
+        accessorThread.join(500)
+
+        os.isInitialized shouldBe true
+        accessorThread.isAlive shouldBe true
+
+        // release the lock on SharedPreferences
+        trigger.release()
+
+        accessorThread.join(500)
+        accessorThread.isAlive shouldBe false
+        os.user.externalId shouldBe externalId
+    }
+
+    test("a push subscription should be created right after initWithContext") {
+        // Given
+        val context = getApplicationContext<Context>()
+        val os = OneSignalImp()
+        os.initWithContext(context, "appId")
+
+        // When
+        val pushSub = os.user.pushSubscription
+
+        // Then
+        pushSub shouldNotBe null
+        pushSub.token shouldNotBe null
+    }
+
+    test("externalId retrieved correctly when login right after init") {
+        // Given
+        val context = getApplicationContext<Context>()
+        val os = OneSignalImp()
+        val testExternalId = "testUser"
+
+        // When
+        os.initWithContext(context, "appId")
+        val oldExternalId = os.user.externalId
+        os.login(testExternalId)
+        val newExternalId = os.user.externalId
+
+        oldExternalId shouldBe ""
+        newExternalId shouldBe testExternalId
+    }
+
+    test("accessor instances after multiple initWithContext calls are consistent") {
+        // Given
+        val context = getApplicationContext<Context>()
+        val os = OneSignalImp()
+
+        // When
+        os.initWithContext(context, "appId")
+        val oldUser = os.user
+
+        // Second init from some internal class
+        os.initWithContext(context)
+        val newUser = os.user
+
+        // Then
+        oldUser shouldBe newUser
+    }
+
+    test("integration: full user workflow after initialization") {
+        val context = getApplicationContext<Context>()
+        val os = OneSignalImp()
+        val testExternalId = "test-user"
+        val tags = mapOf("test" to "integration", "version" to "1.0")
+
+        os.initWithContext(context, "appId")
+
+        // Test user workflow
+        // init
+        val initialExternalId = os.user.externalId
+        initialExternalId shouldBe ""
+
+        // login
+        os.login(testExternalId)
+        os.user.externalId shouldBe testExternalId
+
+        // addTags and getTags
+        os.user.addTags(tags)
+        val retrievedTags = os.user.getTags()
+        retrievedTags shouldContain ("test" to "integration")
+        retrievedTags shouldContain ("version" to "1.0")
+
+        // logout
+        os.logout()
+        os.user.externalId shouldBe ""
+    }
+})
+
+/**
+ * Simulate a context awaiting for a shared preference until the trigger is signaled
+ */
+class BlockingPrefsContext(
+    context: Context,
+    private val unblockTrigger: LatchAwaiter,
+    private val timeoutInMillis: Long,
+) : ContextWrapper(context) {
+    override fun getSharedPreferences(
+        name: String,
+        mode: Int,
+    ): SharedPreferences {
+        try {
+            unblockTrigger.await(timeoutInMillis)
+        } catch (e: InterruptedException) {
+            throw e
+        } catch (e: TimeoutCancellationException) {
+            throw e
+        }
+
+        return super.getSharedPreferences(name, mode)
+    }
+}

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/operations/OperationRepoTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/operations/OperationRepoTests.kt
@@ -542,14 +542,14 @@ class OperationRepoTests : FunSpec({
     test("starting OperationModelStore should be processed, following normal delay rules") {
         // Given
         val mocks = Mocks()
-        mocks.configModelStore.model.opRepoExecutionInterval = 100
+        mocks.configModelStore.model.opRepoExecutionInterval = 200
         every { mocks.operationModelStore.list() } returns listOf(mockOperation())
         val executeOperationsCall = mockExecuteOperations(mocks.operationRepo)
 
         // When
         mocks.operationRepo.start()
         val immediateResult =
-            withTimeoutOrNull(100) {
+            withTimeoutOrNull(200) {
                 executeOperationsCall.waitForWake()
             }
         val delayedResult =

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/NotificationOpenedActivityHMS.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/NotificationOpenedActivityHMS.kt
@@ -72,13 +72,13 @@ class NotificationOpenedActivityHMS : Activity() {
     }
 
     private fun processOpen(intent: Intent?) {
-        if (!OneSignal.initWithContext(applicationContext)) {
-            return
-        }
-
-        var notificationPayloadProcessorHMS = OneSignal.getService<INotificationOpenedProcessorHMS>()
-        val self = this
         suspendifyBlocking {
+            if (!OneSignal.initWithContext(applicationContext)) {
+                return@suspendifyBlocking
+            }
+
+            val notificationPayloadProcessorHMS = OneSignal.getService<INotificationOpenedProcessorHMS>()
+            val self = this
             notificationPayloadProcessorHMS.handleHMSNotificationOpenIntent(self, intent)
         }
     }

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/activities/NotificationOpenedActivityBase.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/activities/NotificationOpenedActivityBase.kt
@@ -46,25 +46,23 @@ abstract class NotificationOpenedActivityBase : Activity() {
     }
 
     internal open fun processIntent() {
-        if (!OneSignal.initWithContext(applicationContext)) {
-            return
+        suspendifyOnThread {
+            if (!OneSignal.initWithContext(applicationContext)) {
+                return@suspendifyOnThread
+            }
+
+            val openedProcessor = OneSignal.getService<INotificationOpenedProcessor>()
+            openedProcessor.processFromContext(this, intent)
+            // KEEP: Xiaomi Compatibility:
+            // Must keep this Activity alive while trampolining, that is
+            // startActivity() must be called BEFORE finish(), otherwise
+            // the app is never foregrounded.
+
+            // Safely finish the activity on the main thread after processing is complete.
+            // This gives the system enough time to complete rendering before closing the Trampoline activity.
+            runOnUiThread {
+                AndroidUtils.finishSafely(this)
+            }
         }
-        suspendifyOnThread(
-            block = {
-                val openedProcessor = OneSignal.getService<INotificationOpenedProcessor>()
-                openedProcessor.processFromContext(this, intent)
-                // KEEP: Xiaomi Compatibility:
-                // Must keep this Activity alive while trampolining, that is
-                // startActivity() must be called BEFORE finish(), otherwise
-                // the app is never foregrounded.
-            },
-            onComplete = {
-                // Safely finish the activity on the main thread after processing is complete.
-                // This gives the system enough time to complete rendering before closing the Trampoline activity.
-                runOnUiThread {
-                    AndroidUtils.finishSafely(this)
-                }
-            },
-        )
     }
 }

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/generation/impl/NotificationGenerationWorkManager.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/generation/impl/NotificationGenerationWorkManager.kt
@@ -64,6 +64,7 @@ internal class NotificationGenerationWorkManager : INotificationGenerationWorkMa
     class NotificationGenerationWorker(context: Context, workerParams: WorkerParameters) : CoroutineWorker(context, workerParams) {
         override suspend fun doWork(): Result {
             if (!OneSignal.initWithContext(applicationContext)) {
+                Logging.warn("NotificationWorker skipped due to failed OneSignal initialization")
                 return Result.success()
             }
 
@@ -71,11 +72,16 @@ internal class NotificationGenerationWorkManager : INotificationGenerationWorkMa
             val inputData = inputData
             val id = inputData.getString(OS_ID_DATA_PARAM) ?: return Result.failure()
 
-            try {
+            return try {
                 Logging.debug("NotificationWorker running doWork with data: $inputData")
+
                 val androidNotificationId = inputData.getInt(ANDROID_NOTIF_ID_WORKER_DATA_PARAM, 0)
                 val jsonPayload = JSONObject(inputData.getString(JSON_PAYLOAD_WORKER_DATA_PARAM))
-                val timestamp = inputData.getLong(TIMESTAMP_WORKER_DATA_PARAM, System.currentTimeMillis() / 1000L)
+                val timestamp =
+                    inputData.getLong(
+                        TIMESTAMP_WORKER_DATA_PARAM,
+                        System.currentTimeMillis() / 1000L,
+                    )
                 val isRestoring = inputData.getBoolean(IS_RESTORING_WORKER_DATA_PARAM, false)
 
                 notificationProcessor.processNotificationData(
@@ -85,13 +91,13 @@ internal class NotificationGenerationWorkManager : INotificationGenerationWorkMa
                     isRestoring,
                     timestamp,
                 )
+                Result.success()
             } catch (e: JSONException) {
                 Logging.error("Error occurred doing work for job with id: $id", e)
-                return Result.failure()
+                Result.failure()
             } finally {
                 removeNotificationIdProcessed(id!!)
             }
-            return Result.success()
         }
     }
 

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/lifecycle/impl/NotificationLifecycleService.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/lifecycle/impl/NotificationLifecycleService.kt
@@ -33,6 +33,8 @@ import com.onesignal.notifications.internal.lifecycle.INotificationLifecycleServ
 import com.onesignal.notifications.internal.receivereceipt.IReceiveReceiptWorkManager
 import com.onesignal.session.internal.influence.IInfluenceManager
 import com.onesignal.user.internal.subscriptions.ISubscriptionManager
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
@@ -266,7 +268,9 @@ internal class NotificationLifecycleService(
             val intent = intentGenerator.getIntentVisible()
             if (intent != null) {
                 Logging.info("SDK running startActivity with Intent: $intent")
-                activity.startActivity(intent)
+                withContext(Dispatchers.Main) {
+                    activity.startActivity(intent)
+                }
             } else {
                 Logging.info("SDK not showing an Activity automatically due to it's settings.")
             }

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/receivereceipt/impl/ReceiveReceiptWorkManager.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/receivereceipt/impl/ReceiveReceiptWorkManager.kt
@@ -74,12 +74,13 @@ internal class ReceiveReceiptWorkManager(
     class ReceiveReceiptWorker(context: Context, workerParams: WorkerParameters) : CoroutineWorker(context, workerParams) {
         override suspend fun doWork(): Result {
             if (!OneSignal.initWithContext(applicationContext)) {
+                Logging.warn("ReceiveReceiptWorker skipped due to failed OneSignal initialization")
                 return Result.success()
             }
 
-            val notificationId = inputData.getString(OS_NOTIFICATION_ID)!!
-            val appId = inputData.getString(OS_APP_ID)!!
-            val subscriptionId = inputData.getString(OS_SUBSCRIPTION_ID)!!
+            val notificationId = inputData.getString(OS_NOTIFICATION_ID) ?: return Result.failure()
+            val appId = inputData.getString(OS_APP_ID) ?: return Result.failure()
+            val subscriptionId = inputData.getString(OS_SUBSCRIPTION_ID) ?: return Result.failure()
 
             val receiveReceiptProcessor = OneSignal.getService<IReceiveReceiptProcessor>()
             receiveReceiptProcessor.sendReceiveReceipt(appId, subscriptionId, notificationId)

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/restoration/impl/NotificationRestoreWorkManager.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/restoration/impl/NotificationRestoreWorkManager.kt
@@ -6,6 +6,7 @@ import androidx.work.ExistingWorkPolicy
 import androidx.work.OneTimeWorkRequest
 import androidx.work.WorkerParameters
 import com.onesignal.OneSignal
+import com.onesignal.debug.internal.logging.Logging
 import com.onesignal.notifications.internal.common.NotificationHelper
 import com.onesignal.notifications.internal.common.OSWorkManagerHelper
 import com.onesignal.notifications.internal.restoration.INotificationRestoreProcessor
@@ -48,16 +49,18 @@ internal class NotificationRestoreWorkManager : INotificationRestoreWorkManager 
         override suspend fun doWork(): Result {
             val context = applicationContext
 
-            if (!OneSignal.initWithContext(context)) {
+            val initialized = OneSignal.initWithContext(context)
+            if (!initialized) {
+                Logging.warn("NotificationRestoreWorker skipped due to failed OneSignal init")
                 return Result.success()
             }
 
             if (!NotificationHelper.areNotificationsEnabled(context)) {
+                Logging.debug("NotificationRestoreWorker failed: Notifications disabled")
                 return Result.failure()
             }
 
             val processor = OneSignal.getService<INotificationRestoreProcessor>()
-
             processor.process()
 
             return Result.success()

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/receivers/BootUpReceiver.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/receivers/BootUpReceiver.kt
@@ -30,6 +30,8 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import com.onesignal.OneSignal
+import com.onesignal.common.threading.suspendifyOnThread
+import com.onesignal.debug.internal.logging.Logging
 import com.onesignal.notifications.internal.restoration.INotificationRestoreWorkManager
 
 class BootUpReceiver : BroadcastReceiver() {
@@ -37,12 +39,18 @@ class BootUpReceiver : BroadcastReceiver() {
         context: Context,
         intent: Intent,
     ) {
-        if (!OneSignal.initWithContext(context.applicationContext)) {
-            return
+        val pendingResult = goAsync()
+        // in background, init onesignal and begin enqueueing restore work
+        suspendifyOnThread {
+            if (!OneSignal.initWithContext(context.applicationContext)) {
+                Logging.warn("NotificationRestoreReceiver skipped due to failed OneSignal init")
+                pendingResult.finish()
+                return@suspendifyOnThread
+            }
+
+            val restoreWorkManager = OneSignal.getService<INotificationRestoreWorkManager>()
+            restoreWorkManager.beginEnqueueingWork(context, true)
+            pendingResult.finish()
         }
-
-        val restoreWorkManager = OneSignal.getService<INotificationRestoreWorkManager>()
-
-        restoreWorkManager.beginEnqueueingWork(context, true)
     }
 }

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/receivers/FCMBroadcastReceiver.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/receivers/FCMBroadcastReceiver.kt
@@ -5,6 +5,8 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import com.onesignal.OneSignal
+import com.onesignal.common.threading.suspendifyOnThread
+import com.onesignal.debug.internal.logging.Logging
 import com.onesignal.notifications.internal.bundle.INotificationBundleProcessor
 
 // This is the entry point when a FCM payload is received from the Google Play services app
@@ -23,26 +25,35 @@ class FCMBroadcastReceiver : BroadcastReceiver() {
             return
         }
 
-        if (!OneSignal.initWithContext(context.applicationContext)) {
-            return
-        }
+        val pendingResult = goAsync()
+        // process in background
+        suspendifyOnThread {
+            if (!OneSignal.initWithContext(context.applicationContext)) {
+                Logging.warn("FCMBroadcastReceiver skipped due to failed OneSignal init")
+                pendingResult.finish()
+                return@suspendifyOnThread
+            }
 
-        val bundleProcessor = OneSignal.getService<INotificationBundleProcessor>()
+            val bundleProcessor = OneSignal.getService<INotificationBundleProcessor>()
 
-        if (!isFCMMessage(intent)) {
+            if (!isFCMMessage(intent)) {
+                setSuccessfulResultCode()
+                pendingResult.finish()
+                return@suspendifyOnThread
+            }
+
+            val processedResult = bundleProcessor.processBundleFromReceiver(context, bundle)
+
+            // Prevent other FCM receivers from firing if work manager is processing the notification
+            if (processedResult?.isWorkManagerProcessing == true) {
+                setAbort()
+                pendingResult.finish()
+                return@suspendifyOnThread
+            }
+
             setSuccessfulResultCode()
-            return
+            pendingResult.finish()
         }
-
-        val processedResult = bundleProcessor.processBundleFromReceiver(context, bundle)
-
-        // Prevent other FCM receivers from firing if work manager is processing the notification
-        if (processedResult!!.isWorkManagerProcessing) {
-            setAbort()
-            return
-        }
-
-        setSuccessfulResultCode()
     }
 
     private fun setSuccessfulResultCode() {

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/receivers/UpgradeReceiver.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/receivers/UpgradeReceiver.kt
@@ -31,6 +31,8 @@ import android.content.Context
 import android.content.Intent
 import android.os.Build
 import com.onesignal.OneSignal
+import com.onesignal.common.threading.suspendifyOnThread
+import com.onesignal.debug.internal.logging.Logging
 import com.onesignal.notifications.internal.restoration.INotificationRestoreWorkManager
 
 class UpgradeReceiver : BroadcastReceiver() {
@@ -38,19 +40,27 @@ class UpgradeReceiver : BroadcastReceiver() {
         context: Context,
         intent: Intent,
     ) {
-        // TODO: Now that we arent restoring like we use to, think we can remove this? Ill do some
-        //  testing and look at the issue but maybe someone has a answer or rems what directly
-        //  was causing this issue
+        // TODO: Now that we aren't restoring like we used to, think we can remove this?
+        // I'll do some testing and look at the issue, but maybe someone has an answer or
+        // remembers what directly was causing this issue.
         // Return early if using Android 7.0 due to upgrade restore crash (#263)
         if (Build.VERSION.SDK_INT == Build.VERSION_CODES.N) {
             return
         }
 
-        if (!OneSignal.initWithContext(context.applicationContext)) {
-            return
-        }
+        val pendingResult = goAsync()
 
-        val restoreWorkManager = OneSignal.getService<INotificationRestoreWorkManager>()
-        restoreWorkManager.beginEnqueueingWork(context, true)
+        // init OneSignal and enqueue restore work in background
+        suspendifyOnThread {
+            if (!OneSignal.initWithContext(context.applicationContext)) {
+                Logging.warn("UpgradeReceiver skipped due to failed OneSignal init")
+                pendingResult.finish()
+                return@suspendifyOnThread
+            }
+
+            val restoreWorkManager = OneSignal.getService<INotificationRestoreWorkManager>()
+            restoreWorkManager.beginEnqueueingWork(context, true)
+            pendingResult.finish()
+        }
     }
 }

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/services/ADMMessageHandler.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/services/ADMMessageHandler.kt
@@ -13,15 +13,17 @@ import com.onesignal.notifications.internal.registration.impl.IPushRegistratorCa
 class ADMMessageHandler : ADMMessageHandlerBase("ADMMessageHandler") {
     override fun onMessage(intent: Intent) {
         val context = applicationContext
-        if (!OneSignal.initWithContext(context)) {
-            return
+        val bundle = intent.extras ?: return
+
+        suspendifyOnThread {
+            if (!OneSignal.initWithContext(context)) {
+                Logging.warn("onMessage skipped due to failed OneSignal init")
+                return@suspendifyOnThread
+            }
+
+            val bundleProcessor = OneSignal.getService<INotificationBundleProcessor>()
+            bundleProcessor.processBundleFromReceiver(context, bundle)
         }
-
-        val bundle = intent.extras
-
-        val bundleProcessor = OneSignal.getService<INotificationBundleProcessor>()
-
-        bundleProcessor.processBundleFromReceiver(context, bundle!!)
     }
 
     override fun onRegistered(newRegistrationId: String) {


### PR DESCRIPTION
# Description
## One Line Summary
Move slow/IO-bound parts of initWithContext off the main thread and add an async overload with a completion callback for internal usage. 

## Details

### Motivation
Avoid main-thread stalls and potential ANRs during initialization, especially when SharedPreferences or other disk/network operations are involved. Provide an async path so app components (Activities/Receivers) can trigger initialization without blocking UI or risking Receiver timeouts.

### Scope
* initWithContext(contex, appId): now move all initialization to background and return immediately. 
* initWithContext(contex) is now suspend and can only be called from a coroutine. This method should used by internal classes only. It will remain suspend until all initialization is completed.
* Accessors remain blocked if called immediately after initWithContext and before initialization is fully completed. This is to ensure no breaking change or expectation on existing consumer use cases.
* Receivers will now call initWithContext(contex) in background, and switch back to main on tasks that must be executed in main thread, eg, finish(), startActivity() and other app lifecycle or UI operations. 
* Workers run doWork() in background will now directly call initWithContext(contex)
* Retain the existing synchronous overload for backward compatibility; the new overload provides a non-blocking path with a completion callback.
* Introduces a centralized ANR timeout constant. 
* No behavioral change to notification delivery formats, APIs, or user-visible features.

# Testing
## Unit testing
* New Robolectric/Kotest tests cover initWithContext in different scenarios. Ex:
  * Accessors throw before initialization.
  * Init does not block even when SharedPreferences access is artificially delayed.
  * Tags, local onesignalId, push subscription, and immediate login right after init. 
* LatchAwaiterTests testing the genetic functionalities of the waiter.

## Manual testing
* Cold-start the sample app with logging at VERBOSE. Ensure all initial operations are created in the same order.
* Trigger init from an Activity and verify UI remains responsive.
* For Receivers: simulate a boot or FCM broadcast; verify the receiver returns promptly (no >10s wait), and OneSignal completes initialization shortly after.
* Notification click when app is killed / backgrounded. 
* Login, logout, addTag, addTrigger, permission update, IAM interaction
* Environment: Android Studio Hedgehog or later; Pixel 6 emulator API 33; fresh install of the demo app.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [x] Public API changes

# Checklist
## Overview
   - [ ] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [ ] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [ ] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2368)
<!-- Reviewable:end -->
