### PR TITLE
feat(jwt): foundation: gates singleton, JWT token store, feature flag entry (1/6)

### DIFF
--- a/OneSignalSDK/detekt/detekt-baseline-core.xml
+++ b/OneSignalSDK/detekt/detekt-baseline-core.xml
@@ -42,6 +42,7 @@
     <ID>ConstructorParameterNaming:InfluenceManager.kt$InfluenceManager$private val _configModelStore: ConfigModelStore</ID>
     <ID>ConstructorParameterNaming:InfluenceManager.kt$InfluenceManager$private val _sessionService: ISessionService</ID>
     <ID>ConstructorParameterNaming:InstallIdService.kt$InstallIdService$private val _prefs: IPreferencesService</ID>
+    <ID>ConstructorParameterNaming:JwtTokenStore.kt$JwtTokenStore$private val _prefs: IPreferencesService</ID>
     <ID>ConstructorParameterNaming:LanguageContext.kt$LanguageContext$private val _propertiesModelStore: PropertiesModelStore</ID>
     <ID>ConstructorParameterNaming:LoginUserFromSubscriptionOperationExecutor.kt$LoginUserFromSubscriptionOperationExecutor$private val _identityModelStore: IdentityModelStore</ID>
     <ID>ConstructorParameterNaming:LoginUserFromSubscriptionOperationExecutor.kt$LoginUserFromSubscriptionOperationExecutor$private val _propertiesModelStore: PropertiesModelStore</ID>

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/CoreModule.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/CoreModule.kt
@@ -45,6 +45,7 @@ import com.onesignal.location.ILocationManager
 import com.onesignal.location.internal.MisconfiguredLocationManager
 import com.onesignal.notifications.INotificationsManager
 import com.onesignal.notifications.internal.MisconfiguredNotificationsManager
