### PR TITLE
bug: catch exception if opening a notification fails

### DIFF
--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/lifecycle/impl/NotificationLifecycleService.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/lifecycle/impl/NotificationLifecycleService.kt
@@ -1,6 +1,7 @@
 package com.onesignal.notifications.internal.lifecycle.impl
 
 import android.app.Activity
+import android.content.ActivityNotFoundException
 import android.content.Context
 import com.onesignal.common.AndroidUtils
 import com.onesignal.common.JSONUtils
@@ -282,6 +283,13 @@ internal class NotificationLifecycleService(
                 Logging.info("SDK not showing an Activity automatically due to it's settings.")
             }
         } catch (e: JSONException) {
+            Logging.error("Could not parse JSON to open notification activity.")
+            e.printStackTrace()
+        } catch (e: ActivityNotFoundException) {
+            Logging.error("No activity found to handle notification open intent.")
+            e.printStackTrace()
+        } catch (e: Exception) {
+            Logging.error("Could not open notification activity.")
             e.printStackTrace()
         }
     }


### PR DESCRIPTION
# Description
## One Line Summary
Catch and Log an exception when opening a destination activity fails thru Notification

## Details

### Motivation
Provide better user experience by catching and logging errors when it fails to open a destination activity.
This is in response to the PR https://github.com/OneSignal/OneSignal-Android-SDK/pull/1954/changes

### Scope
Better logging.

# Testing
## Unit testing

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2508)
<!-- Reviewable:end -->
