### PR TITLE
feat(jwt): add externalId and requiresJwt to Operation base class (2/6)

### DIFF
--- a/OneSignalSDK/detekt/detekt-baseline-core.xml
+++ b/OneSignalSDK/detekt/detekt-baseline-core.xml
@@ -42,6 +42,7 @@
     <ID>ConstructorParameterNaming:InfluenceManager.kt$InfluenceManager$private val _configModelStore: ConfigModelStore</ID>
     <ID>ConstructorParameterNaming:InfluenceManager.kt$InfluenceManager$private val _sessionService: ISessionService</ID>
     <ID>ConstructorParameterNaming:InstallIdService.kt$InstallIdService$private val _prefs: IPreferencesService</ID>
+    <ID>ConstructorParameterNaming:JwtTokenStore.kt$JwtTokenStore$private val _prefs: IPreferencesService</ID>
     <ID>ConstructorParameterNaming:LanguageContext.kt$LanguageContext$private val _propertiesModelStore: PropertiesModelStore</ID>
     <ID>ConstructorParameterNaming:LoginUserFromSubscriptionOperationExecutor.kt$LoginUserFromSubscriptionOperationExecutor$private val _identityModelStore: IdentityModelStore</ID>
     <ID>ConstructorParameterNaming:LoginUserFromSubscriptionOperationExecutor.kt$LoginUserFromSubscriptionOperationExecutor$private val _propertiesModelStore: PropertiesModelStore</ID>

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/CoreModule.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/CoreModule.kt
@@ -45,6 +45,7 @@ import com.onesignal.location.ILocationManager
 import com.onesignal.location.internal.MisconfiguredLocationManager
 import com.onesignal.notifications.INotificationsManager
 import com.onesignal.notifications.internal.MisconfiguredNotificationsManager
