### PR TITLE
fix: add otel consumer R8 rule for optional jackson classes

### DIFF
--- a/OneSignalSDK/onesignal/otel/consumer-rules.pro
+++ b/OneSignalSDK/onesignal/otel/consumer-rules.pro
@@ -1,0 +1,3 @@
+# OpenTelemetry OTLP exporter references Jackson core classes that are optional on Android.
+# Suppress R8 missing-class errors when apps don't include jackson-core.
+-dontwarn com.fasterxml.jackson.core.**


### PR DESCRIPTION
# Description
## One Line Summary
Add an OTEL consumer ProGuard rule to suppress optional Jackson core missing-class warnings so Android release builds with R8/Proguard succeed on 5.7.x.

## Details

### Motivation
Fixes the R8 missing class failure reported in #2576 where `io.opentelemetry.exporter` references optional `com.fasterxml.jackson.core.*` classes not present on Android by default.

### Scope
- Affects only the `otel` module consumer ProGuard configuration.
- No runtime behavior changes.
- No public API changes.

### OPTIONAL - Other
Rule added in `OneSignalSDK/onesignal/otel/consumer-rules.pro`:
- `-dontwarn com.fasterxml.jackson.core.**`

# Testing
## Unit testing
No unit tests were needed because this is a consumer ProGuard metadata change.

## Manual testing
- Ran `./gradlew :OneSignal:otel:assemble` successfully.
- Verified `consumer-rules.pro` is packaged via existing `consumerProguardFiles` config.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

Made with [Cursor](https://cursor.com)