### PR TITLE
fix: SDK stuck in bad state when calling login with restricted external IDs

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/IOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/IOperationExecutor.kt
@@ -79,6 +79,13 @@ enum class ExecutionResult {
 
     /**
      * Used in special create user case.
+     * The operation failed due to invalid arguments (eg. restricted external ID is used.)
+     * We should not retry the operation as the external ID should not be used again.
+     */
+    FAIL_INVALID_LOGIN,
+
+    /**
+     * Used in special create user case.
      * The operation failed due to a non-retryable error. Pause the operation repo
      * and retry on a new session, giving the SDK a chance to recover from the failed user create.
      */

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/IOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/IOperationExecutor.kt
@@ -83,11 +83,4 @@ enum class ExecutionResult {
      * We should not retry the operation as the external ID should not be used again.
      */
     FAIL_INVALID_LOGIN,
-
-    /**
-     * Used in special create user case.
-     * The operation failed due to a non-retryable error. Pause the operation repo
-     * and retry on a new session, giving the SDK a chance to recover from the failed user create.
-     */
-    FAIL_PAUSE_OPREPO,
 }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/impl/OperationRepo.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/impl/OperationRepo.kt
@@ -270,6 +270,7 @@ internal class OperationRepo(
                 }
                 ExecutionResult.FAIL_UNAUTHORIZED, // TODO: Need to provide callback for app to reset JWT. For now, fail with no retry.
                 ExecutionResult.FAIL_NORETRY,
+                ExecutionResult.FAIL_INVALID_LOGIN,
                 ExecutionResult.FAIL_CONFLICT,
                 -> {
                     Logging.error("Operation execution failed without retry: $operations")

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/LoginUserOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/LoginUserOperationExecutor.kt
@@ -239,10 +239,8 @@ internal class LoginUserOperationExecutor(
                     ExecutionResponse(ExecutionResult.FAIL_RETRY, retryAfterSeconds = ex.retryAfterSeconds)
                 NetworkUtils.ResponseStatusType.UNAUTHORIZED ->
                     ExecutionResponse(ExecutionResult.FAIL_UNAUTHORIZED, retryAfterSeconds = ex.retryAfterSeconds)
-                NetworkUtils.ResponseStatusType.INVALID ->
-                    ExecutionResponse(ExecutionResult.FAIL_INVALID_LOGIN)
                 else ->
-                    ExecutionResponse(ExecutionResult.FAIL_PAUSE_OPREPO)
+                    ExecutionResponse(ExecutionResult.FAIL_INVALID_LOGIN)
             }
         }
     }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/LoginUserOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/LoginUserOperationExecutor.kt
@@ -238,7 +238,7 @@ internal class LoginUserOperationExecutor(
                 NetworkUtils.ResponseStatusType.UNAUTHORIZED ->
                     ExecutionResponse(ExecutionResult.FAIL_UNAUTHORIZED, retryAfterSeconds = ex.retryAfterSeconds)
                 NetworkUtils.ResponseStatusType.INVALID ->
-                    ExecutionResponse(ExecutionResult.FAIL_NORETRY)
+                    ExecutionResponse(ExecutionResult.FAIL_INVALID_LOGIN)
                 else ->
                     ExecutionResponse(ExecutionResult.FAIL_PAUSE_OPREPO)
             }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/LoginUserOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/LoginUserOperationExecutor.kt
@@ -134,6 +134,8 @@ internal class LoginUserOperationExecutor(
                     )
                     createUser(loginUserOp, operations)
                 }
+                // For all other errors, the request will be dropped and will not create the user
+                // e.g. ExecutionResult.FAIL_INVALID_LOGIN
                 else -> ExecutionResponse(result.result)
             }
         }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/LoginUserOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/LoginUserOperationExecutor.kt
