### PR TITLE
fix: keep OneSignal WorkManager workers in consumer R8 rules

### DIFF
--- a/OneSignalSDK/onesignal/notifications/consumer-rules.pro
+++ b/OneSignalSDK/onesignal/notifications/consumer-rules.pro
@@ -60,5 +60,3 @@
 -keep class com.onesignal.notifications.internal.** extends androidx.work.ListenableWorker {
     public <init>(android.content.Context, androidx.work.WorkerParameters);
 }
-
--keep class androidx.work.WorkerParameters { *; }


### PR DESCRIPTION
## Summary
- Add a targeted consumer ProGuard keep rule in `OneSignalSDK/onesignal/notifications/consumer-rules.pro` so OneSignal WorkManager workers are retained in minified app builds.
- Keep `com.onesignal.notifications.internal.**` classes that extend `androidx.work.ListenableWorker` along with their required `(Context, WorkerParameters)` constructor for runtime instantiation.
- Scoped narrowly to avoid unnecessary APK size impact — only the worker classes and their two-arg constructors are kept; no broad `WorkerParameters` keep rule.

Fixes https://github.com/OneSignal/OneSignal-Android-SDK/issues/2582
Linear: [SDK-4185](https://linear.app/onesignal/issue/SDK-4185/bug-push-notifications-not-displayed-with-r8minify-enabled-android-sdk)

## Root cause
When a consumer app enables `minifyEnabled = true` (R8), the SDK's `NotificationGenerationWorker`, `NotificationRestoreWorker`, and `ReceiveReceiptWorker` classes (all inner classes extending `CoroutineWorker`) can have their constructors stripped or obfuscated. WorkManager instantiates workers by reflection via `(Context, WorkerParameters)` — if that constructor is removed, `enqueueUniqueWork` succeeds but the worker never runs, so notifications are enqueued but never displayed.

## What changed
A single targeted keep rule added to the notifications module `consumer-rules.pro`:

```
-keep class com.onesignal.notifications.internal.** extends androidx.work.ListenableWorker {
    public <init>(android.content.Context, androidx.work.WorkerParameters);
}
```

This is automatically applied to any consuming app via the AAR consumer ProGuard mechanism.

## Test plan
- [x] **Build verification** (SDK module only, no demo changes committed)
  - `cd OneSignalSDK && ./gradlew :OneSignal:notifications:assemble` → `BUILD SUCCESSFUL`
- [x] **Runtime test 1** — minified build with initial fix (`SNAPSHOT`)
  - Demo app: `isMinifyEnabled = true`, `isShrinkResources = true`, `gmsProfileable` variant
  - Fresh install on emulator (Pixel, API 36), `POST_NOTIFICATIONS` granted
  - Sent push from dashboard while app backgrounded → notification displayed
- [x] **Runtime test 2** — minified build with narrowed rule (`SNAPSHOT2`)
  - Removed broad `WorkerParameters` keep, republished all modules
  - Rebuilt/reinstalled minified demo app
  - Confirmed SDK version in logs: `SDK-Version=[onesignal/android/050702-sdk4185-SNAPSHOT2]`
  - Awaiting final push send for log capture (emulator ready, live capture running)

### Runtime log evidence (minified build, test 1)
```text
03-19 14:48:45.205 D/OneSignal: NotificationWorkManager enqueueing notification work with notificationId: 8ed31bbf ...
03-19 14:48:47.316 I/WM-WorkerWrapper: Worker result SUCCESS for Work [ tags={ ...NotificationGenerationWorker } ]
03-19 14:48:47.724 I/WM-WorkerWrapper: Worker result SUCCESS for Work [ tags={ ...NotificationGenerationWorker } ]
```
(10 unique notification IDs processed successfully in a single batch)

### SDK version confirmation
```text
SDK-Version=[onesignal/android/050702-sdk4185-SNAPSHOT]   # test 1
SDK-Version=[onesignal/android/050702-sdk4185-SNAPSHOT2]   # test 2 (narrowed rule)
```