### PR TITLE
feat: hash PII (email/SMS) in SharedPreferences at rest

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/PIIHasher.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/PIIHasher.kt
@@ -1,0 +1,23 @@
+package com.onesignal.common
+
+import java.security.MessageDigest
+
+/**
+ * Deterministic SHA-256 hashing for PII fields (email, phone number) so that
+ * sensitive data stored in SharedPreferences is not readable in plain text on
+ * rooted devices or via ADB backup.
+ *
+ * The hash is hex-encoded and always 64 characters long.
+ */
+object PIIHasher {
+    private const val SHA256_HEX_LENGTH = 64
+    private val SHA256_HEX_REGEX = Regex("^[a-f0-9]{$SHA256_HEX_LENGTH}$")
+
+    fun hash(value: String): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        val bytes = digest.digest(value.toByteArray(Charsets.UTF_8))
+        return bytes.joinToString("") { "%02x".format(it) }
+    }
+
+    fun isHashed(value: String): Boolean = SHA256_HEX_REGEX.matches(value)
+}

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/PIIHasher.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/PIIHasher.kt
@@ -13,11 +13,13 @@ object PIIHasher {
     private const val SHA256_HEX_LENGTH = 64
     private val SHA256_HEX_REGEX = Regex("^[a-f0-9]{$SHA256_HEX_LENGTH}$")
 
+    /** Returns the lowercase hex-encoded SHA-256 hash of [value]. */
     fun hash(value: String): String {
         val digest = MessageDigest.getInstance("SHA-256")
         val bytes = digest.digest(value.toByteArray(Charsets.UTF_8))
         return bytes.joinToString("") { "%02x".format(it) }
     }
 
+    /** Returns `true` if [value] looks like a 64-char lowercase hex SHA-256 digest. */
     fun isHashed(value: String): Boolean = SHA256_HEX_REGEX.matches(value)
 }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/modeling/ModelStore.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/modeling/ModelStore.kt
@@ -7,6 +7,7 @@ import com.onesignal.core.internal.preferences.PreferenceOneSignalKeys
 import com.onesignal.core.internal.preferences.PreferenceStores
 import com.onesignal.debug.internal.logging.Logging
 import org.json.JSONArray
+import org.json.JSONObject
 
 /**
  * The abstract implementation of a model store.  Implements all but the [create] method,
@@ -212,12 +213,21 @@ abstract class ModelStore<TModel>(
         val jsonArray = JSONArray()
         synchronized(models) {
             for (model in models) {
-                jsonArray.put(model.toJSON())
+                jsonArray.put(transformJsonForPersistence(model, model.toJSON()))
             }
         }
 
         _prefs.saveString(PreferenceStores.ONESIGNAL, PreferenceOneSignalKeys.MODEL_STORE_PREFIX + name, jsonArray.toString())
     }
+
+    /**
+     * Hook for subclasses to transform a model's JSON representation before it is
+     * written to SharedPreferences. The default implementation returns the JSON unchanged.
+     */
+    protected open fun transformJsonForPersistence(
+        model: TModel,
+        json: JSONObject,
+    ): JSONObject = json
 
     override fun subscribe(handler: IModelStoreChangeHandler<TModel>) = changeSubscription.subscribe(handler)
 

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/EmailSubscription.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/EmailSubscription.kt
@@ -1,5 +1,6 @@
 package com.onesignal.user.internal
 
+import com.onesignal.common.PIIHasher
 import com.onesignal.user.internal.subscriptions.SubscriptionModel
 import com.onesignal.user.subscriptions.IEmailSubscription
 
@@ -7,5 +8,8 @@ internal class EmailSubscription(
     model: SubscriptionModel,
 ) : Subscription(model), IEmailSubscription {
     override val email: String
-        get() = model.address
+        get() {
+            val address = model.address
+            return if (PIIHasher.isHashed(address)) "" else address
+        }
 }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/SmsSubscription.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/SmsSubscription.kt
