### PR TITLE
Add AGENTS.md for Cursor Cloud development environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Project overview
+This is the **OneSignal Android SDK** — a multi-module Gradle project (Kotlin/Java) that provides push notifications, in-app messaging, SMS, and email integration for Android apps. There are no backend services or databases; this is a pure client-side library tested entirely via JVM unit tests (Robolectric).
+
+### Prerequisites
+- **JDK 17+** (JDK 21 works fine; Gradle 8.10.2 requires JDK 17+)
+- **Android SDK** with platform 34 and build-tools installed
+- Environment variables: `JAVA_HOME`, `ANDROID_HOME`/`ANDROID_SDK_ROOT`, and `$ANDROID_HOME/cmdline-tools/latest/bin` on `PATH`
+
+### Key paths
+- SDK modules: `OneSignalSDK/onesignal/{core,notifications,in-app-messages,location,otel,testhelpers}/`
+- Demo app: `examples/demo/app/`
+- Gradle wrapper: `OneSignalSDK/gradlew` (run all commands from `OneSignalSDK/`)
+
+### Build, lint, and test commands
+All commands run from `OneSignalSDK/`:
+- **Build all modules + demo app:** `./gradlew assembleRelease`
+- **Build demo app debug (GMS):** `./gradlew :app:assembleGmsDebug`
+- **Lint (formatting):** `./gradlew spotlessCheck`
+- **Lint (static analysis):** `./gradlew detekt`
+- **Unit tests:** `./gradlew testDebugUnitTest`
+- **Apply formatting fixes:** `./gradlew spotlessApply`
+
+### Gotchas
+- The `settings.gradle` includes the demo app as `:app` and performs dependency substitution so local SDK source is used. The `SDK_VERSION` property must be set (it is in `gradle.properties`).
+- First Gradle run auto-downloads additional build-tools (e.g., build-tools 35) and Android SDK components as needed.
+- There are a small number of **pre-existing test failures** (4 out of ~982) in `SDKInitTests` and `RecoverFromDroppedLoginBugTests` on `main`. These are not environment issues.
+- Tests use Robolectric and run on the JVM — no emulator or physical device is needed.
+- The `--no-daemon` flag is recommended for CI-like runs; for interactive development `--daemon` (the default) is faster.
+- Detekt reports some pre-existing findings (warnings), but the task succeeds (does not fail the build).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Description
## One Line Summary
Adds `AGENTS.md` with Cursor Cloud-specific development environment instructions for the OneSignal Android SDK.

## Details

### Motivation
Enables Cursor Cloud agents to quickly set up and work with this Android SDK codebase by documenting prerequisites, key commands, and gotchas discovered during environment setup.

### Scope
Only adds a new `AGENTS.md` file. No existing code is modified.

## Testing
### Environment validation performed:
- **Build:** `./gradlew assembleRelease` — all 358 tasks successful (SDK modules + demo app)
- **Debug build:** `./gradlew :app:assembleGmsDebug` — APK produced at `app-gms-debug.apk` (19.5 MB)
- **Lint (formatting):** `./gradlew spotlessCheck` — passed (61 tasks)
- **Lint (static analysis):** `./gradlew detekt` — passed with pre-existing warnings
- **Unit tests:** `./gradlew testDebugUnitTest` — 982 tests run, 978 passed, 4 pre-existing failures

Build log evidence:
[gradle_build.log](https://cursor.com/agents/bc-fb9d1577-1123-475e-be39-42cf0d894b08/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgradle_build.log)
[gradle_test.log](https://cursor.com/agents/bc-fb9d1577-1123-475e-be39-42cf0d894b08/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgradle_test.log)

# Checklist
## Overview
- [x] I have filled out all **REQUIRED** sections above
- [x] PR does one thing — adds development environment documentation
- [x] No Public API changes

## Testing
- [x] All automated tests pass (4 pre-existing failures unrelated to this change)
- [x] Verified build, lint, and test commands work correctly

## Final pass
- [x] Code is as readable as possible
- [x] I have reviewed this PR myself

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fb9d1577-1123-475e-be39-42cf0d894b08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fb9d1577-1123-475e-be39-42cf0d894b08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

