### PR TITLE
Improvement: failure message shows that appID is missing

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
@@ -282,7 +282,7 @@ internal class OneSignalImp(
         val startupService = bootstrapServices()
         val result = resolveAppId(appId, configModel, preferencesService)
         if (result.failed) {
-            val message = "No OneSignal appId provided or found in local storage. Please pass a valid appId to initWithContext()."
+            val message = "suspendInitInternal: no appId provided or found in local storage. Please pass a valid appId to initWithContext()."
             val exception = IllegalStateException(message)
             // attach the real crash cause to the init failure exception that will be throw shortly after
             initFailureException?.addSuppressed(exception)

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/application/SDKInitTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/application/SDKInitTests.kt
@@ -65,7 +65,11 @@ class SDKInitTests : FunSpec({
         val ex = shouldThrow<IllegalStateException> {
             os.user.onesignalId // Should trigger waitUntilInitInternal → throw failure message
         }
-        ex.message shouldBe "suspendInitInternal: no appId provided or found in local storage. Please pass a valid appId to initWithContext()."
+        // The main exception preserves the caller's stack trace
+        ex.message shouldBe "OneSignal initWithContext failed."
+        // The detailed failure reason is in the suppressed exception
+        ex.suppressed.size shouldBe 1
+        ex.suppressed[0].message shouldBe "suspendInitInternal: no appId provided or found in local storage. Please pass a valid appId to initWithContext()."
 
         // Calling initWithContext with an appID after the failure should not throw anymore
         val result = os.initWithContext(context, "appID")


### PR DESCRIPTION
# Description
## One Line Summary
Update the failure message so it is clear when appID is previously not provided.

## Details

### Motivation
The original failure message "Initialization failed. Cannot proceed." is vague and can potentially hide the real cause when appID is not provided as expected. We want to show this message so developers can immediately figure out the wrong usage.

### Scope
OneSignalImp.kt will now save and throw a clearer error message when OneSignal is accessed before initWithContext is called with an appID. 

### Comparison with 5.1.x behavior
5.1.x:
* Calling initWithContext without an appId does not throw immediately.
  * The first time we access OneSignal afterward, we get:
`Caused by: java.lang.Exception: Must call 'initWithContext' before use`
  * This points to the accessor call site, but it hides the real root cause: the missing appId.

5.4.x:
* The internal initWithContext(context) is now suspend and must be called from a coroutine.
  1. If a consumer migrates to 5.4.x and still calls the internal initWithContext directly on the main thread, they’ll get a compile-time error, which makes the incorrect usage obvious.
  2. Initialization is generally performed in a “fire-and-forget” coroutine. When the IO coroutine fails inside the SDK, there is no longer a meaningful JVM call stack back to the original caller (e.g., which Activity or method triggered init). It’s a separate async execution.
    * In this case, the error message is:
`suspendInitInternal: no appId provided or found in local storage. Please pass a valid appId to initWithContext().`
    * This message clearly states the root cause (no appId supplied), but the consumer will need to locate where they call init in their own code to fix it.

# Testing
## Unit testing
Add a new test case to assert the error message. 

## Manual testing
Tested on Emulator Pixel 9 API 35:
 1. Remove the appID and call OneSignal.initWithContext(context) in MainApplicationKT.kt
 3. Fresh install and observe the error message asking to provide an appID.
<img width="1260" height="435" alt="image" src="https://github.com/user-attachments/assets/89e3b812-7d8e-4ca0-8910-da09e0668ddc" />

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2506)
<!-- Reviewable:end -->
