### PR TITLE
fix: Example app building, due to old Kotlin version

### DIFF
--- a/Examples/OneSignalDemo/build.gradle
+++ b/Examples/OneSignalDemo/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
     ext {
-        kotlinVersion = '1.7.10'
+        kotlinVersion = '1.9.25'
     }
     repositories {
         google()


### PR DESCRIPTION
# Description
## One Line Summary
Fix example app not building when opening it directly due do too old of a Kotlin version.

## Details

### Motivation
This is the public example app it should work

### Scope
Just updating the example app.

# Testing
## Unit testing
N/A

## Manual testing
Tested it builds and runs on an Android 14 emulator.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2542)
<!-- Reviewable:end -->
