### PR TITLE
fix: [SDK-4901] skip ShortcutBadger on API 26+ to prevent SIGSEGV on Xiaomi devices

### DIFF
--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/badges/impl/BadgeCountUpdater.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/badges/impl/BadgeCountUpdater.kt
@@ -3,6 +3,7 @@ package com.onesignal.notifications.internal.badges.impl
 import android.content.pm.PackageManager
 import android.os.Build
 import androidx.annotation.RequiresApi
+import androidx.annotation.VisibleForTesting
 import com.onesignal.core.internal.application.IApplicationService
 import com.onesignal.core.internal.database.IDatabaseProvider
 import com.onesignal.core.internal.database.impl.OneSignalDbContract
@@ -14,11 +15,28 @@ import com.onesignal.notifications.internal.common.NotificationHelper
 import com.onesignal.notifications.internal.data.INotificationQueryHelper
 import com.onesignal.notifications.internal.limiting.INotificationLimitManager
 
-internal class BadgeCountUpdater(
+internal class BadgeCountUpdater private constructor(
     private val _applicationService: IApplicationService,
     private val _queryHelper: INotificationQueryHelper,
     private val _databaseProvider: IDatabaseProvider,
+    private val _sdkInt: Int,
 ) : IBadgeCountUpdater {
+    constructor(
+        applicationService: IApplicationService,
+        queryHelper: INotificationQueryHelper,
+        databaseProvider: IDatabaseProvider,
+    ) : this(applicationService, queryHelper, databaseProvider, Build.VERSION.SDK_INT)
+
+    companion object {
+        @VisibleForTesting
+        internal fun createForTesting(
+            applicationService: IApplicationService,
+            queryHelper: INotificationQueryHelper,
+            databaseProvider: IDatabaseProvider,
+            sdkInt: Int,
+        ) = BadgeCountUpdater(applicationService, queryHelper, databaseProvider, sdkInt)
+    }
+
     // Cache for manifest setting.
     private var badgesEnabled = -1
 
@@ -50,6 +68,10 @@ internal class BadgeCountUpdater(
 
     override fun update() {
         if (!areBadgesEnabled()) return
+        // On API 26+ the system handles badges via NotificationChannel, and
+        // ShortcutBadger can cause native SIGSEGV crashes on some OEM devices
+        // (e.g. Xiaomi Redmi) where the broadcast receiver has buggy native code.
+        if (_sdkInt >= Build.VERSION_CODES.O) return
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             updateStandard()
         } else {
@@ -83,6 +105,7 @@ internal class BadgeCountUpdater(
 
     override fun updateCount(count: Int) {
         if (!areBadgeSettingsEnabled()) return
+        if (_sdkInt >= Build.VERSION_CODES.O) return
         try {
             ShortcutBadger.applyCountOrThrow(_applicationService.appContext, count)
         } catch (e: ShortcutBadgeException) {

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/badges/impl/BadgeCountUpdater.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/badges/impl/BadgeCountUpdater.kt
@@ -72,7 +72,7 @@ internal class BadgeCountUpdater private constructor(
         // ShortcutBadger can cause native SIGSEGV crashes on some OEM devices
         // (e.g. Xiaomi Redmi) where the broadcast receiver has buggy native code.
         if (_sdkInt >= Build.VERSION_CODES.O) return
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        if (_sdkInt >= Build.VERSION_CODES.M) {
             updateStandard()
         } else {
             updateFallback()

--- a/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/badges/BadgeCountUpdaterTests.kt
+++ b/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/badges/BadgeCountUpdaterTests.kt
@@ -1,0 +1,89 @@
+package com.onesignal.notifications.internal.badges
+
+import android.content.Context
+import android.content.pm.ApplicationInfo
+import android.content.pm.PackageManager
+import android.os.Build
+import com.onesignal.core.internal.application.IApplicationService
+import com.onesignal.core.internal.database.IDatabaseProvider
+import com.onesignal.notifications.internal.badges.impl.BadgeCountUpdater
+import com.onesignal.notifications.internal.badges.impl.shortcutbadger.ShortcutBadger
+import com.onesignal.notifications.internal.common.NotificationHelper
+import com.onesignal.notifications.internal.data.INotificationQueryHelper
+import io.kotest.core.spec.style.FunSpec
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkObject
+import io.mockk.unmockkStatic
+import io.mockk.verify
+
+private class Mocks {
+    val applicationService = mockk<IApplicationService>()
+    val queryHelper = mockk<INotificationQueryHelper>(relaxed = true)
+    val databaseProvider = mockk<IDatabaseProvider>(relaxed = true)
+
+    init {
+        val context = mockk<Context>()
+        val packageManager = mockk<PackageManager>()
+        val applicationInfo = ApplicationInfo()
+
+        every { applicationService.appContext } returns context
+        every { context.packageManager } returns packageManager
+        every { context.packageName } returns "com.onesignal.example"
+        every {
+            packageManager.getApplicationInfo("com.onesignal.example", PackageManager.GET_META_DATA)
+        } returns applicationInfo
+    }
+
+    fun badgeCountUpdater(sdkInt: Int) =
+        BadgeCountUpdater.createForTesting(
+            applicationService,
+            queryHelper,
+            databaseProvider,
+            sdkInt,
+        )
+}
+
+class BadgeCountUpdaterTests : FunSpec({
+    beforeEach {
+        mockkObject(NotificationHelper)
+        every { NotificationHelper.areNotificationsEnabled(any()) } returns true
+        mockkStatic(ShortcutBadger::class)
+        every { ShortcutBadger.applyCountOrThrow(any(), any()) } just Runs
+    }
+
+    afterEach {
+        unmockkStatic(ShortcutBadger::class)
+        unmockkObject(NotificationHelper)
+    }
+
+    test("update should not use ShortcutBadger on Android O") {
+        Mocks().badgeCountUpdater(Build.VERSION_CODES.O).update()
+
+        verify(exactly = 0) { ShortcutBadger.applyCountOrThrow(any(), any()) }
+    }
+
+    test("updateCount should not use ShortcutBadger on Android O") {
+        Mocks().badgeCountUpdater(Build.VERSION_CODES.O).updateCount(3)
+
+        verify(exactly = 0) { ShortcutBadger.applyCountOrThrow(any(), any()) }
+    }
+
+    test("updateCount should use ShortcutBadger before Android O") {
+        val mocks = Mocks()
+        val updater =
+            BadgeCountUpdater(
+                mocks.applicationService,
+                mocks.queryHelper,
+                mocks.databaseProvider,
+            )
+
+        updater.updateCount(3)
+
+        verify(exactly = 1) { ShortcutBadger.applyCountOrThrow(any(), 3) }
+    }
+})

--- a/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/badges/BadgeCountUpdaterTests.kt
+++ b/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/badges/BadgeCountUpdaterTests.kt
@@ -5,6 +5,8 @@ import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
 import android.os.Build
 import com.onesignal.core.internal.application.IApplicationService
+import com.onesignal.core.internal.database.ICursor
+import com.onesignal.core.internal.database.IDatabase
 import com.onesignal.core.internal.database.IDatabaseProvider
 import com.onesignal.notifications.internal.badges.impl.BadgeCountUpdater
 import com.onesignal.notifications.internal.badges.impl.shortcutbadger.ShortcutBadger
@@ -14,6 +16,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
+import io.mockk.lastArg
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.mockkStatic
@@ -24,7 +27,11 @@ import io.mockk.verify
 private class Mocks {
     val applicationService = mockk<IApplicationService>()
     val queryHelper = mockk<INotificationQueryHelper>(relaxed = true)
-    val databaseProvider = mockk<IDatabaseProvider>(relaxed = true)
+    val database = mockk<IDatabase>(relaxed = true)
+    val databaseProvider =
+        mockk<IDatabaseProvider> {
+            every { os } returns database
+        }
 
     init {
         val context = mockk<Context>()
@@ -37,6 +44,16 @@ private class Mocks {
         every {
             packageManager.getApplicationInfo("com.onesignal.example", PackageManager.GET_META_DATA)
         } returns applicationInfo
+    }
+
+    fun queryReturnsCount(count: Int) {
+        val cursor = mockk<ICursor>()
+        every { cursor.count } returns count
+        every {
+            database.query(any(), any(), any(), any(), any(), any(), any(), any(), any())
+        } answers {
+            lastArg<(ICursor) -> Unit>().invoke(cursor)
+        }
     }
 
     fun badgeCountUpdater(sdkInt: Int) =
@@ -71,6 +88,23 @@ class BadgeCountUpdaterTests : FunSpec({
         Mocks().badgeCountUpdater(Build.VERSION_CODES.O).updateCount(3)
 
         verify(exactly = 0) { ShortcutBadger.applyCountOrThrow(any(), any()) }
+    }
+
+    test("update should use ShortcutBadger on Android N MR1") {
+        every { NotificationHelper.getActiveNotifications(any()) } returns emptyArray()
+
+        Mocks().badgeCountUpdater(Build.VERSION_CODES.N_MR1).update()
+
+        verify(exactly = 1) { ShortcutBadger.applyCountOrThrow(any(), 0) }
+    }
+
+    test("update should use ShortcutBadger before Android M") {
+        val mocks = Mocks()
+        mocks.queryReturnsCount(3)
+
+        mocks.badgeCountUpdater(Build.VERSION_CODES.LOLLIPOP_MR1).update()
+
+        verify(exactly = 1) { ShortcutBadger.applyCountOrThrow(any(), 3) }
     }
 
     test("updateCount should use ShortcutBadger before Android O") {

--- a/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/badges/BadgeCountUpdaterTests.kt
+++ b/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/badges/BadgeCountUpdaterTests.kt
@@ -16,7 +16,6 @@ import io.kotest.core.spec.style.FunSpec
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
-import io.mockk.lastArg
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.mockkStatic
@@ -52,7 +51,7 @@ private class Mocks {
         every {
             database.query(any(), any(), any(), any(), any(), any(), any(), any(), any())
         } answers {
-            lastArg<(ICursor) -> Unit>().invoke(cursor)
+            arg<(ICursor) -> Unit>(8).invoke(cursor)
         }
     }
 

--- a/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/badges/BadgeCountUpdaterTests.kt
+++ b/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/badges/BadgeCountUpdaterTests.kt
@@ -74,15 +74,7 @@ class BadgeCountUpdaterTests : FunSpec({
     }
 
     test("updateCount should use ShortcutBadger before Android O") {
-        val mocks = Mocks()
-        val updater =
-            BadgeCountUpdater(
-                mocks.applicationService,
-                mocks.queryHelper,
-                mocks.databaseProvider,
-            )
-
-        updater.updateCount(3)
+        Mocks().badgeCountUpdater(Build.VERSION_CODES.O - 1).updateCount(3)
 
         verify(exactly = 1) { ShortcutBadger.applyCountOrThrow(any(), 3) }
     }

--- a/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/badges/BadgeCountUpdaterTests.kt
+++ b/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/badges/BadgeCountUpdaterTests.kt
@@ -40,6 +40,7 @@ private class Mocks {
         every { applicationService.appContext } returns context
         every { context.packageManager } returns packageManager
         every { context.packageName } returns "com.onesignal.example"
+        every { queryHelper.recentUninteractedWithNotificationsWhere() } returns StringBuilder("1=1")
         every {
             packageManager.getApplicationInfo("com.onesignal.example", PackageManager.GET_META_DATA)
         } returns applicationInfo


### PR DESCRIPTION
# Description
## One Line Summary
Skip ShortcutBadger badge updates on Android 8+ (API 26) to prevent native SIGSEGV crashes on Xiaomi devices.

## Details

### Motivation
ShortcutBadger causes a native SIGSEGV on certain Xiaomi devices (Redmi 10C, Redmi 9A) running Android 11-13. The crash occurs while updating the legacy launcher badge. Since SIGSEGV is a native crash, Java exception handling cannot intercept it.

Android 8+ handles app icon badges through notification channels and active notifications, so the legacy ShortcutBadger path is unnecessary on those versions.

Reported in OneSignal/react-native-onesignal#1766 and OneSignal/OneSignal-Android-SDK#2222. Tracked by SDK-4901.

### Scope
On API 26+, skip both automatic and explicit ShortcutBadger updates. Pre-API 26 devices continue using ShortcutBadger unchanged.

# Testing
## Unit testing
Added `BadgeCountUpdaterTests` covering:
- `update()` does not invoke ShortcutBadger on API 26.
- `updateCount()` does not invoke ShortcutBadger on API 26.
- `updateCount()` continues invoking ShortcutBadger before API 26.

Local validation:
- Spotless
- Detekt
- Full debug unit-test suite
- Minified GMS and Huawei release demo builds
- Changed-line coverage: 100% (5/5 executable lines)

## Manual testing
The affected Xiaomi hardware was not available locally. The regression tests prevent the crashing code path from being reached on the reported Android versions.

# Affected code checklist
   - [x] Notifications
      - [x] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
