### PR TITLE
fix: R8 AutoValue + Huawei CI (cherry-pick #2592)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,10 @@ jobs:
         working-directory: OneSignalSDK
         run: |
           ./gradlew testDebugUnitTest --console=plain --continue
-      - name: "[Build] Demo app (minified release)"
+      - name: "[Build] Demo app (minified GMS + Huawei release)"
         working-directory: OneSignalSDK
         run: |
-          ./gradlew :app:assembleGmsRelease --console=plain
+          ./gradlew :app:assembleGmsRelease :app:assembleHuaweiRelease --console=plain
       - name: "[Diff Coverage] Check for bypass"
         id: coverage_bypass
         run: |

--- a/OneSignalSDK/onesignal/otel/consumer-rules.pro
+++ b/OneSignalSDK/onesignal/otel/consumer-rules.pro
@@ -1,3 +1,8 @@
 # OpenTelemetry OTLP exporter references Jackson core classes that are optional on Android.
 # Suppress R8 missing-class errors when apps don't include jackson-core.
 -dontwarn com.fasterxml.jackson.core.**
+
+# OTel / disk buffering reference Google Auto Value types that are not on the app classpath.
+-dontwarn com.google.auto.value.AutoValue
+-dontwarn com.google.auto.value.AutoValue$Builder
+-dontwarn com.google.auto.value.AutoValue$CopyAnnotations

--- a/examples/demo/app/proguard-rules.pro
+++ b/examples/demo/app/proguard-rules.pro
@@ -20,7 +20,9 @@
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
 
-# Demo-only suppression for optional OTel transitive classes.
+# Demo-only: optional transitive classes pulled in via OneSignal OTel / R8 (GMS + Huawei minified builds).
 -dontwarn com.fasterxml.jackson.core.JsonFactory
 -dontwarn com.fasterxml.jackson.core.JsonGenerator
+-dontwarn com.google.auto.value.AutoValue
+-dontwarn com.google.auto.value.AutoValue$Builder
 -dontwarn com.google.auto.value.AutoValue$CopyAnnotations


### PR DESCRIPTION
## Summary
Cherry-pick of [`f090837a`](https://github.com/OneSignal/OneSignal-Android-SDK/commit/f090837a7569ac398569cec426228aae2cdf18f8) / #2592 onto `5.7-main`.

- **OTel consumer-rules:** `-dontwarn` for Google Auto Value types referenced by OpenTelemetry (fixes R8 missing-class errors on minified Huawei/GMS builds).
- **Demo proguard:** Same Auto Value suppressions in `examples/demo`.
- **CI:** Run `:app:assembleHuaweiRelease` alongside `:app:assembleGmsRelease` in the demo minified-release step.

## Parent
- main PR: #2592

Made with [Cursor](https://cursor.com)