### PR TITLE
fix: use versionName instead of versionCode for app version reporting

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/AndroidUtils.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/AndroidUtils.kt
@@ -80,14 +80,12 @@ object AndroidUtils {
     }
 
     fun getAppVersion(context: Context): String? {
-        val appVersion: Int? =
-            try {
-                context.packageManager.getPackageInfo(context.packageName, 0).versionCode
-            } catch (e: PackageManager.NameNotFoundException) {
-                null
-            }
-
-        return appVersion?.toString()
+        return try {
+            val packageInfo = context.packageManager.getPackageInfo(context.packageName, 0)
+            packageInfo.versionName ?: packageInfo.versionCode.toString()
+        } catch (e: PackageManager.NameNotFoundException) {
+            null
+        }
     }
 
     fun getManifestMeta(


### PR DESCRIPTION
# Description
## One Line Summary
Use `versionName` instead of `versionCode` in `AndroidUtils.getAppVersion()` to align with iOS behavior.

## Details

### Motivation
Android reports `versionCode` (integer build number) as the app version while iOS reports `CFBundleShortVersionString` (display version string). This causes inconsistent `app_version` values across platforms, especially for cross-platform frameworks like .NET MAUI where `ApplicationVersion` (build number) and `ApplicationDisplayVersion` (display version) are distinct.

Fixes https://github.com/OneSignal/OneSignal-DotNet-SDK/issues/82

### Scope
Only affects `AndroidUtils.getAppVersion()`. All existing call sites (`OneSignalImp`, `SubscriptionOperationExecutor`, `LoginUserOperationExecutor`, `SubscriptionManager`, `CustomEventOperationExecutor`, `OtelPlatformProvider`) will now receive the display version string instead of the build number. Falls back to `versionCode.toString()` if `versionName` is null.

# Testing
## Unit testing
Existing test in `OtelPlatformProviderTest` validates `getAppVersion` is non-null and non-empty, which still passes.

## Manual testing
Not yet tested on device.

# Affected code checklist
   - [x] REST API requests
   - [x] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

Made with [Cursor](https://cursor.com)