### PR TITLE
closed

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/impl/OperationRepo.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/impl/OperationRepo.kt
@@ -173,6 +173,19 @@ internal class OperationRepo(
                 return
             }
 
+            // Dedupe LoginUserOperation for the same user — prevents RecoverFromDroppedLoginBug
+            // and the real login() call from both enqueuing a login op during the timing window.
+            // Wake the waiter as if we succeeded, since the already-queued op will do the work
+            // and enqueueAndWait callers (e.g. loginSuspend) would otherwise hang forever.
+            val op = queueItem.operation
+            if (op is LoginUserOperation &&
+                queue.any { it.operation is LoginUserOperation && it.operation.onesignalId == op.onesignalId }
+            ) {
+                Logging.debug("OperationRepo: internalEnqueue - LoginUserOperation for onesignalId: ${op.onesignalId} already exists in the queue.")
+                queueItem.waiter?.wake(true)
+                return
+            }
+
             if (index != null) {
                 queue.add(index, queueItem)
             } else {


### PR DESCRIPTION
## One Line Summary
Dedupe LoginUserOperation at enqueue time to prevent duplicate login ops from crashing the executor.

## Details

### Motivation
After #2600, `OneSignal.login()` was split into `switchUser()` (synchronous) and `enqueueLogin()` (async via `suspendifyOnIO`). This introduced a window between the two steps where `RecoverFromDroppedLoginBug.start()` can fire and observe:
- `externalId` is set (login was just called)
- `onesignalId` is a local ID (user not yet created on backend)
- No `LoginUserOperation` in the queue yet (enqueue is still pending)

This matches the "dropped login bug" criteria, so it enqueues its own recovery `LoginUserOperation`. Shortly after, the real `enqueueLogin()` adds another one. When both ops land in the queue they get grouped (same `modifyComparisonKey`), and `LoginUserOperationExecutor.createUser()` throws "Unrecognized operation" on the second `LoginUserOperation` in the batch — dropping both ops and logging "Could not login user". Before #2600, `login()` enqueued synchronously so `RecoverFromDroppedLoginBug` would always see the op already queued and skip.

### Scope
- `OperationRepo.internalEnqueue()` — added a second dedupe check: if a `LoginUserOperation` for the same `onesignalId` is already queued, drop the incoming one.
- The dedupe path wakes the dropped op's waiter with `true` so `loginSuspend()` callers don't hang on `enqueueAndWait.waitForWake()` forever.
- Not IV/JWT-specific — this race affects any login flow.

# Testing
## Manual testing
- Fresh install with cached anonymous user: call `OneSignal.login()` right after `initWithContext` → user created on backend, no "Unrecognized operation" error in logs.
- Verified the executor no longer receives a grouped `[login-user, create-subscription, login-user]` batch.

# Affected code checklist
   - [x] REST API requests

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item