### PR TITLE
fix: retrieve    
  push token on startup when notification permission already granted

### DIFF
--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/listeners/DeviceRegistrationListener.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/listeners/DeviceRegistrationListener.kt
@@ -39,15 +39,30 @@ internal class DeviceRegistrationListener(
         _subscriptionManager.subscribe(this)
 
         // If notification permission is already granted at startup (e.g. after reinstall or
-        // app data clear), the push subscription status may still be NO_PERMISSION because
-        // no permission-change event will fire — permission was already true when the SDK
-        // initialized, so oldPermission == newPermission and no event is emitted.
-        // The config-hydration path (onModelReplaced/HYDRATE) only fires when the config
-        // cache is invalid, so it cannot be relied on either.
-        // Eagerly retrieve the push token here to ensure the subscription is active.
-        if (_notificationsManager.permission) {
+        // app data clear), the cached push subscription can be stuck at NO_PERMISSION:
+        //   - The permission observer (onNotificationPermissionChange) won't fire because
+        //     permission did not change — NotificationsManager.setPermissionStatusAndFire
+        //     only emits when oldPermissionStatus != isEnabled.
+        //   - The config-hydration path (onModelReplaced/HYDRATE) is triggered by
+        //     ConfigModelStoreListener.fetchParams on every startup, but it runs on IO and
+        //     depends on a successful params backend call, so it leaves a window of stale
+        //     state and may not run at all when the device is offline.
+        // Eagerly retrieve the push token here to close that window, but only when the
+        // cached push subscription doesn't already reflect a healthy SUBSCRIBED state —
+        // this avoids a redundant FCM round-trip on every warm start.
+        if (_notificationsManager.permission && needsPushTokenRefresh()) {
             retrievePushTokenAndUpdateSubscription()
         }
+    }
+
+    private fun needsPushTokenRefresh(): Boolean {
+        val pushModel = _subscriptionManager.pushSubscriptionModel
+        // An uninitialized push subscription has an empty model.id (see UninitializedPushSubscription);
+        // a real push subscription always has an id (local UUID or server-assigned).
+        if (pushModel.id.isEmpty()) {
+            return true
+        }
+        return pushModel.status != SubscriptionStatus.SUBSCRIBED
     }
 
     override fun onModelReplaced(

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/listeners/DeviceRegistrationListener.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/listeners/DeviceRegistrationListener.kt
@@ -37,6 +37,17 @@ internal class DeviceRegistrationListener(
         _configModelStore.subscribe(this)
         _notificationsManager.addPermissionObserver(this)
         _subscriptionManager.subscribe(this)
+
+        // If notification permission is already granted at startup (e.g. after reinstall or
+        // app data clear), the push subscription status may still be NO_PERMISSION because
+        // no permission-change event will fire — permission was already true when the SDK
+        // initialized, so oldPermission == newPermission and no event is emitted.
+        // The config-hydration path (onModelReplaced/HYDRATE) only fires when the config
+        // cache is invalid, so it cannot be relied on either.
+        // Eagerly retrieve the push token here to ensure the subscription is active.
+        if (_notificationsManager.permission) {
+            retrievePushTokenAndUpdateSubscription()
+        }
     }
 
     override fun onModelReplaced(

--- a/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/listeners/DeviceRegistrationListenerTests.kt
+++ b/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/listeners/DeviceRegistrationListenerTests.kt
@@ -1,0 +1,273 @@
+package com.onesignal.notifications.internal.listeners
+
+import com.onesignal.core.internal.config.ConfigModelStore
+import com.onesignal.debug.LogLevel
+import com.onesignal.debug.internal.logging.Logging
+import com.onesignal.mocks.IOMockHelper
+import com.onesignal.mocks.IOMockHelper.awaitIO
+import com.onesignal.notifications.INotificationsManager
+import com.onesignal.notifications.internal.channels.INotificationChannelManager
+import com.onesignal.notifications.internal.pushtoken.IPushTokenManager
+import com.onesignal.notifications.internal.pushtoken.PushTokenResponse
+import com.onesignal.user.internal.subscriptions.ISubscriptionManager
+import com.onesignal.user.internal.subscriptions.SubscriptionModel
+import com.onesignal.user.internal.subscriptions.SubscriptionStatus
+import com.onesignal.user.internal.subscriptions.SubscriptionType
+import io.kotest.core.spec.style.FunSpec
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+
+private const val NEW_TOKEN = "new-token"
+
+/** Mirrors the shape of a real, persisted push subscription model. */
+private fun realPushModel(
+    status: SubscriptionStatus,
+    address: String = "existing-token",
+): SubscriptionModel =
+    SubscriptionModel().apply {
+        id = "sub-id"
+        type = SubscriptionType.PUSH
+        this.address = address
+        this.status = status
+        optedIn = true
+    }
+
+/** Mirrors UninitializedPushSubscription.createFakePushSub() — empty id signals "no real push sub yet". */
+private fun uninitializedPushModel(): SubscriptionModel =
+    SubscriptionModel().apply {
+        id = ""
+        type = SubscriptionType.PUSH
+        address = ""
+        optedIn = false
+    }
+
+private class Harness(
+    permission: Boolean,
+    pushModel: SubscriptionModel,
+    pushTokenResponse: PushTokenResponse =
+        PushTokenResponse(NEW_TOKEN, SubscriptionStatus.SUBSCRIBED),
+) {
+    val configModelStore: ConfigModelStore = mockk(relaxed = true)
+    val channelManager: INotificationChannelManager = mockk(relaxed = true)
+    val pushTokenManager: IPushTokenManager = mockk()
+    val notificationsManager: INotificationsManager = mockk(relaxed = true)
+    val subscriptionManager: ISubscriptionManager = mockk(relaxed = true)
+    val listener: DeviceRegistrationListener
+
+    init {
+        coEvery { pushTokenManager.retrievePushToken() } returns pushTokenResponse
+        every { notificationsManager.permission } returns permission
+        every { subscriptionManager.pushSubscriptionModel } returns pushModel
+
+        listener =
+            DeviceRegistrationListener(
+                configModelStore,
+                channelManager,
+                pushTokenManager,
+                notificationsManager,
+                subscriptionManager,
+            )
+    }
+}
+
+class DeviceRegistrationListenerTests : FunSpec({
+    listener(IOMockHelper)
+
+    beforeAny {
+        Logging.logLevel = LogLevel.NONE
+    }
+
+    test("start subscribes to config, permission and subscription observables") {
+        // Given
+        val harness =
+            Harness(
+                permission = false,
+                pushModel = uninitializedPushModel(),
+            )
+
+        // When
+        harness.listener.start()
+        awaitIO()
+
+        // Then
+        verify(exactly = 1) { harness.configModelStore.subscribe(harness.listener) }
+        verify(exactly = 1) { harness.notificationsManager.addPermissionObserver(harness.listener) }
+        verify(exactly = 1) { harness.subscriptionManager.subscribe(harness.listener) }
+    }
+
+    test("start does not eagerly retrieve push token when permission is denied") {
+        // Given
+        val harness =
+            Harness(
+                permission = false,
+                pushModel = uninitializedPushModel(),
+            )
+
+        // When
+        harness.listener.start()
+        awaitIO()
+
+        // Then
+        coVerify(exactly = 0) { harness.pushTokenManager.retrievePushToken() }
+        verify(exactly = 0) {
+            harness.subscriptionManager.addOrUpdatePushSubscriptionToken(any(), any())
+        }
+    }
+
+    test("start does not eagerly retrieve push token when permission denied even if status is NO_PERMISSION") {
+        // Given
+        val harness =
+            Harness(
+                permission = false,
+                pushModel = realPushModel(SubscriptionStatus.NO_PERMISSION, address = ""),
+            )
+
+        // When
+        harness.listener.start()
+        awaitIO()
+
+        // Then
+        coVerify(exactly = 0) { harness.pushTokenManager.retrievePushToken() }
+        verify(exactly = 0) {
+            harness.subscriptionManager.addOrUpdatePushSubscriptionToken(any(), any())
+        }
+    }
+
+    test("start does not eagerly retrieve push token when cached push subscription is already SUBSCRIBED") {
+        // Given
+        val harness =
+            Harness(
+                permission = true,
+                pushModel = realPushModel(SubscriptionStatus.SUBSCRIBED),
+            )
+
+        // When
+        harness.listener.start()
+        awaitIO()
+
+        // Then
+        coVerify(exactly = 0) { harness.pushTokenManager.retrievePushToken() }
+        verify(exactly = 0) {
+            harness.subscriptionManager.addOrUpdatePushSubscriptionToken(any(), any())
+        }
+    }
+
+    test("start eagerly retrieves push token when push subscription is uninitialized") {
+        // Given
+        val harness =
+            Harness(
+                permission = true,
+                pushModel = uninitializedPushModel(),
+            )
+
+        // When
+        harness.listener.start()
+        awaitIO()
+
+        // Then
+        coVerify(exactly = 1) { harness.pushTokenManager.retrievePushToken() }
+        verify(exactly = 1) {
+            harness.subscriptionManager.addOrUpdatePushSubscriptionToken(
+                NEW_TOKEN,
+                SubscriptionStatus.SUBSCRIBED,
+            )
+        }
+    }
+
+    test("start eagerly retrieves push token when cached status is NO_PERMISSION but OS permission is granted") {
+        // Given — the bug scenario from PR #2622: reinstall / app data clear leaves the
+        // subscription stuck at NO_PERMISSION because the permission observer never fires.
+        val harness =
+            Harness(
+                permission = true,
+                pushModel = realPushModel(SubscriptionStatus.NO_PERMISSION, address = ""),
+            )
+
+        // When
+        harness.listener.start()
+        awaitIO()
+
+        // Then
+        coVerify(exactly = 1) { harness.pushTokenManager.retrievePushToken() }
+        verify(exactly = 1) {
+            harness.subscriptionManager.addOrUpdatePushSubscriptionToken(
+                NEW_TOKEN,
+                SubscriptionStatus.SUBSCRIBED,
+            )
+        }
+    }
+
+    test("start eagerly retrieves push token when cached status is a retryable runtime error") {
+        // Given
+        val harness =
+            Harness(
+                permission = true,
+                pushModel = realPushModel(SubscriptionStatus.FIREBASE_FCM_ERROR_MISC_EXCEPTION),
+            )
+
+        // When
+        harness.listener.start()
+        awaitIO()
+
+        // Then
+        coVerify(exactly = 1) { harness.pushTokenManager.retrievePushToken() }
+        verify(exactly = 1) {
+            harness.subscriptionManager.addOrUpdatePushSubscriptionToken(
+                NEW_TOKEN,
+                SubscriptionStatus.SUBSCRIBED,
+            )
+        }
+    }
+
+    test("onNotificationPermissionChange always retrieves push token regardless of cached state") {
+        // Given — gate is intentionally bypassed for explicit permission-change events.
+        val harness =
+            Harness(
+                permission = true,
+                pushModel = realPushModel(SubscriptionStatus.SUBSCRIBED),
+            )
+
+        // When
+        harness.listener.onNotificationPermissionChange(true)
+        awaitIO()
+
+        // Then
+        coVerify(exactly = 1) { harness.pushTokenManager.retrievePushToken() }
+        verify(exactly = 1) {
+            harness.subscriptionManager.addOrUpdatePushSubscriptionToken(
+                NEW_TOKEN,
+                SubscriptionStatus.SUBSCRIBED,
+            )
+        }
+    }
+
+    test("retrieved push token is written with NO_PERMISSION when OS permission is denied at the time of the call") {
+        // Given — covers the existing branch in retrievePushTokenAndUpdateSubscription that
+        // overrides the FCM-reported status with NO_PERMISSION when permission is missing.
+        val harness =
+            Harness(
+                permission = true,
+                pushModel = uninitializedPushModel(),
+                pushTokenResponse =
+                    PushTokenResponse(NEW_TOKEN, SubscriptionStatus.SUBSCRIBED),
+            )
+        // Permission flips off between gate evaluation and the IO callback.
+        every { harness.notificationsManager.permission } returns true andThen false
+
+        // When
+        harness.listener.start()
+        awaitIO()
+
+        // Then
+        coVerify(exactly = 1) { harness.pushTokenManager.retrievePushToken() }
+        verify(exactly = 1) {
+            harness.subscriptionManager.addOrUpdatePushSubscriptionToken(
+                NEW_TOKEN,
+                SubscriptionStatus.NO_PERMISSION,
+            )
+        }
+    }
+})


### PR DESCRIPTION
# Description
## One Line Summary
Fix push subscription stuck at `NO_PERMISSION` after reinstall when notification permission is already granted.

## Details

### Motivation
After reinstall or app data clear, the push subscription is created fresh with `status = NO_PERMISSION`. If the system notification permission was already granted before reinstall, no permission-change event fires on startup — because `NotificationsManager.permission` is initialized to the correct value of `true`, so `oldPermission == newPermission` and `setPermissionStatusAndFire()` never emits an event.

The `onModelReplaced(HYDRATE)` path only fires when the config cache is invalid, so it cannot be relied on either.

Result: `retrievePushTokenAndUpdateSubscription()` is never called → subscription stays stuck at `NO_PERMISSION` indefinitely → user cannot receive push notifications even though system permission is granted.

Fixes #2621

### Scope
Only affects `DeviceRegistrationListener.start()`. The change adds one conditional call to `retrievePushTokenAndUpdateSubscription()` which is already called from two other places in the same class. No behaviour changes when permission is not granted at startup.

# Testing
## Unit testing
No unit tests added — the existing test suite for `DeviceRegistrationListener` covers `onNotificationPermissionChange` and `onModelReplaced`. A new test case for the `start()` path when `permission = true` would be the appropriate addition, but I don't have a local Android build environment to verify it compiles and passes CI.

## Manual testing
Reproduced with react-native-onesignal 5.4.2 (Android SDK 5.7.7) on a Pixel device (Android 14):
1. Install app → grant notification permission → confirm `getOptedInAsync()` returns `true`
2. Clear app data via Settings → reopen app (permission still granted)
3. Without fix: `getOptedInAsync()` returns `false` indefinitely
4. With fix: `getOptedInAsync()` returns `true` within a few seconds

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [x] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item