### PR TITLE
fix: crash around com.onesignal.SyncJobService

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/AndroidManifest.xml
+++ b/OneSignalSDK/onesignal/core/src/main/AndroidManifest.xml
@@ -10,6 +10,13 @@
           android:permission="android.permission.BIND_JOB_SERVICE"
           android:exported="false" />
 
+        <!-- Temporary shim for old OneSignal v4 jobs pointing to com.onesignal.SyncJobService -->
+        <service
+            android:name="com.onesignal.SyncJobService"
+            android:permission="android.permission.BIND_JOB_SERVICE"
+            android:exported="false">
+        </service>
+
         <activity android:name="com.onesignal.core.activities.PermissionsActivity"
                   android:theme="@android:style/Theme.Translucent.NoTitleBar"
                   android:exported="false" />

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/SyncJobService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/SyncJobService.kt
@@ -1,0 +1,31 @@
+package com.onesignal
+
+import android.app.job.JobParameters
+import android.app.job.JobService
+
+/**
+ * Temporary shim for old OneSignal v4 jobs pointing to com.onesignal.SyncJobService.
+ *
+ * The v4 SyncJobService was used to run background sync; v5 has moved to a new architecture,
+ *  but scheduled jobs from the old service can still be lingering in JobScheduler on devices
+ *  that previously had v4 installed. When those old jobs fire, the system tries to instantiate
+ *  com.onesignal.SyncJobService. Since the class isn’t in the v5 SDK anymore, we will get a
+ *  ClassNotFoundException and a crash.
+ *
+ *  Providing a no-op implementation with the same fully qualified name lets those old jobs run
+ *   once, do nothing, and finish, which clears them out. This is intentionally a no-op and
+ *   finishes immediately.
+ */
+class SyncJobService : JobService() {
+
+    override fun onStartJob(params: JobParameters?): Boolean {
+        // Job finishes immediately, nothing to do.
+        jobFinished(params, false)
+        return false // No more work on a background thread.
+    }
+
+    override fun onStopJob(params: JobParameters?): Boolean {
+        // Don't reschedule the job.
+        return false
+    }
+}


### PR DESCRIPTION
# Description
## One Line Summary
Add temporary stub implementation of com.onesignal.SyncJobService to prevent background crashes caused by upgrading OneSignal from v4 to v5.

## Details

### Motivation
Apps upgrading from OneSignal SDK v4 to v5 may encounter a crash when the system attempts to start the legacy com.onesignal.SyncJobService, which no longer exists in the v5 SDK. Devices with previously scheduled v4 JobScheduler jobs will still try to invoke this class, resulting in a ClassNotFoundException and app process crash in the background.

This PR introduces a no-op stub implementation of com.onesignal.SyncJobService so that any remaining v4-scheduled jobs can gracefully run once, complete, and be cleared without crashing the app.
This can be considered a temporary workaround.

### Scope
Adds com.onesignal.SyncJobService as a minimal JobService that immediately finishes.

# Testing
## Unit testing
No testing needed as this is a dummy class.

## Manual testing
I am unable to reproduce from the migration path. This is from crashlytics and there must be some conditions for this to happen. Example app is manually ran on an Android emulator Pixel 9 API 35 to ensure normal app usage and no functionality change. 

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2515)
<!-- Reviewable:end -->