+import com.onesignal.user.internal.jwt.JwtTokenStore
 
 internal class CoreModule : IModule {
     override fun register(builder: ServiceBuilder) {
@@ -67,6 +68,8 @@ internal class CoreModule : IModule {
         builder.register<FeatureFlagsBackendService>().provides<IFeatureFlagsBackendService>()
         builder.register<ConfigModelStoreListener>().provides<IStartableService>()
         builder.register<FeatureFlagsRefreshService>().provides<IStartableService>()
+
+        builder.register<JwtTokenStore>().provides<JwtTokenStore>()
 
         // Operations
         builder.register<OperationModelStore>().provides<OperationModelStore>()

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/config/ConfigModel.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/config/ConfigModel.kt
@@ -236,13 +236,11 @@ class ConfigModel : Model() {
             setBooleanProperty(::enterprise.name, value)
         }
 
-    /**
-     * Whether SMS auth hash should be used.
-     */
-    var useIdentityVerification: Boolean
-        get() = getBooleanProperty(::useIdentityVerification.name) { false }
+    /** Mirrors backend `jwt_required`. `null` = pre-HYDRATE (distinguish from `false`). */
+    var useIdentityVerification: Boolean?
+        get() = getOptBooleanProperty(::useIdentityVerification.name)
         set(value) {
-            setBooleanProperty(::useIdentityVerification.name, value)
+            setOptBooleanProperty(::useIdentityVerification.name, value)
         }
 
     /**

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/config/ConfigModel.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/config/ConfigModel.kt
@@ -2,6 +2,7 @@ package com.onesignal.core.internal.config
 
 import com.onesignal.common.modeling.Model
 import com.onesignal.core.internal.http.OneSignalService.ONESIGNAL_API_BASE_URL
+import com.onesignal.user.internal.jwt.JwtRequirement
 import org.json.JSONArray
 import org.json.JSONObject
 
@@ -236,11 +237,18 @@ class ConfigModel : Model() {
             setBooleanProperty(::enterprise.name, value)
         }
 
-    /** Mirrors backend `jwt_required`. `null` = pre-HYDRATE (distinguish from `false`). */
-    var useIdentityVerification: Boolean?
-        get() = getOptBooleanProperty(::useIdentityVerification.name)
+    /** Mirrors backend `jwt_required`. Pre-HYDRATE callers see [JwtRequirement.UNKNOWN]. */
+    internal var useIdentityVerification: JwtRequirement
+        get() = JwtRequirement.fromBoolean(getOptBooleanProperty(::useIdentityVerification.name))
         set(value) {
-            setOptBooleanProperty(::useIdentityVerification.name, value)
+            setOptBooleanProperty(
+                ::useIdentityVerification.name,
+                when (value) {
+                    JwtRequirement.UNKNOWN -> null
+                    JwtRequirement.NOT_REQUIRED -> false
+                    JwtRequirement.REQUIRED -> true
+                },
+            )
         }
 
     /**

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/config/impl/ConfigModelStoreListener.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/config/impl/ConfigModelStoreListener.kt
@@ -10,6 +10,7 @@ import com.onesignal.core.internal.config.ConfigModel
 import com.onesignal.core.internal.config.ConfigModelStore
 import com.onesignal.core.internal.startup.IStartableService
 import com.onesignal.debug.internal.logging.Logging
+import com.onesignal.user.internal.jwt.JwtRequirement
 import com.onesignal.user.internal.subscriptions.ISubscriptionManager
 import kotlinx.coroutines.delay
 import java.net.HttpURLConnection
@@ -85,7 +86,9 @@ internal class ConfigModelStoreListener(
 
                     // these are only copied from the backend params when the backend has set them.
                     params.enterprise?.let { config.enterprise = it }
-                    params.useIdentityVerification?.let { config.useIdentityVerification = it }
+                    params.useIdentityVerification?.let {
+                        config.useIdentityVerification = JwtRequirement.fromBoolean(it)
+                    }
                     params.firebaseAnalytics?.let { config.firebaseAnalytics = it }
                     params.restoreTTLFilter?.let { config.restoreTTLFilter = it }
                     params.clearGroupOnSummaryClick?.let { config.clearGroupOnSummaryClick = it }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/features/FeatureFlag.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/features/FeatureFlag.kt
@@ -32,8 +32,8 @@ internal enum class FeatureFlag(
     ),
 
     /** JWT signing of SDK requests. IMMEDIATE so a kill-switch doesn't need a cold start. */
-    IDENTITY_VERIFICATION(
-        "identity_verification",
+    SDK_IDENTITY_VERIFICATION(
+        "sdk_identity_verification",
         FeatureActivationMode.IMMEDIATE
     ),
     ;

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/features/FeatureFlag.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/features/FeatureFlag.kt
@@ -24,6 +24,7 @@ internal enum class FeatureFlag(
     val key: String,
     val activationMode: FeatureActivationMode
 ) {
+    // Threading mode is selected once per app startup to avoid mixed-mode behavior mid-session.
     // Remote key (lowercase) must match backend / Turbine flag id.
     SDK_BACKGROUND_THREADING(
         "sdk_background_threading",

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/features/FeatureFlag.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/features/FeatureFlag.kt
@@ -24,13 +24,16 @@ internal enum class FeatureFlag(
     val key: String,
     val activationMode: FeatureActivationMode
 ) {
-    // Threading mode is selected once per app startup to avoid mixed-mode behavior mid-session.
-    //
     // Remote key (lowercase) must match backend / Turbine flag id.
-    //
     SDK_BACKGROUND_THREADING(
         "sdk_background_threading",
         FeatureActivationMode.APP_STARTUP
+    ),
+
+    /** JWT signing of SDK requests. IMMEDIATE so a kill-switch doesn't need a cold start. */
+    IDENTITY_VERIFICATION(
+        "identity_verification",
+        FeatureActivationMode.IMMEDIATE
     ),
     ;
 

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/features/FeatureManager.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/features/FeatureManager.kt
@@ -169,7 +169,7 @@ internal class FeatureManager(
             FeatureFlag.IDENTITY_VERIFICATION ->
                 IdentityVerificationGates.update(
                     featureFlagOn = enabled,
-                    jwtRequired = model.useIdentityVerification,
+                    jwtRequirement = model.useIdentityVerification,
                     source = "FeatureManager:${feature.activationMode}"
                 )
         }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/features/FeatureManager.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/features/FeatureManager.kt
@@ -8,6 +8,7 @@ import com.onesignal.core.internal.backend.impl.FeatureFlagsJsonParser
 import com.onesignal.core.internal.config.ConfigModel
 import com.onesignal.core.internal.config.ConfigModelStore
 import com.onesignal.debug.internal.logging.Logging
+import com.onesignal.user.internal.jwt.IdentityVerificationGates
 import kotlinx.serialization.json.JsonObject
 
 internal interface IFeatureManager {
@@ -122,14 +123,14 @@ internal class FeatureManager(
             when (feature.activationMode) {
                 FeatureActivationMode.IMMEDIATE -> {
                     nextStates[feature] = desiredState
-                    applySideEffects(feature, desiredState)
+                    applySideEffects(feature, desiredState, model)
                 }
 
                 FeatureActivationMode.APP_STARTUP -> {
                     val hasBeenInitialized = nextStates.containsKey(feature)
                     if (applyNextRunOnlyFeatures || !hasBeenInitialized) {
                         nextStates[feature] = desiredState
-                        applySideEffects(feature, desiredState)
+                        applySideEffects(feature, desiredState, model)
                     } else {
                         val currentState = nextStates[feature] ?: false
                         if (currentState != desiredState) {
@@ -156,11 +157,19 @@ internal class FeatureManager(
     private fun applySideEffects(
         feature: FeatureFlag,
         enabled: Boolean,
+        model: ConfigModel,
     ) {
         when (feature) {
             FeatureFlag.SDK_BACKGROUND_THREADING ->
                 ThreadingMode.updateUseBackgroundThreading(
                     enabled = enabled,
+                    source = "FeatureManager:${feature.activationMode}"
+                )
+
+            FeatureFlag.IDENTITY_VERIFICATION ->
+                IdentityVerificationGates.update(
+                    featureFlagOn = enabled,
+                    jwtRequired = model.useIdentityVerification,
                     source = "FeatureManager:${feature.activationMode}"
                 )
         }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/features/FeatureManager.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/features/FeatureManager.kt
@@ -165,7 +165,7 @@ internal class FeatureManager(
                     source = "FeatureManager:${feature.activationMode}"
                 )
 
-            FeatureFlag.IDENTITY_VERIFICATION ->
+            FeatureFlag.SDK_IDENTITY_VERIFICATION ->
                 IdentityVerificationGates.update(
                     featureFlagOn = enabled,
                     jwtRequirement = configModelStore.model.useIdentityVerification,

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/features/FeatureManager.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/features/FeatureManager.kt
@@ -123,14 +123,14 @@ internal class FeatureManager(
             when (feature.activationMode) {
                 FeatureActivationMode.IMMEDIATE -> {
                     nextStates[feature] = desiredState
-                    applySideEffects(feature, desiredState, model)
+                    applySideEffects(feature, desiredState)
                 }
 
                 FeatureActivationMode.APP_STARTUP -> {
                     val hasBeenInitialized = nextStates.containsKey(feature)
                     if (applyNextRunOnlyFeatures || !hasBeenInitialized) {
                         nextStates[feature] = desiredState
-                        applySideEffects(feature, desiredState, model)
+                        applySideEffects(feature, desiredState)
                     } else {
                         val currentState = nextStates[feature] ?: false
                         if (currentState != desiredState) {
@@ -157,7 +157,6 @@ internal class FeatureManager(
     private fun applySideEffects(
         feature: FeatureFlag,
         enabled: Boolean,
-        model: ConfigModel,
     ) {
         when (feature) {
             FeatureFlag.SDK_BACKGROUND_THREADING ->
@@ -169,7 +168,7 @@ internal class FeatureManager(
             FeatureFlag.IDENTITY_VERIFICATION ->
                 IdentityVerificationGates.update(
                     featureFlagOn = enabled,
-                    jwtRequirement = model.useIdentityVerification,
+                    jwtRequirement = configModelStore.model.useIdentityVerification,
                     source = "FeatureManager:${feature.activationMode}"
                 )
         }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/Operation.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/Operation.kt
@@ -16,6 +16,23 @@ abstract class Operation(name: String) : Model() {
             setStringProperty(::name.name, value)
         }
 
+    /**
+     * externalId of the user this operation was enqueued for. Captured at construction
+     * time so the op stays bound to its original user even if the current user changes
+     * before the op executes. Null for anonymous users.
+     */
+    var externalId: String?
+        get() = getOptStringProperty(::externalId.name)
+        set(value) {
+            setOptStringProperty(::externalId.name, value)
+        }
+
+    /**
+     * Whether this operation requires a valid JWT when Identity Verification is active.
+     * Subclasses may override to `false` for endpoints that don't require auth.
+     */
+    open val requiresJwt: Boolean get() = true
+
     init {
         this.name = name
     }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/Operation.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/Operation.kt
@@ -23,7 +23,7 @@ abstract class Operation(name: String) : Model() {
      */
     var externalId: String?
         get() = getOptStringProperty(::externalId.name)
-        set(value) {
+        internal set(value) { // `internal` so subclass constructors can assign at construction time
             setOptStringProperty(::externalId.name, value)
         }
 

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/preferences/IPreferencesService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/preferences/IPreferencesService.kt
@@ -204,6 +204,9 @@ object PreferenceOneSignalKeys {
      */
     const val PREFS_OS_LOCATION_SHARED = "OS_LOCATION_SHARED"
 
+    /** (String) JSON object mapping externalId -> JWT token. */
+    const val PREFS_OS_JWT_TOKENS = "PREFS_OS_JWT_TOKENS"
+
     // Permissions
 
     /**

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/purchases/impl/TrackGooglePurchase.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/purchases/impl/TrackGooglePurchase.kt
@@ -240,6 +240,7 @@ internal class TrackGooglePurchase(
                         TrackPurchaseOperation(
                             _configModelStore.model.appId,
                             _identityModelStore.model.onesignalId,
+                            _identityModelStore.model.externalId,
                             newAsExisting,
                             BigDecimal(0),
                             purchasesToReport,

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/session/internal/session/impl/SessionListener.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/session/internal/session/impl/SessionListener.kt
@@ -44,7 +44,14 @@ internal class SessionListener(
 
     override fun onSessionStarted() {
         _propertiesModelStore.model.timezone = TimeUtils.getTimeZoneId()
-        _operationRepo.enqueue(TrackSessionStartOperation(_configModelStore.model.appId, _identityModelStore.model.onesignalId), true)
+        _operationRepo.enqueue(
+            TrackSessionStartOperation(
+                _configModelStore.model.appId,
+                _identityModelStore.model.onesignalId,
+                _identityModelStore.model.externalId,
+            ),
+            true,
+        )
     }
 
     override fun onSessionActive() {
@@ -60,7 +67,12 @@ internal class SessionListener(
         }
 
         _operationRepo.enqueue(
-            TrackSessionEndOperation(_configModelStore.model.appId, _identityModelStore.model.onesignalId, durationInSeconds),
+            TrackSessionEndOperation(
+                _configModelStore.model.appId,
+                _identityModelStore.model.onesignalId,
+                _identityModelStore.model.externalId,
+                durationInSeconds,
+            ),
         )
 
         suspendifyOnIO {

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/UserSwitcher.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/UserSwitcher.kt
@@ -173,6 +173,7 @@ class UserSwitcher(
             LoginUserFromSubscriptionOperation(
                 configModel.appId,
                 identityModelStore.model.onesignalId,
+                identityModelStore.model.externalId,
                 legacyPlayerId,
             ),
         )

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/builduser/impl/RebuildUserService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/builduser/impl/RebuildUserService.kt
@@ -52,6 +52,7 @@ class RebuildUserService(
                 CreateSubscriptionOperation(
                     appId,
                     onesignalId,
+                    identityModel.externalId,
                     pushSubscription.id,
                     pushSubscription.type,
                     pushSubscription.optedIn,
@@ -60,7 +61,7 @@ class RebuildUserService(
                 ),
             )
         }
-        operations.add(RefreshUserOperation(appId, onesignalId))
+        operations.add(RefreshUserOperation(appId, onesignalId, identityModel.externalId))
         return operations
     }
 }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/jwt/IJwtUpdateListener.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/jwt/IJwtUpdateListener.kt
@@ -1,0 +1,6 @@
+package com.onesignal.user.internal.jwt
+
+/** Notified by [JwtTokenStore] on put/invalidate. Null [jwt] means invalidated. */
+internal interface IJwtUpdateListener {
+    fun onJwtUpdated(externalId: String, jwt: String?)
+}

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/jwt/IJwtUpdateListener.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/jwt/IJwtUpdateListener.kt
@@ -1,6 +1,10 @@
 package com.onesignal.user.internal.jwt
 
-/** Notified by [JwtTokenStore] on put/invalidate. Null [jwt] means invalidated. */
+/**
+ * Wake-up notification from [JwtTokenStore] when the JWT for [externalId] changes.
+ * Listeners must call [JwtTokenStore.getJwt] for the current value — event delivery
+ * order is not guaranteed to match mutation order across concurrent writers.
+ */
 internal interface IJwtUpdateListener {
-    fun onJwtUpdated(externalId: String, jwt: String?)
+    fun onJwtUpdated(externalId: String)
 }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/jwt/IdentityVerificationGates.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/jwt/IdentityVerificationGates.kt
@@ -27,29 +27,18 @@ internal object IdentityVerificationGates {
     val newCodePathsRun: Boolean
         get() = _featureFlagOn || ivBehaviorActive
 
-    /** Idempotent. [source] is logged for traceability when gates change. */
+    /** Idempotent. [source] is logged for traceability. */
     fun update(
         featureFlagOn: Boolean,
         jwtRequirement: JwtRequirement,
         source: String,
     ) {
-        val previousNewCode = newCodePathsRun
-        val previousIvActive = ivBehaviorActive
-
         _featureFlagOn = featureFlagOn
         ivBehaviorActive = jwtRequirement == JwtRequirement.REQUIRED
 
-        if (previousNewCode != newCodePathsRun || previousIvActive != ivBehaviorActive) {
-            Logging.info(
-                "OneSignal: IdentityVerificationGates updated: " +
-                    "newCodePathsRun=$newCodePathsRun, ivBehaviorActive=$ivBehaviorActive " +
-                    "(source=$source, featureFlagOn=$featureFlagOn, jwtRequirement=$jwtRequirement)",
-            )
-        } else {
-            Logging.debug(
-                "OneSignal: IdentityVerificationGates unchanged " +
-                    "(source=$source, newCodePathsRun=$newCodePathsRun, ivBehaviorActive=$ivBehaviorActive)",
-            )
-        }
+        Logging.debug(
+            "OneSignal: IdentityVerificationGates.update: newCodePathsRun=$newCodePathsRun, " +
+                "ivBehaviorActive=$ivBehaviorActive (source=$source)",
+        )
     }
 }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/jwt/IdentityVerificationGates.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/jwt/IdentityVerificationGates.kt
@@ -23,20 +23,21 @@ internal object IdentityVerificationGates {
     /** Idempotent. [source] is logged for traceability when gates change. */
     fun update(
         featureFlagOn: Boolean,
-        jwtRequired: Boolean?,
+        jwtRequirement: JwtRequirement,
         source: String,
     ) {
         val previousNewCode = newCodePathsRun
         val previousIvActive = ivBehaviorActive
 
-        newCodePathsRun = featureFlagOn || (jwtRequired == true)
-        ivBehaviorActive = jwtRequired == true
+        val required = jwtRequirement == JwtRequirement.REQUIRED
+        newCodePathsRun = featureFlagOn || required
+        ivBehaviorActive = required
 
         if (previousNewCode != newCodePathsRun || previousIvActive != ivBehaviorActive) {
             Logging.info(
                 "OneSignal: IdentityVerificationGates updated: " +
                     "newCodePathsRun=$newCodePathsRun, ivBehaviorActive=$ivBehaviorActive " +
-                    "(source=$source, featureFlagOn=$featureFlagOn, jwtRequired=$jwtRequired)",
+                    "(source=$source, featureFlagOn=$featureFlagOn, jwtRequirement=$jwtRequirement)",
             )
         } else {
             Logging.debug(

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/jwt/IdentityVerificationGates.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/jwt/IdentityVerificationGates.kt
@@ -8,17 +8,24 @@ import com.onesignal.debug.internal.logging.Logging
  * The two gates differ on purpose: [newCodePathsRun] also flips on when customer config
  * (`jwt_required`) is true — honoring customer setup even if our feature flag is off.
  * [ivBehaviorActive] tracks customer config alone.
+ *
+ * Invariant `ivBehaviorActive == true ⇒ newCodePathsRun == true` is preserved at every
+ * observation because [newCodePathsRun] is derived on read from the stored inputs; a reader
+ * can't observe a state where one field is `true` and the other is `false` inconsistent
+ * with the formula.
  */
 internal object IdentityVerificationGates {
-    /** Whether new IV-related code paths should run. `featureFlag_IV_ON || jwt_required == true`. */
     @Volatile
-    var newCodePathsRun: Boolean = false
-        private set
+    private var _featureFlagOn: Boolean = false
 
     /** Whether IV-specific behavior (JWT attachment, auth error handling) applies. `jwt_required == true`. */
     @Volatile
     var ivBehaviorActive: Boolean = false
         private set
+
+    /** Whether new IV-related code paths should run. `featureFlag_IV_ON || jwt_required == true`. */
+    val newCodePathsRun: Boolean
+        get() = _featureFlagOn || ivBehaviorActive
 
     /** Idempotent. [source] is logged for traceability when gates change. */
     fun update(
@@ -29,9 +36,8 @@ internal object IdentityVerificationGates {
         val previousNewCode = newCodePathsRun
         val previousIvActive = ivBehaviorActive
 
-        val required = jwtRequirement == JwtRequirement.REQUIRED
-        newCodePathsRun = featureFlagOn || required
-        ivBehaviorActive = required
+        _featureFlagOn = featureFlagOn
+        ivBehaviorActive = jwtRequirement == JwtRequirement.REQUIRED
 
         if (previousNewCode != newCodePathsRun || previousIvActive != ivBehaviorActive) {
             Logging.info(

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/jwt/IdentityVerificationGates.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/jwt/IdentityVerificationGates.kt
@@ -5,25 +5,33 @@ import com.onesignal.debug.internal.logging.Logging
 /**
  * Current Identity Verification gate state, pushed by `FeatureManager.applySideEffects`.
  *
- * The two gates differ on purpose: [newCodePathsRun] also flips on when customer config
- * (`jwt_required`) is true — honoring customer setup even if our feature flag is off.
- * [ivBehaviorActive] tracks customer config alone.
+ * Stored state is the tri-state [jwtRequirement] — UNKNOWN until the first HYDRATE so consumers
+ * that need to distinguish "we don't know yet" from "customer opted out" can. The Boolean
+ * derivations [ivBehaviorActive] and [newCodePathsRun] cover the common case where consumers
+ * just want yes/no; UNKNOWN reads as `false` for both, which is the safe default before HYDRATE.
+ *
+ * The two gates differ on purpose: [newCodePathsRun] also flips on when our SDK feature flag is
+ * on, honoring rollout state even when the customer hasn't opted in. [ivBehaviorActive] tracks
+ * customer config alone.
  *
  * Invariant `ivBehaviorActive == true ⇒ newCodePathsRun == true` is preserved at every
- * observation because [newCodePathsRun] is derived on read from the stored inputs; a reader
- * can't observe a state where one field is `true` and the other is `false` inconsistent
- * with the formula.
+ * observation because both are derived on read from the stored inputs; a reader can't observe an
+ * inconsistent state.
  */
 internal object IdentityVerificationGates {
     @Volatile
     private var _featureFlagOn: Boolean = false
 
-    /** Whether IV-specific behavior (JWT attachment, auth error handling) applies. `jwt_required == true`. */
+    /** Customer config (`jwt_required`); [JwtRequirement.UNKNOWN] until the first HYDRATE. */
     @Volatile
-    var ivBehaviorActive: Boolean = false
+    var jwtRequirement: JwtRequirement = JwtRequirement.UNKNOWN
         private set
 
-    /** Whether new IV-related code paths should run. `featureFlag_IV_ON || jwt_required == true`. */
+    /** Whether IV-specific behavior (JWT attachment, auth error handling) applies. UNKNOWN reads as `false`. */
+    val ivBehaviorActive: Boolean
+        get() = jwtRequirement == JwtRequirement.REQUIRED
+
+    /** Whether new IV-related code paths should run. `featureFlag_IV_ON || jwt_required == REQUIRED`. */
     val newCodePathsRun: Boolean
         get() = _featureFlagOn || ivBehaviorActive
 
@@ -34,7 +42,7 @@ internal object IdentityVerificationGates {
         source: String,
     ) {
         _featureFlagOn = featureFlagOn
-        ivBehaviorActive = jwtRequirement == JwtRequirement.REQUIRED
+        this.jwtRequirement = jwtRequirement
 
         Logging.debug(
             "OneSignal: IdentityVerificationGates.update: newCodePathsRun=$newCodePathsRun, " +

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/jwt/IdentityVerificationGates.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/jwt/IdentityVerificationGates.kt
@@ -1,0 +1,48 @@
+package com.onesignal.user.internal.jwt
+
+import com.onesignal.debug.internal.logging.Logging
+
+/**
+ * Current Identity Verification gate state, pushed by `FeatureManager.applySideEffects`.
+ *
+ * The two gates differ on purpose: [newCodePathsRun] also flips on when customer config
+ * (`jwt_required`) is true — honoring customer setup even if our feature flag is off.
+ * [ivBehaviorActive] tracks customer config alone.
+ */
+internal object IdentityVerificationGates {
+    /** Whether new IV-related code paths should run. `featureFlag_IV_ON || jwt_required == true`. */
+    @Volatile
+    var newCodePathsRun: Boolean = false
+        private set
+
+    /** Whether IV-specific behavior (JWT attachment, auth error handling) applies. `jwt_required == true`. */
+    @Volatile
+    var ivBehaviorActive: Boolean = false
+        private set
+
+    /** Idempotent. [source] is logged for traceability when gates change. */
+    fun update(
+        featureFlagOn: Boolean,
+        jwtRequired: Boolean?,
+        source: String,
+    ) {
+        val previousNewCode = newCodePathsRun
+        val previousIvActive = ivBehaviorActive
+
+        newCodePathsRun = featureFlagOn || (jwtRequired == true)
+        ivBehaviorActive = jwtRequired == true
+
+        if (previousNewCode != newCodePathsRun || previousIvActive != ivBehaviorActive) {
+            Logging.info(
+                "OneSignal: IdentityVerificationGates updated: " +
+                    "newCodePathsRun=$newCodePathsRun, ivBehaviorActive=$ivBehaviorActive " +
+                    "(source=$source, featureFlagOn=$featureFlagOn, jwtRequired=$jwtRequired)",
+            )
+        } else {
+            Logging.debug(
+                "OneSignal: IdentityVerificationGates unchanged " +
+                    "(source=$source, newCodePathsRun=$newCodePathsRun, ivBehaviorActive=$ivBehaviorActive)",
+            )
+        }
+    }
+}

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/jwt/JwtRequirement.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/jwt/JwtRequirement.kt
@@ -1,0 +1,31 @@
+package com.onesignal.user.internal.jwt
+
+/**
+ * Customer-side JWT requirement, mirrored from the backend `jwt_required` remote param.
+ * Explicit [UNKNOWN] so callers can distinguish pre-HYDRATE (no value yet) from
+ * [NOT_REQUIRED] (customer opted out).
+ *
+ * Represents only the customer-config side of Identity Verification; do not confuse
+ * with [com.onesignal.core.internal.features.FeatureFlag.IDENTITY_VERIFICATION] (our
+ * SDK-side rollout switch).
+ */
+internal enum class JwtRequirement {
+    /** Remote params have not been fetched yet. Treat as non-IV until known. */
+    UNKNOWN,
+
+    /** Customer config `jwt_required=false`. No JWT signing. */
+    NOT_REQUIRED,
+
+    /** Customer config `jwt_required=true`. IV-specific behavior active. */
+    REQUIRED,
+    ;
+
+    companion object {
+        fun fromBoolean(value: Boolean?): JwtRequirement =
+            when (value) {
+                null -> UNKNOWN
+                false -> NOT_REQUIRED
+                true -> REQUIRED
+            }
+    }
+}

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/jwt/JwtRequirement.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/jwt/JwtRequirement.kt
@@ -6,7 +6,7 @@ package com.onesignal.user.internal.jwt
  * [NOT_REQUIRED] (customer opted out).
  *
  * Represents only the customer-config side of Identity Verification; do not confuse
- * with [com.onesignal.core.internal.features.FeatureFlag.IDENTITY_VERIFICATION] (our
+ * with [com.onesignal.core.internal.features.FeatureFlag.SDK_IDENTITY_VERIFICATION] (our
  * SDK-side rollout switch).
  */
 internal enum class JwtRequirement {

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/jwt/JwtTokenStore.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/jwt/JwtTokenStore.kt
@@ -51,11 +51,11 @@ internal class JwtTokenStore(
             }
         }
         if (changed) {
-            updates.fire { it.onJwtUpdated(externalId, jwt) }
+            updates.fire { it.onJwtUpdated(externalId) }
         }
     }
 
-    /** Removes the JWT for [externalId] and broadcasts with `jwt = null`. */
+    /** Removes the JWT for [externalId] and notifies subscribers. */
     fun invalidateJwt(externalId: String) {
         val existed: Boolean
         synchronized(tokens) {
@@ -66,7 +66,7 @@ internal class JwtTokenStore(
             }
         }
         if (existed) {
-            updates.fire { it.onJwtUpdated(externalId, null) }
+            updates.fire { it.onJwtUpdated(externalId) }
         }
     }
 
@@ -83,7 +83,7 @@ internal class JwtTokenStore(
             }
         }
         for (externalId in removed) {
-            updates.fire { it.onJwtUpdated(externalId, null) }
+            updates.fire { it.onJwtUpdated(externalId) }
         }
     }
 

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/jwt/JwtTokenStore.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/jwt/JwtTokenStore.kt
@@ -1,0 +1,119 @@
+package com.onesignal.user.internal.jwt
+
+import com.onesignal.common.events.EventProducer
+import com.onesignal.common.events.IEventNotifier
+import com.onesignal.core.internal.preferences.IPreferencesService
+import com.onesignal.core.internal.preferences.PreferenceOneSignalKeys
+import com.onesignal.core.internal.preferences.PreferenceStores
+import com.onesignal.debug.internal.logging.Logging
+import org.json.JSONException
+import org.json.JSONObject
+
+/**
+ * Persistent store mapping externalId -> JWT. Multi-user so ops queued under a previous user
+ * can still resolve their JWT at execution time. Storage is unconditional; *usage* of JWTs is
+ * gated on [IdentityVerificationGates.ivBehaviorActive].
+ */
+internal class JwtTokenStore(
+    private val _prefs: IPreferencesService,
+) : IEventNotifier<IJwtUpdateListener> {
+    private val tokens: MutableMap<String, String> = mutableMapOf()
+    private var isLoaded: Boolean = false
+    private val updates = EventProducer<IJwtUpdateListener>()
+
+    override val hasSubscribers: Boolean
+        get() = updates.hasSubscribers
+
+    override fun subscribe(handler: IJwtUpdateListener) = updates.subscribe(handler)
+
+    override fun unsubscribe(handler: IJwtUpdateListener) = updates.unsubscribe(handler)
+
+    fun getJwt(externalId: String): String? {
+        synchronized(tokens) {
+            ensureLoaded()
+            return tokens[externalId]
+        }
+    }
+
+    /** Null [jwt] is a no-op; call [invalidateJwt] to remove a token. */
+    fun putJwt(
+        externalId: String,
+        jwt: String?,
+    ) {
+        if (jwt == null) return
+        val changed: Boolean
+        synchronized(tokens) {
+            ensureLoaded()
+            changed = tokens[externalId] != jwt
+            tokens[externalId] = jwt
+            if (changed) {
+                persist()
+            }
+        }
+        if (changed) {
+            updates.fire { it.onJwtUpdated(externalId, jwt) }
+        }
+    }
+
+    /** Removes the JWT for [externalId] and broadcasts with `jwt = null`. */
+    fun invalidateJwt(externalId: String) {
+        val existed: Boolean
+        synchronized(tokens) {
+            ensureLoaded()
+            existed = tokens.remove(externalId) != null
+            if (existed) {
+                persist()
+            }
+        }
+        if (existed) {
+            updates.fire { it.onJwtUpdated(externalId, null) }
+        }
+    }
+
+    /** Drops JWTs whose externalId isn't in [activeIds]. Call on cold start to bound growth. */
+    fun pruneToExternalIds(activeIds: Set<String>) {
+        val removed: Set<String>
+        synchronized(tokens) {
+            ensureLoaded()
+            val toRemove = tokens.keys - activeIds
+            removed = toRemove.toSet()
+            if (removed.isNotEmpty()) {
+                tokens.keys.removeAll(removed)
+                persist()
+            }
+        }
+        for (externalId in removed) {
+            updates.fire { it.onJwtUpdated(externalId, null) }
+        }
+    }
+
+    /** Caller must hold `synchronized(tokens)`. */
+    private fun ensureLoaded() {
+        if (isLoaded) return
+        val json =
+            _prefs.getString(
+                PreferenceStores.ONESIGNAL,
+                PreferenceOneSignalKeys.PREFS_OS_JWT_TOKENS,
+            )
+        if (json != null) {
+            try {
+                val obj = JSONObject(json)
+                for (key in obj.keys()) {
+                    tokens[key] = obj.getString(key)
+                }
+            } catch (e: JSONException) {
+                Logging.warn("JwtTokenStore: failed to parse persisted tokens, starting fresh: ${e.message}")
+            }
+        }
+        isLoaded = true
+    }
+
+    /** Caller must hold `synchronized(tokens)`. */
+    private fun persist() {
+        _prefs.saveString(
+            PreferenceStores.ONESIGNAL,
+            PreferenceOneSignalKeys.PREFS_OS_JWT_TOKENS,
+            JSONObject(tokens.toMap()).toString(),
+        )
+    }
+}

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/CreateSubscriptionOperation.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/CreateSubscriptionOperation.kt
@@ -88,9 +88,10 @@ class CreateSubscriptionOperation() : Operation(SubscriptionOperationExecutor.CR
     override val canStartExecute: Boolean get() = !IDManager.isLocalId(onesignalId)
     override val applyToRecordId: String get() = onesignalId
 
-    constructor(appId: String, onesignalId: String, subscriptionId: String, type: SubscriptionType, enabled: Boolean, address: String, status: SubscriptionStatus) : this() {
+    constructor(appId: String, onesignalId: String, externalId: String?, subscriptionId: String, type: SubscriptionType, enabled: Boolean, address: String, status: SubscriptionStatus) : this() {
         this.appId = appId
         this.onesignalId = onesignalId
+        this.externalId = externalId
         this.subscriptionId = subscriptionId
         this.type = type
         this.enabled = enabled

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/DeleteAliasOperation.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/DeleteAliasOperation.kt
@@ -43,9 +43,10 @@ class DeleteAliasOperation() : Operation(IdentityOperationExecutor.DELETE_ALIAS)
     override val canStartExecute: Boolean get() = !IDManager.isLocalId(onesignalId)
     override val applyToRecordId: String get() = onesignalId
 
-    constructor(appId: String, onesignalId: String, label: String) : this() {
+    constructor(appId: String, onesignalId: String, externalId: String?, label: String) : this() {
         this.appId = appId
         this.onesignalId = onesignalId
+        this.externalId = externalId
         this.label = label
     }
 

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/DeleteSubscriptionOperation.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/DeleteSubscriptionOperation.kt
@@ -44,9 +44,10 @@ class DeleteSubscriptionOperation() : Operation(SubscriptionOperationExecutor.DE
     override val canStartExecute: Boolean get() = !IDManager.isLocalId(onesignalId) && !IDManager.isLocalId(subscriptionId)
     override val applyToRecordId: String get() = subscriptionId
 
-    constructor(appId: String, onesignalId: String, subscriptionId: String) : this() {
+    constructor(appId: String, onesignalId: String, externalId: String?, subscriptionId: String) : this() {
         this.appId = appId
         this.onesignalId = onesignalId
+        this.externalId = externalId
         this.subscriptionId = subscriptionId
     }
 

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/DeleteTagOperation.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/DeleteTagOperation.kt
@@ -44,9 +44,10 @@ class DeleteTagOperation() : Operation(UpdateUserOperationExecutor.DELETE_TAG) {
     override val canStartExecute: Boolean get() = !IDManager.isLocalId(onesignalId)
     override val applyToRecordId: String get() = onesignalId
 
-    constructor(appId: String, onesignalId: String, key: String) : this() {
+    constructor(appId: String, onesignalId: String, externalId: String?, key: String) : this() {
         this.appId = appId
         this.onesignalId = onesignalId
+        this.externalId = externalId
         this.key = key
     }
 

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/LoginUserFromSubscriptionOperation.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/LoginUserFromSubscriptionOperation.kt
@@ -42,9 +42,10 @@ class LoginUserFromSubscriptionOperation() : Operation(LoginUserFromSubscription
     override val canStartExecute: Boolean = true
     override val applyToRecordId: String get() = subscriptionId
 
-    constructor(appId: String, onesignalId: String, subscriptionId: String) : this() {
+    constructor(appId: String, onesignalId: String, externalId: String?, subscriptionId: String) : this() {
         this.appId = appId
         this.onesignalId = onesignalId
+        this.externalId = externalId
         this.subscriptionId = subscriptionId
     }
 }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/LoginUserFromSubscriptionOperation.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/LoginUserFromSubscriptionOperation.kt
@@ -28,7 +28,8 @@ class LoginUserFromSubscriptionOperation() : Operation(LoginUserFromSubscription
         }
 
     /**
-     * The optional external ID of this newly logged-in user. Must be unique for the [appId].
+     * The subscription ID used to look up the user to log in as. Typically a v4 player ID being
+     * migrated to v5.
      */
     var subscriptionId: String
         get() = getStringProperty(::subscriptionId.name)

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/LoginUserOperation.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/LoginUserOperation.kt
@@ -33,15 +33,6 @@ class LoginUserOperation() : Operation(LoginUserOperationExecutor.LOGIN_USER) {
         }
 
     /**
-     * The optional external ID of this newly logged-in user. Must be unique for the [appId].
-     */
-    var externalId: String?
-        get() = getOptStringProperty(::externalId.name)
-        private set(value) {
-            setOptStringProperty(::externalId.name, value)
-        }
-
-    /**
      * The user ID of an existing user the [externalId] will be attempted to be associated to first.
      * When null (or non-null but unsuccessful), a new user will be upserted. This ID *may* be locally generated
      * and can be checked via [IDManager.isLocalId] to ensure correct processing.

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/RefreshUserOperation.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/RefreshUserOperation.kt
@@ -35,9 +35,10 @@ class RefreshUserOperation() : Operation(RefreshUserOperationExecutor.REFRESH_US
     override val canStartExecute: Boolean get() = !IDManager.isLocalId(onesignalId)
     override val applyToRecordId: String get() = onesignalId
 
-    constructor(appId: String, onesignalId: String) : this() {
+    constructor(appId: String, onesignalId: String, externalId: String?) : this() {
         this.appId = appId
         this.onesignalId = onesignalId
+        this.externalId = externalId
     }
 
     override fun translateIds(map: Map<String, String>) {

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/SetAliasOperation.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/SetAliasOperation.kt
@@ -53,9 +53,10 @@ class SetAliasOperation() : Operation(IdentityOperationExecutor.SET_ALIAS) {
     override val canStartExecute: Boolean get() = !IDManager.isLocalId(onesignalId)
     override val applyToRecordId: String get() = onesignalId
 
-    constructor(appId: String, onesignalId: String, label: String, value: String) : this() {
+    constructor(appId: String, onesignalId: String, externalId: String?, label: String, value: String) : this() {
         this.appId = appId
         this.onesignalId = onesignalId
+        this.externalId = externalId
         this.label = label
         this.value = value
     }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/SetPropertyOperation.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/SetPropertyOperation.kt
@@ -52,9 +52,10 @@ class SetPropertyOperation() : Operation(UpdateUserOperationExecutor.SET_PROPERT
     override val canStartExecute: Boolean get() = !IDManager.isLocalId(onesignalId)
     override val applyToRecordId: String get() = onesignalId
 
-    constructor(appId: String, onesignalId: String, property: String, value: Any?) : this() {
+    constructor(appId: String, onesignalId: String, externalId: String?, property: String, value: Any?) : this() {
         this.appId = appId
         this.onesignalId = onesignalId
+        this.externalId = externalId
         this.property = property
         this.value = value
     }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/SetTagOperation.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/SetTagOperation.kt
@@ -53,9 +53,10 @@ class SetTagOperation() : Operation(UpdateUserOperationExecutor.SET_TAG) {
     override val canStartExecute: Boolean get() = !IDManager.isLocalId(onesignalId)
     override val applyToRecordId: String get() = onesignalId
 
-    constructor(appId: String, onesignalId: String, key: String, value: String) : this() {
+    constructor(appId: String, onesignalId: String, externalId: String?, key: String, value: String) : this() {
         this.appId = appId
         this.onesignalId = onesignalId
+        this.externalId = externalId
         this.key = key
         this.value = value
     }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/TrackCustomEventOperation.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/TrackCustomEventOperation.kt
@@ -31,15 +31,6 @@ class TrackCustomEventOperation() : Operation(CustomEventOperationExecutor.CUSTO
         }
 
     /**
-     * The optional external ID of current logged-in user. Must be unique for the [appId].
-     */
-    var externalId: String?
-        get() = getOptStringProperty(::externalId.name)
-        private set(value) {
-            setOptStringProperty(::externalId.name, value)
-        }
-
-    /**
      * The timestamp when the custom event was created.
      */
     var timeStamp: Long

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/TrackPurchaseOperation.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/TrackPurchaseOperation.kt
@@ -65,9 +65,10 @@ class TrackPurchaseOperation() : Operation(UpdateUserOperationExecutor.TRACK_PUR
     override val canStartExecute: Boolean get() = !IDManager.isLocalId(onesignalId)
     override val applyToRecordId: String get() = onesignalId
 
-    constructor(appId: String, onesignalId: String, treatNewAsExisting: Boolean, amountSpent: BigDecimal, purchases: List<PurchaseInfo>) : this() {
+    constructor(appId: String, onesignalId: String, externalId: String?, treatNewAsExisting: Boolean, amountSpent: BigDecimal, purchases: List<PurchaseInfo>) : this() {
         this.appId = appId
         this.onesignalId = onesignalId
+        this.externalId = externalId
         this.treatNewAsExisting = treatNewAsExisting
         this.amountSpent = amountSpent
         this.purchases = purchases

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/TrackSessionEndOperation.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/TrackSessionEndOperation.kt
@@ -43,9 +43,10 @@ class TrackSessionEndOperation() : Operation(UpdateUserOperationExecutor.TRACK_S
     override val canStartExecute: Boolean get() = !IDManager.isLocalId(onesignalId)
     override val applyToRecordId: String get() = onesignalId
 
-    constructor(appId: String, onesignalId: String, sessionTime: Long) : this() {
+    constructor(appId: String, onesignalId: String, externalId: String?, sessionTime: Long) : this() {
         this.appId = appId
         this.onesignalId = onesignalId
+        this.externalId = externalId
         this.sessionTime = sessionTime
     }
 

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/TrackSessionStartOperation.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/TrackSessionStartOperation.kt
@@ -34,9 +34,10 @@ class TrackSessionStartOperation() : Operation(UpdateUserOperationExecutor.TRACK
     override val canStartExecute: Boolean get() = !IDManager.isLocalId(onesignalId)
     override val applyToRecordId: String get() = onesignalId
 
-    constructor(appId: String, onesignalId: String) : this() {
+    constructor(appId: String, onesignalId: String, externalId: String?) : this() {
         this.appId = appId
         this.onesignalId = onesignalId
+        this.externalId = externalId
     }
 
     override fun translateIds(map: Map<String, String>) {

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/TransferSubscriptionOperation.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/TransferSubscriptionOperation.kt
@@ -50,10 +50,11 @@ class TransferSubscriptionOperation() : Operation(SubscriptionOperationExecutor.
     override val canStartExecute: Boolean get() = !IDManager.isLocalId(onesignalId) && !IDManager.isLocalId(subscriptionId)
     override val applyToRecordId: String get() = subscriptionId
 
-    constructor(appId: String, subscriptionId: String, onesignalId: String) : this() {
+    constructor(appId: String, subscriptionId: String, onesignalId: String, externalId: String?) : this() {
         this.appId = appId
         this.subscriptionId = subscriptionId
         this.onesignalId = onesignalId
+        this.externalId = externalId
     }
 
     override fun translateIds(map: Map<String, String>) {

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/UpdateSubscriptionOperation.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/UpdateSubscriptionOperation.kt
@@ -87,9 +87,10 @@ class UpdateSubscriptionOperation() : Operation(SubscriptionOperationExecutor.UP
     override val canStartExecute: Boolean get() = !IDManager.isLocalId(onesignalId) && !IDManager.isLocalId(subscriptionId)
     override val applyToRecordId: String get() = subscriptionId
 
-    constructor(appId: String, onesignalId: String, subscriptionId: String, type: SubscriptionType, enabled: Boolean, address: String, status: SubscriptionStatus) : this() {
+    constructor(appId: String, onesignalId: String, externalId: String?, subscriptionId: String, type: SubscriptionType, enabled: Boolean, address: String, status: SubscriptionStatus) : this() {
         this.appId = appId
         this.onesignalId = onesignalId
+        this.externalId = externalId
         this.subscriptionId = subscriptionId
         this.type = type
         this.enabled = enabled

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/LoginUserFromSubscriptionOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/LoginUserFromSubscriptionOperationExecutor.kt
@@ -74,7 +74,7 @@ internal class LoginUserFromSubscriptionOperationExecutor(
             return ExecutionResponse(
                 ExecutionResult.SUCCESS,
                 idTranslations,
-                listOf(RefreshUserOperation(loginUserOp.appId, backendOneSignalId)),
+                listOf(RefreshUserOperation(loginUserOp.appId, backendOneSignalId, loginUserOp.externalId)),
             )
         } catch (ex: BackendException) {
             val responseType = NetworkUtils.getResponseStatusType(ex.statusCode)

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/LoginUserOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/LoginUserOperationExecutor.kt
@@ -89,6 +89,7 @@ internal class LoginUserOperationExecutor(
                         SetAliasOperation(
                             loginUserOp.appId,
                             loginUserOp.existingOnesignalId!!,
+                            loginUserOp.externalId,
                             IdentityConstants.EXTERNAL_ID,
                             loginUserOp.externalId!!,
                         ),
@@ -223,7 +224,7 @@ internal class LoginUserOperationExecutor(
             val wasPossiblyAnUpsert = identities.isNotEmpty()
             val followUpOperations =
                 if (wasPossiblyAnUpsert) {
-                    listOf(RefreshUserOperation(createUserOperation.appId, backendOneSignalId))
+                    listOf(RefreshUserOperation(createUserOperation.appId, backendOneSignalId, createUserOperation.externalId))
                 } else {
                     null
                 }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/SubscriptionOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/SubscriptionOperationExecutor.kt
@@ -220,6 +220,7 @@ internal class SubscriptionOperationExecutor(
                             CreateSubscriptionOperation(
                                 lastOperation.appId,
                                 lastOperation.onesignalId,
+                                lastOperation.externalId,
                                 lastOperation.subscriptionId,
                                 lastOperation.type,
                                 lastOperation.enabled,

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/listeners/IdentityModelStoreListener.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/listeners/IdentityModelStoreListener.kt
@@ -27,9 +27,9 @@ internal class IdentityModelStoreListener(
         newValue: Any?,
     ): Operation {
         return if (newValue != null && newValue is String) {
-            SetAliasOperation(_configModelStore.model.appId, model.onesignalId, property, newValue)
+            SetAliasOperation(_configModelStore.model.appId, model.onesignalId, model.externalId, property, newValue)
         } else {
-            DeleteAliasOperation(_configModelStore.model.appId, model.onesignalId, property)
+            DeleteAliasOperation(_configModelStore.model.appId, model.onesignalId, model.externalId, property)
         }
     }
 }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/listeners/PropertiesModelStoreListener.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/listeners/PropertiesModelStoreListener.kt
@@ -4,6 +4,7 @@ import com.onesignal.core.internal.config.ConfigModelStore
 import com.onesignal.core.internal.operations.IOperationRepo
 import com.onesignal.core.internal.operations.Operation
 import com.onesignal.core.internal.operations.listeners.SingletonModelStoreListener
+import com.onesignal.user.internal.identity.IdentityModelStore
 import com.onesignal.user.internal.operations.DeleteTagOperation
 import com.onesignal.user.internal.operations.SetPropertyOperation
 import com.onesignal.user.internal.operations.SetTagOperation
@@ -14,6 +15,7 @@ internal class PropertiesModelStoreListener(
     store: PropertiesModelStore,
     opRepo: IOperationRepo,
     private val _configModelStore: ConfigModelStore,
+    private val _identityModelStore: IdentityModelStore,
 ) : SingletonModelStoreListener<PropertiesModel>(store, opRepo) {
     override fun getReplaceOperation(model: PropertiesModel): Operation? {
         // when the property model is replaced, nothing to do on the backend. Already handled via login process.
@@ -36,14 +38,15 @@ internal class PropertiesModelStoreListener(
             return null
         }
 
+        val externalId = _identityModelStore.model.externalId
         if (path.startsWith(PropertiesModel::tags.name)) {
             return if (newValue != null && newValue is String) {
-                SetTagOperation(_configModelStore.model.appId, model.onesignalId, property, newValue)
+                SetTagOperation(_configModelStore.model.appId, model.onesignalId, externalId, property, newValue)
             } else {
-                DeleteTagOperation(_configModelStore.model.appId, model.onesignalId, property)
+                DeleteTagOperation(_configModelStore.model.appId, model.onesignalId, externalId, property)
             }
         }
 
-        return SetPropertyOperation(_configModelStore.model.appId, model.onesignalId, property, newValue)
+        return SetPropertyOperation(_configModelStore.model.appId, model.onesignalId, externalId, property, newValue)
     }
 }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/listeners/SubscriptionModelStoreListener.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/listeners/SubscriptionModelStoreListener.kt
@@ -23,6 +23,7 @@ internal class SubscriptionModelStoreListener(
         return CreateSubscriptionOperation(
             _configModelStore.model.appId,
             _identityModelStore.model.onesignalId,
+            _identityModelStore.model.externalId,
             model.id,
             model.type,
             enabledAndStatus.first,
@@ -32,7 +33,12 @@ internal class SubscriptionModelStoreListener(
     }
 
     override fun getRemoveOperation(model: SubscriptionModel): Operation {
-        return DeleteSubscriptionOperation(_configModelStore.model.appId, _identityModelStore.model.onesignalId, model.id)
+        return DeleteSubscriptionOperation(
+            _configModelStore.model.appId,
+            _identityModelStore.model.onesignalId,
+            _identityModelStore.model.externalId,
+            model.id,
+        )
     }
 
     override fun getUpdateOperation(
@@ -46,6 +52,7 @@ internal class SubscriptionModelStoreListener(
         return UpdateSubscriptionOperation(
             _configModelStore.model.appId,
             _identityModelStore.model.onesignalId,
+            _identityModelStore.model.externalId,
             model.id,
             model.type,
             enabledAndStatus.first,

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/service/UserRefreshService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/service/UserRefreshService.kt
@@ -32,6 +32,7 @@ class UserRefreshService(
             RefreshUserOperation(
                 _configModelStore.model.appId,
                 _identityModelStore.model.onesignalId,
+                _identityModelStore.model.externalId,
             ),
         )
     }

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/features/FeatureFlagTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/features/FeatureFlagTests.kt
@@ -15,4 +15,9 @@ class FeatureFlagTests : FunSpec({
     test("SDK_BACKGROUND_THREADING uses the expected remote key") {
         FeatureFlag.SDK_BACKGROUND_THREADING.key shouldBe "sdk_background_threading"
     }
+
+    test("IDENTITY_VERIFICATION uses the expected remote key and IMMEDIATE activation") {
+        FeatureFlag.IDENTITY_VERIFICATION.key shouldBe "identity_verification"
+        FeatureFlag.IDENTITY_VERIFICATION.activationMode shouldBe FeatureActivationMode.IMMEDIATE
+    }
 })

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/features/FeatureFlagTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/features/FeatureFlagTests.kt
@@ -16,8 +16,8 @@ class FeatureFlagTests : FunSpec({
         FeatureFlag.SDK_BACKGROUND_THREADING.key shouldBe "sdk_background_threading"
     }
 
-    test("IDENTITY_VERIFICATION uses the expected remote key and IMMEDIATE activation") {
-        FeatureFlag.IDENTITY_VERIFICATION.key shouldBe "identity_verification"
-        FeatureFlag.IDENTITY_VERIFICATION.activationMode shouldBe FeatureActivationMode.IMMEDIATE
+    test("SDK_IDENTITY_VERIFICATION uses the expected remote key and IMMEDIATE activation") {
+        FeatureFlag.SDK_IDENTITY_VERIFICATION.key shouldBe "sdk_identity_verification"
+        FeatureFlag.SDK_IDENTITY_VERIFICATION.activationMode shouldBe FeatureActivationMode.IMMEDIATE
     }
 })

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/features/FeatureManagerTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/features/FeatureManagerTests.kt
@@ -202,7 +202,7 @@ class FeatureManagerTests : FunSpec({
 
         val manager = FeatureManager(configModelStore)
 
-        manager.isEnabled(FeatureFlag.IDENTITY_VERIFICATION) shouldBe false
+        manager.isEnabled(FeatureFlag.SDK_IDENTITY_VERIFICATION) shouldBe false
         IdentityVerificationGates.newCodePathsRun shouldBe false
         IdentityVerificationGates.ivBehaviorActive shouldBe false
     }
@@ -210,14 +210,14 @@ class FeatureManagerTests : FunSpec({
     test("initial state: IDENTITY_VERIFICATION flag on → newCodePathsRun=true, ivBehaviorActive=false") {
         val initialModel = mockk<ConfigModel>()
         stubConfigModel(initialModel)
-        every { initialModel.sdkRemoteFeatureFlags } returns listOf(FeatureFlag.IDENTITY_VERIFICATION.key)
+        every { initialModel.sdkRemoteFeatureFlags } returns listOf(FeatureFlag.SDK_IDENTITY_VERIFICATION.key)
         val configModelStore = mockk<ConfigModelStore>()
         every { configModelStore.model } returns initialModel
         every { configModelStore.subscribe(any()) } just runs
 
         val manager = FeatureManager(configModelStore)
 
-        manager.isEnabled(FeatureFlag.IDENTITY_VERIFICATION) shouldBe true
+        manager.isEnabled(FeatureFlag.SDK_IDENTITY_VERIFICATION) shouldBe true
         IdentityVerificationGates.newCodePathsRun shouldBe true
         IdentityVerificationGates.ivBehaviorActive shouldBe false
     }
@@ -232,7 +232,7 @@ class FeatureManagerTests : FunSpec({
 
         val manager = FeatureManager(configModelStore)
 
-        manager.isEnabled(FeatureFlag.IDENTITY_VERIFICATION) shouldBe false
+        manager.isEnabled(FeatureFlag.SDK_IDENTITY_VERIFICATION) shouldBe false
         IdentityVerificationGates.newCodePathsRun shouldBe true
         IdentityVerificationGates.ivBehaviorActive shouldBe true
     }
@@ -240,7 +240,7 @@ class FeatureManagerTests : FunSpec({
     test("initial state: flag on + jwt_required=true → full IV (both gates true)") {
         val initialModel = mockk<ConfigModel>()
         stubConfigModel(initialModel)
-        every { initialModel.sdkRemoteFeatureFlags } returns listOf(FeatureFlag.IDENTITY_VERIFICATION.key)
+        every { initialModel.sdkRemoteFeatureFlags } returns listOf(FeatureFlag.SDK_IDENTITY_VERIFICATION.key)
         every { initialModel.useIdentityVerification } returns JwtRequirement.REQUIRED
         val configModelStore = mockk<ConfigModelStore>()
         every { configModelStore.model } returns initialModel
@@ -248,7 +248,7 @@ class FeatureManagerTests : FunSpec({
 
         val manager = FeatureManager(configModelStore)
 
-        manager.isEnabled(FeatureFlag.IDENTITY_VERIFICATION) shouldBe true
+        manager.isEnabled(FeatureFlag.SDK_IDENTITY_VERIFICATION) shouldBe true
         IdentityVerificationGates.newCodePathsRun shouldBe true
         IdentityVerificationGates.ivBehaviorActive shouldBe true
     }
@@ -286,14 +286,14 @@ class FeatureManagerTests : FunSpec({
         // Mid-session model replacement enables the flag remotely.
         val updatedModel = mockk<ConfigModel>()
         stubConfigModel(updatedModel)
-        every { updatedModel.sdkRemoteFeatureFlags } returns listOf(FeatureFlag.IDENTITY_VERIFICATION.key)
+        every { updatedModel.sdkRemoteFeatureFlags } returns listOf(FeatureFlag.SDK_IDENTITY_VERIFICATION.key)
         every { updatedModel.useIdentityVerification } returns JwtRequirement.NOT_REQUIRED
         every { configModelStore.model } returns updatedModel
 
         manager.onModelReplaced(updatedModel, ModelChangeTags.HYDRATE)
 
         // Feature flag flips in-memory because IDENTITY_VERIFICATION is IMMEDIATE.
-        manager.isEnabled(FeatureFlag.IDENTITY_VERIFICATION) shouldBe true
+        manager.isEnabled(FeatureFlag.SDK_IDENTITY_VERIFICATION) shouldBe true
         // newCodePathsRun reflects the flipped flag; ivBehaviorActive still false (jwt_required=false).
         IdentityVerificationGates.newCodePathsRun shouldBe true
         IdentityVerificationGates.ivBehaviorActive shouldBe false

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/features/FeatureManagerTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/features/FeatureManagerTests.kt
@@ -5,6 +5,7 @@ import com.onesignal.common.threading.ThreadingMode
 import com.onesignal.core.internal.config.ConfigModel
 import com.onesignal.core.internal.config.ConfigModelStore
 import com.onesignal.user.internal.jwt.IdentityVerificationGates
+import com.onesignal.user.internal.jwt.JwtRequirement
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
@@ -16,13 +17,13 @@ import kotlinx.serialization.json.jsonPrimitive
 class FeatureManagerTests : FunSpec({
     beforeEach {
         ThreadingMode.useBackgroundThreading = false
-        IdentityVerificationGates.update(false, null, "test-reset")
+        IdentityVerificationGates.update(false, JwtRequirement.UNKNOWN, "test-reset")
     }
 
     fun stubConfigModel(model: ConfigModel) {
         every { model.sdkRemoteFeatureFlags } returns emptyList()
         every { model.sdkRemoteFeatureFlagMetadata } returns null
-        every { model.useIdentityVerification } returns null
+        every { model.useIdentityVerification } returns JwtRequirement.UNKNOWN
     }
 
     test("initial state enables BACKGROUND_THREADING when key is present in sdk remote flags") {
@@ -224,7 +225,7 @@ class FeatureManagerTests : FunSpec({
     test("ERROR STATE: flag off + jwt_required=true → both gates true (customer config wins)") {
         val initialModel = mockk<ConfigModel>()
         stubConfigModel(initialModel)
-        every { initialModel.useIdentityVerification } returns true
+        every { initialModel.useIdentityVerification } returns JwtRequirement.REQUIRED
         val configModelStore = mockk<ConfigModelStore>()
         every { configModelStore.model } returns initialModel
         every { configModelStore.subscribe(any()) } just runs
@@ -240,7 +241,7 @@ class FeatureManagerTests : FunSpec({
         val initialModel = mockk<ConfigModel>()
         stubConfigModel(initialModel)
         every { initialModel.sdkRemoteFeatureFlags } returns listOf(FeatureFlag.IDENTITY_VERIFICATION.key)
-        every { initialModel.useIdentityVerification } returns true
+        every { initialModel.useIdentityVerification } returns JwtRequirement.REQUIRED
         val configModelStore = mockk<ConfigModelStore>()
         every { configModelStore.model } returns initialModel
         every { configModelStore.subscribe(any()) } just runs
@@ -264,7 +265,7 @@ class FeatureManagerTests : FunSpec({
 
         val updatedModel = mockk<ConfigModel>()
         stubConfigModel(updatedModel)
-        every { updatedModel.useIdentityVerification } returns true
+        every { updatedModel.useIdentityVerification } returns JwtRequirement.REQUIRED
 
         manager.onModelReplaced(updatedModel, ModelChangeTags.HYDRATE)
 
@@ -284,7 +285,7 @@ class FeatureManagerTests : FunSpec({
         val updatedModel = mockk<ConfigModel>()
         stubConfigModel(updatedModel)
         every { updatedModel.sdkRemoteFeatureFlags } returns listOf(FeatureFlag.IDENTITY_VERIFICATION.key)
-        every { updatedModel.useIdentityVerification } returns false
+        every { updatedModel.useIdentityVerification } returns JwtRequirement.NOT_REQUIRED
 
         manager.onModelReplaced(updatedModel, ModelChangeTags.HYDRATE)
 

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/features/FeatureManagerTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/features/FeatureManagerTests.kt
@@ -266,6 +266,8 @@ class FeatureManagerTests : FunSpec({
         val updatedModel = mockk<ConfigModel>()
         stubConfigModel(updatedModel)
         every { updatedModel.useIdentityVerification } returns JwtRequirement.REQUIRED
+        // Match production: store's model is swapped before onModelReplaced fires.
+        every { configModelStore.model } returns updatedModel
 
         manager.onModelReplaced(updatedModel, ModelChangeTags.HYDRATE)
 
@@ -286,6 +288,7 @@ class FeatureManagerTests : FunSpec({
         stubConfigModel(updatedModel)
         every { updatedModel.sdkRemoteFeatureFlags } returns listOf(FeatureFlag.IDENTITY_VERIFICATION.key)
         every { updatedModel.useIdentityVerification } returns JwtRequirement.NOT_REQUIRED
+        every { configModelStore.model } returns updatedModel
 
         manager.onModelReplaced(updatedModel, ModelChangeTags.HYDRATE)
 

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/features/FeatureManagerTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/features/FeatureManagerTests.kt
@@ -4,6 +4,7 @@ import com.onesignal.common.modeling.ModelChangeTags
 import com.onesignal.common.threading.ThreadingMode
 import com.onesignal.core.internal.config.ConfigModel
 import com.onesignal.core.internal.config.ConfigModelStore
+import com.onesignal.user.internal.jwt.IdentityVerificationGates
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
@@ -15,11 +16,13 @@ import kotlinx.serialization.json.jsonPrimitive
 class FeatureManagerTests : FunSpec({
     beforeEach {
         ThreadingMode.useBackgroundThreading = false
+        IdentityVerificationGates.update(false, null, "test-reset")
     }
 
     fun stubConfigModel(model: ConfigModel) {
         every { model.sdkRemoteFeatureFlags } returns emptyList()
         every { model.sdkRemoteFeatureFlagMetadata } returns null
+        every { model.useIdentityVerification } returns null
     }
 
     test("initial state enables BACKGROUND_THREADING when key is present in sdk remote flags") {
@@ -187,5 +190,108 @@ class FeatureManagerTests : FunSpec({
         manager.onModelReplaced(updatedModel, ModelChangeTags.HYDRATE)
 
         manager.enabledFeatureKeys() shouldBe emptyList()
+    }
+
+    test("initial state: IDENTITY_VERIFICATION flag off + jwt_required=null → gates both false") {
+        val initialModel = mockk<ConfigModel>()
+        stubConfigModel(initialModel)
+        val configModelStore = mockk<ConfigModelStore>()
+        every { configModelStore.model } returns initialModel
+        every { configModelStore.subscribe(any()) } just runs
+
+        val manager = FeatureManager(configModelStore)
+
+        manager.isEnabled(FeatureFlag.IDENTITY_VERIFICATION) shouldBe false
+        IdentityVerificationGates.newCodePathsRun shouldBe false
+        IdentityVerificationGates.ivBehaviorActive shouldBe false
+    }
+
+    test("initial state: IDENTITY_VERIFICATION flag on → newCodePathsRun=true, ivBehaviorActive=false") {
+        val initialModel = mockk<ConfigModel>()
+        stubConfigModel(initialModel)
+        every { initialModel.sdkRemoteFeatureFlags } returns listOf(FeatureFlag.IDENTITY_VERIFICATION.key)
+        val configModelStore = mockk<ConfigModelStore>()
+        every { configModelStore.model } returns initialModel
+        every { configModelStore.subscribe(any()) } just runs
+
+        val manager = FeatureManager(configModelStore)
+
+        manager.isEnabled(FeatureFlag.IDENTITY_VERIFICATION) shouldBe true
+        IdentityVerificationGates.newCodePathsRun shouldBe true
+        IdentityVerificationGates.ivBehaviorActive shouldBe false
+    }
+
+    test("ERROR STATE: flag off + jwt_required=true → both gates true (customer config wins)") {
+        val initialModel = mockk<ConfigModel>()
+        stubConfigModel(initialModel)
+        every { initialModel.useIdentityVerification } returns true
+        val configModelStore = mockk<ConfigModelStore>()
+        every { configModelStore.model } returns initialModel
+        every { configModelStore.subscribe(any()) } just runs
+
+        val manager = FeatureManager(configModelStore)
+
+        manager.isEnabled(FeatureFlag.IDENTITY_VERIFICATION) shouldBe false
+        IdentityVerificationGates.newCodePathsRun shouldBe true
+        IdentityVerificationGates.ivBehaviorActive shouldBe true
+    }
+
+    test("initial state: flag on + jwt_required=true → full IV (both gates true)") {
+        val initialModel = mockk<ConfigModel>()
+        stubConfigModel(initialModel)
+        every { initialModel.sdkRemoteFeatureFlags } returns listOf(FeatureFlag.IDENTITY_VERIFICATION.key)
+        every { initialModel.useIdentityVerification } returns true
+        val configModelStore = mockk<ConfigModelStore>()
+        every { configModelStore.model } returns initialModel
+        every { configModelStore.subscribe(any()) } just runs
+
+        val manager = FeatureManager(configModelStore)
+
+        manager.isEnabled(FeatureFlag.IDENTITY_VERIFICATION) shouldBe true
+        IdentityVerificationGates.newCodePathsRun shouldBe true
+        IdentityVerificationGates.ivBehaviorActive shouldBe true
+    }
+
+    test("HYDRATE updates gates when useIdentityVerification arrives as true") {
+        val initialModel = mockk<ConfigModel>()
+        stubConfigModel(initialModel)
+        val configModelStore = mockk<ConfigModelStore>()
+        every { configModelStore.model } returns initialModel
+        every { configModelStore.subscribe(any()) } just runs
+        val manager = FeatureManager(configModelStore)
+
+        IdentityVerificationGates.ivBehaviorActive shouldBe false
+
+        val updatedModel = mockk<ConfigModel>()
+        stubConfigModel(updatedModel)
+        every { updatedModel.useIdentityVerification } returns true
+
+        manager.onModelReplaced(updatedModel, ModelChangeTags.HYDRATE)
+
+        IdentityVerificationGates.newCodePathsRun shouldBe true
+        IdentityVerificationGates.ivBehaviorActive shouldBe true
+    }
+
+    test("IDENTITY_VERIFICATION is IMMEDIATE: mid-session flag flip flows through to the gates") {
+        val initialModel = mockk<ConfigModel>()
+        stubConfigModel(initialModel)
+        val configModelStore = mockk<ConfigModelStore>()
+        every { configModelStore.model } returns initialModel
+        every { configModelStore.subscribe(any()) } just runs
+        val manager = FeatureManager(configModelStore)
+
+        // Mid-session model replacement enables the flag remotely.
+        val updatedModel = mockk<ConfigModel>()
+        stubConfigModel(updatedModel)
+        every { updatedModel.sdkRemoteFeatureFlags } returns listOf(FeatureFlag.IDENTITY_VERIFICATION.key)
+        every { updatedModel.useIdentityVerification } returns false
+
+        manager.onModelReplaced(updatedModel, ModelChangeTags.HYDRATE)
+
+        // Feature flag flips in-memory because IDENTITY_VERIFICATION is IMMEDIATE.
+        manager.isEnabled(FeatureFlag.IDENTITY_VERIFICATION) shouldBe true
+        // newCodePathsRun reflects the flipped flag; ivBehaviorActive still false (jwt_required=false).
+        IdentityVerificationGates.newCodePathsRun shouldBe true
+        IdentityVerificationGates.ivBehaviorActive shouldBe false
     }
 })

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/operations/OperationModelStoreTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/operations/OperationModelStoreTests.kt
@@ -28,7 +28,7 @@ class OperationModelStoreTests : FunSpec({
         val jsonArray = JSONArray()
 
         // 1. Create a VALID Operation with onesignalId
-        val validOperation = SetPropertyOperation(UUID.randomUUID().toString(), UUID.randomUUID().toString(), "property", "value")
+        val validOperation = SetPropertyOperation(UUID.randomUUID().toString(), UUID.randomUUID().toString(), null, "property", "value")
         validOperation.id = UUID.randomUUID().toString()
 
         // 2. Create a VALID operation missing onesignalId

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/jwt/IdentityVerificationGatesTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/jwt/IdentityVerificationGatesTests.kt
@@ -6,7 +6,7 @@ import io.kotest.matchers.shouldBe
 class IdentityVerificationGatesTests : FunSpec({
     // Singleton state leaks across tests; reset before each.
     beforeEach {
-        IdentityVerificationGates.update(false, null, "test-reset")
+        IdentityVerificationGates.update(false, JwtRequirement.UNKNOWN, "test-reset")
     }
 
     test("defaults to newCodePathsRun=false and ivBehaviorActive=false") {
@@ -14,60 +14,60 @@ class IdentityVerificationGatesTests : FunSpec({
         IdentityVerificationGates.ivBehaviorActive shouldBe false
     }
 
-    test("featureFlagOn=false, jwtRequired=null: both gates are false (safe default)") {
+    test("featureFlagOn=false, jwtRequirement=UNKNOWN: both gates are false (safe default)") {
         IdentityVerificationGates.update(
             featureFlagOn = false,
-            jwtRequired = null,
+            jwtRequirement = JwtRequirement.UNKNOWN,
             source = "test",
         )
         IdentityVerificationGates.newCodePathsRun shouldBe false
         IdentityVerificationGates.ivBehaviorActive shouldBe false
     }
 
-    test("featureFlagOn=false, jwtRequired=false: both gates are false") {
+    test("featureFlagOn=false, jwtRequirement=NOT_REQUIRED: both gates are false") {
         IdentityVerificationGates.update(
             featureFlagOn = false,
-            jwtRequired = false,
+            jwtRequirement = JwtRequirement.NOT_REQUIRED,
             source = "test",
         )
         IdentityVerificationGates.newCodePathsRun shouldBe false
         IdentityVerificationGates.ivBehaviorActive shouldBe false
     }
 
-    test("ERROR STATE — featureFlagOn=false, jwtRequired=true: both gates true (customer config wins)") {
+    test("ERROR STATE — featureFlagOn=false, jwtRequirement=REQUIRED: both gates true (customer config wins)") {
         IdentityVerificationGates.update(
             featureFlagOn = false,
-            jwtRequired = true,
+            jwtRequirement = JwtRequirement.REQUIRED,
             source = "test",
         )
         IdentityVerificationGates.newCodePathsRun shouldBe true
         IdentityVerificationGates.ivBehaviorActive shouldBe true
     }
 
-    test("featureFlagOn=true, jwtRequired=null: newCodePathsRun true, ivBehaviorActive false") {
+    test("featureFlagOn=true, jwtRequirement=UNKNOWN: newCodePathsRun true, ivBehaviorActive false") {
         IdentityVerificationGates.update(
             featureFlagOn = true,
-            jwtRequired = null,
+            jwtRequirement = JwtRequirement.UNKNOWN,
             source = "test",
         )
         IdentityVerificationGates.newCodePathsRun shouldBe true
         IdentityVerificationGates.ivBehaviorActive shouldBe false
     }
 
-    test("featureFlagOn=true, jwtRequired=false: newCodePathsRun true, ivBehaviorActive false (Phase 3)") {
+    test("featureFlagOn=true, jwtRequirement=NOT_REQUIRED: newCodePathsRun true, ivBehaviorActive false (Phase 3)") {
         IdentityVerificationGates.update(
             featureFlagOn = true,
-            jwtRequired = false,
+            jwtRequirement = JwtRequirement.NOT_REQUIRED,
             source = "test",
         )
         IdentityVerificationGates.newCodePathsRun shouldBe true
         IdentityVerificationGates.ivBehaviorActive shouldBe false
     }
 
-    test("featureFlagOn=true, jwtRequired=true: both gates true (full IV)") {
+    test("featureFlagOn=true, jwtRequirement=REQUIRED: both gates true (full IV)") {
         IdentityVerificationGates.update(
             featureFlagOn = true,
-            jwtRequired = true,
+            jwtRequirement = JwtRequirement.REQUIRED,
             source = "test",
         )
         IdentityVerificationGates.newCodePathsRun shouldBe true
@@ -75,22 +75,22 @@ class IdentityVerificationGatesTests : FunSpec({
     }
 
     test("updating to the same values is a no-op but still reflects in reads") {
-        IdentityVerificationGates.update(true, true, "first")
-        IdentityVerificationGates.update(true, true, "second")
+        IdentityVerificationGates.update(true, JwtRequirement.REQUIRED, "first")
+        IdentityVerificationGates.update(true, JwtRequirement.REQUIRED, "second")
         IdentityVerificationGates.newCodePathsRun shouldBe true
         IdentityVerificationGates.ivBehaviorActive shouldBe true
     }
 
     test("transition: non-IV → IV-active → off") {
-        IdentityVerificationGates.update(false, false, "phase-1-non-iv")
+        IdentityVerificationGates.update(false, JwtRequirement.NOT_REQUIRED, "phase-1-non-iv")
         IdentityVerificationGates.newCodePathsRun shouldBe false
         IdentityVerificationGates.ivBehaviorActive shouldBe false
 
-        IdentityVerificationGates.update(true, true, "phase-2-iv-on")
+        IdentityVerificationGates.update(true, JwtRequirement.REQUIRED, "phase-2-iv-on")
         IdentityVerificationGates.newCodePathsRun shouldBe true
         IdentityVerificationGates.ivBehaviorActive shouldBe true
 
-        IdentityVerificationGates.update(false, false, "kill-switch")
+        IdentityVerificationGates.update(false, JwtRequirement.NOT_REQUIRED, "kill-switch")
         IdentityVerificationGates.newCodePathsRun shouldBe false
         IdentityVerificationGates.ivBehaviorActive shouldBe false
     }

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/jwt/IdentityVerificationGatesTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/jwt/IdentityVerificationGatesTests.kt
@@ -1,0 +1,97 @@
+package com.onesignal.user.internal.jwt
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class IdentityVerificationGatesTests : FunSpec({
+    // Singleton state leaks across tests; reset before each.
+    beforeEach {
+        IdentityVerificationGates.update(false, null, "test-reset")
+    }
+
+    test("defaults to newCodePathsRun=false and ivBehaviorActive=false") {
+        IdentityVerificationGates.newCodePathsRun shouldBe false
+        IdentityVerificationGates.ivBehaviorActive shouldBe false
+    }
+
+    test("featureFlagOn=false, jwtRequired=null: both gates are false (safe default)") {
+        IdentityVerificationGates.update(
+            featureFlagOn = false,
+            jwtRequired = null,
+            source = "test",
+        )
+        IdentityVerificationGates.newCodePathsRun shouldBe false
+        IdentityVerificationGates.ivBehaviorActive shouldBe false
+    }
+
+    test("featureFlagOn=false, jwtRequired=false: both gates are false") {
+        IdentityVerificationGates.update(
+            featureFlagOn = false,
+            jwtRequired = false,
+            source = "test",
+        )
+        IdentityVerificationGates.newCodePathsRun shouldBe false
+        IdentityVerificationGates.ivBehaviorActive shouldBe false
+    }
+
+    test("ERROR STATE — featureFlagOn=false, jwtRequired=true: both gates true (customer config wins)") {
+        IdentityVerificationGates.update(
+            featureFlagOn = false,
+            jwtRequired = true,
+            source = "test",
+        )
+        IdentityVerificationGates.newCodePathsRun shouldBe true
+        IdentityVerificationGates.ivBehaviorActive shouldBe true
+    }
+
+    test("featureFlagOn=true, jwtRequired=null: newCodePathsRun true, ivBehaviorActive false") {
+        IdentityVerificationGates.update(
+            featureFlagOn = true,
+            jwtRequired = null,
+            source = "test",
+        )
+        IdentityVerificationGates.newCodePathsRun shouldBe true
+        IdentityVerificationGates.ivBehaviorActive shouldBe false
+    }
+
+    test("featureFlagOn=true, jwtRequired=false: newCodePathsRun true, ivBehaviorActive false (Phase 3)") {
+        IdentityVerificationGates.update(
+            featureFlagOn = true,
+            jwtRequired = false,
+            source = "test",
+        )
+        IdentityVerificationGates.newCodePathsRun shouldBe true
+        IdentityVerificationGates.ivBehaviorActive shouldBe false
+    }
+
+    test("featureFlagOn=true, jwtRequired=true: both gates true (full IV)") {
+        IdentityVerificationGates.update(
+            featureFlagOn = true,
+            jwtRequired = true,
+            source = "test",
+        )
+        IdentityVerificationGates.newCodePathsRun shouldBe true
+        IdentityVerificationGates.ivBehaviorActive shouldBe true
+    }
+
+    test("updating to the same values is a no-op but still reflects in reads") {
+        IdentityVerificationGates.update(true, true, "first")
+        IdentityVerificationGates.update(true, true, "second")
+        IdentityVerificationGates.newCodePathsRun shouldBe true
+        IdentityVerificationGates.ivBehaviorActive shouldBe true
+    }
+
+    test("transition: non-IV → IV-active → off") {
+        IdentityVerificationGates.update(false, false, "phase-1-non-iv")
+        IdentityVerificationGates.newCodePathsRun shouldBe false
+        IdentityVerificationGates.ivBehaviorActive shouldBe false
+
+        IdentityVerificationGates.update(true, true, "phase-2-iv-on")
+        IdentityVerificationGates.newCodePathsRun shouldBe true
+        IdentityVerificationGates.ivBehaviorActive shouldBe true
+
+        IdentityVerificationGates.update(false, false, "kill-switch")
+        IdentityVerificationGates.newCodePathsRun shouldBe false
+        IdentityVerificationGates.ivBehaviorActive shouldBe false
+    }
+})

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/jwt/JwtTokenStoreTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/jwt/JwtTokenStoreTests.kt
@@ -1,0 +1,231 @@
+package com.onesignal.user.internal.jwt
+
+import com.onesignal.core.internal.preferences.PreferenceOneSignalKeys
+import com.onesignal.core.internal.preferences.PreferenceStores
+import com.onesignal.debug.LogLevel
+import com.onesignal.debug.internal.logging.Logging
+import com.onesignal.mocks.MockPreferencesService
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import org.json.JSONObject
+
+class JwtTokenStoreTests : FunSpec({
+    beforeEach {
+        // Silence logging to avoid android.util.Log.w not-mocked failures in Logging.warn
+        Logging.logLevel = LogLevel.NONE
+    }
+
+    test("getJwt returns null for an externalId never stored") {
+        val store = JwtTokenStore(MockPreferencesService())
+
+        store.getJwt("alice") shouldBe null
+    }
+
+    test("putJwt stores a token retrievable by externalId") {
+        val store = JwtTokenStore(MockPreferencesService())
+
+        store.putJwt("alice", "token-a")
+
+        store.getJwt("alice") shouldBe "token-a"
+    }
+
+    test("putJwt replaces an existing token for the same externalId") {
+        val store = JwtTokenStore(MockPreferencesService())
+        store.putJwt("alice", "token-a1")
+
+        store.putJwt("alice", "token-a2")
+
+        store.getJwt("alice") shouldBe "token-a2"
+    }
+
+    test("putJwt with null is a no-op (invalidate is the explicit path)") {
+        val store = JwtTokenStore(MockPreferencesService())
+        store.putJwt("alice", "token-a")
+
+        store.putJwt("alice", null)
+
+        store.getJwt("alice") shouldBe "token-a"
+    }
+
+    test("invalidateJwt removes the token for externalId") {
+        val store = JwtTokenStore(MockPreferencesService())
+        store.putJwt("alice", "token-a")
+
+        store.invalidateJwt("alice")
+
+        store.getJwt("alice") shouldBe null
+    }
+
+    test("invalidateJwt on an absent externalId is a no-op (no crash)") {
+        val store = JwtTokenStore(MockPreferencesService())
+
+        store.invalidateJwt("alice")
+
+        store.getJwt("alice") shouldBe null
+    }
+
+    test("putJwt persists to preferences and can be recovered by a fresh store instance") {
+        val prefs = MockPreferencesService()
+        val first = JwtTokenStore(prefs)
+        first.putJwt("alice", "token-a")
+        first.putJwt("bob", "token-b")
+
+        val second = JwtTokenStore(prefs)
+
+        second.getJwt("alice") shouldBe "token-a"
+        second.getJwt("bob") shouldBe "token-b"
+    }
+
+    test("invalidateJwt persists so next launch does not see the token") {
+        val prefs = MockPreferencesService()
+        val first = JwtTokenStore(prefs)
+        first.putJwt("alice", "token-a")
+        first.invalidateJwt("alice")
+
+        val second = JwtTokenStore(prefs)
+
+        second.getJwt("alice") shouldBe null
+    }
+
+    test("pruneToExternalIds removes tokens whose externalId is not in the active set") {
+        val store = JwtTokenStore(MockPreferencesService())
+        store.putJwt("alice", "token-a")
+        store.putJwt("bob", "token-b")
+        store.putJwt("chris", "token-c")
+
+        store.pruneToExternalIds(setOf("alice", "chris"))
+
+        store.getJwt("alice") shouldBe "token-a"
+        store.getJwt("bob") shouldBe null
+        store.getJwt("chris") shouldBe "token-c"
+    }
+
+    test("subscribers are notified when a new JWT is put") {
+        val store = JwtTokenStore(MockPreferencesService())
+        val calls = mutableListOf<Pair<String, String?>>()
+        store.subscribe(
+            object : IJwtUpdateListener {
+                override fun onJwtUpdated(externalId: String, jwt: String?) {
+                    calls.add(externalId to jwt)
+                }
+            },
+        )
+
+        store.putJwt("alice", "token-a")
+
+        calls shouldBe listOf("alice" to "token-a")
+    }
+
+    test("subscribers are NOT notified when putJwt does not change the stored token") {
+        val store = JwtTokenStore(MockPreferencesService())
+        store.putJwt("alice", "token-a")
+        val calls = mutableListOf<Pair<String, String?>>()
+        store.subscribe(
+            object : IJwtUpdateListener {
+                override fun onJwtUpdated(externalId: String, jwt: String?) {
+                    calls.add(externalId to jwt)
+                }
+            },
+        )
+
+        store.putJwt("alice", "token-a")
+
+        calls.isEmpty() shouldBe true
+    }
+
+    test("subscribers are notified on invalidation with null jwt") {
+        val store = JwtTokenStore(MockPreferencesService())
+        store.putJwt("alice", "token-a")
+        val calls = mutableListOf<Pair<String, String?>>()
+        store.subscribe(
+            object : IJwtUpdateListener {
+                override fun onJwtUpdated(externalId: String, jwt: String?) {
+                    calls.add(externalId to jwt)
+                }
+            },
+        )
+
+        store.invalidateJwt("alice")
+
+        calls shouldBe listOf("alice" to null)
+    }
+
+    test("subscribers are NOT notified when invalidating a non-existent token") {
+        val store = JwtTokenStore(MockPreferencesService())
+        val calls = mutableListOf<Pair<String, String?>>()
+        store.subscribe(
+            object : IJwtUpdateListener {
+                override fun onJwtUpdated(externalId: String, jwt: String?) {
+                    calls.add(externalId to jwt)
+                }
+            },
+        )
+
+        store.invalidateJwt("alice")
+
+        calls.isEmpty() shouldBe true
+    }
+
+    test("pruneToExternalIds fires invalidation for each removed externalId") {
+        val store = JwtTokenStore(MockPreferencesService())
+        store.putJwt("alice", "token-a")
+        store.putJwt("bob", "token-b")
+        store.putJwt("chris", "token-c")
+        val calls = mutableListOf<Pair<String, String?>>()
+        store.subscribe(
+            object : IJwtUpdateListener {
+                override fun onJwtUpdated(externalId: String, jwt: String?) {
+                    calls.add(externalId to jwt)
+                }
+            },
+        )
+
+        store.pruneToExternalIds(setOf("alice"))
+
+        // Order is not deterministic across JVMs; check set semantics.
+        calls.toSet() shouldBe setOf("bob" to null, "chris" to null)
+    }
+
+    test("unsubscribed listener is not notified") {
+        val store = JwtTokenStore(MockPreferencesService())
+        val calls = mutableListOf<Pair<String, String?>>()
+        val listener =
+            object : IJwtUpdateListener {
+                override fun onJwtUpdated(externalId: String, jwt: String?) {
+                    calls.add(externalId to jwt)
+                }
+            }
+        store.subscribe(listener)
+        store.unsubscribe(listener)
+
+        store.putJwt("alice", "token-a")
+
+        calls.isEmpty() shouldBe true
+    }
+
+    test("persisted JSON is the expected shape") {
+        val prefs = MockPreferencesService()
+        val store = JwtTokenStore(prefs)
+
+        store.putJwt("alice", "token-a")
+        store.putJwt("bob", "token-b")
+
+        val raw = prefs.getString(PreferenceStores.ONESIGNAL, PreferenceOneSignalKeys.PREFS_OS_JWT_TOKENS)
+        val obj = JSONObject(requireNotNull(raw))
+        obj.getString("alice") shouldBe "token-a"
+        obj.getString("bob") shouldBe "token-b"
+    }
+
+    test("malformed persisted JSON starts fresh without crashing") {
+        val prefs =
+            MockPreferencesService(
+                mapOf(PreferenceOneSignalKeys.PREFS_OS_JWT_TOKENS to "{not valid json"),
+            )
+        val store = JwtTokenStore(prefs)
+
+        store.getJwt("alice") shouldBe null
+        // Can still store new tokens after a malformed load
+        store.putJwt("alice", "token-a")
+        store.getJwt("alice") shouldBe "token-a"
+    }
+})

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/jwt/JwtTokenStoreTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/jwt/JwtTokenStoreTests.kt
@@ -102,28 +102,28 @@ class JwtTokenStoreTests : FunSpec({
 
     test("subscribers are notified when a new JWT is put") {
         val store = JwtTokenStore(MockPreferencesService())
-        val calls = mutableListOf<Pair<String, String?>>()
+        val calls = mutableListOf<String>()
         store.subscribe(
             object : IJwtUpdateListener {
-                override fun onJwtUpdated(externalId: String, jwt: String?) {
-                    calls.add(externalId to jwt)
+                override fun onJwtUpdated(externalId: String) {
+                    calls.add(externalId)
                 }
             },
         )
 
         store.putJwt("alice", "token-a")
 
-        calls shouldBe listOf("alice" to "token-a")
+        calls shouldBe listOf("alice")
     }
 
     test("subscribers are NOT notified when putJwt does not change the stored token") {
         val store = JwtTokenStore(MockPreferencesService())
         store.putJwt("alice", "token-a")
-        val calls = mutableListOf<Pair<String, String?>>()
+        val calls = mutableListOf<String>()
         store.subscribe(
             object : IJwtUpdateListener {
-                override fun onJwtUpdated(externalId: String, jwt: String?) {
-                    calls.add(externalId to jwt)
+                override fun onJwtUpdated(externalId: String) {
+                    calls.add(externalId)
                 }
             },
         )
@@ -133,30 +133,30 @@ class JwtTokenStoreTests : FunSpec({
         calls.isEmpty() shouldBe true
     }
 
-    test("subscribers are notified on invalidation with null jwt") {
+    test("subscribers are notified on invalidation") {
         val store = JwtTokenStore(MockPreferencesService())
         store.putJwt("alice", "token-a")
-        val calls = mutableListOf<Pair<String, String?>>()
+        val calls = mutableListOf<String>()
         store.subscribe(
             object : IJwtUpdateListener {
-                override fun onJwtUpdated(externalId: String, jwt: String?) {
-                    calls.add(externalId to jwt)
+                override fun onJwtUpdated(externalId: String) {
+                    calls.add(externalId)
                 }
             },
         )
 
         store.invalidateJwt("alice")
 
-        calls shouldBe listOf("alice" to null)
+        calls shouldBe listOf("alice")
     }
 
     test("subscribers are NOT notified when invalidating a non-existent token") {
         val store = JwtTokenStore(MockPreferencesService())
-        val calls = mutableListOf<Pair<String, String?>>()
+        val calls = mutableListOf<String>()
         store.subscribe(
             object : IJwtUpdateListener {
-                override fun onJwtUpdated(externalId: String, jwt: String?) {
-                    calls.add(externalId to jwt)
+                override fun onJwtUpdated(externalId: String) {
+                    calls.add(externalId)
                 }
             },
         )
@@ -166,16 +166,16 @@ class JwtTokenStoreTests : FunSpec({
         calls.isEmpty() shouldBe true
     }
 
-    test("pruneToExternalIds fires invalidation for each removed externalId") {
+    test("pruneToExternalIds fires for each removed externalId") {
         val store = JwtTokenStore(MockPreferencesService())
         store.putJwt("alice", "token-a")
         store.putJwt("bob", "token-b")
         store.putJwt("chris", "token-c")
-        val calls = mutableListOf<Pair<String, String?>>()
+        val calls = mutableListOf<String>()
         store.subscribe(
             object : IJwtUpdateListener {
-                override fun onJwtUpdated(externalId: String, jwt: String?) {
-                    calls.add(externalId to jwt)
+                override fun onJwtUpdated(externalId: String) {
+                    calls.add(externalId)
                 }
             },
         )
@@ -183,16 +183,16 @@ class JwtTokenStoreTests : FunSpec({
         store.pruneToExternalIds(setOf("alice"))
 
         // Order is not deterministic across JVMs; check set semantics.
-        calls.toSet() shouldBe setOf("bob" to null, "chris" to null)
+        calls.toSet() shouldBe setOf("bob", "chris")
     }
 
     test("unsubscribed listener is not notified") {
         val store = JwtTokenStore(MockPreferencesService())
-        val calls = mutableListOf<Pair<String, String?>>()
+        val calls = mutableListOf<String>()
         val listener =
             object : IJwtUpdateListener {
-                override fun onJwtUpdated(externalId: String, jwt: String?) {
-                    calls.add(externalId to jwt)
+                override fun onJwtUpdated(externalId: String) {
+                    calls.add(externalId)
                 }
             }
         store.subscribe(listener)

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/IdentityOperationExecutorTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/IdentityOperationExecutorTests.kt
@@ -40,7 +40,7 @@ class IdentityOperationExecutorTests : FunSpec({
 
         val identityOperationExecutor =
             IdentityOperationExecutor(mockIdentityBackendService, mockIdentityModelStore, mockBuildUserService, getNewRecordState())
-        val operations = listOf<Operation>(SetAliasOperation("appId", "onesignalId", "aliasKey1", "aliasValue1"))
+        val operations = listOf<Operation>(SetAliasOperation("appId", "onesignalId", null, "aliasKey1", "aliasValue1"))
 
         // When
         val response = identityOperationExecutor.execute(operations)
@@ -70,7 +70,7 @@ class IdentityOperationExecutorTests : FunSpec({
 
         val identityOperationExecutor =
             IdentityOperationExecutor(mockIdentityBackendService, mockIdentityModelStore, mockBuildUserService, getNewRecordState())
-        val operations = listOf<Operation>(SetAliasOperation("appId", "onesignalId", "aliasKey1", "aliasValue1"))
+        val operations = listOf<Operation>(SetAliasOperation("appId", "onesignalId", null, "aliasKey1", "aliasValue1"))
 
         // When
 
@@ -91,7 +91,7 @@ class IdentityOperationExecutorTests : FunSpec({
 
         val identityOperationExecutor =
             IdentityOperationExecutor(mockIdentityBackendService, mockIdentityModelStore, mockBuildUserService, getNewRecordState())
-        val operations = listOf<Operation>(SetAliasOperation("appId", "onesignalId", "aliasKey1", "aliasValue1"))
+        val operations = listOf<Operation>(SetAliasOperation("appId", "onesignalId", null, "aliasKey1", "aliasValue1"))
 
         // When
 
@@ -112,7 +112,7 @@ class IdentityOperationExecutorTests : FunSpec({
 
         val identityOperationExecutor =
             IdentityOperationExecutor(mockIdentityBackendService, mockIdentityModelStore, mockBuildUserService, getNewRecordState())
-        val operations = listOf<Operation>(SetAliasOperation("appId", "onesignalId", "aliasKey1", "aliasValue1"))
+        val operations = listOf<Operation>(SetAliasOperation("appId", "onesignalId", null, "aliasKey1", "aliasValue1"))
 
         // When
 
@@ -135,7 +135,7 @@ class IdentityOperationExecutorTests : FunSpec({
         val newRecordState = getNewRecordState(mockConfigModelStore).also { it.add("onesignalId") }
         val identityOperationExecutor =
             IdentityOperationExecutor(mockIdentityBackendService, mockIdentityModelStore, mockBuildUserService, newRecordState)
-        val operations = listOf<Operation>(SetAliasOperation("appId", "onesignalId", "aliasKey1", "aliasValue1"))
+        val operations = listOf<Operation>(SetAliasOperation("appId", "onesignalId", null, "aliasKey1", "aliasValue1"))
 
         // When
 
@@ -161,7 +161,7 @@ class IdentityOperationExecutorTests : FunSpec({
 
         val identityOperationExecutor =
             IdentityOperationExecutor(mockIdentityBackendService, mockIdentityModelStore, mockBuildUserService, getNewRecordState())
-        val operations = listOf<Operation>(DeleteAliasOperation("appId", "onesignalId", "aliasKey1"))
+        val operations = listOf<Operation>(DeleteAliasOperation("appId", "onesignalId", null, "aliasKey1"))
 
         // When
         val response = identityOperationExecutor.execute(operations)
@@ -184,7 +184,7 @@ class IdentityOperationExecutorTests : FunSpec({
 
         val identityOperationExecutor =
             IdentityOperationExecutor(mockIdentityBackendService, mockIdentityModelStore, mockBuildUserService, getNewRecordState())
-        val operations = listOf<Operation>(DeleteAliasOperation("appId", "onesignalId", "aliasKey1"))
+        val operations = listOf<Operation>(DeleteAliasOperation("appId", "onesignalId", null, "aliasKey1"))
 
         // When
 
@@ -204,7 +204,7 @@ class IdentityOperationExecutorTests : FunSpec({
 
         val identityOperationExecutor =
             IdentityOperationExecutor(mockIdentityBackendService, mockIdentityModelStore, mockBuildUserService, getNewRecordState())
-        val operations = listOf<Operation>(DeleteAliasOperation("appId", "onesignalId", "aliasKey1"))
+        val operations = listOf<Operation>(DeleteAliasOperation("appId", "onesignalId", null, "aliasKey1"))
 
         // When
 
@@ -226,7 +226,7 @@ class IdentityOperationExecutorTests : FunSpec({
 
         val identityOperationExecutor =
             IdentityOperationExecutor(mockIdentityBackendService, mockIdentityModelStore, mockBuildUserService, getNewRecordState())
-        val operations = listOf<Operation>(DeleteAliasOperation("appId", "onesignalId", "aliasKey1"))
+        val operations = listOf<Operation>(DeleteAliasOperation("appId", "onesignalId", null, "aliasKey1"))
 
         // When
 
@@ -251,7 +251,7 @@ class IdentityOperationExecutorTests : FunSpec({
         val newRecordState = getNewRecordState(mockConfigModelStore).also { it.add("onesignalId") }
         val identityOperationExecutor =
             IdentityOperationExecutor(mockIdentityBackendService, mockIdentityModelStore, mockBuildUserService, newRecordState)
-        val operations = listOf<Operation>(DeleteAliasOperation("appId", "onesignalId", "aliasKey1"))
+        val operations = listOf<Operation>(DeleteAliasOperation("appId", "onesignalId", null, "aliasKey1"))
 
         // When
         val response = identityOperationExecutor.execute(operations)

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/LoginUserOperationExecutorTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/LoginUserOperationExecutorTests.kt
@@ -43,6 +43,7 @@ class LoginUserOperationExecutorTests : FunSpec({
         CreateSubscriptionOperation(
             appId,
             localOneSignalId,
+            null,
             "subscriptionId1",
             SubscriptionType.PUSH,
             true,
@@ -410,6 +411,7 @@ class LoginUserOperationExecutorTests : FunSpec({
                 CreateSubscriptionOperation(
                     appId,
                     localOneSignalId,
+                    null,
                     "subscriptionId1",
                     SubscriptionType.PUSH,
                     true,
@@ -419,6 +421,7 @@ class LoginUserOperationExecutorTests : FunSpec({
                 UpdateSubscriptionOperation(
                     appId,
                     localOneSignalId,
+                    null,
                     "subscriptionId1",
                     SubscriptionType.PUSH,
                     true,
@@ -428,13 +431,14 @@ class LoginUserOperationExecutorTests : FunSpec({
                 CreateSubscriptionOperation(
                     appId,
                     localOneSignalId,
+                    null,
                     "subscriptionId2",
                     SubscriptionType.EMAIL,
                     true,
                     "name@company.com",
                     SubscriptionStatus.SUBSCRIBED,
                 ),
-                DeleteSubscriptionOperation(appId, localOneSignalId, "subscriptionId2"),
+                DeleteSubscriptionOperation(appId, localOneSignalId, null, "subscriptionId2"),
             )
 
         // When
@@ -511,6 +515,7 @@ class LoginUserOperationExecutorTests : FunSpec({
                 CreateSubscriptionOperation(
                     appId,
                     localOneSignalId,
+                    null,
                     localSubscriptionId1,
                     SubscriptionType.PUSH,
                     true,
@@ -520,6 +525,7 @@ class LoginUserOperationExecutorTests : FunSpec({
                 CreateSubscriptionOperation(
                     appId,
                     localOneSignalId,
+                    null,
                     localSubscriptionId2,
                     SubscriptionType.EMAIL,
                     true,
@@ -597,6 +603,7 @@ class LoginUserOperationExecutorTests : FunSpec({
                 CreateSubscriptionOperation(
                     appId,
                     localOneSignalId,
+                    null,
                     localSubscriptionId1,
                     SubscriptionType.PUSH,
                     true,
@@ -606,6 +613,7 @@ class LoginUserOperationExecutorTests : FunSpec({
                 CreateSubscriptionOperation(
                     appId,
                     localOneSignalId,
+                    null,
                     localSubscriptionId2,
                     SubscriptionType.EMAIL,
                     true,
@@ -669,6 +677,7 @@ class LoginUserOperationExecutorTests : FunSpec({
                 CreateSubscriptionOperation(
                     appId,
                     localOneSignalId,
+                    null,
                     localSubscriptionId1,
                     SubscriptionType.PUSH,
                     true,
@@ -678,6 +687,7 @@ class LoginUserOperationExecutorTests : FunSpec({
                 CreateSubscriptionOperation(
                     appId,
                     localOneSignalId,
+                    null,
                     localSubscriptionId2,
                     SubscriptionType.EMAIL,
                     true,
@@ -777,8 +787,8 @@ class LoginUserOperationExecutorTests : FunSpec({
         val ops =
             listOf(
                 LoginUserOperation(appId, localOneSignalId, null, null),
-                CreateSubscriptionOperation(appId, localOneSignalId, localSubscriptionId1, SubscriptionType.PUSH, true, "pushToken2", SubscriptionStatus.SUBSCRIBED),
-                CreateSubscriptionOperation(appId, localOneSignalId, localSubscriptionId2, SubscriptionType.EMAIL, true, "name@company.com", SubscriptionStatus.SUBSCRIBED),
+                CreateSubscriptionOperation(appId, localOneSignalId, null, localSubscriptionId1, SubscriptionType.PUSH, true, "pushToken2", SubscriptionStatus.SUBSCRIBED),
+                CreateSubscriptionOperation(appId, localOneSignalId, null, localSubscriptionId2, SubscriptionType.EMAIL, true, "name@company.com", SubscriptionStatus.SUBSCRIBED),
             )
 
         // When
@@ -840,7 +850,7 @@ class LoginUserOperationExecutorTests : FunSpec({
         val ops =
             listOf(
                 LoginUserOperation(appId, localOneSignalId, null, null),
-                CreateSubscriptionOperation(appId, localOneSignalId, localSubscriptionId1, SubscriptionType.PUSH, true, "pushToken1", SubscriptionStatus.SUBSCRIBED),
+                CreateSubscriptionOperation(appId, localOneSignalId, null, localSubscriptionId1, SubscriptionType.PUSH, true, "pushToken1", SubscriptionStatus.SUBSCRIBED),
             )
 
         // When

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/RefreshUserOperationExecutorTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/RefreshUserOperationExecutorTests.kt
@@ -109,7 +109,7 @@ class RefreshUserOperationExecutorTests : FunSpec({
                 getNewRecordState(),
             )
 
-        val operations = listOf<Operation>(RefreshUserOperation(appId, remoteOneSignalId))
+        val operations = listOf<Operation>(RefreshUserOperation(appId, remoteOneSignalId, null))
 
         try {
             // When
@@ -193,7 +193,7 @@ class RefreshUserOperationExecutorTests : FunSpec({
                 getNewRecordState(),
             )
 
-        val operations = listOf<Operation>(RefreshUserOperation(appId, remoteOneSignalId))
+        val operations = listOf<Operation>(RefreshUserOperation(appId, remoteOneSignalId, null))
 
         // When
         val response = refreshUserOperationExecutor.execute(operations)
@@ -232,7 +232,7 @@ class RefreshUserOperationExecutorTests : FunSpec({
                 getNewRecordState(),
             )
 
-        val operations = listOf<Operation>(RefreshUserOperation(appId, remoteOneSignalId))
+        val operations = listOf<Operation>(RefreshUserOperation(appId, remoteOneSignalId, null))
 
         // When
         val response = refreshUserOperationExecutor.execute(operations)
@@ -267,7 +267,7 @@ class RefreshUserOperationExecutorTests : FunSpec({
                 getNewRecordState(),
             )
 
-        val operations = listOf<Operation>(RefreshUserOperation(appId, remoteOneSignalId))
+        val operations = listOf<Operation>(RefreshUserOperation(appId, remoteOneSignalId, null))
 
         // When
         val response = refreshUserOperationExecutor.execute(operations)
@@ -302,7 +302,7 @@ class RefreshUserOperationExecutorTests : FunSpec({
                 getNewRecordState(),
             )
 
-        val operations = listOf<Operation>(RefreshUserOperation(appId, remoteOneSignalId))
+        val operations = listOf<Operation>(RefreshUserOperation(appId, remoteOneSignalId, null))
 
         // When
         val response = refreshUserOperationExecutor.execute(operations)
@@ -339,7 +339,7 @@ class RefreshUserOperationExecutorTests : FunSpec({
                 newRecordState,
             )
 
-        val operations = listOf<Operation>(RefreshUserOperation(appId, remoteOneSignalId))
+        val operations = listOf<Operation>(RefreshUserOperation(appId, remoteOneSignalId, null))
 
         // When
         val response = refreshUserOperationExecutor.execute(operations)

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/SubscriptionOperationExecutorTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/SubscriptionOperationExecutorTests.kt
@@ -75,6 +75,7 @@ class SubscriptionOperationExecutorTests :
                     CreateSubscriptionOperation(
                         appId,
                         remoteOneSignalId,
+                        null,
                         localSubscriptionId,
                         SubscriptionType.PUSH,
                         true,
@@ -135,6 +136,7 @@ class SubscriptionOperationExecutorTests :
                     CreateSubscriptionOperation(
                         appId,
                         remoteOneSignalId,
+                        null,
                         remoteSubscriptionId,
                         SubscriptionType.PUSH,
                         true,
@@ -185,6 +187,7 @@ class SubscriptionOperationExecutorTests :
                     CreateSubscriptionOperation(
                         appId,
                         remoteOneSignalId,
+                        null,
                         localSubscriptionId,
                         SubscriptionType.PUSH,
                         true,
@@ -240,6 +243,7 @@ class SubscriptionOperationExecutorTests :
                     CreateSubscriptionOperation(
                         appId,
                         remoteOneSignalId,
+                        null,
                         localSubscriptionId,
                         SubscriptionType.PUSH,
                         true,
@@ -295,6 +299,7 @@ class SubscriptionOperationExecutorTests :
                     CreateSubscriptionOperation(
                         appId,
                         remoteOneSignalId,
+                        null,
                         localSubscriptionId,
                         SubscriptionType.PUSH,
                         true,
@@ -338,13 +343,14 @@ class SubscriptionOperationExecutorTests :
                     CreateSubscriptionOperation(
                         appId,
                         remoteOneSignalId,
+                        null,
                         localSubscriptionId,
                         SubscriptionType.PUSH,
                         true,
                         "pushToken",
                         SubscriptionStatus.SUBSCRIBED,
                     ),
-                    DeleteSubscriptionOperation(appId, remoteOneSignalId, localSubscriptionId),
+                    DeleteSubscriptionOperation(appId, remoteOneSignalId, null, localSubscriptionId),
                 )
 
             // When
@@ -384,6 +390,7 @@ class SubscriptionOperationExecutorTests :
                     CreateSubscriptionOperation(
                         appId,
                         remoteOneSignalId,
+                        null,
                         localSubscriptionId,
                         SubscriptionType.PUSH,
                         true,
@@ -393,6 +400,7 @@ class SubscriptionOperationExecutorTests :
                     UpdateSubscriptionOperation(
                         appId,
                         remoteOneSignalId,
+                        null,
                         localSubscriptionId,
                         SubscriptionType.PUSH,
                         true,
@@ -454,6 +462,7 @@ class SubscriptionOperationExecutorTests :
                     UpdateSubscriptionOperation(
                         appId,
                         remoteOneSignalId,
+                        null,
                         remoteSubscriptionId,
                         SubscriptionType.PUSH,
                         true,
@@ -463,6 +472,7 @@ class SubscriptionOperationExecutorTests :
                     UpdateSubscriptionOperation(
                         appId,
                         remoteOneSignalId,
+                        null,
                         remoteSubscriptionId,
                         SubscriptionType.PUSH,
                         true,
@@ -515,6 +525,7 @@ class SubscriptionOperationExecutorTests :
                     UpdateSubscriptionOperation(
                         appId,
                         remoteOneSignalId,
+                        null,
                         remoteSubscriptionId,
                         SubscriptionType.PUSH,
                         true,
@@ -567,6 +578,7 @@ class SubscriptionOperationExecutorTests :
                     UpdateSubscriptionOperation(
                         appId,
                         remoteOneSignalId,
+                        null,
                         remoteSubscriptionId,
                         SubscriptionType.PUSH,
                         true,
@@ -621,6 +633,7 @@ class SubscriptionOperationExecutorTests :
                     UpdateSubscriptionOperation(
                         appId,
                         remoteOneSignalId,
+                        null,
                         remoteSubscriptionId,
                         SubscriptionType.PUSH,
                         true,
@@ -660,7 +673,7 @@ class SubscriptionOperationExecutorTests :
 
             val operations =
                 listOf<Operation>(
-                    DeleteSubscriptionOperation(appId, remoteOneSignalId, remoteSubscriptionId),
+                    DeleteSubscriptionOperation(appId, remoteOneSignalId, null, remoteSubscriptionId),
                 )
 
             // When
@@ -694,7 +707,7 @@ class SubscriptionOperationExecutorTests :
 
             val operations =
                 listOf<Operation>(
-                    DeleteSubscriptionOperation(appId, remoteOneSignalId, remoteSubscriptionId),
+                    DeleteSubscriptionOperation(appId, remoteOneSignalId, null, remoteSubscriptionId),
                 )
 
             // When
@@ -729,7 +742,7 @@ class SubscriptionOperationExecutorTests :
 
             val operations =
                 listOf<Operation>(
-                    DeleteSubscriptionOperation(appId, remoteOneSignalId, remoteSubscriptionId),
+                    DeleteSubscriptionOperation(appId, remoteOneSignalId, null, remoteSubscriptionId),
                 )
 
             // When
@@ -764,7 +777,7 @@ class SubscriptionOperationExecutorTests :
 
             val operations =
                 listOf<Operation>(
-                    DeleteSubscriptionOperation(appId, remoteOneSignalId, remoteSubscriptionId),
+                    DeleteSubscriptionOperation(appId, remoteOneSignalId, null, remoteSubscriptionId),
                 )
 
             // When
@@ -808,6 +821,7 @@ class SubscriptionOperationExecutorTests :
                     UpdateSubscriptionOperation(
                         appId,
                         remoteOneSignalId,
+                        null,
                         remoteSubscriptionId,
                         SubscriptionType.PUSH,
                         true,

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/UpdateUserOperationExecutorTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/UpdateUserOperationExecutorTests.kt
@@ -57,7 +57,7 @@ class UpdateUserOperationExecutorTests :
                     getNewRecordState(),
                     mockConsistencyManager,
                 )
-            val operations = listOf<Operation>(SetTagOperation(appId, remoteOneSignalId, "tagKey1", "tagValue1"))
+            val operations = listOf<Operation>(SetTagOperation(appId, remoteOneSignalId, null, "tagKey1", "tagValue1"))
 
             // When
             val response = loginUserOperationExecutor.execute(operations)
@@ -99,21 +99,21 @@ class UpdateUserOperationExecutorTests :
                 )
             val operations =
                 listOf<Operation>(
-                    SetTagOperation(appId, remoteOneSignalId, "tagKey1", "tagValue1-1"),
-                    SetTagOperation(appId, remoteOneSignalId, "tagKey1", "tagValue1-2"),
-                    SetTagOperation(appId, remoteOneSignalId, "tagKey2", "tagValue2"),
-                    SetTagOperation(appId, remoteOneSignalId, "tagKey3", "tagValue3"),
-                    DeleteTagOperation(appId, remoteOneSignalId, "tagKey3"),
-                    SetPropertyOperation(appId, localOneSignalId, PropertiesModel::language.name, "lang1"),
-                    SetPropertyOperation(appId, localOneSignalId, PropertiesModel::language.name, "lang2"),
-                    SetPropertyOperation(appId, localOneSignalId, PropertiesModel::timezone.name, "timezone"),
-                    SetPropertyOperation(appId, localOneSignalId, PropertiesModel::country.name, "country"),
-                    SetPropertyOperation(appId, localOneSignalId, PropertiesModel::locationLatitude.name, 123.45),
-                    SetPropertyOperation(appId, localOneSignalId, PropertiesModel::locationLongitude.name, 678.90),
-                    SetPropertyOperation(appId, localOneSignalId, PropertiesModel::locationType.name, 1),
-                    SetPropertyOperation(appId, localOneSignalId, PropertiesModel::locationAccuracy.name, 0.15),
-                    SetPropertyOperation(appId, localOneSignalId, PropertiesModel::locationBackground.name, true),
-                    SetPropertyOperation(appId, localOneSignalId, PropertiesModel::locationTimestamp.name, 1111L),
+                    SetTagOperation(appId, remoteOneSignalId, null, "tagKey1", "tagValue1-1"),
+                    SetTagOperation(appId, remoteOneSignalId, null, "tagKey1", "tagValue1-2"),
+                    SetTagOperation(appId, remoteOneSignalId, null, "tagKey2", "tagValue2"),
+                    SetTagOperation(appId, remoteOneSignalId, null, "tagKey3", "tagValue3"),
+                    DeleteTagOperation(appId, remoteOneSignalId, null, "tagKey3"),
+                    SetPropertyOperation(appId, localOneSignalId, null, PropertiesModel::language.name, "lang1"),
+                    SetPropertyOperation(appId, localOneSignalId, null, PropertiesModel::language.name, "lang2"),
+                    SetPropertyOperation(appId, localOneSignalId, null, PropertiesModel::timezone.name, "timezone"),
+                    SetPropertyOperation(appId, localOneSignalId, null, PropertiesModel::country.name, "country"),
+                    SetPropertyOperation(appId, localOneSignalId, null, PropertiesModel::locationLatitude.name, 123.45),
+                    SetPropertyOperation(appId, localOneSignalId, null, PropertiesModel::locationLongitude.name, 678.90),
+                    SetPropertyOperation(appId, localOneSignalId, null, PropertiesModel::locationType.name, 1),
+                    SetPropertyOperation(appId, localOneSignalId, null, PropertiesModel::locationAccuracy.name, 0.15),
+                    SetPropertyOperation(appId, localOneSignalId, null, PropertiesModel::locationBackground.name, true),
+                    SetPropertyOperation(appId, localOneSignalId, null, PropertiesModel::locationTimestamp.name, 1111L),
                 )
 
             // When
@@ -161,7 +161,7 @@ class UpdateUserOperationExecutorTests :
                 )
             val operations =
                 listOf<Operation>(
-                    TrackSessionEndOperation(appId, remoteOneSignalId, 1111),
+                    TrackSessionEndOperation(appId, remoteOneSignalId, null, 1111),
                 )
 
             // When
@@ -206,10 +206,11 @@ class UpdateUserOperationExecutorTests :
                 )
             val operations =
                 listOf<Operation>(
-                    TrackSessionEndOperation(appId, remoteOneSignalId, 1111),
+                    TrackSessionEndOperation(appId, remoteOneSignalId, null, 1111),
                     TrackPurchaseOperation(
                         appId,
                         remoteOneSignalId,
+                        null,
                         false,
                         BigDecimal(2222),
                         listOf(
@@ -217,7 +218,7 @@ class UpdateUserOperationExecutorTests :
                             PurchaseInfo("sku2", "iso2", BigDecimal(1222)),
                         ),
                     ),
-                    TrackSessionEndOperation(appId, remoteOneSignalId, 3333),
+                    TrackSessionEndOperation(appId, remoteOneSignalId, null, 3333),
                 )
 
             // When
@@ -271,9 +272,9 @@ class UpdateUserOperationExecutorTests :
                 )
             val operations =
                 listOf<Operation>(
-                    TrackSessionEndOperation(appId, remoteOneSignalId, 1111),
-                    SetTagOperation(appId, remoteOneSignalId, "tagKey1", "tagValue1"),
-                    TrackSessionEndOperation(appId, remoteOneSignalId, 3333),
+                    TrackSessionEndOperation(appId, remoteOneSignalId, null, 1111),
+                    SetTagOperation(appId, remoteOneSignalId, null, "tagKey1", "tagValue1"),
+                    TrackSessionEndOperation(appId, remoteOneSignalId, null, 3333),
                 )
 
             // When
@@ -317,7 +318,7 @@ class UpdateUserOperationExecutorTests :
                     getNewRecordState(),
                     mockConsistencyManager,
                 )
-            val operations = listOf(SetTagOperation(appId, remoteOneSignalId, "tagKey1", "tagValue1"))
+            val operations = listOf(SetTagOperation(appId, remoteOneSignalId, null, "tagKey1", "tagValue1"))
 
             // When
             val response = loginUserOperationExecutor.execute(operations)
@@ -350,7 +351,7 @@ class UpdateUserOperationExecutorTests :
                     newRecordState,
                     mockConsistencyManager,
                 )
-            val operations = listOf(SetTagOperation(appId, remoteOneSignalId, "tagKey1", "tagValue1"))
+            val operations = listOf(SetTagOperation(appId, remoteOneSignalId, null, "tagKey1", "tagValue1"))
 
             // When
             val response = loginUserOperationExecutor.execute(operations)
@@ -383,7 +384,7 @@ class UpdateUserOperationExecutorTests :
 
             val operations =
                 listOf<Operation>(
-                    TrackSessionStartOperation(appId, onesignalId = remoteOneSignalId),
+                    TrackSessionStartOperation(appId, remoteOneSignalId, null),
                 )
 
             // When

--- a/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/listeners/DeviceRegistrationListenerTests.kt
+++ b/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/listeners/DeviceRegistrationListenerTests.kt
@@ -252,7 +252,7 @@ class DeviceRegistrationListenerTests : FunSpec({
                 permission = true,
                 pushModel = uninitializedPushModel(),
                 pushTokenResponse =
-                    PushTokenResponse(NEW_TOKEN, SubscriptionStatus.SUBSCRIBED),
+                PushTokenResponse(NEW_TOKEN, SubscriptionStatus.SUBSCRIBED),
             )
         // Permission flips off between gate evaluation and the IO callback.
         every { harness.notificationsManager.permission } returns true andThen false


### PR DESCRIPTION
# Description

## One Line Summary
PR 2 of 6 against the Identity Verification integration branch — mechanical refactor that adds `externalId: String?` and `requiresJwt: Boolean` to the `Operation` base class so the next PR can implement queue-level IV gating. No runtime behavior change.

## Details

### Motivation
The next PR in the series (PR 3/6, "queue-level IV") needs to read `op.externalId` polymorphically from `OperationRepo`. Today `externalId` is declared on `LoginUserOperation` and `TrackCustomEventOperation` only — `OperationRepo` can't read it from a generic `Operation` reference without casting to each of the 16 subclass types. This PR hoists the property (and a companion `requiresJwt` flag) to the base class so downstream consumers can read them uniformly.

Kept deliberately narrow so the base-class refactor has its own reviewable surface; the behavior changes (pre-HYDRATE deferral, FAIL_UNAUTHORIZED handling, `IdentityVerificationService` with anon-op purge) come in the next PR.

### Scope
**`Operation` base class:**
- New `var externalId: String?` — captures the externalId of the user the op was enqueued for. Nullable because anonymous users have no externalId; base-class declaration keeps the type `String?` uniformly across all subclasses.
- New `open val requiresJwt: Boolean get() = true` — declares whether an op's backend endpoint needs a JWT when IV is active. Subclasses may override to `false` for endpoints that don't require auth (none do yet — default `true` covers every current op).

**Operation subclasses (16):**
- All 16 constructors gain `externalId: String?` as the 3rd parameter (after `appId` and `onesignalId`).
- `LoginUserOperation` and `TrackCustomEventOperation` shed their local `externalId` property in favor of the inherited base-class property (previously defined on each subclass independently).
- `TransferSubscriptionOperation` is the one exception in parameter position — its constructor is `(appId, subscriptionId, onesignalId, externalId)` to match the existing layout where `onesignalId` comes after `subscriptionId`.

**Call sites updated to pass `externalId` at construction time (10 files):**
- `IdentityModelStoreListener`, `PropertiesModelStoreListener`, `SubscriptionModelStoreListener` — read `_identityModelStore.model.externalId`.
- `SessionListener` (session start + end).
- `TrackGooglePurchase` (purchase tracking).
- `UserSwitcher` (legacy player ID migration).
- `RebuildUserService` (reconstructs queued ops from cached models).
- `UserRefreshService` (foreground user refresh).
- `LoginUserOperationExecutor`, `LoginUserFromSubscriptionOperationExecutor`, `SubscriptionOperationExecutor` (ops they emit as side effects, e.g. post-login `RefreshUserOperation`, post-subscription-recreate `CreateSubscriptionOperation`).

**`PropertiesModelStoreListener` gains `IdentityModelStore` as a constructor dependency** — the properties model doesn't carry externalId, so the listener has to read it from the identity model.

### Placement decision: base class vs per-subclass
`onesignalId` is declared on each subclass individually, not on the base. Considered matching that convention for `externalId`/`requiresJwt`, but chose base-class placement:
- `externalId` is naturally nullable; `String?` works uniformly across every subclass without weakening any type.
- Cross-cutting consumers (next PR's `hasValidJwtIfRequired`, `removeOperationsWithoutExternalId`) need to read `op.externalId` polymorphically — that requires at least an abstract declaration on the base. Per-subclass with abstract-on-base would mean ~80 lines of boilerplate (override + getter/setter × 16 subclasses) vs the 5-line base-class declaration.
- `requiresJwt` has natural override semantics (`open val` with default), which is idiomatic on a base class.

`name` on `Operation` is precedent for a non-nullable universal property on the base, so there's no technical constraint keeping `onesignalId` off the base — that placement is a historical style preference that this PR does not touch.

### What is NOT in this PR
- `IdentityVerificationService` — PR 3/6.
- `OperationRepo` IV gating (`hasValidJwtIfRequired` dispatch, FAIL_UNAUTHORIZED handler, pre-HYDRATE deferral in `getNextOps`) — PR 3/6.
- HTTP layer JWT attachment — PR 4/6.
- Public API (`login(externalId, jwt)`, `updateUserJwt`, listeners) — PR 5/6.
- Logout + IAM integration — PR 6/6.

# Testing

## Unit testing
- Compile verified — every call site updated to pass `externalId` (see compile errors list narrowed from 50+ to 0).
- All existing test fixtures updated to the new constructor signature. Most were mechanical substitutions (add `null` as 3rd arg for anon/un-scoped tests; add the relevant externalId where the test exercises it).
- 791 core tests run, 789 pass, 2 fail — both are pre-existing `SDKInitTests` failures on the integration branch (unrelated: one is about an error-message assertion, the other about init not blocking). Same two failures exist on `feat/iv-foundation-01` without this PR.

## Manual testing
Not applicable — this PR adds a property + parameter with no runtime behavior change. Every call site still passes identically-shaped data; the only difference is that `externalId` is now available for polymorphic reads in the next PR.

# Affected code checklist
   - [ ] Notifications
   - [ ] Outcomes
   - [x] Sessions (session listener passes externalId to track-session ops)
   - [ ] In-App Messaging
   - [x] REST API requests (only op shape; no new network traffic)
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing — adds two properties to `Operation` and updates every subclass + call site
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs (no public API changes)

## Testing
   - [x] I have included test coverage for these changes (existing tests cover via construction; no new behavior to test in this PR)
   - [x] All automated tests pass locally (pre-existing `SDKInitTests` failures are unrelated — see Manual testing)
   - [x] Manual testing not applicable — no runtime behavior change

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