+import com.onesignal.user.internal.jwt.JwtTokenStore
 
 internal class CoreModule : IModule {
     override fun register(builder: ServiceBuilder) {
@@ -67,6 +68,8 @@ internal class CoreModule : IModule {
         builder.register<FeatureFlagsBackendService>().provides<IFeatureFlagsBackendService>()
         builder.register<ConfigModelStoreListener>().provides<IStartableService>()
         builder.register<FeatureFlagsRefreshService>().provides<IStartableService>()
+
+        builder.register<JwtTokenStore>().provides<JwtTokenStore>()
 
         // Operations
         builder.register<OperationModelStore>().provides<OperationModelStore>()

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/config/ConfigModel.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/config/ConfigModel.kt
@@ -236,13 +236,11 @@ class ConfigModel : Model() {
             setBooleanProperty(::enterprise.name, value)
         }
 
-    /**
-     * Whether SMS auth hash should be used.
-     */
-    var useIdentityVerification: Boolean
-        get() = getBooleanProperty(::useIdentityVerification.name) { false }
+    /** Mirrors backend `jwt_required`. `null` = pre-HYDRATE (distinguish from `false`). */
+    var useIdentityVerification: Boolean?
+        get() = getOptBooleanProperty(::useIdentityVerification.name)
         set(value) {
-            setBooleanProperty(::useIdentityVerification.name, value)
+            setOptBooleanProperty(::useIdentityVerification.name, value)
         }
 
     /**

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/config/ConfigModel.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/config/ConfigModel.kt
@@ -2,6 +2,7 @@ package com.onesignal.core.internal.config
 
 import com.onesignal.common.modeling.Model
 import com.onesignal.core.internal.http.OneSignalService.ONESIGNAL_API_BASE_URL
+import com.onesignal.user.internal.jwt.JwtRequirement
 import org.json.JSONArray
 import org.json.JSONObject
 
@@ -236,11 +237,18 @@ class ConfigModel : Model() {
             setBooleanProperty(::enterprise.name, value)
         }
 
-    /** Mirrors backend `jwt_required`. `null` = pre-HYDRATE (distinguish from `false`). */
-    var useIdentityVerification: Boolean?
-        get() = getOptBooleanProperty(::useIdentityVerification.name)
+    /** Mirrors backend `jwt_required`. Pre-HYDRATE callers see [JwtRequirement.UNKNOWN]. */
+    internal var useIdentityVerification: JwtRequirement
+        get() = JwtRequirement.fromBoolean(getOptBooleanProperty(::useIdentityVerification.name))
         set(value) {
-            setOptBooleanProperty(::useIdentityVerification.name, value)
+            setOptBooleanProperty(
+                ::useIdentityVerification.name,
+                when (value) {
+                    JwtRequirement.UNKNOWN -> null
+                    JwtRequirement.NOT_REQUIRED -> false
+                    JwtRequirement.REQUIRED -> true
+                },
+            )
         }
 
     /**

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/config/impl/ConfigModelStoreListener.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/config/impl/ConfigModelStoreListener.kt
@@ -10,6 +10,7 @@ import com.onesignal.core.internal.config.ConfigModel
 import com.onesignal.core.internal.config.ConfigModelStore
 import com.onesignal.core.internal.startup.IStartableService
 import com.onesignal.debug.internal.logging.Logging
+import com.onesignal.user.internal.jwt.JwtRequirement
 import com.onesignal.user.internal.subscriptions.ISubscriptionManager
 import kotlinx.coroutines.delay
 import java.net.HttpURLConnection
@@ -85,7 +86,9 @@ internal class ConfigModelStoreListener(
 
                     // these are only copied from the backend params when the backend has set them.
                     params.enterprise?.let { config.enterprise = it }
-                    params.useIdentityVerification?.let { config.useIdentityVerification = it }
+                    params.useIdentityVerification?.let {
+                        config.useIdentityVerification = JwtRequirement.fromBoolean(it)
+                    }
                     params.firebaseAnalytics?.let { config.firebaseAnalytics = it }
                     params.restoreTTLFilter?.let { config.restoreTTLFilter = it }
                     params.clearGroupOnSummaryClick?.let { config.clearGroupOnSummaryClick = it }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/features/FeatureFlag.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/features/FeatureFlag.kt
@@ -32,8 +32,8 @@ internal enum class FeatureFlag(
     ),
 
     /** JWT signing of SDK requests. IMMEDIATE so a kill-switch doesn't need a cold start. */
-    IDENTITY_VERIFICATION(
-        "identity_verification",
+    SDK_IDENTITY_VERIFICATION(
+        "sdk_identity_verification",
         FeatureActivationMode.IMMEDIATE
     ),
     ;

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/features/FeatureFlag.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/features/FeatureFlag.kt
@@ -24,6 +24,7 @@ internal enum class FeatureFlag(
     val key: String,
     val activationMode: FeatureActivationMode
 ) {
+    // Threading mode is selected once per app startup to avoid mixed-mode behavior mid-session.
     // Remote key (lowercase) must match backend / Turbine flag id.
     SDK_BACKGROUND_THREADING(
         "sdk_background_threading",

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/features/FeatureFlag.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/features/FeatureFlag.kt
@@ -24,13 +24,16 @@ internal enum class FeatureFlag(
     val key: String,
     val activationMode: FeatureActivationMode
 ) {
-    // Threading mode is selected once per app startup to avoid mixed-mode behavior mid-session.
-    //
     // Remote key (lowercase) must match backend / Turbine flag id.
-    //
     SDK_BACKGROUND_THREADING(
         "sdk_background_threading",
         FeatureActivationMode.APP_STARTUP
+    ),
+
+    /** JWT signing of SDK requests. IMMEDIATE so a kill-switch doesn't need a cold start. */
+    IDENTITY_VERIFICATION(
+        "identity_verification",
+        FeatureActivationMode.IMMEDIATE
     ),
     ;
 

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/features/FeatureManager.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/features/FeatureManager.kt
@@ -169,7 +169,7 @@ internal class FeatureManager(
             FeatureFlag.IDENTITY_VERIFICATION ->
                 IdentityVerificationGates.update(
                     featureFlagOn = enabled,
-                    jwtRequired = model.useIdentityVerification,
+                    jwtRequirement = model.useIdentityVerification,
                     source = "FeatureManager:${feature.activationMode}"
                 )
         }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/features/FeatureManager.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/features/FeatureManager.kt
@@ -8,6 +8,7 @@ import com.onesignal.core.internal.backend.impl.FeatureFlagsJsonParser
 import com.onesignal.core.internal.config.ConfigModel
 import com.onesignal.core.internal.config.ConfigModelStore
 import com.onesignal.debug.internal.logging.Logging
+import com.onesignal.user.internal.jwt.IdentityVerificationGates
 import kotlinx.serialization.json.JsonObject
 
 internal interface IFeatureManager {
@@ -122,14 +123,14 @@ internal class FeatureManager(
             when (feature.activationMode) {
                 FeatureActivationMode.IMMEDIATE -> {
                     nextStates[feature] = desiredState
-                    applySideEffects(feature, desiredState)
+                    applySideEffects(feature, desiredState, model)
                 }
 
                 FeatureActivationMode.APP_STARTUP -> {
                     val hasBeenInitialized = nextStates.containsKey(feature)
                     if (applyNextRunOnlyFeatures || !hasBeenInitialized) {
                         nextStates[feature] = desiredState
-                        applySideEffects(feature, desiredState)
+                        applySideEffects(feature, desiredState, model)
                     } else {
                         val currentState = nextStates[feature] ?: false
                         if (currentState != desiredState) {
@@ -156,11 +157,19 @@ internal class FeatureManager(
     private fun applySideEffects(
         feature: FeatureFlag,
         enabled: Boolean,
+        model: ConfigModel,
     ) {
         when (feature) {
             FeatureFlag.SDK_BACKGROUND_THREADING ->
                 ThreadingMode.updateUseBackgroundThreading(
                     enabled = enabled,
+                    source = "FeatureManager:${feature.activationMode}"
+                )
+
+            FeatureFlag.IDENTITY_VERIFICATION ->
+                IdentityVerificationGates.update(
+                    featureFlagOn = enabled,
+                    jwtRequired = model.useIdentityVerification,
                     source = "FeatureManager:${feature.activationMode}"
                 )
         }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/features/FeatureManager.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/features/FeatureManager.kt
@@ -165,7 +165,7 @@ internal class FeatureManager(
                     source = "FeatureManager:${feature.activationMode}"
                 )
 
-            FeatureFlag.IDENTITY_VERIFICATION ->
+            FeatureFlag.SDK_IDENTITY_VERIFICATION ->
                 IdentityVerificationGates.update(
                     featureFlagOn = enabled,
                     jwtRequirement = configModelStore.model.useIdentityVerification,

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/features/FeatureManager.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/features/FeatureManager.kt
@@ -123,14 +123,14 @@ internal class FeatureManager(
             when (feature.activationMode) {
                 FeatureActivationMode.IMMEDIATE -> {
                     nextStates[feature] = desiredState
-                    applySideEffects(feature, desiredState, model)
+                    applySideEffects(feature, desiredState)
                 }
 
                 FeatureActivationMode.APP_STARTUP -> {
                     val hasBeenInitialized = nextStates.containsKey(feature)
                     if (applyNextRunOnlyFeatures || !hasBeenInitialized) {
                         nextStates[feature] = desiredState
-                        applySideEffects(feature, desiredState, model)
+                        applySideEffects(feature, desiredState)
                     } else {
                         val currentState = nextStates[feature] ?: false
                         if (currentState != desiredState) {
@@ -157,7 +157,6 @@ internal class FeatureManager(
     private fun applySideEffects(
         feature: FeatureFlag,
         enabled: Boolean,
-        model: ConfigModel,
     ) {
         when (feature) {
             FeatureFlag.SDK_BACKGROUND_THREADING ->
@@ -169,7 +168,7 @@ internal class FeatureManager(
             FeatureFlag.IDENTITY_VERIFICATION ->
                 IdentityVerificationGates.update(
                     featureFlagOn = enabled,
-                    jwtRequirement = model.useIdentityVerification,
+                    jwtRequirement = configModelStore.model.useIdentityVerification,
                     source = "FeatureManager:${feature.activationMode}"
                 )
         }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/preferences/IPreferencesService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/preferences/IPreferencesService.kt
@@ -204,6 +204,9 @@ object PreferenceOneSignalKeys {
      */
     const val PREFS_OS_LOCATION_SHARED = "OS_LOCATION_SHARED"
 
+    /** (String) JSON object mapping externalId -> JWT token. */
+    const val PREFS_OS_JWT_TOKENS = "PREFS_OS_JWT_TOKENS"
+
     // Permissions
 
     /**

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/jwt/IJwtUpdateListener.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/jwt/IJwtUpdateListener.kt
@@ -1,0 +1,6 @@
+package com.onesignal.user.internal.jwt
+
+/** Notified by [JwtTokenStore] on put/invalidate. Null [jwt] means invalidated. */
+internal interface IJwtUpdateListener {
+    fun onJwtUpdated(externalId: String, jwt: String?)
+}

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/jwt/IJwtUpdateListener.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/jwt/IJwtUpdateListener.kt
@@ -1,6 +1,10 @@
 package com.onesignal.user.internal.jwt
 
-/** Notified by [JwtTokenStore] on put/invalidate. Null [jwt] means invalidated. */
+/**
+ * Wake-up notification from [JwtTokenStore] when the JWT for [externalId] changes.
+ * Listeners must call [JwtTokenStore.getJwt] for the current value — event delivery
+ * order is not guaranteed to match mutation order across concurrent writers.
+ */
 internal interface IJwtUpdateListener {
-    fun onJwtUpdated(externalId: String, jwt: String?)
+    fun onJwtUpdated(externalId: String)
 }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/jwt/IdentityVerificationGates.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/jwt/IdentityVerificationGates.kt
@@ -27,29 +27,18 @@ internal object IdentityVerificationGates {
     val newCodePathsRun: Boolean
         get() = _featureFlagOn || ivBehaviorActive
 
-    /** Idempotent. [source] is logged for traceability when gates change. */
+    /** Idempotent. [source] is logged for traceability. */
     fun update(
         featureFlagOn: Boolean,
         jwtRequirement: JwtRequirement,
         source: String,
     ) {
-        val previousNewCode = newCodePathsRun
-        val previousIvActive = ivBehaviorActive
-
         _featureFlagOn = featureFlagOn
         ivBehaviorActive = jwtRequirement == JwtRequirement.REQUIRED
 
-        if (previousNewCode != newCodePathsRun || previousIvActive != ivBehaviorActive) {
-            Logging.info(
-                "OneSignal: IdentityVerificationGates updated: " +
-                    "newCodePathsRun=$newCodePathsRun, ivBehaviorActive=$ivBehaviorActive " +
-                    "(source=$source, featureFlagOn=$featureFlagOn, jwtRequirement=$jwtRequirement)",
-            )
-        } else {
-            Logging.debug(
-                "OneSignal: IdentityVerificationGates unchanged " +
-                    "(source=$source, newCodePathsRun=$newCodePathsRun, ivBehaviorActive=$ivBehaviorActive)",
-            )
-        }
+        Logging.debug(
+            "OneSignal: IdentityVerificationGates.update: newCodePathsRun=$newCodePathsRun, " +
+                "ivBehaviorActive=$ivBehaviorActive (source=$source)",
+        )
     }
 }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/jwt/IdentityVerificationGates.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/jwt/IdentityVerificationGates.kt
@@ -23,20 +23,21 @@ internal object IdentityVerificationGates {
     /** Idempotent. [source] is logged for traceability when gates change. */
     fun update(
         featureFlagOn: Boolean,
-        jwtRequired: Boolean?,
+        jwtRequirement: JwtRequirement,
         source: String,
     ) {
         val previousNewCode = newCodePathsRun
         val previousIvActive = ivBehaviorActive
 
-        newCodePathsRun = featureFlagOn || (jwtRequired == true)
-        ivBehaviorActive = jwtRequired == true
+        val required = jwtRequirement == JwtRequirement.REQUIRED
+        newCodePathsRun = featureFlagOn || required
+        ivBehaviorActive = required
 
         if (previousNewCode != newCodePathsRun || previousIvActive != ivBehaviorActive) {
             Logging.info(
                 "OneSignal: IdentityVerificationGates updated: " +
                     "newCodePathsRun=$newCodePathsRun, ivBehaviorActive=$ivBehaviorActive " +
-                    "(source=$source, featureFlagOn=$featureFlagOn, jwtRequired=$jwtRequired)",
+                    "(source=$source, featureFlagOn=$featureFlagOn, jwtRequirement=$jwtRequirement)",
             )
         } else {
             Logging.debug(

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/jwt/IdentityVerificationGates.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/jwt/IdentityVerificationGates.kt
@@ -8,17 +8,24 @@ import com.onesignal.debug.internal.logging.Logging
  * The two gates differ on purpose: [newCodePathsRun] also flips on when customer config
  * (`jwt_required`) is true — honoring customer setup even if our feature flag is off.
  * [ivBehaviorActive] tracks customer config alone.
+ *
+ * Invariant `ivBehaviorActive == true ⇒ newCodePathsRun == true` is preserved at every
+ * observation because [newCodePathsRun] is derived on read from the stored inputs; a reader
+ * can't observe a state where one field is `true` and the other is `false` inconsistent
+ * with the formula.
  */
 internal object IdentityVerificationGates {
-    /** Whether new IV-related code paths should run. `featureFlag_IV_ON || jwt_required == true`. */
     @Volatile
-    var newCodePathsRun: Boolean = false
-        private set
+    private var _featureFlagOn: Boolean = false
 
     /** Whether IV-specific behavior (JWT attachment, auth error handling) applies. `jwt_required == true`. */
     @Volatile
     var ivBehaviorActive: Boolean = false
         private set
+
+    /** Whether new IV-related code paths should run. `featureFlag_IV_ON || jwt_required == true`. */
+    val newCodePathsRun: Boolean
+        get() = _featureFlagOn || ivBehaviorActive
 
     /** Idempotent. [source] is logged for traceability when gates change. */
     fun update(
@@ -29,9 +36,8 @@ internal object IdentityVerificationGates {
         val previousNewCode = newCodePathsRun
         val previousIvActive = ivBehaviorActive
 
-        val required = jwtRequirement == JwtRequirement.REQUIRED
-        newCodePathsRun = featureFlagOn || required
-        ivBehaviorActive = required
+        _featureFlagOn = featureFlagOn
+        ivBehaviorActive = jwtRequirement == JwtRequirement.REQUIRED
 
         if (previousNewCode != newCodePathsRun || previousIvActive != ivBehaviorActive) {
             Logging.info(

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/jwt/IdentityVerificationGates.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/jwt/IdentityVerificationGates.kt
@@ -5,25 +5,33 @@ import com.onesignal.debug.internal.logging.Logging
 /**
  * Current Identity Verification gate state, pushed by `FeatureManager.applySideEffects`.
  *
- * The two gates differ on purpose: [newCodePathsRun] also flips on when customer config
- * (`jwt_required`) is true — honoring customer setup even if our feature flag is off.
- * [ivBehaviorActive] tracks customer config alone.
+ * Stored state is the tri-state [jwtRequirement] — UNKNOWN until the first HYDRATE so consumers
+ * that need to distinguish "we don't know yet" from "customer opted out" can. The Boolean
+ * derivations [ivBehaviorActive] and [newCodePathsRun] cover the common case where consumers
+ * just want yes/no; UNKNOWN reads as `false` for both, which is the safe default before HYDRATE.
+ *
+ * The two gates differ on purpose: [newCodePathsRun] also flips on when our SDK feature flag is
+ * on, honoring rollout state even when the customer hasn't opted in. [ivBehaviorActive] tracks
+ * customer config alone.
  *
  * Invariant `ivBehaviorActive == true ⇒ newCodePathsRun == true` is preserved at every
- * observation because [newCodePathsRun] is derived on read from the stored inputs; a reader
- * can't observe a state where one field is `true` and the other is `false` inconsistent
- * with the formula.
+ * observation because both are derived on read from the stored inputs; a reader can't observe an
+ * inconsistent state.
  */
 internal object IdentityVerificationGates {
     @Volatile
     private var _featureFlagOn: Boolean = false
 
-    /** Whether IV-specific behavior (JWT attachment, auth error handling) applies. `jwt_required == true`. */
+    /** Customer config (`jwt_required`); [JwtRequirement.UNKNOWN] until the first HYDRATE. */
     @Volatile
-    var ivBehaviorActive: Boolean = false
+    var jwtRequirement: JwtRequirement = JwtRequirement.UNKNOWN
         private set
 
-    /** Whether new IV-related code paths should run. `featureFlag_IV_ON || jwt_required == true`. */
+    /** Whether IV-specific behavior (JWT attachment, auth error handling) applies. UNKNOWN reads as `false`. */
+    val ivBehaviorActive: Boolean
+        get() = jwtRequirement == JwtRequirement.REQUIRED
+
+    /** Whether new IV-related code paths should run. `featureFlag_IV_ON || jwt_required == REQUIRED`. */
     val newCodePathsRun: Boolean
         get() = _featureFlagOn || ivBehaviorActive
 
@@ -34,7 +42,7 @@ internal object IdentityVerificationGates {
         source: String,
     ) {
         _featureFlagOn = featureFlagOn
-        ivBehaviorActive = jwtRequirement == JwtRequirement.REQUIRED
+        this.jwtRequirement = jwtRequirement
 
         Logging.debug(
             "OneSignal: IdentityVerificationGates.update: newCodePathsRun=$newCodePathsRun, " +

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/jwt/IdentityVerificationGates.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/jwt/IdentityVerificationGates.kt
@@ -1,0 +1,48 @@
+package com.onesignal.user.internal.jwt
+
+import com.onesignal.debug.internal.logging.Logging
+
+/**
+ * Current Identity Verification gate state, pushed by `FeatureManager.applySideEffects`.
+ *
+ * The two gates differ on purpose: [newCodePathsRun] also flips on when customer config
+ * (`jwt_required`) is true — honoring customer setup even if our feature flag is off.
+ * [ivBehaviorActive] tracks customer config alone.
+ */
+internal object IdentityVerificationGates {
+    /** Whether new IV-related code paths should run. `featureFlag_IV_ON || jwt_required == true`. */
+    @Volatile
+    var newCodePathsRun: Boolean = false
+        private set
+
+    /** Whether IV-specific behavior (JWT attachment, auth error handling) applies. `jwt_required == true`. */
+    @Volatile
+    var ivBehaviorActive: Boolean = false
+        private set
+
+    /** Idempotent. [source] is logged for traceability when gates change. */
+    fun update(
+        featureFlagOn: Boolean,
+        jwtRequired: Boolean?,
+        source: String,
+    ) {
+        val previousNewCode = newCodePathsRun
+        val previousIvActive = ivBehaviorActive
+
+        newCodePathsRun = featureFlagOn || (jwtRequired == true)
+        ivBehaviorActive = jwtRequired == true
+
+        if (previousNewCode != newCodePathsRun || previousIvActive != ivBehaviorActive) {
+            Logging.info(
+                "OneSignal: IdentityVerificationGates updated: " +
+                    "newCodePathsRun=$newCodePathsRun, ivBehaviorActive=$ivBehaviorActive " +
+                    "(source=$source, featureFlagOn=$featureFlagOn, jwtRequired=$jwtRequired)",
+            )
+        } else {
+            Logging.debug(
+                "OneSignal: IdentityVerificationGates unchanged " +
+                    "(source=$source, newCodePathsRun=$newCodePathsRun, ivBehaviorActive=$ivBehaviorActive)",
+            )
+        }
+    }
+}

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/jwt/JwtRequirement.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/jwt/JwtRequirement.kt
@@ -1,0 +1,31 @@
+package com.onesignal.user.internal.jwt
+
+/**
+ * Customer-side JWT requirement, mirrored from the backend `jwt_required` remote param.
+ * Explicit [UNKNOWN] so callers can distinguish pre-HYDRATE (no value yet) from
+ * [NOT_REQUIRED] (customer opted out).
+ *
+ * Represents only the customer-config side of Identity Verification; do not confuse
+ * with [com.onesignal.core.internal.features.FeatureFlag.IDENTITY_VERIFICATION] (our
+ * SDK-side rollout switch).
+ */
+internal enum class JwtRequirement {
+    /** Remote params have not been fetched yet. Treat as non-IV until known. */
+    UNKNOWN,
+
+    /** Customer config `jwt_required=false`. No JWT signing. */
+    NOT_REQUIRED,
+
+    /** Customer config `jwt_required=true`. IV-specific behavior active. */
+    REQUIRED,
+    ;
+
+    companion object {
+        fun fromBoolean(value: Boolean?): JwtRequirement =
+            when (value) {
+                null -> UNKNOWN
+                false -> NOT_REQUIRED
+                true -> REQUIRED
+            }
+    }
+}

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/jwt/JwtRequirement.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/jwt/JwtRequirement.kt
@@ -6,7 +6,7 @@ package com.onesignal.user.internal.jwt
  * [NOT_REQUIRED] (customer opted out).
  *
  * Represents only the customer-config side of Identity Verification; do not confuse
- * with [com.onesignal.core.internal.features.FeatureFlag.IDENTITY_VERIFICATION] (our
+ * with [com.onesignal.core.internal.features.FeatureFlag.SDK_IDENTITY_VERIFICATION] (our
  * SDK-side rollout switch).
  */
 internal enum class JwtRequirement {

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/jwt/JwtTokenStore.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/jwt/JwtTokenStore.kt
@@ -51,11 +51,11 @@ internal class JwtTokenStore(
             }
         }
         if (changed) {
-            updates.fire { it.onJwtUpdated(externalId, jwt) }
+            updates.fire { it.onJwtUpdated(externalId) }
         }
     }
 
-    /** Removes the JWT for [externalId] and broadcasts with `jwt = null`. */
+    /** Removes the JWT for [externalId] and notifies subscribers. */
     fun invalidateJwt(externalId: String) {
         val existed: Boolean
         synchronized(tokens) {
@@ -66,7 +66,7 @@ internal class JwtTokenStore(
             }
         }
         if (existed) {
-            updates.fire { it.onJwtUpdated(externalId, null) }
+            updates.fire { it.onJwtUpdated(externalId) }
         }
     }
 
@@ -83,7 +83,7 @@ internal class JwtTokenStore(
             }
         }
         for (externalId in removed) {
-            updates.fire { it.onJwtUpdated(externalId, null) }
+            updates.fire { it.onJwtUpdated(externalId) }
         }
     }
 

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/jwt/JwtTokenStore.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/jwt/JwtTokenStore.kt
@@ -1,0 +1,119 @@
+package com.onesignal.user.internal.jwt
+
+import com.onesignal.common.events.EventProducer
+import com.onesignal.common.events.IEventNotifier
+import com.onesignal.core.internal.preferences.IPreferencesService
+import com.onesignal.core.internal.preferences.PreferenceOneSignalKeys
+import com.onesignal.core.internal.preferences.PreferenceStores
+import com.onesignal.debug.internal.logging.Logging
+import org.json.JSONException
+import org.json.JSONObject
+
+/**
+ * Persistent store mapping externalId -> JWT. Multi-user so ops queued under a previous user
+ * can still resolve their JWT at execution time. Storage is unconditional; *usage* of JWTs is
+ * gated on [IdentityVerificationGates.ivBehaviorActive].
+ */
+internal class JwtTokenStore(
+    private val _prefs: IPreferencesService,
+) : IEventNotifier<IJwtUpdateListener> {
+    private val tokens: MutableMap<String, String> = mutableMapOf()
+    private var isLoaded: Boolean = false
+    private val updates = EventProducer<IJwtUpdateListener>()
+
+    override val hasSubscribers: Boolean
+        get() = updates.hasSubscribers
+
+    override fun subscribe(handler: IJwtUpdateListener) = updates.subscribe(handler)
+
+    override fun unsubscribe(handler: IJwtUpdateListener) = updates.unsubscribe(handler)
+
+    fun getJwt(externalId: String): String? {
+        synchronized(tokens) {
+            ensureLoaded()
+            return tokens[externalId]
+        }
+    }
+
+    /** Null [jwt] is a no-op; call [invalidateJwt] to remove a token. */
+    fun putJwt(
+        externalId: String,
+        jwt: String?,
+    ) {
+        if (jwt == null) return
+        val changed: Boolean
+        synchronized(tokens) {
+            ensureLoaded()
+            changed = tokens[externalId] != jwt
+            tokens[externalId] = jwt
+            if (changed) {
+                persist()
+            }
+        }
+        if (changed) {
+            updates.fire { it.onJwtUpdated(externalId, jwt) }
+        }
+    }
+
+    /** Removes the JWT for [externalId] and broadcasts with `jwt = null`. */
+    fun invalidateJwt(externalId: String) {
+        val existed: Boolean
+        synchronized(tokens) {
+            ensureLoaded()
+            existed = tokens.remove(externalId) != null
+            if (existed) {
+                persist()
+            }
+        }
+        if (existed) {
+            updates.fire { it.onJwtUpdated(externalId, null) }
+        }
+    }
+
+    /** Drops JWTs whose externalId isn't in [activeIds]. Call on cold start to bound growth. */
+    fun pruneToExternalIds(activeIds: Set<String>) {
+        val removed: Set<String>
+        synchronized(tokens) {
+            ensureLoaded()
+            val toRemove = tokens.keys - activeIds
+            removed = toRemove.toSet()
+            if (removed.isNotEmpty()) {
+                tokens.keys.removeAll(removed)
+                persist()
+            }
+        }
+        for (externalId in removed) {
+            updates.fire { it.onJwtUpdated(externalId, null) }
+        }
+    }
+
+    /** Caller must hold `synchronized(tokens)`. */
+    private fun ensureLoaded() {
+        if (isLoaded) return
+        val json =
+            _prefs.getString(
+                PreferenceStores.ONESIGNAL,
+                PreferenceOneSignalKeys.PREFS_OS_JWT_TOKENS,
+            )
+        if (json != null) {
+            try {
+                val obj = JSONObject(json)
+                for (key in obj.keys()) {
+                    tokens[key] = obj.getString(key)
+                }
+            } catch (e: JSONException) {
+                Logging.warn("JwtTokenStore: failed to parse persisted tokens, starting fresh: ${e.message}")
+            }
+        }
+        isLoaded = true
+    }
+
+    /** Caller must hold `synchronized(tokens)`. */
+    private fun persist() {
+        _prefs.saveString(
+            PreferenceStores.ONESIGNAL,
+            PreferenceOneSignalKeys.PREFS_OS_JWT_TOKENS,
+            JSONObject(tokens.toMap()).toString(),
+        )
+    }
+}

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/features/FeatureFlagTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/features/FeatureFlagTests.kt
@@ -15,4 +15,9 @@ class FeatureFlagTests : FunSpec({
     test("SDK_BACKGROUND_THREADING uses the expected remote key") {
         FeatureFlag.SDK_BACKGROUND_THREADING.key shouldBe "sdk_background_threading"
     }
+
+    test("IDENTITY_VERIFICATION uses the expected remote key and IMMEDIATE activation") {
+        FeatureFlag.IDENTITY_VERIFICATION.key shouldBe "identity_verification"
+        FeatureFlag.IDENTITY_VERIFICATION.activationMode shouldBe FeatureActivationMode.IMMEDIATE
+    }
 })

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/features/FeatureFlagTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/features/FeatureFlagTests.kt
@@ -16,8 +16,8 @@ class FeatureFlagTests : FunSpec({
         FeatureFlag.SDK_BACKGROUND_THREADING.key shouldBe "sdk_background_threading"
     }
 
-    test("IDENTITY_VERIFICATION uses the expected remote key and IMMEDIATE activation") {
-        FeatureFlag.IDENTITY_VERIFICATION.key shouldBe "identity_verification"
-        FeatureFlag.IDENTITY_VERIFICATION.activationMode shouldBe FeatureActivationMode.IMMEDIATE
+    test("SDK_IDENTITY_VERIFICATION uses the expected remote key and IMMEDIATE activation") {
+        FeatureFlag.SDK_IDENTITY_VERIFICATION.key shouldBe "sdk_identity_verification"
+        FeatureFlag.SDK_IDENTITY_VERIFICATION.activationMode shouldBe FeatureActivationMode.IMMEDIATE
     }
 })

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/features/FeatureManagerTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/features/FeatureManagerTests.kt
@@ -202,7 +202,7 @@ class FeatureManagerTests : FunSpec({
 
         val manager = FeatureManager(configModelStore)
 
-        manager.isEnabled(FeatureFlag.IDENTITY_VERIFICATION) shouldBe false
+        manager.isEnabled(FeatureFlag.SDK_IDENTITY_VERIFICATION) shouldBe false
         IdentityVerificationGates.newCodePathsRun shouldBe false
         IdentityVerificationGates.ivBehaviorActive shouldBe false
     }
@@ -210,14 +210,14 @@ class FeatureManagerTests : FunSpec({
     test("initial state: IDENTITY_VERIFICATION flag on → newCodePathsRun=true, ivBehaviorActive=false") {
         val initialModel = mockk<ConfigModel>()
         stubConfigModel(initialModel)
-        every { initialModel.sdkRemoteFeatureFlags } returns listOf(FeatureFlag.IDENTITY_VERIFICATION.key)
+        every { initialModel.sdkRemoteFeatureFlags } returns listOf(FeatureFlag.SDK_IDENTITY_VERIFICATION.key)
         val configModelStore = mockk<ConfigModelStore>()
         every { configModelStore.model } returns initialModel
         every { configModelStore.subscribe(any()) } just runs
 
         val manager = FeatureManager(configModelStore)
 
-        manager.isEnabled(FeatureFlag.IDENTITY_VERIFICATION) shouldBe true
+        manager.isEnabled(FeatureFlag.SDK_IDENTITY_VERIFICATION) shouldBe true
         IdentityVerificationGates.newCodePathsRun shouldBe true
         IdentityVerificationGates.ivBehaviorActive shouldBe false
     }
@@ -232,7 +232,7 @@ class FeatureManagerTests : FunSpec({
 
         val manager = FeatureManager(configModelStore)
 
-        manager.isEnabled(FeatureFlag.IDENTITY_VERIFICATION) shouldBe false
+        manager.isEnabled(FeatureFlag.SDK_IDENTITY_VERIFICATION) shouldBe false
         IdentityVerificationGates.newCodePathsRun shouldBe true
         IdentityVerificationGates.ivBehaviorActive shouldBe true
     }
@@ -240,7 +240,7 @@ class FeatureManagerTests : FunSpec({
     test("initial state: flag on + jwt_required=true → full IV (both gates true)") {
         val initialModel = mockk<ConfigModel>()
         stubConfigModel(initialModel)
-        every { initialModel.sdkRemoteFeatureFlags } returns listOf(FeatureFlag.IDENTITY_VERIFICATION.key)
+        every { initialModel.sdkRemoteFeatureFlags } returns listOf(FeatureFlag.SDK_IDENTITY_VERIFICATION.key)
         every { initialModel.useIdentityVerification } returns JwtRequirement.REQUIRED
         val configModelStore = mockk<ConfigModelStore>()
         every { configModelStore.model } returns initialModel
@@ -248,7 +248,7 @@ class FeatureManagerTests : FunSpec({
 
         val manager = FeatureManager(configModelStore)
 
-        manager.isEnabled(FeatureFlag.IDENTITY_VERIFICATION) shouldBe true
+        manager.isEnabled(FeatureFlag.SDK_IDENTITY_VERIFICATION) shouldBe true
         IdentityVerificationGates.newCodePathsRun shouldBe true
         IdentityVerificationGates.ivBehaviorActive shouldBe true
     }
@@ -286,14 +286,14 @@ class FeatureManagerTests : FunSpec({
         // Mid-session model replacement enables the flag remotely.
         val updatedModel = mockk<ConfigModel>()
         stubConfigModel(updatedModel)
-        every { updatedModel.sdkRemoteFeatureFlags } returns listOf(FeatureFlag.IDENTITY_VERIFICATION.key)
+        every { updatedModel.sdkRemoteFeatureFlags } returns listOf(FeatureFlag.SDK_IDENTITY_VERIFICATION.key)
         every { updatedModel.useIdentityVerification } returns JwtRequirement.NOT_REQUIRED
         every { configModelStore.model } returns updatedModel
 
         manager.onModelReplaced(updatedModel, ModelChangeTags.HYDRATE)
 
         // Feature flag flips in-memory because IDENTITY_VERIFICATION is IMMEDIATE.
-        manager.isEnabled(FeatureFlag.IDENTITY_VERIFICATION) shouldBe true
+        manager.isEnabled(FeatureFlag.SDK_IDENTITY_VERIFICATION) shouldBe true
         // newCodePathsRun reflects the flipped flag; ivBehaviorActive still false (jwt_required=false).
         IdentityVerificationGates.newCodePathsRun shouldBe true
         IdentityVerificationGates.ivBehaviorActive shouldBe false

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/features/FeatureManagerTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/features/FeatureManagerTests.kt
@@ -5,6 +5,7 @@ import com.onesignal.common.threading.ThreadingMode
 import com.onesignal.core.internal.config.ConfigModel
 import com.onesignal.core.internal.config.ConfigModelStore
 import com.onesignal.user.internal.jwt.IdentityVerificationGates
+import com.onesignal.user.internal.jwt.JwtRequirement
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
@@ -16,13 +17,13 @@ import kotlinx.serialization.json.jsonPrimitive
 class FeatureManagerTests : FunSpec({
     beforeEach {
         ThreadingMode.useBackgroundThreading = false
-        IdentityVerificationGates.update(false, null, "test-reset")
+        IdentityVerificationGates.update(false, JwtRequirement.UNKNOWN, "test-reset")
     }
 
     fun stubConfigModel(model: ConfigModel) {
         every { model.sdkRemoteFeatureFlags } returns emptyList()
         every { model.sdkRemoteFeatureFlagMetadata } returns null
-        every { model.useIdentityVerification } returns null
+        every { model.useIdentityVerification } returns JwtRequirement.UNKNOWN
     }
 
     test("initial state enables BACKGROUND_THREADING when key is present in sdk remote flags") {
@@ -224,7 +225,7 @@ class FeatureManagerTests : FunSpec({
     test("ERROR STATE: flag off + jwt_required=true → both gates true (customer config wins)") {
         val initialModel = mockk<ConfigModel>()
         stubConfigModel(initialModel)
-        every { initialModel.useIdentityVerification } returns true
+        every { initialModel.useIdentityVerification } returns JwtRequirement.REQUIRED
         val configModelStore = mockk<ConfigModelStore>()
         every { configModelStore.model } returns initialModel
         every { configModelStore.subscribe(any()) } just runs
@@ -240,7 +241,7 @@ class FeatureManagerTests : FunSpec({
         val initialModel = mockk<ConfigModel>()
         stubConfigModel(initialModel)
         every { initialModel.sdkRemoteFeatureFlags } returns listOf(FeatureFlag.IDENTITY_VERIFICATION.key)
-        every { initialModel.useIdentityVerification } returns true
+        every { initialModel.useIdentityVerification } returns JwtRequirement.REQUIRED
         val configModelStore = mockk<ConfigModelStore>()
         every { configModelStore.model } returns initialModel
         every { configModelStore.subscribe(any()) } just runs
@@ -264,7 +265,7 @@ class FeatureManagerTests : FunSpec({
 
         val updatedModel = mockk<ConfigModel>()
         stubConfigModel(updatedModel)
-        every { updatedModel.useIdentityVerification } returns true
+        every { updatedModel.useIdentityVerification } returns JwtRequirement.REQUIRED
 
         manager.onModelReplaced(updatedModel, ModelChangeTags.HYDRATE)
 
@@ -284,7 +285,7 @@ class FeatureManagerTests : FunSpec({
         val updatedModel = mockk<ConfigModel>()
         stubConfigModel(updatedModel)
         every { updatedModel.sdkRemoteFeatureFlags } returns listOf(FeatureFlag.IDENTITY_VERIFICATION.key)
-        every { updatedModel.useIdentityVerification } returns false
+        every { updatedModel.useIdentityVerification } returns JwtRequirement.NOT_REQUIRED
 
         manager.onModelReplaced(updatedModel, ModelChangeTags.HYDRATE)
 

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/features/FeatureManagerTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/features/FeatureManagerTests.kt
@@ -266,6 +266,8 @@ class FeatureManagerTests : FunSpec({
         val updatedModel = mockk<ConfigModel>()
         stubConfigModel(updatedModel)
         every { updatedModel.useIdentityVerification } returns JwtRequirement.REQUIRED
+        // Match production: store's model is swapped before onModelReplaced fires.
+        every { configModelStore.model } returns updatedModel
 
         manager.onModelReplaced(updatedModel, ModelChangeTags.HYDRATE)
 
@@ -286,6 +288,7 @@ class FeatureManagerTests : FunSpec({
         stubConfigModel(updatedModel)
         every { updatedModel.sdkRemoteFeatureFlags } returns listOf(FeatureFlag.IDENTITY_VERIFICATION.key)
         every { updatedModel.useIdentityVerification } returns JwtRequirement.NOT_REQUIRED
+        every { configModelStore.model } returns updatedModel
 
         manager.onModelReplaced(updatedModel, ModelChangeTags.HYDRATE)
 

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/features/FeatureManagerTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/features/FeatureManagerTests.kt
@@ -4,6 +4,7 @@ import com.onesignal.common.modeling.ModelChangeTags
 import com.onesignal.common.threading.ThreadingMode
 import com.onesignal.core.internal.config.ConfigModel
 import com.onesignal.core.internal.config.ConfigModelStore
+import com.onesignal.user.internal.jwt.IdentityVerificationGates
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
@@ -15,11 +16,13 @@ import kotlinx.serialization.json.jsonPrimitive
 class FeatureManagerTests : FunSpec({
     beforeEach {
         ThreadingMode.useBackgroundThreading = false
+        IdentityVerificationGates.update(false, null, "test-reset")
     }
 
     fun stubConfigModel(model: ConfigModel) {
         every { model.sdkRemoteFeatureFlags } returns emptyList()
         every { model.sdkRemoteFeatureFlagMetadata } returns null
+        every { model.useIdentityVerification } returns null
     }
 
     test("initial state enables BACKGROUND_THREADING when key is present in sdk remote flags") {
@@ -187,5 +190,108 @@ class FeatureManagerTests : FunSpec({
         manager.onModelReplaced(updatedModel, ModelChangeTags.HYDRATE)
 
         manager.enabledFeatureKeys() shouldBe emptyList()
+    }
+
+    test("initial state: IDENTITY_VERIFICATION flag off + jwt_required=null → gates both false") {
+        val initialModel = mockk<ConfigModel>()
+        stubConfigModel(initialModel)
+        val configModelStore = mockk<ConfigModelStore>()
+        every { configModelStore.model } returns initialModel
+        every { configModelStore.subscribe(any()) } just runs
+
+        val manager = FeatureManager(configModelStore)
+
+        manager.isEnabled(FeatureFlag.IDENTITY_VERIFICATION) shouldBe false
+        IdentityVerificationGates.newCodePathsRun shouldBe false
+        IdentityVerificationGates.ivBehaviorActive shouldBe false
+    }
+
+    test("initial state: IDENTITY_VERIFICATION flag on → newCodePathsRun=true, ivBehaviorActive=false") {
+        val initialModel = mockk<ConfigModel>()
+        stubConfigModel(initialModel)
+        every { initialModel.sdkRemoteFeatureFlags } returns listOf(FeatureFlag.IDENTITY_VERIFICATION.key)
+        val configModelStore = mockk<ConfigModelStore>()
+        every { configModelStore.model } returns initialModel
+        every { configModelStore.subscribe(any()) } just runs
+
+        val manager = FeatureManager(configModelStore)
+
+        manager.isEnabled(FeatureFlag.IDENTITY_VERIFICATION) shouldBe true
+        IdentityVerificationGates.newCodePathsRun shouldBe true
+        IdentityVerificationGates.ivBehaviorActive shouldBe false
+    }
+
+    test("ERROR STATE: flag off + jwt_required=true → both gates true (customer config wins)") {
+        val initialModel = mockk<ConfigModel>()
+        stubConfigModel(initialModel)
+        every { initialModel.useIdentityVerification } returns true
+        val configModelStore = mockk<ConfigModelStore>()
+        every { configModelStore.model } returns initialModel
+        every { configModelStore.subscribe(any()) } just runs
+
+        val manager = FeatureManager(configModelStore)
+
+        manager.isEnabled(FeatureFlag.IDENTITY_VERIFICATION) shouldBe false
+        IdentityVerificationGates.newCodePathsRun shouldBe true
+        IdentityVerificationGates.ivBehaviorActive shouldBe true
+    }
+
+    test("initial state: flag on + jwt_required=true → full IV (both gates true)") {
+        val initialModel = mockk<ConfigModel>()
+        stubConfigModel(initialModel)
+        every { initialModel.sdkRemoteFeatureFlags } returns listOf(FeatureFlag.IDENTITY_VERIFICATION.key)
+        every { initialModel.useIdentityVerification } returns true
+        val configModelStore = mockk<ConfigModelStore>()
+        every { configModelStore.model } returns initialModel
+        every { configModelStore.subscribe(any()) } just runs
+
+        val manager = FeatureManager(configModelStore)
+
+        manager.isEnabled(FeatureFlag.IDENTITY_VERIFICATION) shouldBe true
+        IdentityVerificationGates.newCodePathsRun shouldBe true
+        IdentityVerificationGates.ivBehaviorActive shouldBe true
+    }
+
+    test("HYDRATE updates gates when useIdentityVerification arrives as true") {
+        val initialModel = mockk<ConfigModel>()
+        stubConfigModel(initialModel)
+        val configModelStore = mockk<ConfigModelStore>()
+        every { configModelStore.model } returns initialModel
+        every { configModelStore.subscribe(any()) } just runs
+        val manager = FeatureManager(configModelStore)
+
+        IdentityVerificationGates.ivBehaviorActive shouldBe false
+
+        val updatedModel = mockk<ConfigModel>()
+        stubConfigModel(updatedModel)
+        every { updatedModel.useIdentityVerification } returns true
+
+        manager.onModelReplaced(updatedModel, ModelChangeTags.HYDRATE)
+
+        IdentityVerificationGates.newCodePathsRun shouldBe true
+        IdentityVerificationGates.ivBehaviorActive shouldBe true
+    }
+
+    test("IDENTITY_VERIFICATION is IMMEDIATE: mid-session flag flip flows through to the gates") {
+        val initialModel = mockk<ConfigModel>()
+        stubConfigModel(initialModel)
+        val configModelStore = mockk<ConfigModelStore>()
+        every { configModelStore.model } returns initialModel
+        every { configModelStore.subscribe(any()) } just runs
+        val manager = FeatureManager(configModelStore)
+
+        // Mid-session model replacement enables the flag remotely.
+        val updatedModel = mockk<ConfigModel>()
+        stubConfigModel(updatedModel)
+        every { updatedModel.sdkRemoteFeatureFlags } returns listOf(FeatureFlag.IDENTITY_VERIFICATION.key)
+        every { updatedModel.useIdentityVerification } returns false
+
+        manager.onModelReplaced(updatedModel, ModelChangeTags.HYDRATE)
+
+        // Feature flag flips in-memory because IDENTITY_VERIFICATION is IMMEDIATE.
+        manager.isEnabled(FeatureFlag.IDENTITY_VERIFICATION) shouldBe true
+        // newCodePathsRun reflects the flipped flag; ivBehaviorActive still false (jwt_required=false).
+        IdentityVerificationGates.newCodePathsRun shouldBe true
+        IdentityVerificationGates.ivBehaviorActive shouldBe false
     }
 })

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/jwt/IdentityVerificationGatesTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/jwt/IdentityVerificationGatesTests.kt
@@ -6,7 +6,7 @@ import io.kotest.matchers.shouldBe
 class IdentityVerificationGatesTests : FunSpec({
     // Singleton state leaks across tests; reset before each.
     beforeEach {
-        IdentityVerificationGates.update(false, null, "test-reset")
+        IdentityVerificationGates.update(false, JwtRequirement.UNKNOWN, "test-reset")
     }
 
     test("defaults to newCodePathsRun=false and ivBehaviorActive=false") {
@@ -14,60 +14,60 @@ class IdentityVerificationGatesTests : FunSpec({
         IdentityVerificationGates.ivBehaviorActive shouldBe false
     }
 
-    test("featureFlagOn=false, jwtRequired=null: both gates are false (safe default)") {
+    test("featureFlagOn=false, jwtRequirement=UNKNOWN: both gates are false (safe default)") {
         IdentityVerificationGates.update(
             featureFlagOn = false,
-            jwtRequired = null,
+            jwtRequirement = JwtRequirement.UNKNOWN,
             source = "test",
         )
         IdentityVerificationGates.newCodePathsRun shouldBe false
         IdentityVerificationGates.ivBehaviorActive shouldBe false
     }
 
-    test("featureFlagOn=false, jwtRequired=false: both gates are false") {
+    test("featureFlagOn=false, jwtRequirement=NOT_REQUIRED: both gates are false") {
         IdentityVerificationGates.update(
             featureFlagOn = false,
-            jwtRequired = false,
+            jwtRequirement = JwtRequirement.NOT_REQUIRED,
             source = "test",
         )
         IdentityVerificationGates.newCodePathsRun shouldBe false
         IdentityVerificationGates.ivBehaviorActive shouldBe false
     }
 
-    test("ERROR STATE — featureFlagOn=false, jwtRequired=true: both gates true (customer config wins)") {
+    test("ERROR STATE — featureFlagOn=false, jwtRequirement=REQUIRED: both gates true (customer config wins)") {
         IdentityVerificationGates.update(
             featureFlagOn = false,
-            jwtRequired = true,
+            jwtRequirement = JwtRequirement.REQUIRED,
             source = "test",
         )
         IdentityVerificationGates.newCodePathsRun shouldBe true
         IdentityVerificationGates.ivBehaviorActive shouldBe true
     }
 
-    test("featureFlagOn=true, jwtRequired=null: newCodePathsRun true, ivBehaviorActive false") {
+    test("featureFlagOn=true, jwtRequirement=UNKNOWN: newCodePathsRun true, ivBehaviorActive false") {
         IdentityVerificationGates.update(
             featureFlagOn = true,
-            jwtRequired = null,
+            jwtRequirement = JwtRequirement.UNKNOWN,
             source = "test",
         )
         IdentityVerificationGates.newCodePathsRun shouldBe true
         IdentityVerificationGates.ivBehaviorActive shouldBe false
     }
 
-    test("featureFlagOn=true, jwtRequired=false: newCodePathsRun true, ivBehaviorActive false (Phase 3)") {
+    test("featureFlagOn=true, jwtRequirement=NOT_REQUIRED: newCodePathsRun true, ivBehaviorActive false (Phase 3)") {
         IdentityVerificationGates.update(
             featureFlagOn = true,
-            jwtRequired = false,
+            jwtRequirement = JwtRequirement.NOT_REQUIRED,
             source = "test",
         )
         IdentityVerificationGates.newCodePathsRun shouldBe true
         IdentityVerificationGates.ivBehaviorActive shouldBe false
     }
 
-    test("featureFlagOn=true, jwtRequired=true: both gates true (full IV)") {
+    test("featureFlagOn=true, jwtRequirement=REQUIRED: both gates true (full IV)") {
         IdentityVerificationGates.update(
             featureFlagOn = true,
-            jwtRequired = true,
+            jwtRequirement = JwtRequirement.REQUIRED,
             source = "test",
         )
         IdentityVerificationGates.newCodePathsRun shouldBe true
@@ -75,22 +75,22 @@ class IdentityVerificationGatesTests : FunSpec({
     }
 
     test("updating to the same values is a no-op but still reflects in reads") {
-        IdentityVerificationGates.update(true, true, "first")
-        IdentityVerificationGates.update(true, true, "second")
+        IdentityVerificationGates.update(true, JwtRequirement.REQUIRED, "first")
+        IdentityVerificationGates.update(true, JwtRequirement.REQUIRED, "second")
         IdentityVerificationGates.newCodePathsRun shouldBe true
         IdentityVerificationGates.ivBehaviorActive shouldBe true
     }
 
     test("transition: non-IV → IV-active → off") {
-        IdentityVerificationGates.update(false, false, "phase-1-non-iv")
+        IdentityVerificationGates.update(false, JwtRequirement.NOT_REQUIRED, "phase-1-non-iv")
         IdentityVerificationGates.newCodePathsRun shouldBe false
         IdentityVerificationGates.ivBehaviorActive shouldBe false
 
-        IdentityVerificationGates.update(true, true, "phase-2-iv-on")
+        IdentityVerificationGates.update(true, JwtRequirement.REQUIRED, "phase-2-iv-on")
         IdentityVerificationGates.newCodePathsRun shouldBe true
         IdentityVerificationGates.ivBehaviorActive shouldBe true
 
-        IdentityVerificationGates.update(false, false, "kill-switch")
+        IdentityVerificationGates.update(false, JwtRequirement.NOT_REQUIRED, "kill-switch")
         IdentityVerificationGates.newCodePathsRun shouldBe false
         IdentityVerificationGates.ivBehaviorActive shouldBe false
     }

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/jwt/IdentityVerificationGatesTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/jwt/IdentityVerificationGatesTests.kt
@@ -1,0 +1,97 @@
+package com.onesignal.user.internal.jwt
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class IdentityVerificationGatesTests : FunSpec({
+    // Singleton state leaks across tests; reset before each.
+    beforeEach {
+        IdentityVerificationGates.update(false, null, "test-reset")
+    }
+
+    test("defaults to newCodePathsRun=false and ivBehaviorActive=false") {
+        IdentityVerificationGates.newCodePathsRun shouldBe false
+        IdentityVerificationGates.ivBehaviorActive shouldBe false
+    }
+
+    test("featureFlagOn=false, jwtRequired=null: both gates are false (safe default)") {
+        IdentityVerificationGates.update(
+            featureFlagOn = false,
+            jwtRequired = null,
+            source = "test",
+        )
+        IdentityVerificationGates.newCodePathsRun shouldBe false
+        IdentityVerificationGates.ivBehaviorActive shouldBe false
+    }
+
+    test("featureFlagOn=false, jwtRequired=false: both gates are false") {
+        IdentityVerificationGates.update(
+            featureFlagOn = false,
+            jwtRequired = false,
+            source = "test",
+        )
+        IdentityVerificationGates.newCodePathsRun shouldBe false
+        IdentityVerificationGates.ivBehaviorActive shouldBe false
+    }
+
+    test("ERROR STATE — featureFlagOn=false, jwtRequired=true: both gates true (customer config wins)") {
+        IdentityVerificationGates.update(
+            featureFlagOn = false,
+            jwtRequired = true,
+            source = "test",
+        )
+        IdentityVerificationGates.newCodePathsRun shouldBe true
+        IdentityVerificationGates.ivBehaviorActive shouldBe true
+    }
+
+    test("featureFlagOn=true, jwtRequired=null: newCodePathsRun true, ivBehaviorActive false") {
+        IdentityVerificationGates.update(
+            featureFlagOn = true,
+            jwtRequired = null,
+            source = "test",
+        )
+        IdentityVerificationGates.newCodePathsRun shouldBe true
+        IdentityVerificationGates.ivBehaviorActive shouldBe false
+    }
+
+    test("featureFlagOn=true, jwtRequired=false: newCodePathsRun true, ivBehaviorActive false (Phase 3)") {
+        IdentityVerificationGates.update(
+            featureFlagOn = true,
+            jwtRequired = false,
+            source = "test",
+        )
+        IdentityVerificationGates.newCodePathsRun shouldBe true
+        IdentityVerificationGates.ivBehaviorActive shouldBe false
+    }
+
+    test("featureFlagOn=true, jwtRequired=true: both gates true (full IV)") {
+        IdentityVerificationGates.update(
+            featureFlagOn = true,
+            jwtRequired = true,
+            source = "test",
+        )
+        IdentityVerificationGates.newCodePathsRun shouldBe true
+        IdentityVerificationGates.ivBehaviorActive shouldBe true
+    }
+
+    test("updating to the same values is a no-op but still reflects in reads") {
+        IdentityVerificationGates.update(true, true, "first")
+        IdentityVerificationGates.update(true, true, "second")
+        IdentityVerificationGates.newCodePathsRun shouldBe true
+        IdentityVerificationGates.ivBehaviorActive shouldBe true
+    }
+
+    test("transition: non-IV → IV-active → off") {
+        IdentityVerificationGates.update(false, false, "phase-1-non-iv")
+        IdentityVerificationGates.newCodePathsRun shouldBe false
+        IdentityVerificationGates.ivBehaviorActive shouldBe false
+
+        IdentityVerificationGates.update(true, true, "phase-2-iv-on")
+        IdentityVerificationGates.newCodePathsRun shouldBe true
+        IdentityVerificationGates.ivBehaviorActive shouldBe true
+
+        IdentityVerificationGates.update(false, false, "kill-switch")
+        IdentityVerificationGates.newCodePathsRun shouldBe false
+        IdentityVerificationGates.ivBehaviorActive shouldBe false
+    }
+})

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/jwt/JwtTokenStoreTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/jwt/JwtTokenStoreTests.kt
@@ -1,0 +1,231 @@
+package com.onesignal.user.internal.jwt
+
+import com.onesignal.core.internal.preferences.PreferenceOneSignalKeys
+import com.onesignal.core.internal.preferences.PreferenceStores
+import com.onesignal.debug.LogLevel
+import com.onesignal.debug.internal.logging.Logging
+import com.onesignal.mocks.MockPreferencesService
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import org.json.JSONObject
+
+class JwtTokenStoreTests : FunSpec({
+    beforeEach {
+        // Silence logging to avoid android.util.Log.w not-mocked failures in Logging.warn
+        Logging.logLevel = LogLevel.NONE
+    }
+
+    test("getJwt returns null for an externalId never stored") {
+        val store = JwtTokenStore(MockPreferencesService())
+
+        store.getJwt("alice") shouldBe null
+    }
+
+    test("putJwt stores a token retrievable by externalId") {
+        val store = JwtTokenStore(MockPreferencesService())
+
+        store.putJwt("alice", "token-a")
+
+        store.getJwt("alice") shouldBe "token-a"
+    }
+
+    test("putJwt replaces an existing token for the same externalId") {
+        val store = JwtTokenStore(MockPreferencesService())
+        store.putJwt("alice", "token-a1")
+
+        store.putJwt("alice", "token-a2")
+
+        store.getJwt("alice") shouldBe "token-a2"
+    }
+
+    test("putJwt with null is a no-op (invalidate is the explicit path)") {
+        val store = JwtTokenStore(MockPreferencesService())
+        store.putJwt("alice", "token-a")
+
+        store.putJwt("alice", null)
+
+        store.getJwt("alice") shouldBe "token-a"
+    }
+
+    test("invalidateJwt removes the token for externalId") {
+        val store = JwtTokenStore(MockPreferencesService())
+        store.putJwt("alice", "token-a")
+
+        store.invalidateJwt("alice")
+
+        store.getJwt("alice") shouldBe null
+    }
+
+    test("invalidateJwt on an absent externalId is a no-op (no crash)") {
+        val store = JwtTokenStore(MockPreferencesService())
+
+        store.invalidateJwt("alice")
+
+        store.getJwt("alice") shouldBe null
+    }
+
+    test("putJwt persists to preferences and can be recovered by a fresh store instance") {
+        val prefs = MockPreferencesService()
+        val first = JwtTokenStore(prefs)
+        first.putJwt("alice", "token-a")
+        first.putJwt("bob", "token-b")
+
+        val second = JwtTokenStore(prefs)
+
+        second.getJwt("alice") shouldBe "token-a"
+        second.getJwt("bob") shouldBe "token-b"
+    }
+
+    test("invalidateJwt persists so next launch does not see the token") {
+        val prefs = MockPreferencesService()
+        val first = JwtTokenStore(prefs)
+        first.putJwt("alice", "token-a")
+        first.invalidateJwt("alice")
+
+        val second = JwtTokenStore(prefs)
+
+        second.getJwt("alice") shouldBe null
+    }
+
+    test("pruneToExternalIds removes tokens whose externalId is not in the active set") {
+        val store = JwtTokenStore(MockPreferencesService())
+        store.putJwt("alice", "token-a")
+        store.putJwt("bob", "token-b")
+        store.putJwt("chris", "token-c")
+
+        store.pruneToExternalIds(setOf("alice", "chris"))
+
+        store.getJwt("alice") shouldBe "token-a"
+        store.getJwt("bob") shouldBe null
+        store.getJwt("chris") shouldBe "token-c"
+    }
+
+    test("subscribers are notified when a new JWT is put") {
+        val store = JwtTokenStore(MockPreferencesService())
+        val calls = mutableListOf<Pair<String, String?>>()
+        store.subscribe(
+            object : IJwtUpdateListener {
+                override fun onJwtUpdated(externalId: String, jwt: String?) {
+                    calls.add(externalId to jwt)
+                }
+            },
+        )
+
+        store.putJwt("alice", "token-a")
+
+        calls shouldBe listOf("alice" to "token-a")
+    }
+
+    test("subscribers are NOT notified when putJwt does not change the stored token") {
+        val store = JwtTokenStore(MockPreferencesService())
+        store.putJwt("alice", "token-a")
+        val calls = mutableListOf<Pair<String, String?>>()
+        store.subscribe(
+            object : IJwtUpdateListener {
+                override fun onJwtUpdated(externalId: String, jwt: String?) {
+                    calls.add(externalId to jwt)
+                }
+            },
+        )
+
+        store.putJwt("alice", "token-a")
+
+        calls.isEmpty() shouldBe true
+    }
+
+    test("subscribers are notified on invalidation with null jwt") {
+        val store = JwtTokenStore(MockPreferencesService())
+        store.putJwt("alice", "token-a")
+        val calls = mutableListOf<Pair<String, String?>>()
+        store.subscribe(
+            object : IJwtUpdateListener {
+                override fun onJwtUpdated(externalId: String, jwt: String?) {
+                    calls.add(externalId to jwt)
+                }
+            },
+        )
+
+        store.invalidateJwt("alice")
+
+        calls shouldBe listOf("alice" to null)
+    }
+
+    test("subscribers are NOT notified when invalidating a non-existent token") {
+        val store = JwtTokenStore(MockPreferencesService())
+        val calls = mutableListOf<Pair<String, String?>>()
+        store.subscribe(
+            object : IJwtUpdateListener {
+                override fun onJwtUpdated(externalId: String, jwt: String?) {
+                    calls.add(externalId to jwt)
+                }
+            },
+        )
+
+        store.invalidateJwt("alice")
+
+        calls.isEmpty() shouldBe true
+    }
+
+    test("pruneToExternalIds fires invalidation for each removed externalId") {
+        val store = JwtTokenStore(MockPreferencesService())
+        store.putJwt("alice", "token-a")
+        store.putJwt("bob", "token-b")
+        store.putJwt("chris", "token-c")
+        val calls = mutableListOf<Pair<String, String?>>()
+        store.subscribe(
+            object : IJwtUpdateListener {
+                override fun onJwtUpdated(externalId: String, jwt: String?) {
+                    calls.add(externalId to jwt)
+                }
+            },
+        )
+
+        store.pruneToExternalIds(setOf("alice"))
+
+        // Order is not deterministic across JVMs; check set semantics.
+        calls.toSet() shouldBe setOf("bob" to null, "chris" to null)
+    }
+
+    test("unsubscribed listener is not notified") {
+        val store = JwtTokenStore(MockPreferencesService())
+        val calls = mutableListOf<Pair<String, String?>>()
+        val listener =
+            object : IJwtUpdateListener {
+                override fun onJwtUpdated(externalId: String, jwt: String?) {
+                    calls.add(externalId to jwt)
+                }
+            }
+        store.subscribe(listener)
+        store.unsubscribe(listener)
+
+        store.putJwt("alice", "token-a")
+
+        calls.isEmpty() shouldBe true
+    }
+
+    test("persisted JSON is the expected shape") {
+        val prefs = MockPreferencesService()
+        val store = JwtTokenStore(prefs)
+
+        store.putJwt("alice", "token-a")
+        store.putJwt("bob", "token-b")
+
+        val raw = prefs.getString(PreferenceStores.ONESIGNAL, PreferenceOneSignalKeys.PREFS_OS_JWT_TOKENS)
+        val obj = JSONObject(requireNotNull(raw))
+        obj.getString("alice") shouldBe "token-a"
+        obj.getString("bob") shouldBe "token-b"
+    }
+
+    test("malformed persisted JSON starts fresh without crashing") {
+        val prefs =
+            MockPreferencesService(
+                mapOf(PreferenceOneSignalKeys.PREFS_OS_JWT_TOKENS to "{not valid json"),
+            )
+        val store = JwtTokenStore(prefs)
+
+        store.getJwt("alice") shouldBe null
+        // Can still store new tokens after a malformed load
+        store.putJwt("alice", "token-a")
+        store.getJwt("alice") shouldBe "token-a"
+    }
+})

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/jwt/JwtTokenStoreTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/jwt/JwtTokenStoreTests.kt
@@ -102,28 +102,28 @@ class JwtTokenStoreTests : FunSpec({
 
     test("subscribers are notified when a new JWT is put") {
         val store = JwtTokenStore(MockPreferencesService())
-        val calls = mutableListOf<Pair<String, String?>>()
+        val calls = mutableListOf<String>()
         store.subscribe(
             object : IJwtUpdateListener {
-                override fun onJwtUpdated(externalId: String, jwt: String?) {
-                    calls.add(externalId to jwt)
+                override fun onJwtUpdated(externalId: String) {
+                    calls.add(externalId)
                 }
             },
         )
 
         store.putJwt("alice", "token-a")
 
-        calls shouldBe listOf("alice" to "token-a")
+        calls shouldBe listOf("alice")
     }
 
     test("subscribers are NOT notified when putJwt does not change the stored token") {
         val store = JwtTokenStore(MockPreferencesService())
         store.putJwt("alice", "token-a")
-        val calls = mutableListOf<Pair<String, String?>>()
+        val calls = mutableListOf<String>()
         store.subscribe(
             object : IJwtUpdateListener {
-                override fun onJwtUpdated(externalId: String, jwt: String?) {
-                    calls.add(externalId to jwt)
+                override fun onJwtUpdated(externalId: String) {
+                    calls.add(externalId)
                 }
             },
         )
@@ -133,30 +133,30 @@ class JwtTokenStoreTests : FunSpec({
         calls.isEmpty() shouldBe true
     }
 
-    test("subscribers are notified on invalidation with null jwt") {
+    test("subscribers are notified on invalidation") {
         val store = JwtTokenStore(MockPreferencesService())
         store.putJwt("alice", "token-a")
-        val calls = mutableListOf<Pair<String, String?>>()
+        val calls = mutableListOf<String>()
         store.subscribe(
             object : IJwtUpdateListener {
-                override fun onJwtUpdated(externalId: String, jwt: String?) {
-                    calls.add(externalId to jwt)
+                override fun onJwtUpdated(externalId: String) {
+                    calls.add(externalId)
                 }
             },
         )
 
         store.invalidateJwt("alice")
 
-        calls shouldBe listOf("alice" to null)
+        calls shouldBe listOf("alice")
     }
 
     test("subscribers are NOT notified when invalidating a non-existent token") {
         val store = JwtTokenStore(MockPreferencesService())
-        val calls = mutableListOf<Pair<String, String?>>()
+        val calls = mutableListOf<String>()
         store.subscribe(
             object : IJwtUpdateListener {
-                override fun onJwtUpdated(externalId: String, jwt: String?) {
-                    calls.add(externalId to jwt)
+                override fun onJwtUpdated(externalId: String) {
+                    calls.add(externalId)
                 }
             },
         )
@@ -166,16 +166,16 @@ class JwtTokenStoreTests : FunSpec({
         calls.isEmpty() shouldBe true
     }
 
-    test("pruneToExternalIds fires invalidation for each removed externalId") {
+    test("pruneToExternalIds fires for each removed externalId") {
         val store = JwtTokenStore(MockPreferencesService())
         store.putJwt("alice", "token-a")
         store.putJwt("bob", "token-b")
         store.putJwt("chris", "token-c")
-        val calls = mutableListOf<Pair<String, String?>>()
+        val calls = mutableListOf<String>()
         store.subscribe(
             object : IJwtUpdateListener {
-                override fun onJwtUpdated(externalId: String, jwt: String?) {
-                    calls.add(externalId to jwt)
+                override fun onJwtUpdated(externalId: String) {
+                    calls.add(externalId)
                 }
             },
         )
@@ -183,16 +183,16 @@ class JwtTokenStoreTests : FunSpec({
         store.pruneToExternalIds(setOf("alice"))
 
         // Order is not deterministic across JVMs; check set semantics.
-        calls.toSet() shouldBe setOf("bob" to null, "chris" to null)
+        calls.toSet() shouldBe setOf("bob", "chris")
     }
 
     test("unsubscribed listener is not notified") {
         val store = JwtTokenStore(MockPreferencesService())
-        val calls = mutableListOf<Pair<String, String?>>()
+        val calls = mutableListOf<String>()
         val listener =
             object : IJwtUpdateListener {
-                override fun onJwtUpdated(externalId: String, jwt: String?) {
-                    calls.add(externalId to jwt)
+                override fun onJwtUpdated(externalId: String) {
+                    calls.add(externalId)
                 }
             }
         store.subscribe(listener)

--- a/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/listeners/DeviceRegistrationListenerTests.kt
+++ b/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/listeners/DeviceRegistrationListenerTests.kt
@@ -252,7 +252,7 @@ class DeviceRegistrationListenerTests : FunSpec({
                 permission = true,
                 pushModel = uninitializedPushModel(),
                 pushTokenResponse =
-                    PushTokenResponse(NEW_TOKEN, SubscriptionStatus.SUBSCRIBED),
+                PushTokenResponse(NEW_TOKEN, SubscriptionStatus.SUBSCRIBED),
             )
         // Permission flips off between gate evaluation and the IO callback.
         every { harness.notificationsManager.permission } returns true andThen false


### PR DESCRIPTION
# Description

## One Line Summary
First of five PRs against the Identity Verification integration branch — lands foundation primitives (`IdentityVerificationGates` singleton, `JwtTokenStore`, `FeatureFlag.IDENTITY_VERIFICATION` entry) with no consumer wiring or public API yet.

## Details

### Motivation

IV is gated behind two nested conditions:
- **SDK-side rollout switch** — `FeatureFlag.IDENTITY_VERIFICATION` controlled via Turbine.
- **Customer config** — `jwt_required` remote param from the backend.

Post-release rollout strategy: ship with feature flag OFF; customers with `jwt_required=true` get IV via the customer-config override; progressively flip the feature flag ON for remaining customers to validate structural changes independent of IV activation.

### Scope
All additions are inert at runtime — nothing consumes the gates or the JWT store yet. Subsequent PRs wire them in:
- **PR 2 - 3** — `OperationRepo` IV gating, pre-HYDRATE deferral, anon-op purge race fix.
- **PR 4** — HTTP Authorization header + executor JWT integration.
- **PR 5** — Public API (`login(externalId, jwt)`, `updateUserJwt`, listeners) + replay.
- **PR 6** — Logout + IAM integration + RYW plumbing.

**What lands in this PR:**

*New files:*
- `IdentityVerificationGates.kt` — singleton `object` mirroring `ThreadingMode`. Volatile `newCodePathsRun` (= `featureFlag || jwtRequired == REQUIRED`) and `ivBehaviorActive` (= `jwtRequired == REQUIRED`). The two gates differ on purpose: customer config must be honored even when the feature flag is off, otherwise a kill-switch flip would break customers who've already enabled IV server-side.
- `JwtRequirement.kt` — tri-state enum (`UNKNOWN` / `NOT_REQUIRED` / `REQUIRED`) for `ConfigModel.useIdentityVerification`, replacing the original `Boolean?`. Explicit about pre-HYDRATE; visually distinct from `FeatureFlag.IDENTITY_VERIFICATION`.
- `JwtTokenStore.kt` — `SharedPreferences`-backed `externalId → JWT` map. Multi-user so ops queued under a previous user can still resolve their JWT at execution time. Storage is unconditional; *usage* is gated on `IdentityVerificationGates.ivBehaviorActive`.
- `IJwtUpdateListener.kt` — pure wake-up notification (`onJwtUpdated(externalId)` with no payload). Subscribers must re-read `getJwt(externalId)`; matches the `ModelStore` convention and avoids stale-ordering hazards when multiple threads write.

*Modified files:*
- `FeatureFlag.kt` — added `IDENTITY_VERIFICATION("identity_verification", IMMEDIATE)`. IMMEDIATE because a Turbine kill-switch should take effect within a foreground-poll cycle rather than wait for a cold start, and because the `jwt_required` side of the gate is already live-updating via HYDRATE — keeping both inputs symmetric.
- `FeatureManager.kt` — `applySideEffects` now has an `IDENTITY_VERIFICATION` branch pushing both into `IdentityVerificationGates`.
- `ConfigModel.kt` — `useIdentityVerification` type changed to `JwtRequirement` (internal property because the enum is internal). Backing storage is unchanged (still a nullable boolean), so no cache migration needed.
- `IPreferencesService.kt` — added `PREFS_OS_JWT_TOKENS` key.
- `CoreModule.kt` — registered `JwtTokenStore` in DI.

**Gate-access pattern:** single-tier. Consumers read `IdentityVerificationGates.newCodePathsRun` / `.ivBehaviorActive` directly. Pre-init the volatile fields default to `false` (safe fallback). Post-init they're populated by `FeatureManager.init → refreshEnabledFeatures → applySideEffects`, and refreshed on every HYDRATE because `IDENTITY_VERIFICATION` is IMMEDIATE.

**`IdentityVerificationService` is NOT in this PR** — moves to PR 2 where its HYDRATE handler has real work (anon-op purge, queue wake). The IMMEDIATE activation mode means `FeatureManager.applySideEffects` refreshes the gates on every HYDRATE without needing a separate listener in PR 1.

# Testing

## Unit testing
- `IdentityVerificationGatesTests` — 9 tests covering the full gate matrix including the ERROR STATE row (feature flag off, `jwt_required=REQUIRED` → customer config wins).
- `JwtTokenStoreTests` — 17 tests: put/get/invalidate/prune, persistence round-trip, listener notifications (fire on change, no-op on no-change, fire on invalidation/prune), malformed JSON recovery.
- `FeatureManagerTests` — added IV coverage: flag-off baseline, flag-on newCodePathsRun, ERROR STATE row, full IV, HYDRATE propagation, IMMEDIATE mid-session flip.
- `FeatureFlagTests` — key and activation-mode assertions for `IDENTITY_VERIFICATION`.
- `stubConfigModel` helper updated to stub `useIdentityVerification` with `JwtRequirement.UNKNOWN` by default.

## Manual testing
Not applicable — no runtime behavior change in this PR. All new code is unreferenced by consumers.

# Affected code checklist
   - [ ] Notifications
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing — lands IV foundation primitives only
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs (none in this PR)

## Testing
   - [x] I have included test coverage for these changes
   - [x] All automated tests pass locally (pre-existing `SDKInitTests` failures on the integration branch are unrelated)
   - [x] Manual testing is not applicable — no runtime behavior change

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
