### PR TITLE
fix: login/logout race causes subsequent calls to target previous user

### DIFF
--- a/OneSignalSDK/detekt/detekt-baseline-core.xml
+++ b/OneSignalSDK/detekt/detekt-baseline-core.xml
@@ -179,6 +179,7 @@
     <ID>LongMethod:LoginUserOperationExecutor.kt$LoginUserOperationExecutor$private suspend fun createUser( createUserOperation: LoginUserOperation, operations: List&lt;Operation>, ): ExecutionResponse</ID>
     <ID>LongMethod:LoginUserOperationExecutor.kt$LoginUserOperationExecutor$private suspend fun loginUser( loginUserOp: LoginUserOperation, operations: List&lt;Operation>, ): ExecutionResponse</ID>
     <ID>LongMethod:OperationRepo.kt$OperationRepo$internal suspend fun executeOperations(ops: List&lt;OperationQueueItem>)</ID>
+    <ID>LongMethod:OperationRepo.kt$OperationRepo$private fun internalEnqueue( queueItem: OperationQueueItem, flush: Boolean, addToStore: Boolean, index: Int? = null, )</ID>
     <ID>LongMethod:OutcomeEventsController.kt$OutcomeEventsController$private suspend fun sendAndCreateOutcomeEvent( name: String, weight: Float, // Note: this is optional sessionTime: Long, influences: List&lt;Influence>, ): OutcomeEvent?</ID>
     <ID>LongMethod:OutcomeEventsController.kt$OutcomeEventsController$private suspend fun sendUniqueOutcomeEvent( name: String, sessionInfluences: List&lt;Influence>, ): OutcomeEvent?</ID>
     <ID>LongMethod:OutcomeEventsRepository.kt$OutcomeEventsRepository$override suspend fun getAllEventsToSend(): List&lt;OutcomeEventParams></ID>
@@ -609,6 +610,9 @@
     <ID>UnusedPrivateMember:OperationRepo.kt$OperationRepo$private val _time: ITime</ID>
     <ID>UseCheckOrError:OneSignalImp.kt$OneSignalImp$throw IllegalStateException("'initWithContext failed' before 'login'")</ID>
     <ID>UseCheckOrError:OneSignalImp.kt$OneSignalImp$throw IllegalStateException("'initWithContext failed' before 'logout'")</ID>
+    <ID>UseCheckOrError:OneSignalImp.kt$OneSignalImp$throw IllegalStateException("Must call 'initWithContext' before 'login'")</ID>
+    <ID>UseCheckOrError:OneSignalImp.kt$OneSignalImp$throw IllegalStateException("Must call 'initWithContext' before 'logout'")</ID>
+    <ID>UseCheckOrError:OneSignalImp.kt$OneSignalImp$throw IllegalStateException("Must call 'initWithContext' before use")</ID>
     <ID>UseCheckOrError:OneSignalImp.kt$OneSignalImp$throw initFailureException ?: IllegalStateException("Initialization failed. Cannot proceed.")</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/impl/OperationRepo.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/impl/OperationRepo.kt
@@ -333,9 +333,15 @@ internal class OperationRepo(
                     Logging.error("Operation execution failed with eventual retry, pausing the operation repo: $operations")
                     // keep the failed operation and pause the operation repo from executing
                     paused = true
-                    // add back all operations to the front of the queue to be re-executed.
+                    // Unblock any enqueueAndWait callers so loginSuspend doesn't hang.
+                    ops.forEach { it.waiter?.wake(false) }
+                    // Re-queue with waiter = null: the operation is preserved for retry
+                    // on next cold start, but the original waiter is detached since it
+                    // was already woken above.
                     synchronized(queue) {
-                        ops.reversed().forEach { queue.add(0, it) }
+                        ops.reversed().forEach {
+                            queue.add(0, OperationQueueItem(it.operation, waiter = null, bucket = it.bucket, retries = it.retries))
+                        }
                     }
                 }
             }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/impl/OperationRepo.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/impl/OperationRepo.kt
