### PR TITLE
fix: R8 InputMerger + minified demo + CI (#2589 → 5.7-main)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,10 @@ jobs:
         working-directory: OneSignalSDK
         run: |
           ./gradlew testDebugUnitTest --console=plain --continue
+      - name: "[Build] Demo app (minified release)"
+        working-directory: OneSignalSDK
+        run: |
+          ./gradlew :app:assembleGmsRelease --console=plain
       - name: "[Diff Coverage] Check for bypass"
         id: coverage_bypass
         run: |

--- a/OneSignalSDK/onesignal/notifications/consumer-rules.pro
+++ b/OneSignalSDK/onesignal/notifications/consumer-rules.pro
@@ -60,3 +60,12 @@
 -keep class com.onesignal.notifications.internal.** extends androidx.work.ListenableWorker {
     public <init>(android.content.Context, androidx.work.WorkerParameters);
 }
+
+# WorkManager instantiates InputMerger classes via reflection (InputMerger.fromClassName).
+# R8 full mode (AGP 8+) strips no-arg constructors, causing:
+# java.lang.NoSuchMethodException: androidx.work.OverwritingInputMerger.<init>()
+# WM-WorkerWrapper E Could not create Input Merger androidx.work.OverwritingInputMerger
+# Keep all InputMerger subclasses (OverwritingInputMerger, ArrayCreatingInputMerger, etc.)
+-keep class * extends androidx.work.InputMerger {
+    public <init>();
+}

--- a/examples/demo/app/build.gradle.kts
+++ b/examples/demo/app/build.gradle.kts
@@ -52,7 +52,11 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = false
+            // Minify MUST be enabled to exercise R8 and validate WorkManager/ProGuard rules.
+            // See: SDK-4185, https://github.com/OneSignal/OneSignal-Android-SDK/issues/2582
+            isMinifyEnabled = true
+            isShrinkResources = true
+            signingConfig = signingConfigs.getByName("debug")
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
@@ -65,7 +69,8 @@ android {
             initWith(getByName("release"))
             isDebuggable = false
             isProfileable = true
-            isMinifyEnabled = false
+            isMinifyEnabled = true
+            isShrinkResources = true
             signingConfig = signingConfigs.getByName("debug")
             matchingFallbacks += listOf("release")
         }

--- a/examples/demo/app/proguard-rules.pro
+++ b/examples/demo/app/proguard-rules.pro
@@ -19,3 +19,8 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+# Demo-only suppression for optional OTel transitive classes.
+-dontwarn com.fasterxml.jackson.core.JsonFactory
+-dontwarn com.fasterxml.jackson.core.JsonGenerator
+-dontwarn com.google.auto.value.AutoValue$CopyAnnotations


### PR DESCRIPTION
## Summary

Cherry-picks [0827c614](https://github.com/OneSignal/OneSignal-Android-SDK/commit/0827c614566baeb4e3e846b72a79f0d9829a0407) (merged as **#2589** on `main`) into **`5.7-main`**.

### Contents (from #2589)

- Consumer ProGuard: keep `androidx.work.InputMerger` subclasses + no-arg constructors (AGP 9 / R8 follow-up to worker-only fix in #2585).
- Demo app: minify + shrink on release/profileable; demo `proguard-rules.pro` `-dontwarn` for optional OTel transitive refs.
- CI: `assembleGmsRelease`; extended triggers (`push` / `workflow_dispatch`) and publish-release minified demo step (as in that merge commit).

### Target

Merge into **`5.7-main`** for the 5.7.x release line.
