### PR TITLE
ci: Option to release or just publish the SDK on maven

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -145,7 +145,7 @@ jobs:
           echo "$PR_BODY" > release_notes.md
 
       - name: Tag and create GitHub Release
-        if: github.event.inputs.release_on_maven != 'true'
+        if: github.event.inputs.release_on_maven == 'true'
         run: |
           VERSION="${{ env.SDK_VERSION }}"
 


### PR DESCRIPTION
# Description
## One Line Summary
Add another option to publish but not release for testing

## Details

### Motivation
We want to be able to publish the SDK on maven but not release it for testing purposes.

### Scope
Internal CI/CD only

# Testing
## Unit testing
NA

## Manual testing
Tested

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2393)
<!-- Reviewable:end -->