@@ -32,7 +32,7 @@ internal class OperationRepo(
 ) : IOperationRepo, IStartableService {
     internal class OperationQueueItem(
         val operation: Operation,
-        var waiter: WaiterWithValue<Boolean>? = null,
+        var waiter: WaiterWithValue<Boolean>? = null, // waiter may transfer during operation de-dupe
         val bucket: Int,
         var retries: Int = 0,
     ) {
@@ -162,10 +162,7 @@ internal class OperationRepo(
                 return
             }
 
-            // Dedupe LoginUserOperation for the same user. Merge the incoming
-            // existingOnesignalId so the anon-user conversion isn't lost when
-            // RecoverFromDroppedLoginBug wins the race (it enqueues with null).
-            // Transfer the waiter so enqueueAndWait callers get the real result.
+            // Dedupe LoginUserOperation by onesignalId.
             val op = queueItem.operation
             if (op is LoginUserOperation) {
                 val existing =
@@ -174,12 +171,14 @@ internal class OperationRepo(
                     }
                 if (existing != null) {
                     val existingOp = existing.operation as LoginUserOperation
+                    // Preserve the anon-user conversion link if the queued op lacks it (e.g. RecoverFromDroppedLoginBug enqueued with null).
                     if (op.existingOnesignalId != null && existingOp.existingOnesignalId == null) {
                         Logging.debug("OperationRepo: internalEnqueue - merging existingOnesignalId=${op.existingOnesignalId} into queued LoginUserOperation for onesignalId: ${op.onesignalId}.")
                         existingOp.existingOnesignalId = op.existingOnesignalId
                     } else {
                         Logging.debug("OperationRepo: internalEnqueue - LoginUserOperation for onesignalId: ${op.onesignalId} already exists in the queue.")
                     }
+                    // Transfer the waiter so enqueueAndWait callers see the queued op's real execution result.
                     if (queueItem.waiter != null && existing.waiter == null) {
                         existing.waiter = queueItem.waiter
                     } else {

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/impl/OperationRepo.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/impl/OperationRepo.kt
@@ -162,25 +162,29 @@ internal class OperationRepo(
                 return
             }
 
-            // Dedupe LoginUserOperation for the same user — prevents RecoverFromDroppedLoginBug
-            // and the real login() call from both enqueuing a login op during the timing window.
-            // Wake the waiter optimistically with `true`: the already-queued op will do the work,
-            // but we don't await its real result (that would require waiter chaining). enqueueAndWait
-            // callers like loginSuspend would otherwise hang forever. The only caller today is
-            // LoginHelper.enqueueLogin which just logs on failure, so the lost signal is acceptable.
-            // If the op came from loadSavedOperations (addToStore = false) it's also a stale
-            // duplicate in the store; remove it to avoid an orphan entry that lingers until the
-            // next cold start.
+            // Dedupe LoginUserOperation for the same user. Merge the incoming
+            // existingOnesignalId in so the anon-user conversion isn't lost when
+            // RecoverFromDroppedLoginBug wins the race (it enqueues with null).
             val op = queueItem.operation
-            if (op is LoginUserOperation &&
-                queue.any { it.operation is LoginUserOperation && it.operation.onesignalId == op.onesignalId }
-            ) {
-                Logging.debug("OperationRepo: internalEnqueue - LoginUserOperation for onesignalId: ${op.onesignalId} already exists in the queue.")
-                if (!addToStore) {
-                    _operationModelStore.remove(queueItem.operation.id)
+            if (op is LoginUserOperation) {
+                val existing =
+                    queue.firstOrNull {
+                        it.operation is LoginUserOperation && it.operation.onesignalId == op.onesignalId
+                    }
+                if (existing != null) {
+                    val existingOp = existing.operation as LoginUserOperation
+                    if (op.existingOnesignalId != null && existingOp.existingOnesignalId == null) {
+                        Logging.debug("OperationRepo: internalEnqueue - merged existingOnesignalId=${op.existingOnesignalId} into queued LoginUserOperation for onesignalId: ${op.onesignalId}.")
+                        existingOp.existingOnesignalId = op.existingOnesignalId
+                    } else {
+                        Logging.debug("OperationRepo: internalEnqueue - LoginUserOperation for onesignalId: ${op.onesignalId} already exists in the queue.")
+                    }
+                    if (!addToStore) {
+                        _operationModelStore.remove(queueItem.operation.id)
+                    }
+                    queueItem.waiter?.wake(true)
+                    return
                 }
-                queueItem.waiter?.wake(true)
-                return
             }
 
             if (index != null) {

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/impl/OperationRepo.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/impl/OperationRepo.kt
@@ -32,7 +32,7 @@ internal class OperationRepo(
 ) : IOperationRepo, IStartableService {
     internal class OperationQueueItem(
         val operation: Operation,
-        val waiter: WaiterWithValue<Boolean>? = null,
+        var waiter: WaiterWithValue<Boolean>? = null,
         val bucket: Int,
         var retries: Int = 0,
     ) {
@@ -163,8 +163,9 @@ internal class OperationRepo(
             }
 
             // Dedupe LoginUserOperation for the same user. Merge the incoming
-            // existingOnesignalId in so the anon-user conversion isn't lost when
+            // existingOnesignalId so the anon-user conversion isn't lost when
             // RecoverFromDroppedLoginBug wins the race (it enqueues with null).
+            // Transfer the waiter so enqueueAndWait callers get the real result.
             val op = queueItem.operation
             if (op is LoginUserOperation) {
                 val existing =
@@ -174,15 +175,19 @@ internal class OperationRepo(
                 if (existing != null) {
                     val existingOp = existing.operation as LoginUserOperation
                     if (op.existingOnesignalId != null && existingOp.existingOnesignalId == null) {
-                        Logging.debug("OperationRepo: internalEnqueue - merged existingOnesignalId=${op.existingOnesignalId} into queued LoginUserOperation for onesignalId: ${op.onesignalId}.")
+                        Logging.debug("OperationRepo: internalEnqueue - merging existingOnesignalId=${op.existingOnesignalId} into queued LoginUserOperation for onesignalId: ${op.onesignalId}.")
                         existingOp.existingOnesignalId = op.existingOnesignalId
                     } else {
                         Logging.debug("OperationRepo: internalEnqueue - LoginUserOperation for onesignalId: ${op.onesignalId} already exists in the queue.")
                     }
+                    if (queueItem.waiter != null && existing.waiter == null) {
+                        existing.waiter = queueItem.waiter
+                    } else {
+                        queueItem.waiter?.wake(true)
+                    }
                     if (!addToStore) {
                         _operationModelStore.remove(queueItem.operation.id)
                     }
-                    queueItem.waiter?.wake(true)
                     return
                 }
             }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/impl/OperationRepo.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/impl/OperationRepo.kt
@@ -11,6 +11,7 @@ import com.onesignal.core.internal.startup.IStartableService
 import com.onesignal.core.internal.time.ITime
 import com.onesignal.debug.LogLevel
 import com.onesignal.debug.internal.logging.Logging
+import com.onesignal.user.internal.operations.LoginUserOperation
 import com.onesignal.user.internal.operations.impl.states.NewRecordsState
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
@@ -158,6 +159,27 @@ internal class OperationRepo(
             val hasExisting = queue.any { it.operation.id == queueItem.operation.id }
             if (hasExisting) {
                 Logging.debug("OperationRepo: internalEnqueue - operation.id: ${queueItem.operation.id} already exists in the queue.")
+                return
+            }
+
+            // Dedupe LoginUserOperation for the same user — prevents RecoverFromDroppedLoginBug
+            // and the real login() call from both enqueuing a login op during the timing window.
+            // Wake the waiter optimistically with `true`: the already-queued op will do the work,
+            // but we don't await its real result (that would require waiter chaining). enqueueAndWait
+            // callers like loginSuspend would otherwise hang forever. The only caller today is
+            // LoginHelper.enqueueLogin which just logs on failure, so the lost signal is acceptable.
+            // If the op came from loadSavedOperations (addToStore = false) it's also a stale
+            // duplicate in the store; remove it to avoid an orphan entry that lingers until the
+            // next cold start.
+            val op = queueItem.operation
+            if (op is LoginUserOperation &&
+                queue.any { it.operation is LoginUserOperation && it.operation.onesignalId == op.onesignalId }
+            ) {
+                Logging.debug("OperationRepo: internalEnqueue - LoginUserOperation for onesignalId: ${op.onesignalId} already exists in the queue.")
+                if (!addToStore) {
+                    _operationModelStore.remove(queueItem.operation.id)
+                }
+                queueItem.waiter?.wake(true)
                 return
             }
 

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/impl/OperationRepo.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/impl/OperationRepo.kt
@@ -1,5 +1,6 @@
 package com.onesignal.core.internal.operations.impl
 
+import com.onesignal.common.IDManager
 import com.onesignal.common.threading.WaiterWithValue
 import com.onesignal.core.internal.config.ConfigModelStore
 import com.onesignal.core.internal.operations.ExecutionResult
@@ -172,9 +173,15 @@ internal class OperationRepo(
                 if (existing != null) {
                     val existingOp = existing.operation as LoginUserOperation
                     // Preserve the anon-user conversion link if the queued op lacks it (e.g. RecoverFromDroppedLoginBug enqueued with null).
-                    if (op.existingOnesignalId != null && existingOp.existingOnesignalId == null) {
-                        Logging.debug("OperationRepo: internalEnqueue - merging existingOnesignalId=${op.existingOnesignalId} into queued LoginUserOperation for onesignalId: ${op.onesignalId}.")
-                        existingOp.existingOnesignalId = op.existingOnesignalId
+                    // Skip local ids: merging one would flip canStartExecute to false and strand the op,
+                    // since a local id that never hit the backend will never receive an idTranslation.
+                    val incomingExistingId = op.existingOnesignalId
+                    if (incomingExistingId != null &&
+                        !IDManager.isLocalId(incomingExistingId) &&
+                        existingOp.existingOnesignalId == null
+                    ) {
+                        Logging.debug("OperationRepo: internalEnqueue - merging existingOnesignalId=$incomingExistingId into queued LoginUserOperation for onesignalId: ${op.onesignalId}.")
+                        existingOp.existingOnesignalId = incomingExistingId
                     } else {
                         Logging.debug("OperationRepo: internalEnqueue - LoginUserOperation for onesignalId: ${op.onesignalId} already exists in the queue.")
                     }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
@@ -378,14 +378,20 @@ internal class OneSignalImp(
 
         if (isBackgroundThreadingEnabled) {
             waitForInit(operationName = "login")
-            suspendifyOnIO { loginHelper.login(externalId, jwtBearerToken) }
         } else {
             if (!isInitialized) {
                 throw IllegalStateException("Must call 'initWithContext' before 'login'")
             }
+        }
+
+        val context = loginHelper.switchUser(externalId, jwtBearerToken) ?: return
+
+        if (isBackgroundThreadingEnabled) {
+            suspendifyOnIO { loginHelper.enqueueLogin(context) }
+        } else {
             Thread {
                 runBlocking(runtimeIoDispatcher) {
-                    loginHelper.login(externalId, jwtBearerToken)
+                    loginHelper.enqueueLogin(context)
                 }
             }.start()
         }
@@ -646,7 +652,8 @@ internal class OneSignalImp(
             throw IllegalStateException("'initWithContext failed' before 'login'")
         }
 
-        loginHelper.login(externalId, jwtBearerToken)
+        val context = loginHelper.switchUser(externalId, jwtBearerToken) ?: return@withContext
+        loginHelper.enqueueLogin(context)
     }
 
     override suspend fun logoutSuspend() =

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
@@ -402,14 +402,20 @@ internal class OneSignalImp(
 
         if (isBackgroundThreadingEnabled) {
             waitForInit(operationName = "logout")
-            suspendifyOnIO { logoutHelper.logout() }
         } else {
             if (!isInitialized) {
                 throw IllegalStateException("Must call 'initWithContext' before 'logout'")
             }
+        }
+
+        val context = logoutHelper.switchUser() ?: return
+
+        if (isBackgroundThreadingEnabled) {
+            suspendifyOnIO { logoutHelper.enqueueLogout(context) }
+        } else {
             Thread {
                 runBlocking(runtimeIoDispatcher) {
-                    logoutHelper.logout()
+                    logoutHelper.enqueueLogout(context)
                 }
             }.start()
         }
@@ -666,6 +672,7 @@ internal class OneSignalImp(
                 throw IllegalStateException("'initWithContext failed' before 'logout'")
             }
 
-            logoutHelper.logout()
+            val context = logoutHelper.switchUser() ?: return@withContext
+            logoutHelper.enqueueLogout(context)
         }
 }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/LoginHelper.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/LoginHelper.kt
@@ -13,20 +13,29 @@ class LoginHelper(
     private val configModel: ConfigModel,
     private val lock: Any,
 ) {
-    suspend fun login(
+    internal data class LoginEnqueueContext(
+        val appId: String,
+        val newIdentityOneSignalId: String,
+        val externalId: String,
+        val existingOneSignalId: String?,
+    )
+
+    /**
+     * Synchronously switches local user models under the login/logout lock so subsequent
+     * SDK calls (e.g. addTag) see the new user's identity immediately. Returns context
+     * needed for [enqueueLogin], or null if the user was already logged in with [externalId]
+     * (no switch needed).
+     */
+    internal fun switchUser(
         externalId: String,
         jwtBearerToken: String? = null,
-    ) {
-        var currentIdentityExternalId: String? = null
-        var currentIdentityOneSignalId: String? = null
-        var newIdentityOneSignalId: String = ""
-
+    ): LoginEnqueueContext? {
         synchronized(lock) {
-            currentIdentityExternalId = identityModelStore.model.externalId
-            currentIdentityOneSignalId = identityModelStore.model.onesignalId
+            val currentExternalId = identityModelStore.model.externalId
+            val currentOneSignalId = identityModelStore.model.onesignalId
 
-            if (currentIdentityExternalId == externalId) {
-                return
+            if (currentExternalId == externalId) {
+                return null
             }
 
             // TODO: Set JWT Token for all future requests.
@@ -34,16 +43,25 @@ class LoginHelper(
                 identityModel.externalId = externalId
             }
 
-            newIdentityOneSignalId = identityModelStore.model.onesignalId
-        }
+            val newOneSignalId = identityModelStore.model.onesignalId
+            val existingOneSignalId =
+                if (currentExternalId == null) currentOneSignalId else null
 
+            return LoginEnqueueContext(configModel.appId, newOneSignalId, externalId, existingOneSignalId)
+        }
+    }
+
+    /**
+     * Enqueues the [LoginUserOperation] and suspends until it completes.
+     */
+    internal suspend fun enqueueLogin(context: LoginEnqueueContext) {
         val result =
             operationRepo.enqueueAndWait(
                 LoginUserOperation(
-                    configModel.appId,
-                    newIdentityOneSignalId,
-                    externalId,
-                    if (currentIdentityExternalId == null) currentIdentityOneSignalId else null,
+                    context.appId,
+                    context.newIdentityOneSignalId,
+                    context.externalId,
+                    context.existingOneSignalId,
                 ),
             )
 

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/LogoutHelper.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/LogoutHelper.kt
@@ -12,26 +12,43 @@ class LogoutHelper(
     private val configModel: ConfigModel,
     private val lock: Any,
 ) {
-    fun logout() {
+    internal data class LogoutEnqueueContext(
+        val appId: String,
+        val newOnesignalId: String,
+    )
+
+    /**
+     * Synchronously switches to a new device-scoped user under the login/logout lock
+     * so subsequent SDK calls (e.g. addTag) see the new anonymous user immediately.
+     * Returns context needed for [enqueueLogout], or null if no user was logged in
+     * (no switch needed).
+     */
+    internal fun switchUser(): LogoutEnqueueContext? {
         synchronized(lock) {
             if (identityModelStore.model.externalId == null) {
-                return
+                return null
             }
 
             // Create new device-scoped user (clears external ID)
             userSwitcher.createAndSwitchToNewUser()
 
-            // Enqueue login operation for the new device-scoped user (no external ID)
-            operationRepo.enqueue(
-                LoginUserOperation(
-                    configModel.appId,
-                    identityModelStore.model.onesignalId,
-                    null,
-                    // No external ID for device-scoped user
-                ),
-            )
-
             // TODO: remove JWT Token for all future requests.
+
+            return LogoutEnqueueContext(configModel.appId, identityModelStore.model.onesignalId)
         }
+    }
+
+    /**
+     * Enqueues the anonymous [LoginUserOperation] for the newly-created device-scoped user.
+     */
+    internal fun enqueueLogout(context: LogoutEnqueueContext) {
+        operationRepo.enqueue(
+            LoginUserOperation(
+                context.appId,
+                context.newOnesignalId,
+                null,
+                // No external ID for device-scoped user
+            ),
+        )
     }
 }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/LoginUserOperation.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/LoginUserOperation.kt
@@ -48,7 +48,7 @@ class LoginUserOperation() : Operation(LoginUserOperationExecutor.LOGIN_USER) {
      */
     var existingOnesignalId: String?
         get() = getOptStringProperty(::existingOnesignalId.name)
-        internal set(value) {
+        internal set(value) { // `internal` so OperationRepo can merge during de-dupe
             setOptStringProperty(::existingOnesignalId.name, value)
         }
 

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/LoginUserOperation.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/LoginUserOperation.kt
@@ -48,7 +48,7 @@ class LoginUserOperation() : Operation(LoginUserOperationExecutor.LOGIN_USER) {
      */
     var existingOnesignalId: String?
         get() = getOptStringProperty(::existingOnesignalId.name)
-        private set(value) {
+        internal set(value) {
             setOptStringProperty(::existingOnesignalId.name, value)
         }
 

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/operations/OperationRepoTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/operations/OperationRepoTests.kt
@@ -161,9 +161,7 @@ class OperationRepoTests : FunSpec({
 
         // When — enqueue the incoming op (simulates enqueueLogin landing after recovery)
         operationRepo.enqueue(incomingOp)
-
-        // Yield so the launched coroutine in enqueue() can run
-        kotlinx.coroutines.runBlocking { delay(100) }
+        mocks.waitForInternalEnqueue()
 
         // Then — queue has only the original op, with merged existingOnesignalId
         operationRepo.queue.size shouldBe 1

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/operations/OperationRepoTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/operations/OperationRepoTests.kt
@@ -100,8 +100,8 @@ class OperationRepoTests : FunSpec({
                 ),
             )
 
-        val cachedOperation = LoginUserOperation()
-        val newOperation = LoginUserOperation()
+        val cachedOperation = LoginUserOperation("appId", "cached-onesignal-id", null, null)
+        val newOperation = LoginUserOperation("appId", "new-onesignal-id", null, null)
         val jsonArray = JSONArray()
 
         // cache the operation

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/operations/OperationRepoTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/operations/OperationRepoTests.kt
@@ -170,6 +170,35 @@ class OperationRepoTests : FunSpec({
         merged.existingOnesignalId shouldBe "anon-uuid"
     }
 
+    test("enqueue dedupe does not merge a local existingOnesignalId onto the queued op") {
+        // Regression: when upgrading from 5.0.0-5.1.7, an anon user's backend-create
+        // may have been dropped, so its onesignalId is still "local-". If
+        // RecoverFromDroppedLoginBug wins the race (queued op has existingOnesignalId=null,
+        // canStartExecute=true), we must NOT overwrite it with the incoming op's local
+        // existingOnesignalId — doing so flips canStartExecute to false and strands the op
+        // forever (the local id will never receive an idTranslation).
+        val mocks = Mocks()
+        val operationRepo = mocks.operationRepo
+
+        val queuedOp = LoginUserOperation("appId", "local-new", "alice", null)
+        queuedOp.id = UUID.randomUUID().toString()
+        synchronized(operationRepo.queue) {
+            operationRepo.queue.add(OperationQueueItem(queuedOp, bucket = 0))
+        }
+
+        val incomingOp = LoginUserOperation("appId", "local-new", "alice", "local-anon")
+
+        // When
+        operationRepo.enqueue(incomingOp)
+        mocks.waitForInternalEnqueue()
+
+        // Then — queue still has one op, existingOnesignalId stays null (canStartExecute stays true)
+        operationRepo.queue.size shouldBe 1
+        val survivor = operationRepo.queue.first().operation as LoginUserOperation
+        survivor.existingOnesignalId shouldBe null
+        survivor.canStartExecute shouldBe true
+    }
+
     test("containsInstanceOf") {
         // Given
         val mocks = Mocks()

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/operations/OperationRepoTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/operations/OperationRepoTests.kt
@@ -29,6 +29,7 @@ import io.mockk.runs
 import io.mockk.slot
 import io.mockk.spyk
 import io.mockk.verify
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -197,6 +198,41 @@ class OperationRepoTests : FunSpec({
         val survivor = operationRepo.queue.first().operation as LoginUserOperation
         survivor.existingOnesignalId shouldBe null
         survivor.canStartExecute shouldBe true
+    }
+
+    test("enqueue dedupe wakes both queued and incoming enqueueAndWait callers on SUCCESS") {
+        // A LoginUserOperation is queued via enqueueAndWait while the loop is not yet
+        // started, so it sits in the queue with its waiter attached. A second
+        // enqueueAndWait arrives for the same onesignalId. Dedupe wakes the incoming
+        // caller immediately with true; the queued op's waiter wakes with the real
+        // execution result when SUCCESS lands.
+        val mocks = Mocks()
+        val opRepo = mocks.operationRepo
+        val executeOperationsCall = mockExecuteOperations(opRepo)
+
+        val queuedOp = LoginUserOperation("appId", "alice", "ext", "anon-uuid")
+        val incomingOp = LoginUserOperation("appId", "alice", "ext", "anon-uuid")
+
+        // When — first enqueueAndWait runs (loop not started, op stays in queue).
+        // UNDISPATCHED so enqueueAndWait reaches its scope.launch + suspend before
+        // we send the incoming op below; otherwise the scope's single thread would
+        // see the incoming op's internalEnqueue first and dedupe direction reverses.
+        val queuedDone = WaiterWithValue<Boolean>()
+        launch(start = CoroutineStart.UNDISPATCHED) {
+            queuedDone.wake(opRepo.enqueueAndWait(queuedOp))
+        }
+        mocks.waitForInternalEnqueue()
+
+        // Incoming dedupes against the queued op and is woken immediately
+        val incomingResult = withTimeout(1_000) { opRepo.enqueueAndWait(incomingOp) }
+        // Run the loop; mocked executor SUCCESS wakes the queued op's waiter
+        opRepo.start()
+        executeOperationsCall.waitForWake()
+        val queuedResult = withTimeout(1_000) { queuedDone.waitForWake() }
+
+        // Then
+        incomingResult shouldBe true
+        queuedResult shouldBe true
     }
 
     test("containsInstanceOf") {

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/operations/OperationRepoTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/operations/OperationRepoTests.kt
@@ -142,6 +142,36 @@ class OperationRepoTests : FunSpec({
         operationRepo.queue.first().operation shouldBe cachedOperation
     }
 
+    test("enqueue dedupes LoginUserOperation for same onesignalId and merges existingOnesignalId") {
+        // Reproduces the RecoverFromDroppedLoginBug race: a recovery login op
+        // (existingOnesignalId=null) is already queued; an incoming enqueueLogin
+        // op for the same user carries the anon UUID needed for conversion.
+        // Dedup must merge the incoming existingOnesignalId into the queued op
+        // and transfer the waiter so the caller receives the real result.
+        val mocks = Mocks()
+        val operationRepo = mocks.operationRepo
+
+        val queuedOp = LoginUserOperation("appId", "local-new", "alice", null)
+        queuedOp.id = UUID.randomUUID().toString()
+        synchronized(operationRepo.queue) {
+            operationRepo.queue.add(OperationQueueItem(queuedOp, bucket = 0))
+        }
+
+        val incomingOp = LoginUserOperation("appId", "local-new", "alice", "anon-uuid")
+
+        // When — enqueue the incoming op (simulates enqueueLogin landing after recovery)
+        operationRepo.enqueue(incomingOp)
+
+        // Yield so the launched coroutine in enqueue() can run
+        kotlinx.coroutines.runBlocking { delay(100) }
+
+        // Then — queue has only the original op, with merged existingOnesignalId
+        operationRepo.queue.size shouldBe 1
+        val merged = operationRepo.queue.first().operation as LoginUserOperation
+        merged.onesignalId shouldBe "local-new"
+        merged.existingOnesignalId shouldBe "anon-uuid"
+    }
+
     test("containsInstanceOf") {
         // Given
         val mocks = Mocks()

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/LoginHelperTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/LoginHelperTests.kt
@@ -61,7 +61,8 @@ class LoginHelperTests : FunSpec({
 
         // When
         runBlocking {
-            loginHelper.login(currentExternalId)
+            val context = loginHelper.switchUser(currentExternalId)
+            if (context != null) loginHelper.enqueueLogin(context)
         }
 
         // Then - should return early without any operations
@@ -113,7 +114,8 @@ class LoginHelperTests : FunSpec({
 
         // When
         runBlocking {
-            loginHelper.login(newExternalId)
+            val context = loginHelper.switchUser(newExternalId)
+            if (context != null) loginHelper.enqueueLogin(context)
         }
 
         // Then - should switch users and enqueue login operation
@@ -178,7 +180,8 @@ class LoginHelperTests : FunSpec({
 
         // When
         runBlocking {
-            loginHelper.login(newExternalId)
+            val context = loginHelper.switchUser(newExternalId)
+            if (context != null) loginHelper.enqueueLogin(context)
         }
 
         // Then - should provide existing OneSignal ID for anonymous user conversion
@@ -239,7 +242,8 @@ class LoginHelperTests : FunSpec({
 
         // When
         runBlocking {
-            loginHelper.login(newExternalId)
+            val context = loginHelper.switchUser(newExternalId)
+            if (context != null) loginHelper.enqueueLogin(context)
         }
 
         // Then - should still switch users but operation fails

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/LogoutHelperTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/LogoutHelperTests.kt
@@ -53,7 +53,8 @@ class LogoutHelperTests : FunSpec({
             )
 
         // When
-        logoutHelper.logout()
+        val context = logoutHelper.switchUser()
+        if (context != null) logoutHelper.enqueueLogout(context)
 
         // Then - should return early without any operations
         verify(exactly = 0) { mockUserSwitcher.createAndSwitchToNewUser() }
@@ -83,7 +84,8 @@ class LogoutHelperTests : FunSpec({
             )
 
         // When
-        logoutHelper.logout()
+        val context = logoutHelper.switchUser()
+        if (context != null) logoutHelper.enqueueLogout(context)
 
         // Then - should create new user and enqueue login operation for device-scoped user
         verify(exactly = 1) { mockUserSwitcher.createAndSwitchToNewUser() }
@@ -122,7 +124,8 @@ class LogoutHelperTests : FunSpec({
             )
 
         // When
-        logoutHelper.logout()
+        val context = logoutHelper.switchUser()
+        if (context != null) logoutHelper.enqueueLogout(context)
 
         // Then - operations should happen in the correct order
         verifyOrder {
@@ -157,7 +160,8 @@ class LogoutHelperTests : FunSpec({
         val threads =
             (1..10).map {
                 Thread {
-                    logoutHelper.logout()
+                    val context = logoutHelper.switchUser()
+                    if (context != null) logoutHelper.enqueueLogout(context)
                 }
             }
 


### PR DESCRIPTION
# Description
## One Line Summary
**_(Not JWT related)_**
Implementation of https://github.com/OneSignal/OneSignal-Android-SDK/pull/2600

Fix a race in `OneSignal.login()` and `OneSignal.logout()` where SDK calls made immediately after either operation (e.g. `addTag`) landed on the previous user's identity.

## Details

### Motivation
Both `OneSignal.login()` and `OneSignal.logout()` scheduled the local user switch asynchronously via `suspendifyOnIO`, so the API call returned before the identity/properties/subscription models were updated. Calls made right after targeted the OLD user.

Example reproduction:
```kotlin
OneSignal.login("alice")
OneSignal.User.addTag("name_aa", "alice")    // lands on old user, not alice

OneSignal.login("bob")
OneSignal.User.addTag("name_bb", "bob")      // lands on alice (or whoever), not bob

OneSignal.logout()
OneSignal.User.addTag("post_logout", "val")  // lands on bob, not the new anonymous user
```

### Scope
Split both `LoginHelper.login()` and `LogoutHelper.logout()` into two phases each:
- **`switchUser()`** — synchronous under the login/logout lock. Swaps the local identity/properties/subscription models immediately so subsequent SDK calls see the new user.
- **`enqueueLogin()` / `enqueueLogout()`** — async. Enqueues the `LoginUserOperation` (and for login, awaits completion of the backend user creation).

`OneSignalImp.login()`, `loginSuspend()`, `logout()`, and `logoutSuspend()` all call `switchUser()` synchronously, then launch the enqueue in the coroutine scope.

Because `switchUser` returns before the enqueue runs, there's a brief window where `RecoverFromDroppedLoginBug` can observe the intermediate state (new `externalId`, local `onesignalId`, no `LoginUserOperation` in queue) and enqueue its own recovery login. When the real enqueue then adds another login op, the executor crashes on a grouped batch containing two `LoginUserOperation`s with "Unrecognized operation".

To handle this:
- `OperationRepo.internalEnqueue` dedupes `LoginUserOperation` by `onesignalId`. If a queued op already exists for the same user, the incoming op is dropped. The incoming op's `existingOnesignalId` is merged into the queued op first so the anonymous-user conversion link isn't lost (the recovery op always has `existingOnesignalId = null`, the real login op may carry the anon UUID needed for the backend merge).
- The incoming op's waiter is transferred to the queued op so `enqueueAndWait` callers (e.g. `loginSuspend`) receive the real execution result.
- `LoginUserOperation.existingOnesignalId` setter relaxed from `private` to `internal` to allow the in-place merge.

Also applies the `FAIL_PAUSE_OPREPO` waker fix from #2600: ops re-queued on pause detach their waiters (wake with `false`) so `enqueueAndWait` callers don't hang on a paused queue.

Related: #2600 made the same split on `feat/identity_verification_5.8`, but that branch hasn't merged. This port brings the fix to `main` so all users get the race fix in the next release, and extends the pattern symmetrically to logout.

# Testing
## Unit testing
- Updated `LoginHelperTests` to use the new `switchUser()` + `enqueueLogin()` split; existing tests pass.
- Updated `LogoutHelperTests` to use the new `switchUser()` + `enqueueLogout()` split; existing tests pass.
- Added a new `OperationRepoTests` case for the dedupe+merge path: seed a `LoginUserOperation(existingOnesignalId=null)` in the queue (simulates `RecoverFromDroppedLoginBug`), enqueue an incoming op with the same `onesignalId` and a non-null `existingOnesignalId`, verify the queued op is merged in place and the incoming op is dropped. Uses `waitForInternalEnqueue` helper for determinism.
- Updated the `loadSavedOperations` test to construct `LoginUserOperation` with full args (the previous no-args construction stopped working once the dedupe reads `onesignalId`).

## Manual testing
- Reproduced the original login bug in the demo app with back-to-back `login()` + `addTag()` calls — confirmed each tag landed on the wrong user before the fix.
- After the fix: each tag lands on the intended user.
- Verified the symmetric logout case: `logout()` + `addTag()` now attaches the tag to the new anonymous user instead of the previously logged-in one.
- Reproduced the RecoverFromDroppedLoginBug race on fresh install + quick `login()` call — confirmed the executor no longer crashes with "Unrecognized operation" and the anonymous-user conversion link is preserved.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