@@ -237,6 +237,8 @@ internal class LoginUserOperationExecutor(
                     ExecutionResponse(ExecutionResult.FAIL_RETRY, retryAfterSeconds = ex.retryAfterSeconds)
                 NetworkUtils.ResponseStatusType.UNAUTHORIZED ->
                     ExecutionResponse(ExecutionResult.FAIL_UNAUTHORIZED, retryAfterSeconds = ex.retryAfterSeconds)
+                NetworkUtils.ResponseStatusType.INVALID ->
+                    ExecutionResponse(ExecutionResult.FAIL_NORETRY)
                 else ->
                     ExecutionResponse(ExecutionResult.FAIL_PAUSE_OPREPO)
             }

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/LoginUserOperationExecutorTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/LoginUserOperationExecutorTests.kt
@@ -163,7 +163,7 @@ class LoginUserOperationExecutorTests : FunSpec({
         coVerify(exactly = 1) { mockUserBackendService.createUser(appId, mapOf(), any(), any()) }
     }
 
-    test("login anonymous user fails with no retry when hit with backend error 400") {
+    test("login anonymous user fails with LOGIN_INVALID when hit with backend error 400") {
         // Given
         val mockUserBackendService = mockk<IUserBackendService>()
         coEvery { mockUserBackendService.createUser(any(), any(), any(), any()) } throws BackendException(400, "INVALID")
@@ -186,7 +186,7 @@ class LoginUserOperationExecutorTests : FunSpec({
         val response = loginUserOperationExecutor.execute(operations)
 
         // Then
-        response.result shouldBe ExecutionResult.FAIL_NORETRY
+        response.result shouldBe ExecutionResult.FAIL_INVALID_LOGIN
         coVerify(exactly = 1) { mockUserBackendService.createUser(appId, mapOf(), any(), any()) }
     }
 

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/LoginUserOperationExecutorTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/LoginUserOperationExecutorTests.kt
@@ -159,7 +159,7 @@ class LoginUserOperationExecutorTests : FunSpec({
         val response = loginUserOperationExecutor.execute(operations)
 
         // Then
-        response.result shouldBe ExecutionResult.FAIL_PAUSE_OPREPO
+        response.result shouldBe ExecutionResult.FAIL_INVALID_LOGIN
         coVerify(exactly = 1) { mockUserBackendService.createUser(appId, mapOf(), any(), any()) }
     }
 

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/LoginUserOperationExecutorTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/LoginUserOperationExecutorTests.kt
@@ -159,7 +159,7 @@ class LoginUserOperationExecutorTests : FunSpec({
         val response = loginUserOperationExecutor.execute(operations)
 
         // Then
-        response.result shouldBe ExecutionResult.FAIL_PAUSE_OPREPO
+        response.result shouldBe ExecutionResult.FAIL_NORETRY
         coVerify(exactly = 1) { mockUserBackendService.createUser(appId, mapOf(), any(), any()) }
     }
 


### PR DESCRIPTION
# Description
## One Line Summary
Treat restricted/invalid External ID login responses as non-retryable failures and does not need further handling so the SDK doesn’t pause the operation repo to get stuck in a bad state.

## Details

### Motivation
We reproduced an issue where calling OneSignal.login() with a restricted / blocked External ID can leave the SDK in a “bad” state where subsequent operations stop working until reinstall. The root cause is that the network response is being mapped to FAIL_PAUSE_OPREPO, which pauses the operation repository and effectively prevents recovery.

This PR changes the execution mapping so invalid (restricted) responses are treated as a non-retryable failure (FAIL_INVALID_LOGIN) that don't retry rather than pausing the op repo. This allows the SDK to continue functioning and lets the app recover (e.g., by retrying with a different External ID or after logout).

* Why don't we map it to FAIL_NO_RETRY? Because when we get a FAIL_NO_RETRY, we still try to recover by creating the user. By mapping the response to FAIL_INVALID_LOGIN, we completely disregard the bad request that will surely be rejected.

### Scope
* Affected: Login-related operations that receive an INVALID response status (e.g., restricted/blocked External IDs). OperationRepo execution handling for this response type.
* Not affected: Retryable / unauthorized handling (RETRYABLE, UNAUTHORIZED) and normal successful login flows. No public API behavior changes besides avoiding an unrecoverable stuck state.

### OPTIONAL - Other
We are basically hitting this loop:
1. login(externalId) updates local identity state (externalId is set)
2. backend rejects it (400 “restricted”), but the op is treated as “pause and retry later”
3. user never gets created (onesignalId stays unset)
4. the “bad state recovery” sees externalId set + onesignalId unset and tries to “recover”
5. recovery replays the same login, which will always be rejected -> stuck

# Testing
## Unit testing
Updated unit coverage to verify ResponseStatusType.INVALID maps to ExecutionResult.FAIL_INVALID_LOGIN (and does not return FAIL_PAUSE_OPREPO).

## Manual testing
Tested on emulator Pixel 7 API 33
Step to reproduce:
1. Install app
2. Call Login with external ID "1"
3. Observe that the SDK is now stuck in a bad state and unable to perform any operation until app is reinstall.

After fix: Now able to call Logout or Login with another valid external ID.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2523)
<!-- Reviewable:end -->
