### PR TITLE
fix: Remove throwing "initWithContext was not called or timed out", introduced in 5.4.0

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
@@ -334,10 +334,7 @@ internal class OneSignalImp(
     override fun <T> getAllServices(c: Class<T>): List<T> = services.getAllServices(c)
 
     private fun waitForInit() {
-        val completed = initAwaiter.await()
-        if (!completed) {
-            throw IllegalStateException("initWithContext was not called or timed out")
-        }
+        initAwaiter.awaitAndLogIfOverTimeout()
     }
 
     /**

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/application/SDKInitTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/application/SDKInitTests.kt
@@ -91,7 +91,7 @@ class SDKInitTests : FunSpec({
         // block SharedPreference before calling init
         val trigger = CompletionAwaiter("Test")
         val context = getApplicationContext<Context>()
-        val blockingPrefContext = BlockingPrefsContext(context, trigger, 2000)
+        val blockingPrefContext = BlockingPrefsContext(context, trigger)
         val os = OneSignalImp()
         var initSuccess = true
 
@@ -137,7 +137,7 @@ class SDKInitTests : FunSpec({
         // block SharedPreference before calling init
         val trigger = CompletionAwaiter("Test")
         val context = getApplicationContext<Context>()
-        val blockingPrefContext = BlockingPrefsContext(context, trigger, 1000)
+        val blockingPrefContext = BlockingPrefsContext(context, trigger)
         val os = OneSignalImp()
 
         // When
@@ -160,7 +160,7 @@ class SDKInitTests : FunSpec({
         // block SharedPreference before calling init
         val trigger = CompletionAwaiter("Test")
         val context = getApplicationContext<Context>()
-        val blockingPrefContext = BlockingPrefsContext(context, trigger, 2000)
+        val blockingPrefContext = BlockingPrefsContext(context, trigger)
         val os = OneSignalImp()
 
         val accessorThread =
@@ -204,7 +204,7 @@ class SDKInitTests : FunSpec({
         // block SharedPreference before calling init
         val trigger = CompletionAwaiter("Test")
         val context = getApplicationContext<Context>()
-        val blockingPrefContext = BlockingPrefsContext(context, trigger, 2000)
+        val blockingPrefContext = BlockingPrefsContext(context, trigger)
         val os = OneSignalImp()
         val externalId = "testUser"
 
@@ -438,14 +438,13 @@ class SDKInitTests : FunSpec({
 class BlockingPrefsContext(
     context: Context,
     private val unblockTrigger: CompletionAwaiter,
-    private val timeoutInMillis: Long,
 ) : ContextWrapper(context) {
     override fun getSharedPreferences(
         name: String,
         mode: Int,
     ): SharedPreferences {
         try {
-            unblockTrigger.await(timeoutInMillis)
+            unblockTrigger.awaitAndLogIfOverTimeout()
         } catch (e: InterruptedException) {
             throw e
         } catch (e: TimeoutCancellationException) {


### PR DESCRIPTION
# Description
## One Line Summary
Revert throwing if things wait on init take too long that was introduced in 5.4.0.

## Details

Starting in 5.4.0 calls such as OneSignal.Notification or OneSignal.Location would throw if they waited on the SDK into to long. This PR changes this to wait forever until init is complete, and log instead if the time is taking longer than expected. If these calls were done from the main thread an ANR is the lesser of two evils and the app can recover, where an uncaught throw it can not.

This commit will bring the behavior similar to 5.1.x. The only difference is you will now never see an ANR with initWithContext, however if you call other parts of the SDK from the main thread, such as OneSignal.Notification, you will continue to see ANRs, just at a different stacktrace. To avoid these ANRs completely call all other SDK methods outside of the main thread.

### Related Issues
* #2407

### Motivation
A behavior change wasn't intended in a non-major release. 

### Scope
Removes throwing and timeout state when things are waiting on SDK initialization. 

# Testing
## Unit testing
Updated existing unit tests to expect waiting without a timeout.

## Manual testing
Tested on an Android 14 emulator. Added an artificial 10 second delay with `Thread.Sleep` just before `latch.countDown()` to ensure the SDK still initializes correctly.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2412)
<!-- Reviewable:end -->
