### PR TITLE
fix(otel): broaden R8 dontwarn for Auto Value (SDK-4207)

### DIFF
--- a/OneSignalSDK/onesignal/otel/consumer-rules.pro
+++ b/OneSignalSDK/onesignal/otel/consumer-rules.pro
@@ -2,7 +2,6 @@
 # Suppress R8 missing-class errors when apps don't include jackson-core.
 -dontwarn com.fasterxml.jackson.core.**
 
-# OTel / disk buffering reference Google Auto Value types that are not on the app classpath.
--dontwarn com.google.auto.value.AutoValue
--dontwarn com.google.auto.value.AutoValue$Builder
--dontwarn com.google.auto.value.AutoValue$CopyAnnotations
+# OTel (e.g. sdk-logs AutoValue-generated types) references Google Auto Value annotations that are
+# not on the app classpath. Wildcard covers inner types and extensions (e.g. Memoized).
+-dontwarn com.google.auto.value.**

--- a/examples/demo/app/proguard-rules.pro
+++ b/examples/demo/app/proguard-rules.pro
@@ -20,5 +20,6 @@
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
 
-# Optional Jackson / Auto Value suppressions for OneSignal OTel are shipped in
-# com.onesignal:otel consumer-rules.pro; the minified demo relies on those (see SDK-4207 / #2596).
+# No app-level -dontwarn for OneSignal OTel here: when com.onesignal:core pulls in com.onesignal:otel
+# (implementation dependency), AGP merges otel's consumer-rules.pro for R8 (SDK-4207 / #2596).
+# Older SDK lines without otel never put those optional classes on the classpath, so duplicates are unnecessary.

--- a/examples/demo/app/proguard-rules.pro
+++ b/examples/demo/app/proguard-rules.pro
@@ -20,9 +20,5 @@
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
 
-# Demo-only: optional transitive classes pulled in via OneSignal OTel / R8 (GMS + Huawei minified builds).
--dontwarn com.fasterxml.jackson.core.JsonFactory
--dontwarn com.fasterxml.jackson.core.JsonGenerator
--dontwarn com.google.auto.value.AutoValue
--dontwarn com.google.auto.value.AutoValue$Builder
--dontwarn com.google.auto.value.AutoValue$CopyAnnotations
+# Optional Jackson / Auto Value suppressions for OneSignal OTel are shipped in
+# com.onesignal:otel consumer-rules.pro; the minified demo relies on those (see SDK-4207 / #2596).


### PR DESCRIPTION
## Summary
Addresses R8 release failures where `opentelemetry-sdk-logs` references Google Auto Value annotation types that are not on the app classpath ([SDK-4207](https://linear.app/onesignal/issue/SDK-4207), [GitHub #2596](https://github.com/OneSignal/OneSignal-Android-SDK/issues/2596)).

## Changes
- **`OneSignalSDK/onesignal/otel/consumer-rules.pro`:** Replace three specific `-dontwarn` lines with `-dontwarn com.google.auto.value.**` so inner types and extensions (e.g. `Memoized`) are covered without follow-up tickets.
- **`examples/demo/app/proguard-rules.pro`:** Remove duplicate suppressions so minified demo builds exercise the library `consumer-rules.pro` (via `OneSignalSDK/settings.gradle` dependency substitution).

## Verification
- `./gradlew :app:minifyGmsReleaseWithR8 :app:minifyHuaweiReleaseWithR8` from `OneSignalSDK/` (PASS).

Made with [Cursor](https://cursor.com)