@@ -1,5 +1,6 @@
 package com.onesignal.user.internal
 
+import com.onesignal.common.PIIHasher
 import com.onesignal.user.internal.subscriptions.SubscriptionModel
 import com.onesignal.user.subscriptions.ISmsSubscription
 
@@ -7,5 +8,8 @@ internal class SmsSubscription(
     model: SubscriptionModel,
 ) : Subscription(model), ISmsSubscription {
     override val number: String
-        get() = model.address
+        get() {
+            val address = model.address
+            return if (PIIHasher.isHashed(address)) "" else address
+        }
 }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/subscriptions/SubscriptionList.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/subscriptions/SubscriptionList.kt
@@ -1,5 +1,7 @@
 package com.onesignal.user.internal.subscriptions
 
+import com.onesignal.common.PIIHasher
+import com.onesignal.user.internal.Subscription
 import com.onesignal.user.subscriptions.IEmailSubscription
 import com.onesignal.user.subscriptions.IPushSubscription
 import com.onesignal.user.subscriptions.ISmsSubscription
@@ -30,15 +32,27 @@ class SubscriptionList(val collection: List<ISubscription>, private val _fallbac
 
     /**
      * Retrieve the Email subscription with the matching email, if there is one.
+     * Compares against the underlying model address (raw or hashed) so lookups
+     * work both before and after server hydration.
      */
     fun getByEmail(email: String): IEmailSubscription? {
-        return emails.firstOrNull { it.email == email }
+        val hashed = PIIHasher.hash(email)
+        return emails.firstOrNull {
+            val address = (it as Subscription).model.address
+            address == email || address == hashed
+        }
     }
 
     /**
      * Retrieve the SMS subscription with the matching SMS number, if there is one.
+     * Compares against the underlying model address (raw or hashed) so lookups
+     * work both before and after server hydration.
      */
     fun getBySMS(sms: String): ISmsSubscription? {
-        return smss.firstOrNull { it.number == sms }
+        val hashed = PIIHasher.hash(sms)
+        return smss.firstOrNull {
+            val address = (it as Subscription).model.address
+            address == sms || address == hashed
+        }
     }
 }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/subscriptions/SubscriptionModelStore.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/subscriptions/SubscriptionModelStore.kt
@@ -1,8 +1,10 @@
 package com.onesignal.user.internal.subscriptions
 
+import com.onesignal.common.PIIHasher
 import com.onesignal.common.modeling.ModelChangeTags
 import com.onesignal.common.modeling.SimpleModelStore
 import com.onesignal.core.internal.preferences.IPreferencesService
+import org.json.JSONObject
 
 open class SubscriptionModelStore(prefs: IPreferencesService) : SimpleModelStore<SubscriptionModel>({
     SubscriptionModel()
@@ -31,5 +33,18 @@ open class SubscriptionModelStore(prefs: IPreferencesService) : SimpleModelStore
             }
             super.replaceAll(models, tag)
         }
+    }
+
+    override fun transformJsonForPersistence(
+        model: SubscriptionModel,
+        json: JSONObject,
+    ): JSONObject {
+        if (model.type == SubscriptionType.PUSH) return json
+
+        val address = json.optString("address", "")
+        if (address.isNotEmpty() && !PIIHasher.isHashed(address)) {
+            json.put("address", PIIHasher.hash(address))
+        }
+        return json
     }
 }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/subscriptions/SubscriptionModelStore.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/subscriptions/SubscriptionModelStore.kt
