### PR TITLE
fix: R8 AutoValue suppressions + Huawei release in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,10 +41,10 @@ jobs:
         working-directory: OneSignalSDK
         run: |
           ./gradlew testDebugUnitTest --console=plain --continue
-      - name: "[Build] Demo app (minified release)"
+      - name: "[Build] Demo app (minified GMS + Huawei release)"
         working-directory: OneSignalSDK
         run: |
-          ./gradlew :app:assembleGmsRelease --console=plain
+          ./gradlew :app:assembleGmsRelease :app:assembleHuaweiRelease --console=plain
       - name: "[Diff Coverage] Check for bypass"
         id: coverage_bypass
         if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'

--- a/OneSignalSDK/onesignal/otel/consumer-rules.pro
+++ b/OneSignalSDK/onesignal/otel/consumer-rules.pro
@@ -1,3 +1,8 @@
 # OpenTelemetry OTLP exporter references Jackson core classes that are optional on Android.
 # Suppress R8 missing-class errors when apps don't include jackson-core.
 -dontwarn com.fasterxml.jackson.core.**
+
+# OTel / disk buffering reference Google Auto Value types that are not on the app classpath.
+-dontwarn com.google.auto.value.AutoValue
+-dontwarn com.google.auto.value.AutoValue$Builder
+-dontwarn com.google.auto.value.AutoValue$CopyAnnotations

--- a/examples/demo/app/proguard-rules.pro
+++ b/examples/demo/app/proguard-rules.pro
@@ -20,7 +20,9 @@
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
 
-# Demo-only suppression for optional OTel transitive classes.
+# Demo-only: optional transitive classes pulled in via OneSignal OTel / R8 (GMS + Huawei minified builds).
 -dontwarn com.fasterxml.jackson.core.JsonFactory
 -dontwarn com.fasterxml.jackson.core.JsonGenerator
+-dontwarn com.google.auto.value.AutoValue
+-dontwarn com.google.auto.value.AutoValue$Builder
 -dontwarn com.google.auto.value.AutoValue$CopyAnnotations


### PR DESCRIPTION
## Summary
- **OTel consumer-rules:** Add `-dontwarn` for `com.google.auto.value.AutoValue`, `AutoValue$Builder`, and `AutoValue$CopyAnnotations` so R8 no longer fails on missing Auto Value types referenced by OpenTelemetry / disk buffering (e.g. Huawei minified release).
- **Demo proguard:** Align `examples/demo` with the same Auto Value suppressions (plus existing Jackson lines).
- **CI:** Run `:app:assembleHuaweiRelease` alongside `:app:assembleGmsRelease` in the existing demo minified-release step (from `OneSignalSDK` composite `:app`).

## Verification
- Local: `./gradlew :app:assembleGmsRelease :app:assembleHuaweiRelease` from `OneSignalSDK` succeeded.

Made with [Cursor](https://cursor.com)