### PR TITLE
fix: end initialization early if device storage is locked

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/AndroidUtils.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/AndroidUtils.kt
@@ -10,6 +10,7 @@ import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.os.Looper
+import android.os.UserManager
 import android.text.TextUtils
 import androidx.annotation.Keep
 import androidx.core.app.NotificationManagerCompat
@@ -39,6 +40,27 @@ object AndroidUtils {
         val decorView = activity.window.decorView
         val insetsAttached = decorView.rootWindowInsets != null
         return hasToken && insetsAttached
+    }
+
+    /**
+     * Retrieve whether the device user is accessible.
+     *
+     * On Android 7.0+ (API 24+), encrypted user data is inaccessible until the user unlocks
+     * the device for the first time after boot. This includes:
+     *  * getSharedPreferences()
+     *  * Any file-based storage in the default credential-encrypted context
+     *
+     * Apps that auto-run on boot or background services triggered early may hit this issue.
+     */
+    fun isAndroidUserUnlocked(appContext: Context): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
+            // Prior to API 24, the device booted into an unlocked state by default
+            return true
+        }
+
+        val userManager = appContext.getSystemService(Context.USER_SERVICE) as? UserManager
+        // assume user is unlocked if the Android UserManager is null
+        return userManager?.isUserUnlocked ?: true
     }
 
     fun hasConfigChangeFlag(

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
@@ -277,6 +277,16 @@ internal class OneSignalImp(
         context: Context,
         appId: String?,
     ): Boolean {
+        // Check whether current Android user is accessible.
+        // Return early if it is inaccessible, as we are unable to complete initialization without access
+        // to device storage like SharedPreferences.
+        if (!AndroidUtils.isAndroidUserUnlocked(context)) {
+            Logging.warn("initWithContext called when device storage is locked, no user data is accessible!")
+            initState = InitState.FAILED
+            notifyInitComplete()
+            return false
+        }
+
         initEssentials(context)
 
         val startupService = bootstrapServices()


### PR DESCRIPTION
# Description
## One Line Summary
Add isDeviceStorageUnlocked check to avoid accessing user data before the device is unlocked on Android 7.0+, and end initialization early if device storage is locked.

## Details

### Motivation
This allows the SDK to avoid reading/writing user data too early (e.g., in boot receivers or early background services), and to avoid crashes with the inconsistent state.

### Scope
Terminate the initialization early depends on user storage availability.

# Testing
## Unit testing
Two test cases are added.

## Manual testing
Tested on Emulator Pixel 9 API 35
Step to reproduce:
1. Set a PIN for the device
2. Modify AndroidManifest.xml
`<receiver android:name="com.onesignal.notifications.receivers.BootUpReceiver" android:exported="true" android:directBootAware="true"> <intent-filter> <action android:name="android.intent.action.BOOT_COMPLETED" /> <action android:name="android.intent.action.QUICKBOOT_POWERON" /> <action android:name="android.intent.action.LOCKED_BOOT_COMPLETED"/> </intent-filter> </receiver>`
3. Run the app once
4. Restart the device
5. Before unlocking the phone, run the command to capture the log
  adb logcat | grep -E "(SharedPreferences|BootUpReceiver)"
  
After fix:
The exception is no longer thrown in the background. After the user has unlocked the device, notifications can be received and interacted as normal even the app is not opened. 

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2520)
<!-- Reviewable:end -->