@@ -39,7 +39,8 @@ open class SubscriptionModelStore(prefs: IPreferencesService) : SimpleModelStore
         model: SubscriptionModel,
         json: JSONObject,
     ): JSONObject {
-        if (model.type == SubscriptionType.PUSH) return json
+        val type = json.optString("type", "")
+        if (type.isEmpty() || type == SubscriptionType.PUSH.toString()) return json
 
         val address = json.optString("address", "")
         if (address.isNotEmpty() && !PIIHasher.isHashed(address)) {

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/subscriptions/impl/SubscriptionManager.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/subscriptions/impl/SubscriptionManager.kt
@@ -5,6 +5,7 @@ import com.onesignal.common.AndroidUtils
 import com.onesignal.common.DeviceUtils
 import com.onesignal.common.IDManager
 import com.onesignal.common.OneSignalUtils
+import com.onesignal.common.PIIHasher
 import com.onesignal.common.events.EventProducer
 import com.onesignal.common.modeling.IModelStoreChangeHandler
 import com.onesignal.common.modeling.ModelChangedArgs
@@ -93,7 +94,11 @@ internal class SubscriptionManager(
     }
 
     override fun removeEmailSubscription(email: String) {
-        val subscriptionToRem = subscriptions.emails.firstOrNull { it is EmailSubscription && it.email == email }
+        val hashedEmail = PIIHasher.hash(email)
+        val subscriptionToRem =
+            subscriptions.emails.firstOrNull {
+                it is EmailSubscription && (it.model.address == email || it.model.address == hashedEmail)
+            }
 
         if (subscriptionToRem != null) {
             removeSubscriptionFromModels(subscriptionToRem)
@@ -101,7 +106,11 @@ internal class SubscriptionManager(
     }
 
     override fun removeSmsSubscription(sms: String) {
-        val subscriptionToRem = subscriptions.smss.firstOrNull { it is SmsSubscription && it.number == sms }
+        val hashedSms = PIIHasher.hash(sms)
+        val subscriptionToRem =
+            subscriptions.smss.firstOrNull {
+                it is SmsSubscription && (it.model.address == sms || it.model.address == hashedSms)
+            }
 
         if (subscriptionToRem != null) {
             removeSubscriptionFromModels(subscriptionToRem)
@@ -113,7 +122,7 @@ internal class SubscriptionManager(
         address: String,
         status: SubscriptionStatus? = null,
     ) {
-        Logging.log(LogLevel.DEBUG, "SubscriptionManager.addSubscription(type: $type, address: $address)")
+        Logging.log(LogLevel.DEBUG, "SubscriptionManager.addSubscription(type: $type, address: ${PIIHasher.hash(address)})")
 
         val subscriptionModel = SubscriptionModel()
         subscriptionModel.id = IDManager.createLocalId()

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/subscriptions/impl/SubscriptionManager.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/subscriptions/impl/SubscriptionManager.kt
@@ -122,7 +122,8 @@ internal class SubscriptionManager(
         address: String,
         status: SubscriptionStatus? = null,
     ) {
-        Logging.log(LogLevel.DEBUG, "SubscriptionManager.addSubscription(type: $type, address: ${PIIHasher.hash(address)})")
+        val logAddress = if (type != SubscriptionType.PUSH) PIIHasher.hash(address) else address
+        Logging.log(LogLevel.DEBUG, "SubscriptionManager.addSubscription(type: $type, address: $logAddress)")
 
         val subscriptionModel = SubscriptionModel()
         subscriptionModel.id = IDManager.createLocalId()

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/common/PIIHasherTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/common/PIIHasherTests.kt
@@ -1,0 +1,60 @@
+package com.onesignal.common
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldHaveLength
+import io.kotest.matchers.string.shouldMatch
+
+class PIIHasherTests : FunSpec({
+
+    test("hash produces 64-char lowercase hex string") {
+        val result = PIIHasher.hash("test@example.com")
+        result shouldHaveLength 64
+        result shouldMatch Regex("^[a-f0-9]{64}$")
+    }
+
+    test("hash is deterministic") {
+        PIIHasher.hash("test@example.com") shouldBe PIIHasher.hash("test@example.com")
+    }
+
+    test("hash produces different output for different input") {
+        val hash1 = PIIHasher.hash("user1@example.com")
+        val hash2 = PIIHasher.hash("user2@example.com")
+        (hash1 != hash2) shouldBe true
+    }
+
+    test("hash matches known SHA-256 digest") {
+        // SHA-256 of "hello" is well-known
+        PIIHasher.hash("hello") shouldBe "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+    }
+
+    test("isHashed returns true for valid 64-char hex string") {
+        val hashed = PIIHasher.hash("test@example.com")
+        PIIHasher.isHashed(hashed) shouldBe true
+    }
+
+    test("isHashed returns false for plain email") {
+        PIIHasher.isHashed("test@example.com") shouldBe false
+    }
+
+    test("isHashed returns false for phone number") {
+        PIIHasher.isHashed("+15558675309") shouldBe false
+    }
+
+    test("isHashed returns false for empty string") {
+        PIIHasher.isHashed("") shouldBe false
+    }
+
+    test("isHashed returns false for uppercase hex") {
+        val upper = PIIHasher.hash("test").uppercase()
+        PIIHasher.isHashed(upper) shouldBe false
+    }
+
+    test("isHashed returns false for 63-char hex string") {
+        PIIHasher.isHashed("a".repeat(63)) shouldBe false
+    }
+
+    test("isHashed returns false for 65-char hex string") {
+        PIIHasher.isHashed("a".repeat(65)) shouldBe false
+    }
+})

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/subscriptions/SubscriptionManagerTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/subscriptions/SubscriptionManagerTests.kt
@@ -1,6 +1,7 @@
 package com.onesignal.user.internal.subscriptions
 
 import com.onesignal.common.IDManager.LOCAL_PREFIX
+import com.onesignal.common.PIIHasher
 import com.onesignal.common.modeling.ModelChangeTags
 import com.onesignal.common.modeling.ModelChangedArgs
 import com.onesignal.core.internal.application.IApplicationService
@@ -415,5 +416,205 @@ class SubscriptionManagerTests : FunSpec({
                 },
             )
         }
+    }
+
+    test("remove email subscription matches hashed address (pre-hydration)") {
+        // Given
+        val mockSubscriptionModelStore = mockk<SubscriptionModelStore>()
+        val mockApplicationService = mockk<IApplicationService>()
+        val mockSessionService = mockk<ISessionService>(relaxed = true)
+
+        val emailSubscription = SubscriptionModel()
+        emailSubscription.id = "subscription1"
+        emailSubscription.type = SubscriptionType.EMAIL
+        emailSubscription.status = SubscriptionStatus.SUBSCRIBED
+        emailSubscription.optedIn = true
+        emailSubscription.address = PIIHasher.hash("name@company.com")
+
+        val listOfSubscriptions = listOf(emailSubscription)
+
+        every { mockSubscriptionModelStore.subscribe(any()) } just runs
+        every { mockSubscriptionModelStore.add(any()) } just runs
+        every { mockSubscriptionModelStore.list() } returns listOfSubscriptions
+        every { mockSubscriptionModelStore.remove("subscription1") } just runs
+
+        val subscriptionManager = SubscriptionManager(mockApplicationService, mockSessionService, mockSubscriptionModelStore)
+
+        // When — raw email is passed but model has hashed address
+        subscriptionManager.removeEmailSubscription("name@company.com")
+
+        // Then
+        verify(exactly = 1) { mockSubscriptionModelStore.remove("subscription1") }
+    }
+
+    test("remove sms subscription matches hashed address (pre-hydration)") {
+        // Given
+        val mockSubscriptionModelStore = mockk<SubscriptionModelStore>()
+        val mockApplicationService = mockk<IApplicationService>()
+        val mockSessionService = mockk<ISessionService>(relaxed = true)
+
+        val smsSubscription = SubscriptionModel()
+        smsSubscription.id = "subscription1"
+        smsSubscription.type = SubscriptionType.SMS
+        smsSubscription.status = SubscriptionStatus.SUBSCRIBED
+        smsSubscription.optedIn = true
+        smsSubscription.address = PIIHasher.hash("+18458675309")
+
+        val listOfSubscriptions = listOf(smsSubscription)
+
+        every { mockSubscriptionModelStore.subscribe(any()) } just runs
+        every { mockSubscriptionModelStore.add(any()) } just runs
+        every { mockSubscriptionModelStore.list() } returns listOfSubscriptions
+        every { mockSubscriptionModelStore.remove("subscription1") } just runs
+
+        val subscriptionManager = SubscriptionManager(mockApplicationService, mockSessionService, mockSubscriptionModelStore)
+
+        // When — raw phone is passed but model has hashed address
+        subscriptionManager.removeSmsSubscription("+18458675309")
+
+        // Then
+        verify(exactly = 1) { mockSubscriptionModelStore.remove("subscription1") }
+    }
+
+    test("email getter returns empty string when address is hashed") {
+        // Given
+        val emailSubscription = SubscriptionModel()
+        emailSubscription.id = "subscription1"
+        emailSubscription.type = SubscriptionType.EMAIL
+        emailSubscription.address = PIIHasher.hash("user@example.com")
+
+        val mockSubscriptionModelStore = mockk<SubscriptionModelStore>()
+        val mockApplicationService = mockk<IApplicationService>()
+        val mockSessionService = mockk<ISessionService>(relaxed = true)
+
+        every { mockSubscriptionModelStore.subscribe(any()) } just runs
+        every { mockSubscriptionModelStore.list() } returns listOf(emailSubscription)
+
+        val subscriptionManager = SubscriptionManager(mockApplicationService, mockSessionService, mockSubscriptionModelStore)
+
+        // When
+        val subscriptions = subscriptionManager.subscriptions
+
+        // Then — public getter returns "" for hashed address
+        subscriptions.emails.count() shouldBe 1
+        subscriptions.emails[0].email shouldBe ""
+    }
+
+    test("email getter returns raw value when address is not hashed") {
+        // Given
+        val emailSubscription = SubscriptionModel()
+        emailSubscription.id = "subscription1"
+        emailSubscription.type = SubscriptionType.EMAIL
+        emailSubscription.address = "user@example.com"
+
+        val mockSubscriptionModelStore = mockk<SubscriptionModelStore>()
+        val mockApplicationService = mockk<IApplicationService>()
+        val mockSessionService = mockk<ISessionService>(relaxed = true)
+
+        every { mockSubscriptionModelStore.subscribe(any()) } just runs
+        every { mockSubscriptionModelStore.list() } returns listOf(emailSubscription)
+
+        val subscriptionManager = SubscriptionManager(mockApplicationService, mockSessionService, mockSubscriptionModelStore)
+
+        // When
+        val subscriptions = subscriptionManager.subscriptions
+
+        // Then
+        subscriptions.emails[0].email shouldBe "user@example.com"
+    }
+
+    test("sms getter returns empty string when address is hashed") {
+        // Given
+        val smsSubscription = SubscriptionModel()
+        smsSubscription.id = "subscription1"
+        smsSubscription.type = SubscriptionType.SMS
+        smsSubscription.address = PIIHasher.hash("+15558675309")
+
+        val mockSubscriptionModelStore = mockk<SubscriptionModelStore>()
+        val mockApplicationService = mockk<IApplicationService>()
+        val mockSessionService = mockk<ISessionService>(relaxed = true)
+
+        every { mockSubscriptionModelStore.subscribe(any()) } just runs
+        every { mockSubscriptionModelStore.list() } returns listOf(smsSubscription)
+
+        val subscriptionManager = SubscriptionManager(mockApplicationService, mockSessionService, mockSubscriptionModelStore)
+
+        // When
+        val subscriptions = subscriptionManager.subscriptions
+
+        // Then — public getter returns "" for hashed address
+        subscriptions.smss.count() shouldBe 1
+        subscriptions.smss[0].number shouldBe ""
+    }
+
+    test("sms getter returns raw value when address is not hashed") {
+        // Given
+        val smsSubscription = SubscriptionModel()
+        smsSubscription.id = "subscription1"
+        smsSubscription.type = SubscriptionType.SMS
+        smsSubscription.address = "+15558675309"
+
+        val mockSubscriptionModelStore = mockk<SubscriptionModelStore>()
+        val mockApplicationService = mockk<IApplicationService>()
+        val mockSessionService = mockk<ISessionService>(relaxed = true)
+
+        every { mockSubscriptionModelStore.subscribe(any()) } just runs
+        every { mockSubscriptionModelStore.list() } returns listOf(smsSubscription)
+
+        val subscriptionManager = SubscriptionManager(mockApplicationService, mockSessionService, mockSubscriptionModelStore)
+
+        // When
+        val subscriptions = subscriptionManager.subscriptions
+
+        // Then
+        subscriptions.smss[0].number shouldBe "+15558675309"
+    }
+
+    test("getByEmail finds subscription with hashed address") {
+        // Given
+        val emailSubscription = SubscriptionModel()
+        emailSubscription.id = "subscription1"
+        emailSubscription.type = SubscriptionType.EMAIL
+        emailSubscription.address = PIIHasher.hash("user@example.com")
+
+        val mockSubscriptionModelStore = mockk<SubscriptionModelStore>()
+        val mockApplicationService = mockk<IApplicationService>()
+        val mockSessionService = mockk<ISessionService>(relaxed = true)
+
+        every { mockSubscriptionModelStore.subscribe(any()) } just runs
+        every { mockSubscriptionModelStore.list() } returns listOf(emailSubscription)
+
+        val subscriptionManager = SubscriptionManager(mockApplicationService, mockSessionService, mockSubscriptionModelStore)
+
+        // When
+        val result = subscriptionManager.subscriptions.getByEmail("user@example.com")
+
+        // Then
+        result shouldNotBe null
+        result!!.id shouldBe "subscription1"
+    }
+
+    test("getBySMS finds subscription with hashed address") {
+        // Given
+        val smsSubscription = SubscriptionModel()
+        smsSubscription.id = "subscription1"
+        smsSubscription.type = SubscriptionType.SMS
+        smsSubscription.address = PIIHasher.hash("+15558675309")
+
+        val mockSubscriptionModelStore = mockk<SubscriptionModelStore>()
+        val mockApplicationService = mockk<IApplicationService>()
+        val mockSessionService = mockk<ISessionService>(relaxed = true)
+
+        every { mockSubscriptionModelStore.subscribe(any()) } just runs
+        every { mockSubscriptionModelStore.list() } returns listOf(smsSubscription)
+
+        val subscriptionManager = SubscriptionManager(mockApplicationService, mockSessionService, mockSubscriptionModelStore)
+
+        // When
+        val result = subscriptionManager.subscriptions.getBySMS("+15558675309")
+
+        // Then
+        result shouldNotBe null
+        result!!.id shouldBe "subscription1"
     }
 })

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/subscriptions/SubscriptionModelStoreTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/subscriptions/SubscriptionModelStoreTests.kt
@@ -1,0 +1,124 @@
+package com.onesignal.user.internal.subscriptions
+
+import com.onesignal.common.PIIHasher
+import com.onesignal.core.internal.preferences.IPreferencesService
+import com.onesignal.core.internal.preferences.PreferenceOneSignalKeys
+import com.onesignal.core.internal.preferences.PreferenceStores
+import com.onesignal.mocks.MockPreferencesService
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldMatch
+import org.json.JSONArray
+
+class SubscriptionModelStoreTests : FunSpec({
+
+    fun getPersistedJson(prefs: IPreferencesService): JSONArray {
+        val raw = prefs.getString(
+            PreferenceStores.ONESIGNAL,
+            PreferenceOneSignalKeys.MODEL_STORE_PREFIX + "subscriptions",
+            null,
+        )
+        return JSONArray(raw!!)
+    }
+
+    test("persist hashes email address in SharedPreferences") {
+        val prefs = MockPreferencesService()
+        val store = SubscriptionModelStore(prefs)
+
+        val model = SubscriptionModel()
+        model.id = "email1"
+        model.type = SubscriptionType.EMAIL
+        model.address = "user@example.com"
+        store.add(model)
+
+        val json = getPersistedJson(prefs)
+        val persisted = json.getJSONObject(0)
+        persisted.getString("address") shouldBe PIIHasher.hash("user@example.com")
+    }
+
+    test("persist hashes SMS address in SharedPreferences") {
+        val prefs = MockPreferencesService()
+        val store = SubscriptionModelStore(prefs)
+
+        val model = SubscriptionModel()
+        model.id = "sms1"
+        model.type = SubscriptionType.SMS
+        model.address = "+15558675309"
+        store.add(model)
+
+        val json = getPersistedJson(prefs)
+        val persisted = json.getJSONObject(0)
+        persisted.getString("address") shouldBe PIIHasher.hash("+15558675309")
+    }
+
+    test("persist does not hash push token in SharedPreferences") {
+        val prefs = MockPreferencesService()
+        val store = SubscriptionModelStore(prefs)
+
+        val pushToken = "dz1A0qydQGCYM9dDgo6rB_:APA91bEqFakeToken"
+        val model = SubscriptionModel()
+        model.id = "push1"
+        model.type = SubscriptionType.PUSH
+        model.address = pushToken
+        store.add(model)
+
+        val json = getPersistedJson(prefs)
+        val persisted = json.getJSONObject(0)
+        persisted.getString("address") shouldBe pushToken
+    }
+
+    test("persist does not double-hash already-hashed email") {
+        val prefs = MockPreferencesService()
+        val store = SubscriptionModelStore(prefs)
+
+        val alreadyHashed = PIIHasher.hash("user@example.com")
+        val model = SubscriptionModel()
+        model.id = "email1"
+        model.type = SubscriptionType.EMAIL
+        model.address = alreadyHashed
+        store.add(model)
+
+        val json = getPersistedJson(prefs)
+        val persisted = json.getJSONObject(0)
+        persisted.getString("address") shouldBe alreadyHashed
+    }
+
+    test("persist keeps in-memory model address as raw value") {
+        val prefs = MockPreferencesService()
+        val store = SubscriptionModelStore(prefs)
+
+        val model = SubscriptionModel()
+        model.id = "email1"
+        model.type = SubscriptionType.EMAIL
+        model.address = "user@example.com"
+        store.add(model)
+
+        model.address shouldBe "user@example.com"
+    }
+
+    test("persist hashes email but not push when both are present") {
+        val prefs = MockPreferencesService()
+        val store = SubscriptionModelStore(prefs)
+
+        val pushModel = SubscriptionModel()
+        pushModel.id = "push1"
+        pushModel.type = SubscriptionType.PUSH
+        pushModel.address = "fcm-token-abc123"
+        store.add(pushModel)
+
+        val emailModel = SubscriptionModel()
+        emailModel.id = "email1"
+        emailModel.type = SubscriptionType.EMAIL
+        emailModel.address = "user@example.com"
+        store.add(emailModel)
+
+        val json = getPersistedJson(prefs)
+        val models = (0 until json.length()).map { json.getJSONObject(it) }
+        val pushJson = models.first { it.getString("type") == SubscriptionType.PUSH.toString() }
+        val emailJson = models.first { it.getString("type") == SubscriptionType.EMAIL.toString() }
+
+        pushJson.getString("address") shouldBe "fcm-token-abc123"
+        emailJson.getString("address") shouldBe PIIHasher.hash("user@example.com")
+        emailJson.getString("address") shouldMatch Regex("^[a-f0-9]{64}$")
+    }
+})


### PR DESCRIPTION
# Description
## One Line Summary
Hash email and SMS subscription addresses (SHA-256) before writing to SharedPreferences so PII is not stored in plain text on device.

## Details

### Motivation
Email addresses and phone numbers are stored in plain text in `OneSignal.xml` under the `MODEL_STORE_subscriptions` key. On rooted devices or via ADB backup, this PII is directly readable. This PR hashes those values at the serialization boundary so the on-disk representation is opaque.

### Scope
- **Email and SMS subscription addresses only.** Push tokens are not hashed — they are not PII and are required for push delivery.
- **On-disk only.** The in-memory `SubscriptionModel.address` always holds the raw value at runtime (after server hydration). Network requests continue to send the real email/phone to the backend API.
- **No public API changes.** The `IEmailSubscription.email` and `ISmsSubscription.number` getters return the raw value post-hydration, or an empty string during the brief cold-start window before `RefreshUserOperationExecutor` restores the real value.

### How it works

1. **`PIIHasher`** — new utility: deterministic SHA-256 hashing and `isHashed()` detection (64-char lowercase hex).
2. **`ModelStore.transformJsonForPersistence()`** — new protected hook called during `persist()`. Default is identity; subclasses can override to transform JSON before it hits SharedPreferences.
3. **`SubscriptionModelStore`** — overrides the hook to hash the `address` field for EMAIL and SMS subscriptions. Skips PUSH. Skips already-hashed values (idempotency guard against double-hashing on restart).
4. **Hash-aware removal/lookup** — `SubscriptionManager.removeEmailSubscription()`, `removeSmsSubscription()`, `SubscriptionList.getByEmail()`, and `getBySMS()` now compare the raw input against both the raw and hashed `model.address`, so lookups work whether the model is pre- or post-hydration.
5. **Log redaction** — `SubscriptionManager.addSubscriptionToModels()` debug log now prints the hash instead of the raw address.
6. Public getter safety — EmailSubscription.email and SmsSubscription.number return "" if the underlying address is detected as a hash (cold-start to hydration window).

### Trade-off
Between cold start and server hydration (~0.5–1s), `model.address` contains a hash loaded from SharedPreferences. During this window, public getters return an empty string. Once `RefreshUserOperationExecutor` hydrates the model from the server response, the real value is restored and persisted as a new hash.

Note: The `IEmailSubscription.email` and `ISmsSubscription.number` getters exist but are not reachable through the current public API (`IUserManager` does not expose email/SMS subscription collections). If a future API exposes them, they will return an empty string during the brief cold-start to hydration window.

# Testing
## Unit testing
All 560 existing unit tests pass. The `ModelingTests` deadlock test exercised the new `transformJsonForPersistence` path — an initial NPE (accessing `model.type` on an uninitialized model) was caught and fixed by reading the type from the JSON object instead.

New tests were added for the following: 
- **PIIHasherTests**: hash output format, determinism, known digest,
  isHashed detection for valid/invalid inputs
- **SubscriptionModelStoreTests**: persist hashes email/SMS but not push,
  idempotent on already-hashed values, in-memory model stays raw
- **SubscriptionManagerTests**: hash-aware removal for email/SMS when
  model.address is hashed (pre-hydration), public getter returns
  empty string for hashed addresses, getByEmail/getBySMS find
  subscriptions with hashed addresses

## Manual testing
Tested on a Pixel emulator (API 35) with the OneSignal demo app:

1. **Fresh email/SMS add** — Added email and SMS via demo app. Dumped SharedPreferences → addresses are 64-char SHA-256 hashes. Push token is unchanged (not hashed).
2. **Network requests** — Verified via logcat that API requests to OneSignal backend contain the raw email/phone, not hashes.
3. **Post-hydration removal** — Removed email after hydration completed → subscription removed from SharedPreferences successfully.
4. **Pre-hydration removal** — Added `removeEmail()` call immediately after `initWithContext` (before `RefreshUserOperationExecutor` runs). The hash-aware comparison matched the raw input against the hashed stored value → subscription removed correctly.
5. **Upgrade migration (plain text → hashed)** — Installed `5.7-main` build, added email (stored as plain text). Installed feature branch build over the top (no uninstall). On first launch, the plain-text address was automatically hashed during the first persist cycle.
7. **Removal after migration** — `removeEmail()` with the raw email successfully removed the now-hashed subscription.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item