### PR TITLE
fix: login with the same externalId fails to update the subscription

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/LoginHelper.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/LoginHelper.kt
@@ -25,10 +25,7 @@ class LoginHelper(
             currentIdentityExternalId = identityModelStore.model.externalId
             currentIdentityOneSignalId = identityModelStore.model.onesignalId
 
-            if (currentIdentityExternalId == externalId) {
-                return
-            }
-
+            // always create a user on login in case of externalId being removed in backend
             // TODO: Set JWT Token for all future requests.
             userSwitcher.createAndSwitchToNewUser { identityModel, _ ->
                 identityModel.externalId = externalId

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/LoginHelperTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/LoginHelperTests.kt
@@ -37,7 +37,9 @@ class LoginHelperTests : FunSpec({
         Logging.logLevel = LogLevel.NONE
     }
 
-    test("login with same external id returns early without creating user") {
+    // in the event of externalId being removed in the backend, SDK needs to send a CreateUser request
+    // to restore the externalId for the subscription
+    test("login with same external id still creates a user") {
         // Given
         val mockIdentityModelStore =
             MockHelper.identityModelStore { model ->
@@ -64,9 +66,9 @@ class LoginHelperTests : FunSpec({
             loginHelper.login(currentExternalId)
         }
 
-        // Then - should return early without any operations
-        verify(exactly = 0) { mockUserSwitcher.createAndSwitchToNewUser(suppressBackendOperation = any(), modify = any()) }
-        coVerify(exactly = 0) { mockOperationRepo.enqueueAndWait(any()) }
+        // Then - should create a user and send a request
+        verify(exactly = 1) { mockUserSwitcher.createAndSwitchToNewUser(suppressBackendOperation = any(), modify = any()) }
+        coVerify(exactly = 1) { mockOperationRepo.enqueueAndWait(any()) }
     }
 
     test("login with different external id creates and switches to new user") {


### PR DESCRIPTION
# Description
## One Line Summary
Fix issue where calling login with the same externalId as the previous app open fails to update the subscription in the backend.

## Details

### Motivation
Previously, when login was called using the same externalId as the previous app open, the SDK detected no change in the externalId and skipped creating a login request. Instead, it issued a refresh user request.

However, if the user’s external ID had been manually removed from the backend (for example, via the OneSignal Dashboard or calling Logout outside of SDK), this refresh request no longer linked the subscription with the intended externalId. The result was that the backend subscription remained unassociated with the external ID after login.

This change ensures that a login request is always created when login is called — even if the same externalId is passed again — so that the backend subscription is correctly updated and re-linked to that external ID. The subscription ID associated to the OneSignalID will still be reused. 

### Scope
- Affects user identity handling and external ID login flow.
- No changes to other SDK modules (notifications, outcomes, or in-app messaging).
- Maintains backward compatibility with existing login APIs.

# Testing
## Unit testing
Added a test unit to ensure a Login request is always created

## Manual testing
Step to reproduce:
  1. On a fresh install, call Login with an externalID right after initWithContext
  2. Observe that the subscription is created with the externalID
  3. Close app and remove the externalID through the dashboard
  4. Open the app again, Login with the same externalID is called but the externalID is still missing for the subscription in backend.
  
After fix: The subscription has successfully restored the externalID after the second Login. 

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [ ] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2406)
<!-- Reviewable:end -->
