### PR TITLE
fix: [SDK-4192] downgrade Kotlin from 2.2.0 to 1.9.25

### DIFF
--- a/OneSignalSDK/build.gradle
+++ b/OneSignalSDK/build.gradle
@@ -14,7 +14,7 @@ buildscript {
         huaweiAgconnectVersion = '1.9.1.304'
         huaweiHMSPushVersion = '6.3.0.304'
         huaweiHMSLocationVersion = '4.0.0.300'
-        kotlinVersion = '2.2.0'
+        kotlinVersion = '1.9.25'
         dokkaVersion = '1.9.10'
         coroutinesVersion = '1.7.3'
         kotestVersion = '5.8.0'

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/debug/internal/crash/OtelIntegrationTest.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/debug/internal/crash/OtelIntegrationTest.kt
@@ -76,7 +76,7 @@ class OtelIntegrationTest : FunSpec({
             put(identityModel)
         }
 
-        sharedPreferences.edit()
+        sharedPreferences!!.edit()
             .putString(PreferenceOneSignalKeys.MODEL_STORE_PREFIX + configNameSpace, configArray.toString())
             .putString(PreferenceOneSignalKeys.MODEL_STORE_PREFIX + identityNameSpace, identityArray.toString())
             .putString(PreferenceOneSignalKeys.PREFS_OS_INSTALL_ID, "test-install-id")

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/debug/internal/crash/OtelIntegrationTest.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/debug/internal/crash/OtelIntegrationTest.kt
@@ -35,133 +35,128 @@ private infix fun <T> T.shouldBeOneOf(expected: List<T>) {
 
 @RobolectricTest
 @Config(sdk = [Build.VERSION_CODES.O])
-class OtelIntegrationTest : FunSpec({
-    var appContext: Context? = null
-    var sharedPreferences: SharedPreferences? = null
+class OtelIntegrationTest : FunSpec() {
+    private lateinit var appContext: Context
+    private lateinit var sharedPreferences: SharedPreferences
 
-    beforeAny {
-        if (appContext == null) {
-            appContext = ApplicationProvider.getApplicationContext()
-            sharedPreferences = appContext!!.getSharedPreferences(PreferenceStores.ONESIGNAL, Context.MODE_PRIVATE)
-        }
-    }
-
-    beforeEach {
-        // Ensure sharedPreferences is initialized
-        if (sharedPreferences == null) {
-            appContext = ApplicationProvider.getApplicationContext()
-            sharedPreferences = appContext!!.getSharedPreferences(PreferenceStores.ONESIGNAL, Context.MODE_PRIVATE)
-        }
-        // Clear and set up SharedPreferences with test data
-        sharedPreferences!!.edit().clear().commit()
-
-        // Set up ConfigModelStore data
-        val configModel = JSONObject().apply {
-            put(ConfigModel::appId.name, "test-app-id")
-            put(ConfigModel::pushSubscriptionId.name, "test-subscription-id")
-            val remoteLoggingParams = JSONObject().apply {
-                put("logLevel", "ERROR")
+    init {
+        beforeAny {
+            if (!::appContext.isInitialized) {
+                appContext = ApplicationProvider.getApplicationContext()
+                sharedPreferences = appContext.getSharedPreferences(PreferenceStores.ONESIGNAL, Context.MODE_PRIVATE)
             }
-            put(ConfigModel::remoteLoggingParams.name, remoteLoggingParams)
-        }
-        val configArray = JSONArray().apply {
-            put(configModel)
         }
 
-        // Set up IdentityModelStore data
-        val identityModel = JSONObject().apply {
-            put(IdentityConstants.ONESIGNAL_ID, "test-onesignal-id")
+        beforeEach {
+            if (!::sharedPreferences.isInitialized) {
+                appContext = ApplicationProvider.getApplicationContext()
+                sharedPreferences = appContext.getSharedPreferences(PreferenceStores.ONESIGNAL, Context.MODE_PRIVATE)
+            }
+            sharedPreferences.edit().clear().commit()
+
+            val configModel = JSONObject().apply {
+                put(ConfigModel::appId.name, "test-app-id")
+                put(ConfigModel::pushSubscriptionId.name, "test-subscription-id")
+                val remoteLoggingParams = JSONObject().apply {
+                    put("logLevel", "ERROR")
+                }
+                put(ConfigModel::remoteLoggingParams.name, remoteLoggingParams)
+            }
+            val configArray = JSONArray().apply {
+                put(configModel)
+            }
+
+            val identityModel = JSONObject().apply {
+                put(IdentityConstants.ONESIGNAL_ID, "test-onesignal-id")
+            }
+            val identityArray = JSONArray().apply {
+                put(identityModel)
+            }
+
+            sharedPreferences.edit()
+                .putString(PreferenceOneSignalKeys.MODEL_STORE_PREFIX + configNameSpace, configArray.toString())
+                .putString(PreferenceOneSignalKeys.MODEL_STORE_PREFIX + identityNameSpace, identityArray.toString())
+                .putString(PreferenceOneSignalKeys.PREFS_OS_INSTALL_ID, "test-install-id")
+                .commit()
         }
-        val identityArray = JSONArray().apply {
-            put(identityModel)
+
+        afterEach {
+            sharedPreferences.edit().clear().commit()
         }
 
-        sharedPreferences!!.edit()
-            .putString(PreferenceOneSignalKeys.MODEL_STORE_PREFIX + configNameSpace, configArray.toString())
-            .putString(PreferenceOneSignalKeys.MODEL_STORE_PREFIX + identityNameSpace, identityArray.toString())
-            .putString(PreferenceOneSignalKeys.PREFS_OS_INSTALL_ID, "test-install-id")
-            .commit()
-    }
+        test("AndroidOtelPlatformProvider should provide correct Android values") {
+            val provider = createAndroidOtelPlatformProvider(appContext)
 
-    afterEach {
-        sharedPreferences!!.edit().clear().commit()
-    }
+            provider.shouldBeInstanceOf<IOtelPlatformProvider>()
+            provider.sdkBase shouldBe "android"
+            provider.appPackageId shouldBe appContext.packageName
+            provider.osName shouldBe "Android"
+            provider.deviceManufacturer shouldBe Build.MANUFACTURER
+            provider.deviceModel shouldBe Build.MODEL
+            provider.osVersion shouldBe Build.VERSION.RELEASE
+            provider.osBuildId shouldBe Build.ID
 
-    test("AndroidOtelPlatformProvider should provide correct Android values") {
-        val provider = createAndroidOtelPlatformProvider(appContext!!)
+            runBlocking {
+                provider.getInstallId() shouldNotBe null
+            }
+        }
 
-        provider.shouldBeInstanceOf<IOtelPlatformProvider>()
-        provider.sdkBase shouldBe "android"
-        provider.appPackageId shouldBe appContext!!.packageName // Use actual package name from context
-        provider.osName shouldBe "Android"
-        provider.deviceManufacturer shouldBe Build.MANUFACTURER
-        provider.deviceModel shouldBe Build.MODEL
-        provider.osVersion shouldBe Build.VERSION.RELEASE
-        provider.osBuildId shouldBe Build.ID
+        test("AndroidOtelPlatformProvider should provide per-event values") {
+            val provider = createAndroidOtelPlatformProvider(appContext)
 
-        runBlocking {
-            provider.getInstallId() shouldNotBe null
+            provider.appId shouldBe "test-app-id"
+            provider.onesignalId shouldBe "test-onesignal-id"
+            provider.pushSubscriptionId shouldBe "test-subscription-id"
+            provider.appState shouldBeOneOf listOf("foreground", "background", "unknown")
+            (provider.processUptime > 0) shouldBe true
+            provider.currentThreadName shouldBe Thread.currentThread().name
+        }
+
+        test("AndroidOtelLogger should delegate to Logging") {
+            val logger = AndroidOtelLogger()
+
+            logger.shouldBeInstanceOf<com.onesignal.otel.IOtelLogger>()
+            logger.debug("test")
+            logger.info("test")
+            logger.warn("test")
+            logger.error("test")
+        }
+
+        test("OtelFactory should create crash handler with Android provider") {
+            val provider = createAndroidOtelPlatformProvider(appContext)
+            val logger = AndroidOtelLogger()
+
+            val handler = OtelFactory.createCrashHandler(provider, logger)
+
+            handler shouldNotBe null
+            handler.shouldBeInstanceOf<IOtelCrashHandler>()
+            handler.initialize()
+        }
+
+        test("OneSignalCrashHandlerFactory should create working crash handler") {
+            val provider = createAndroidOtelPlatformProvider(appContext)
+            val logger = AndroidOtelLogger()
+            val handler = OtelFactory.createCrashHandler(provider, logger)
+
+            handler shouldNotBe null
+            handler.shouldBeInstanceOf<IOtelCrashHandler>()
+            handler.initialize()
+        }
+
+        test("AndroidOtelPlatformProvider should provide crash storage path") {
+            val provider = createAndroidOtelPlatformProvider(appContext)
+
+            provider.crashStoragePath.contains("onesignal") shouldBe true
+            provider.crashStoragePath.contains("otel") shouldBe true
+            provider.crashStoragePath.contains("crashes") shouldBe true
+            provider.minFileAgeForReadMillis shouldBe 5000L
+        }
+
+        test("AndroidOtelPlatformProvider should handle remote logging config") {
+            val provider = createAndroidOtelPlatformProvider(appContext)
+
+            provider.remoteLogLevel shouldBe "ERROR"
+            provider.appIdForHeaders shouldBe "test-app-id"
         }
     }
-
-    test("AndroidOtelPlatformProvider should provide per-event values") {
-        val provider = createAndroidOtelPlatformProvider(appContext!!)
-
-        provider.appId shouldBe "test-app-id"
-        provider.onesignalId shouldBe "test-onesignal-id"
-        provider.pushSubscriptionId shouldBe "test-subscription-id"
-        provider.appState shouldBeOneOf listOf("foreground", "background", "unknown")
-        (provider.processUptime > 0) shouldBe true
-        provider.currentThreadName shouldBe Thread.currentThread().name
-    }
-
-    test("AndroidOtelLogger should delegate to Logging") {
-        val logger = AndroidOtelLogger()
-
-        logger.shouldBeInstanceOf<com.onesignal.otel.IOtelLogger>()
-        // Should not throw
-        logger.debug("test")
-        logger.info("test")
-        logger.warn("test")
-        logger.error("test")
-    }
-
-    test("OtelFactory should create crash handler with Android provider") {
-        val provider = createAndroidOtelPlatformProvider(appContext!!)
-        val logger = AndroidOtelLogger()
-
-        val handler = OtelFactory.createCrashHandler(provider, logger)
-
-        handler shouldNotBe null
-        handler.shouldBeInstanceOf<IOtelCrashHandler>()
-        handler.initialize() // Should not throw
-    }
-
-    test("OneSignalCrashHandlerFactory should create working crash handler") {
-        // Note: OneSignalCrashHandlerFactory may need to be updated to use the new approach
-        // For now, we'll test the direct creation
-        val provider = createAndroidOtelPlatformProvider(appContext!!)
-        val logger = AndroidOtelLogger()
-        val handler = OtelFactory.createCrashHandler(provider, logger)
-
-        handler shouldNotBe null
-        handler.shouldBeInstanceOf<IOtelCrashHandler>()
-        handler.initialize() // Should not throw
-    }
-
-    test("AndroidOtelPlatformProvider should provide crash storage path") {
-        val provider = createAndroidOtelPlatformProvider(appContext!!)
-
-        provider.crashStoragePath.contains("onesignal") shouldBe true
-        provider.crashStoragePath.contains("otel") shouldBe true
-        provider.crashStoragePath.contains("crashes") shouldBe true
-        provider.minFileAgeForReadMillis shouldBe 5000L
-    }
-
-    test("AndroidOtelPlatformProvider should handle remote logging config") {
-        val provider = createAndroidOtelPlatformProvider(appContext!!)
-
-        provider.remoteLogLevel shouldBe "ERROR"
-        provider.appIdForHeaders shouldBe "test-app-id"
-    }
-})
+}

--- a/OneSignalSDK/onesignal/otel/build.gradle
+++ b/OneSignalSDK/onesignal/otel/build.gradle
@@ -36,7 +36,7 @@ android {
 
     kotlinOptions {
         jvmTarget = '1.8'
-        freeCompilerArgs += ['-module-name', namespace]
+        freeCompilerArgs += ['-module-name', namespace, '-Xskip-metadata-version-check']
     }
 }
 

--- a/examples/build.md
+++ b/examples/build.md
@@ -650,7 +650,7 @@ Enable Jetpack Compose in the project:
 
 build.gradle.kts (app):
 - buildFeatures { compose = true }
-- composeOptions { kotlinCompilerExtensionVersion = "1.5.10" }
+- composeOptions { kotlinCompilerExtensionVersion = "1.5.15" }
 
 Dependencies (via BOM):
 - composeBom = "2024.02.00"

--- a/examples/build.md
+++ b/examples/build.md
@@ -154,7 +154,7 @@ In MainViewModel.kt, implement observers:
 11. **Triggers Section** (Add/Add Multiple/Remove Selected/Clear All - IN MEMORY ONLY)
 12. **Track Event Section** (Track Event with JSON validation)
 13. **Location Section** (Location Shared toggle, Prompt Location button)
-14. **Next Activity Button**
+14. **Next Screen Button**
 
 ### Prompt 2.1 - App Section
 
@@ -374,12 +374,12 @@ Location Section:
 - PROMPT LOCATION button
 ```
 
-### Prompt 2.14 - Secondary Activity
+### Prompt 2.14 - Secondary Screen
 
 ```
-Secondary Activity (launched by "Next Activity" button at bottom of main screen):
-- Activity title: "Secondary Activity"
-- Page content: centered text "Secondary Activity" using headlineMedium style
+Secondary Screen (launched by "Next Screen" button at bottom of main screen):
+- Screen title: "Secondary Screen"
+- Page content: centered text "Secondary Screen" using headlineMedium style
 - Simple screen, no additional functionality needed
 ```
 

--- a/examples/demo/GettingStarted.md
+++ b/examples/demo/GettingStarted.md
@@ -145,7 +145,7 @@ Send a named **event** with optional JSON properties for advanced analytics.
 ### Location
 Toggle **location sharing** on or off and **prompt** for location permission.
 
-### Secondary Activity
+### Secondary Screen
 Navigate to a second screen with buttons to **simulate a crash** (`RuntimeException`) and **simulate an ANR** (10-second main-thread block) — useful for testing crash and ANR reporting.
 
 ### Log Viewer

--- a/examples/demo/app/build.gradle.kts
+++ b/examples/demo/app/build.gradle.kts
@@ -1,11 +1,9 @@
 plugins {
     id("com.android.application")
     id("kotlin-android")
-    id("org.jetbrains.kotlin.plugin.compose") version "2.2.0"
 }
 
-// Keep IDE sync stable even if root extra properties are unavailable.
-val kotlinVersion: String = rootProject.findProperty("kotlinVersion") as? String ?: "2.2.0"
+val kotlinVersion: String = rootProject.findProperty("kotlinVersion") as? String ?: "1.9.25"
 
 // Apply GMS or Huawei plugin based on build variant
 // Check at configuration time, not when task graph is ready
@@ -35,6 +33,10 @@ android {
 
     buildFeatures {
         compose = true
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.15"
     }
 
     flavorDimensions += "default"

--- a/examples/demo/app/src/main/AndroidManifest.xml
+++ b/examples/demo/app/src/main/AndroidManifest.xml
@@ -62,7 +62,7 @@
             </intent-filter>
         </activity>
 
-        <!-- Secondary Activity -->
+        <!-- Secondary Screen -->
         <activity
             android:name=".ui.secondary.SecondaryActivity"
             android:exported="false" />

--- a/examples/demo/app/src/main/java/com/onesignal/sdktest/ui/main/MainScreen.kt
+++ b/examples/demo/app/src/main/java/com/onesignal/sdktest/ui/main/MainScreen.kt
@@ -263,9 +263,9 @@ fun MainScreen(viewModel: MainViewModel) {
                 
                 Spacer(modifier = Modifier.height(8.dp))
                 
-                // === NEXT ACTIVITY BUTTON ===
+                // === NEXT SCREEN BUTTON ===
                 PrimaryButton(
-                    text = "NEXT ACTIVITY",
+                    text = "NEXT SCREEN",
                     onClick = {
                         context.startActivity(Intent(context, SecondaryActivity::class.java))
                     }

--- a/examples/demo/app/src/main/java/com/onesignal/sdktest/ui/secondary/SecondaryActivity.kt
+++ b/examples/demo/app/src/main/java/com/onesignal/sdktest/ui/secondary/SecondaryActivity.kt
@@ -42,7 +42,7 @@ class SecondaryActivity : ComponentActivity() {
                 Scaffold(
                     topBar = {
                         CenterAlignedTopAppBar(
-                            title = { Text("Secondary Activity", color = Color.White) },
+                            title = { Text("Secondary Screen", color = Color.White) },
                             navigationIcon = {
                                 IconButton(onClick = { finish() }) {
                                     Icon(
@@ -67,7 +67,7 @@ class SecondaryActivity : ComponentActivity() {
                         verticalArrangement = Arrangement.Center
                     ) {
                         Text(
-                            text = "Secondary Activity",
+                            text = "Secondary Screen",
                             style = MaterialTheme.typography.headlineMedium
                         )
 

--- a/examples/demo/app/src/main/res/values/strings.xml
+++ b/examples/demo/app/src/main/res/values/strings.xml
@@ -105,9 +105,9 @@
     <!-- Send In-App Message -->
     <string name="send_in_app_message">Send In-App Message</string>
 
-    <!-- Next Activity -->
-    <string name="next_activity">NEXT ACTIVITY</string>
-    <string name="secondary_activity">Secondary Activity</string>
+    <!-- Next Screen -->
+    <string name="next_activity">NEXT SCREEN</string>
+    <string name="secondary_activity">Secondary Screen</string>
 
     <!-- Dialog -->
     <string name="external_user_id">External User Id</string>

--- a/examples/demo/build.gradle.kts
+++ b/examples/demo/build.gradle.kts
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    val kotlinVersion by extra("2.2.0")
+    val kotlinVersion by extra("1.9.25")
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
# Description
## One Line Summary
Downgrade Kotlin from 2.2.0 to 1.9.25 to maximize compatibility with consuming projects (including wrapper SDKs on Kotlin 1.9.x).

## Details

### Motivation
The otel crash reporting PR (#2511) bumped Kotlin from 1.9.25 to 2.2.0. This forces all consumers of the SDK to use Kotlin 2.x, which is a messy change for wrapper SDKs (Flutter, React Native, Cordova, Capacitor, Unity, .NET) and any app still on Kotlin 1.9.x. Since no Kotlin 2.x language features are used in the SDK source code, downgrading to 1.9.25 restores the widest compatibility window — consumers on both 1.9.x and 2.x can use the SDK.

### Scope
- **SDK build files**: `kotlinVersion` reverted to `1.9.25` in `OneSignalSDK/build.gradle`
- **Otel module**: Added `-Xskip-metadata-version-check` compiler flag to handle transitive dependencies (okio via OkHttp via OpenTelemetry OTLP exporter) compiled with Kotlin 2.x metadata. This is a compile-time-only metadata check skip; binary compatibility is maintained.
- **Test fix**: `OtelIntegrationTest.kt` required an explicit `!!` non-null assertion that Kotlin 2.x's improved smart casts had made unnecessary.
- **Demo app**: Replaced the Kotlin 2.0+ `org.jetbrains.kotlin.plugin.compose` plugin with the pre-2.0 `composeOptions` approach using Compose compiler extension `1.5.15` (the version compatible with Kotlin 1.9.25). Also renamed user-facing "Activity" labels to "Screen".
- **No source code changes** in the SDK itself — only build config and one test fix.

# Testing
## Unit testing
- `assembleRelease` builds successfully (all modules including otel)
- `:OneSignal:otel:testReleaseUnitTest` passes
- `:OneSignal:core:testReleaseUnitTest` passes (2 pre-existing `SDKInitTests` failures unrelated to this change — also fail on `main`)

## Manual testing
Build verified locally via `./gradlew assembleRelease` — all 358 tasks succeeded.
<img width="1898" height="474" alt="Screenshot 2026-04-07 at 10 39 57 AM" src="https://github.com/user-attachments/assets/9587e12d-9610-480c-a4ac-da64f282cf59" />
<img width="907" height="638" alt="Screenshot 2026-04-07 at 10 38 16 AM" src="https://github.com/user-attachments/assets/06ed5ee2-2469-40e8-908d-58907440e65b" />

Check crash still logs:

# Affected code checklist
   - [ ] Notifications
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

Made with [Cursor](https://cursor.com)