### PR TITLE
tests: Much faster notification module tests

### DIFF
--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/generation/impl/NotificationGenerationProcessor.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/generation/impl/NotificationGenerationProcessor.kt
@@ -37,6 +37,9 @@ internal class NotificationGenerationProcessor(
     private val _lifecycleService: INotificationLifecycleService,
     private val _time: ITime,
 ) : INotificationGenerationProcessor {
+
+    private val EXTERNAL_CALLBACKS_TIMEOUT get() = 30_000L
+
     override suspend fun processNotificationData(
         context: Context,
         androidNotificationId: Int,
@@ -67,7 +70,7 @@ internal class NotificationGenerationProcessor(
 
         try {
             val notificationReceivedEvent = NotificationReceivedEvent(context, notification)
-            withTimeout(30000L) {
+            withTimeout(EXTERNAL_CALLBACKS_TIMEOUT) {
                 launchOnIO {
                     _lifecycleService.externalRemoteNotificationReceived(notificationReceivedEvent)
 
@@ -100,7 +103,7 @@ internal class NotificationGenerationProcessor(
 
                 try {
                     val notificationWillDisplayEvent = NotificationWillDisplayEvent(notificationJob.notification)
-                    withTimeout(30000L) {
+                    withTimeout(EXTERNAL_CALLBACKS_TIMEOUT) {
                         launchOnIO {
                             _lifecycleService.externalNotificationWillShowInForeground(notificationWillDisplayEvent)
 

--- a/OneSignalSDK/onesignal/testhelpers/src/main/java/com/onesignal/mocks/AndroidMockHelper.kt
+++ b/OneSignalSDK/onesignal/testhelpers/src/main/java/com/onesignal/mocks/AndroidMockHelper.kt
@@ -1,8 +1,10 @@
 package com.onesignal.mocks
 
+import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import com.onesignal.core.internal.application.IApplicationService
 import io.mockk.every
+import io.mockk.mockk
 
 /**
  * Singleton which provides common mock services when running in an Android environment.
@@ -11,7 +13,13 @@ object AndroidMockHelper {
     fun applicationService(): IApplicationService {
         val mockAppService = MockHelper.applicationService()
 
-        every { mockAppService.appContext } returns ApplicationProvider.getApplicationContext()
+        try {
+            // Robolectric
+            every { mockAppService.appContext } returns ApplicationProvider.getApplicationContext()
+        } catch (_: IllegalStateException) {
+            // Fallback to simpler mock (using mockk) if Robolectric is not used in the test
+            every { mockAppService.appContext } returns mockk<Context>(relaxed = true)
+        }
 
         return mockAppService
     }


### PR DESCRIPTION
# Description
## One Line Summary
Greatly improve how fast the notification module tests run.

## Details
Mocked out timeout for external lifetime event callbacks, this made the tests for notifications take an extra 90 seconds.

Also removed Robolectric from this test and replaced it with lighter weight mockk mocks.
* The motivation for this specific change is the `spyk` feature doesn't work with Robolectric

### Motivation
Slow tests means slower development speed, also adding more tests would have made the them slower still.

### Scope
Only effects the logic of the notifications tests.

# Testing
## Unit testing
Existing tests pass.

## Manual testing
N/A

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2417)
<!-- Reviewable:end -->
