### PR TITLE
feat: send unattributed sessions to /outcomes/measure

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/session/internal/outcomes/impl/OutcomeEventsController.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/session/internal/outcomes/impl/OutcomeEventsController.kt
@@ -89,14 +89,7 @@ internal class OutcomeEventsController(
 
     override suspend fun sendSessionEndOutcomeEvent(duration: Long): OutcomeEvent? {
         val influences: List<Influence> = _influenceManager.influences
-
-        // only send the outcome if there are any influences associated with the session
-        for (influence in influences) {
-            if (influence.ids != null) {
-                return sendAndCreateOutcomeEvent("os__session_duration", 0f, duration, influences)
-            }
-        }
-        return null
+        return sendAndCreateOutcomeEvent("os__session_duration", 0f, duration, influences)
     }
 
     override suspend fun sendUniqueOutcomeEvent(name: String): OutcomeEvent? {

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/session/internal/outcomes/OutcomeEventsControllerTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/session/internal/outcomes/OutcomeEventsControllerTests.kt
@@ -504,6 +504,176 @@ class OutcomeEventsControllerTests : FunSpec({
         }
     }
 
+    test("send session end outcome with unattributed influence") {
+        // Given
+        val now = 111L
+        val mockSessionService = mockk<ISessionService>()
+        every { mockSessionService.subscribe(any()) } just Runs
+
+        val mockInfluenceManager = mockk<IInfluenceManager>()
+        every { mockInfluenceManager.influences } returns listOf(Influence(InfluenceChannel.NOTIFICATION, InfluenceType.UNATTRIBUTED, null))
+
+        val subscriptionModel = createTestSubscriptionModel()
+
+        val mockSubscriptionManager = mockk<ISubscriptionManager>()
+        every { mockSubscriptionManager.subscriptions.push } returns PushSubscription(subscriptionModel)
+
+        val mockOutcomeEventsRepository = spyk<IOutcomeEventsRepository>()
+        val mockOutcomeEventsPreferences = spyk<IOutcomeEventsPreferences>()
+        val mockOutcomeEventsBackend = spyk<IOutcomeEventsBackendService>()
+
+        val outcomeEventsController =
+            OutcomeEventsController(
+                mockSessionService,
+                mockInfluenceManager,
+                mockOutcomeEventsRepository,
+                mockOutcomeEventsPreferences,
+                mockOutcomeEventsBackend,
+                MockHelper.configModelStore(),
+                MockHelper.identityModelStore { it.onesignalId = "onesignalId" },
+                mockSubscriptionManager,
+                MockHelper.deviceService(),
+                MockHelper.time(now),
+            )
+
+        // When
+        val evnt = outcomeEventsController.sendSessionEndOutcomeEvent(120)
+
+        // Then
+        evnt shouldNotBe null
+        evnt!!.name shouldBe "os__session_duration"
+        evnt.sessionTime shouldBe 120
+        evnt.notificationIds shouldBe null
+        evnt.session shouldBe InfluenceType.UNATTRIBUTED
+
+        coVerify(exactly = 1) {
+            mockOutcomeEventsBackend.sendOutcomeEvent(
+                MockHelper.DEFAULT_APP_ID,
+                "onesignalId",
+                "subscriptionId",
+                "AndroidPush",
+                null,
+                evnt,
+            )
+        }
+    }
+
+    test("send session end outcome with attributed direct influence") {
+        // Given
+        val now = 111L
+        val notificationIds = "[\"notif-1\",\"notif-2\"]"
+        val mockSessionService = mockk<ISessionService>()
+        every { mockSessionService.subscribe(any()) } just Runs
+
+        val mockInfluenceManager = mockk<IInfluenceManager>()
+        every {
+            mockInfluenceManager.influences
+        } returns listOf(Influence(InfluenceChannel.NOTIFICATION, InfluenceType.DIRECT, JSONArray(notificationIds)))
+
+        val subscriptionModel = createTestSubscriptionModel()
+
+        val mockSubscriptionManager = mockk<ISubscriptionManager>()
+        every { mockSubscriptionManager.subscriptions.push } returns PushSubscription(subscriptionModel)
+
+        val mockOutcomeEventsRepository = spyk<IOutcomeEventsRepository>()
+        val mockOutcomeEventsPreferences = spyk<IOutcomeEventsPreferences>()
+        val mockOutcomeEventsBackend = spyk<IOutcomeEventsBackendService>()
+
+        val outcomeEventsController =
+            OutcomeEventsController(
+                mockSessionService,
+                mockInfluenceManager,
+                mockOutcomeEventsRepository,
+                mockOutcomeEventsPreferences,
+                mockOutcomeEventsBackend,
+                MockHelper.configModelStore(),
+                MockHelper.identityModelStore { it.onesignalId = "onesignalId" },
+                mockSubscriptionManager,
+                MockHelper.deviceService(),
+                MockHelper.time(now),
+            )
+
+        // When
+        val evnt = outcomeEventsController.sendSessionEndOutcomeEvent(60)
+
+        // Then
+        evnt shouldNotBe null
+        evnt!!.name shouldBe "os__session_duration"
+        evnt.sessionTime shouldBe 60
+        evnt.notificationIds shouldNotBe null
+        evnt.notificationIds!!.toString() shouldBe notificationIds
+        evnt.session shouldBe InfluenceType.DIRECT
+
+        coVerify(exactly = 1) {
+            mockOutcomeEventsBackend.sendOutcomeEvent(
+                MockHelper.DEFAULT_APP_ID,
+                "onesignalId",
+                "subscriptionId",
+                "AndroidPush",
+                true,
+                evnt,
+            )
+        }
+    }
+
+    test("send session end outcome with attributed indirect influence") {
+        // Given
+        val now = 111L
+        val notificationIds = "[\"notif-1\",\"notif-2\",\"notif-3\"]"
+        val mockSessionService = mockk<ISessionService>()
+        every { mockSessionService.subscribe(any()) } just Runs
+
+        val mockInfluenceManager = mockk<IInfluenceManager>()
+        every {
+            mockInfluenceManager.influences
+        } returns listOf(Influence(InfluenceChannel.NOTIFICATION, InfluenceType.INDIRECT, JSONArray(notificationIds)))
+
+        val subscriptionModel = createTestSubscriptionModel()
+
+        val mockSubscriptionManager = mockk<ISubscriptionManager>()
+        every { mockSubscriptionManager.subscriptions.push } returns PushSubscription(subscriptionModel)
+
+        val mockOutcomeEventsRepository = spyk<IOutcomeEventsRepository>()
+        val mockOutcomeEventsPreferences = spyk<IOutcomeEventsPreferences>()
+        val mockOutcomeEventsBackend = spyk<IOutcomeEventsBackendService>()
+
+        val outcomeEventsController =
+            OutcomeEventsController(
+                mockSessionService,
+                mockInfluenceManager,
+                mockOutcomeEventsRepository,
+                mockOutcomeEventsPreferences,
+                mockOutcomeEventsBackend,
+                MockHelper.configModelStore(),
+                MockHelper.identityModelStore { it.onesignalId = "onesignalId" },
+                mockSubscriptionManager,
+                MockHelper.deviceService(),
+                MockHelper.time(now),
+            )
+
+        // When
+        val evnt = outcomeEventsController.sendSessionEndOutcomeEvent(90)
+
+        // Then
+        evnt shouldNotBe null
+        evnt!!.name shouldBe "os__session_duration"
+        evnt.sessionTime shouldBe 90
+        evnt.notificationIds shouldNotBe null
+        evnt.notificationIds!!.toString() shouldBe notificationIds
+        evnt.session shouldBe InfluenceType.INDIRECT
+
+        coVerify(exactly = 1) {
+            mockOutcomeEventsBackend.sendOutcomeEvent(
+                MockHelper.DEFAULT_APP_ID,
+                "onesignalId",
+                "subscriptionId",
+                "AndroidPush",
+                false,
+                evnt,
+            )
+        }
+    }
+
     test("send outcome in offline mode") {
         // Given
         val now = 111111L


### PR DESCRIPTION
# Description
## One Line Summary
Send unattributed sessions to /outcomes/measure to show unattributed session data on dashboard.

## Details

### Motivation
Show unattributed session data on dashboard.

### Scope
Send unattributed session data to /outcomes/measure, no change to attributed sessions or session time accumulation to update user endpoint.

# Testing
## Unit testing
* Add tests

## Manual testing
Android 35 emulator
- confirmed session counts and session time is being updated in the dashboard (previously always 0)

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [x] Outcomes
   - [x] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Android-SDK/2553)
<!-- Reviewable:end -->
