### PR TITLE
ci: remove extra "Channels" line that gets prepended to the release notes

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -163,8 +163,6 @@ jobs:
             CHANNEL="current"
           fi
 
-          echo -e "Channels: $CHANNEL\n\n$(cat release_notes.md)" > release_notes.md
-
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 


### PR DESCRIPTION
# Description
## One Line Summary
 
Removes a extra line indicating the channel a new release is published to.

  
<img width="1258" height="424" alt="Screenshot 2026-01-23 at 3 49 09 PM" src="https://github.com/user-attachments/assets/1c7c87a8-ca31-4191-bcd4-42862c0759b9" />

## Details

### Motivation
To avoid displaying the same information twice

### Scope
Scope only affects the publish-release workflow

# Testing
## Unit testing
N/A

## Manual testing
N/A

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [ ] I have filled out all **REQUIRED** sections above
   - [ ] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [ ] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [ ] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2529)
<!-- Reviewable:end -->
