### PR TITLE
feat(jwt): attach JWT in HTTP client and operation executors (4/6)

### DIFF
--- a/OneSignalSDK/detekt/detekt-baseline-core.xml
+++ b/OneSignalSDK/detekt/detekt-baseline-core.xml
@@ -36,6 +36,8 @@
     <ID>ConstructorParameterNaming:IdentityOperationExecutor.kt$IdentityOperationExecutor$private val _buildUserService: IRebuildUserService</ID>
     <ID>ConstructorParameterNaming:IdentityOperationExecutor.kt$IdentityOperationExecutor$private val _identityBackend: IIdentityBackendService</ID>
     <ID>ConstructorParameterNaming:IdentityOperationExecutor.kt$IdentityOperationExecutor$private val _identityModelStore: IdentityModelStore</ID>
+    <ID>ConstructorParameterNaming:IdentityOperationExecutor.kt$IdentityOperationExecutor$private val _identityVerificationService: IdentityVerificationService</ID>
+    <ID>ConstructorParameterNaming:IdentityOperationExecutor.kt$IdentityOperationExecutor$private val _jwtTokenStore: JwtTokenStore</ID>
     <ID>ConstructorParameterNaming:IdentityOperationExecutor.kt$IdentityOperationExecutor$private val _newRecordState: NewRecordsState</ID>
     <ID>ConstructorParameterNaming:InfluenceDataRepository.kt$InfluenceDataRepository$private val _configModelStore: ConfigModelStore</ID>
     <ID>ConstructorParameterNaming:InfluenceManager.kt$InfluenceManager$private val _applicationService: IApplicationService</ID>
@@ -45,6 +47,7 @@
     <ID>ConstructorParameterNaming:JwtTokenStore.kt$JwtTokenStore$private val _prefs: IPreferencesService</ID>
     <ID>ConstructorParameterNaming:LanguageContext.kt$LanguageContext$private val _propertiesModelStore: PropertiesModelStore</ID>
     <ID>ConstructorParameterNaming:LoginUserFromSubscriptionOperationExecutor.kt$LoginUserFromSubscriptionOperationExecutor$private val _identityModelStore: IdentityModelStore</ID>
+    <ID>ConstructorParameterNaming:LoginUserFromSubscriptionOperationExecutor.kt$LoginUserFromSubscriptionOperationExecutor$private val _identityVerificationService: IdentityVerificationService</ID>
     <ID>ConstructorParameterNaming:LoginUserFromSubscriptionOperationExecutor.kt$LoginUserFromSubscriptionOperationExecutor$private val _propertiesModelStore: PropertiesModelStore</ID>
     <ID>ConstructorParameterNaming:LoginUserFromSubscriptionOperationExecutor.kt$LoginUserFromSubscriptionOperationExecutor$private val _subscriptionBackend: ISubscriptionBackendService</ID>
     <ID>ConstructorParameterNaming:LoginUserOperationExecutor.kt$LoginUserOperationExecutor$private val _application: IApplicationService</ID>
@@ -52,6 +55,8 @@
     <ID>ConstructorParameterNaming:LoginUserOperationExecutor.kt$LoginUserOperationExecutor$private val _deviceService: IDeviceService</ID>
     <ID>ConstructorParameterNaming:LoginUserOperationExecutor.kt$LoginUserOperationExecutor$private val _identityModelStore: IdentityModelStore</ID>
     <ID>ConstructorParameterNaming:LoginUserOperationExecutor.kt$LoginUserOperationExecutor$private val _identityOperationExecutor: IdentityOperationExecutor</ID>
+    <ID>ConstructorParameterNaming:LoginUserOperationExecutor.kt$LoginUserOperationExecutor$private val _identityVerificationService: IdentityVerificationService</ID>
+    <ID>ConstructorParameterNaming:LoginUserOperationExecutor.kt$LoginUserOperationExecutor$private val _jwtTokenStore: JwtTokenStore</ID>
     <ID>ConstructorParameterNaming:LoginUserOperationExecutor.kt$LoginUserOperationExecutor$private val _languageContext: ILanguageContext</ID>
     <ID>ConstructorParameterNaming:LoginUserOperationExecutor.kt$LoginUserOperationExecutor$private val _propertiesModelStore: PropertiesModelStore</ID>
     <ID>ConstructorParameterNaming:LoginUserOperationExecutor.kt$LoginUserOperationExecutor$private val _subscriptionsModelStore: SubscriptionModelStore</ID>
@@ -97,6 +102,8 @@
     <ID>ConstructorParameterNaming:RefreshUserOperationExecutor.kt$RefreshUserOperationExecutor$private val _buildUserService: IRebuildUserService</ID>
     <ID>ConstructorParameterNaming:RefreshUserOperationExecutor.kt$RefreshUserOperationExecutor$private val _configModelStore: ConfigModelStore</ID>
     <ID>ConstructorParameterNaming:RefreshUserOperationExecutor.kt$RefreshUserOperationExecutor$private val _identityModelStore: IdentityModelStore</ID>
+    <ID>ConstructorParameterNaming:RefreshUserOperationExecutor.kt$RefreshUserOperationExecutor$private val _identityVerificationService: IdentityVerificationService</ID>
+    <ID>ConstructorParameterNaming:RefreshUserOperationExecutor.kt$RefreshUserOperationExecutor$private val _jwtTokenStore: JwtTokenStore</ID>
     <ID>ConstructorParameterNaming:RefreshUserOperationExecutor.kt$RefreshUserOperationExecutor$private val _newRecordState: NewRecordsState</ID>
     <ID>ConstructorParameterNaming:RefreshUserOperationExecutor.kt$RefreshUserOperationExecutor$private val _propertiesModelStore: PropertiesModelStore</ID>
     <ID>ConstructorParameterNaming:RefreshUserOperationExecutor.kt$RefreshUserOperationExecutor$private val _subscriptionsModelStore: SubscriptionModelStore</ID>
@@ -127,6 +134,8 @@
     <ID>ConstructorParameterNaming:SubscriptionOperationExecutor.kt$SubscriptionOperationExecutor$private val _configModelStore: ConfigModelStore</ID>
     <ID>ConstructorParameterNaming:SubscriptionOperationExecutor.kt$SubscriptionOperationExecutor$private val _consistencyManager: IConsistencyManager</ID>
     <ID>ConstructorParameterNaming:SubscriptionOperationExecutor.kt$SubscriptionOperationExecutor$private val _deviceService: IDeviceService</ID>
+    <ID>ConstructorParameterNaming:SubscriptionOperationExecutor.kt$SubscriptionOperationExecutor$private val _identityVerificationService: IdentityVerificationService</ID>
+    <ID>ConstructorParameterNaming:SubscriptionOperationExecutor.kt$SubscriptionOperationExecutor$private val _jwtTokenStore: JwtTokenStore</ID>
     <ID>ConstructorParameterNaming:SubscriptionOperationExecutor.kt$SubscriptionOperationExecutor$private val _newRecordState: NewRecordsState</ID>
     <ID>ConstructorParameterNaming:SubscriptionOperationExecutor.kt$SubscriptionOperationExecutor$private val _subscriptionBackend: ISubscriptionBackendService</ID>
     <ID>ConstructorParameterNaming:SubscriptionOperationExecutor.kt$SubscriptionOperationExecutor$private val _subscriptionModelStore: SubscriptionModelStore</ID>
@@ -138,6 +147,8 @@
     <ID>ConstructorParameterNaming:UpdateUserOperationExecutor.kt$UpdateUserOperationExecutor$private val _buildUserService: IRebuildUserService</ID>
     <ID>ConstructorParameterNaming:UpdateUserOperationExecutor.kt$UpdateUserOperationExecutor$private val _consistencyManager: IConsistencyManager</ID>
     <ID>ConstructorParameterNaming:UpdateUserOperationExecutor.kt$UpdateUserOperationExecutor$private val _identityModelStore: IdentityModelStore</ID>
+    <ID>ConstructorParameterNaming:UpdateUserOperationExecutor.kt$UpdateUserOperationExecutor$private val _identityVerificationService: IdentityVerificationService</ID>
+    <ID>ConstructorParameterNaming:UpdateUserOperationExecutor.kt$UpdateUserOperationExecutor$private val _jwtTokenStore: JwtTokenStore</ID>
     <ID>ConstructorParameterNaming:UpdateUserOperationExecutor.kt$UpdateUserOperationExecutor$private val _newRecordState: NewRecordsState</ID>
     <ID>ConstructorParameterNaming:UpdateUserOperationExecutor.kt$UpdateUserOperationExecutor$private val _propertiesModelStore: PropertiesModelStore</ID>
     <ID>ConstructorParameterNaming:UpdateUserOperationExecutor.kt$UpdateUserOperationExecutor$private val _userBackend: IUserBackendService</ID>
@@ -177,6 +188,7 @@
     <ID>InstanceOfCheckForException:HttpClient.kt$HttpClient$t is UnknownHostException</ID>
     <ID>LongMethod:ApplicationService.kt$ApplicationService$override suspend fun waitUntilSystemConditionsAvailable(): Boolean</ID>
     <ID>LongMethod:ConfigModelStoreListener.kt$ConfigModelStoreListener$private fun fetchParams()</ID>
+    <ID>LongMethod:FeatureFlagsBackendService.kt$FeatureFlagsBackendService$override suspend fun fetchRemoteFeatureFlags(appId: String): RemoteFeatureFlagsFetchOutcome</ID>
     <ID>LongMethod:HttpClient.kt$HttpClient$private suspend fun makeRequestIODispatcher( url: String, method: String?, jsonBody: JSONObject?, timeout: Int, headers: OptionalHeaders?, ): HttpResponse</ID>
     <ID>LongMethod:IdentityOperationExecutor.kt$IdentityOperationExecutor$override suspend fun execute(operations: List&lt;Operation>): ExecutionResponse</ID>
     <ID>LongMethod:LoginUserOperationExecutor.kt$LoginUserOperationExecutor$private suspend fun createUser( createUserOperation: LoginUserOperation, operations: List&lt;Operation>, ): ExecutionResponse</ID>
@@ -197,16 +209,17 @@
     <ID>LongMethod:TrackGooglePurchase.kt$TrackGooglePurchase$private fun sendPurchases( skusToAdd: ArrayList&lt;String>, newPurchaseTokens: ArrayList&lt;String>, )</ID>
     <ID>LongMethod:UpdateUserOperationExecutor.kt$UpdateUserOperationExecutor$override suspend fun execute(operations: List&lt;Operation>): ExecutionResponse</ID>
     <ID>LongParameterList:CreateSubscriptionOperation.kt$CreateSubscriptionOperation$(appId: String, onesignalId: String, externalId: String?, subscriptionId: String, type: SubscriptionType, enabled: Boolean, address: String, status: SubscriptionStatus)</ID>
-    <ID>LongParameterList:ICustomEventBackendService.kt$ICustomEventBackendService$( appId: String, onesignalId: String, externalId: String?, timestamp: Long, eventName: String, eventProperties: String?, metadata: CustomEventMetadata, )</ID>
+    <ID>LongParameterList:ICustomEventBackendService.kt$ICustomEventBackendService$( appId: String, onesignalId: String, externalId: String?, timestamp: Long, eventName: String, eventProperties: String?, metadata: CustomEventMetadata, jwt: String? = null, )</ID>
     <ID>LongParameterList:IDatabase.kt$IDatabase$( table: String, columns: Array&lt;String>? = null, whereClause: String? = null, whereArgs: Array&lt;String>? = null, groupBy: String? = null, having: String? = null, orderBy: String? = null, limit: String? = null, action: (ICursor) -> Unit, )</ID>
     <ID>LongParameterList:IOutcomeEventsBackendService.kt$IOutcomeEventsBackendService$( appId: String, userId: String, subscriptionId: String, deviceType: String, direct: Boolean?, event: OutcomeEvent, )</ID>
-    <ID>LongParameterList:IParamsBackendService.kt$ParamsObject$( var googleProjectNumber: String? = null, var enterprise: Boolean? = null, var useIdentityVerification: Boolean? = null, var notificationChannels: JSONArray? = null, var firebaseAnalytics: Boolean? = null, var restoreTTLFilter: Boolean? = null, var clearGroupOnSummaryClick: Boolean? = null, var receiveReceiptEnabled: Boolean? = null, var disableGMSMissingPrompt: Boolean? = null, var unsubscribeWhenNotificationsDisabled: Boolean? = null, var locationShared: Boolean? = null, var requiresUserPrivacyConsent: Boolean? = null, var opRepoExecutionInterval: Long? = null, var influenceParams: InfluenceParamsObject, var fcmParams: FCMParamsObject, )</ID>
-    <ID>LongParameterList:IUserBackendService.kt$IUserBackendService$( appId: String, aliasLabel: String, aliasValue: String, properties: PropertiesObject, refreshDeviceMetadata: Boolean, propertyiesDelta: PropertiesDeltasObject, )</ID>
-    <ID>LongParameterList:LoginUserOperationExecutor.kt$LoginUserOperationExecutor$( private val _identityOperationExecutor: IdentityOperationExecutor, private val _application: IApplicationService, private val _deviceService: IDeviceService, private val _userBackend: IUserBackendService, private val _identityModelStore: IdentityModelStore, private val _propertiesModelStore: PropertiesModelStore, private val _subscriptionsModelStore: SubscriptionModelStore, private val _configModelStore: ConfigModelStore, private val _languageContext: ILanguageContext, )</ID>
+    <ID>LongParameterList:IUserBackendService.kt$IUserBackendService$( appId: String, aliasLabel: String, aliasValue: String, properties: PropertiesObject, refreshDeviceMetadata: Boolean, propertyiesDelta: PropertiesDeltasObject, jwt: String? = null, )</ID>
+    <ID>LongParameterList:LoginUserOperationExecutor.kt$LoginUserOperationExecutor$( private val _identityOperationExecutor: IdentityOperationExecutor, private val _application: IApplicationService, private val _deviceService: IDeviceService, private val _userBackend: IUserBackendService, private val _identityModelStore: IdentityModelStore, private val _propertiesModelStore: PropertiesModelStore, private val _subscriptionsModelStore: SubscriptionModelStore, private val _configModelStore: ConfigModelStore, private val _languageContext: ILanguageContext, private val _jwtTokenStore: JwtTokenStore, private val _identityVerificationService: IdentityVerificationService, )</ID>
     <ID>LongParameterList:OutcomeEventsController.kt$OutcomeEventsController$( private val _session: ISessionService, private val _influenceManager: IInfluenceManager, private val _outcomeEventsCache: IOutcomeEventsRepository, private val _outcomeEventsPreferences: IOutcomeEventsPreferences, private val _outcomeEventsBackend: IOutcomeEventsBackendService, private val _configModelStore: ConfigModelStore, private val _identityModelStore: IdentityModelStore, private val _subscriptionManager: ISubscriptionManager, private val _deviceService: IDeviceService, private val _time: ITime, )</ID>
+    <ID>LongParameterList:RefreshUserOperationExecutor.kt$RefreshUserOperationExecutor$( private val _userBackend: IUserBackendService, private val _identityModelStore: IdentityModelStore, private val _propertiesModelStore: PropertiesModelStore, private val _subscriptionsModelStore: SubscriptionModelStore, private val _configModelStore: ConfigModelStore, private val _buildUserService: IRebuildUserService, private val _newRecordState: NewRecordsState, private val _jwtTokenStore: JwtTokenStore, private val _identityVerificationService: IdentityVerificationService, )</ID>
     <ID>LongParameterList:SubscriptionObject.kt$SubscriptionObject$( val id: String? = null, val type: SubscriptionObjectType? = null, val token: String? = null, val enabled: Boolean? = null, val notificationTypes: Int? = null, val sdk: String? = null, val deviceModel: String? = null, val deviceOS: String? = null, val rooted: Boolean? = null, val netType: Int? = null, val carrier: String? = null, val appVersion: String? = null, )</ID>
-    <ID>LongParameterList:SubscriptionOperationExecutor.kt$SubscriptionOperationExecutor$( private val _subscriptionBackend: ISubscriptionBackendService, private val _deviceService: IDeviceService, private val _applicationService: IApplicationService, private val _subscriptionModelStore: SubscriptionModelStore, private val _configModelStore: ConfigModelStore, private val _buildUserService: IRebuildUserService, private val _newRecordState: NewRecordsState, private val _consistencyManager: IConsistencyManager, )</ID>
+    <ID>LongParameterList:SubscriptionOperationExecutor.kt$SubscriptionOperationExecutor$( private val _subscriptionBackend: ISubscriptionBackendService, private val _deviceService: IDeviceService, private val _applicationService: IApplicationService, private val _subscriptionModelStore: SubscriptionModelStore, private val _configModelStore: ConfigModelStore, private val _buildUserService: IRebuildUserService, private val _newRecordState: NewRecordsState, private val _consistencyManager: IConsistencyManager, private val _jwtTokenStore: JwtTokenStore, private val _identityVerificationService: IdentityVerificationService, )</ID>
     <ID>LongParameterList:UpdateSubscriptionOperation.kt$UpdateSubscriptionOperation$(appId: String, onesignalId: String, externalId: String?, subscriptionId: String, type: SubscriptionType, enabled: Boolean, address: String, status: SubscriptionStatus)</ID>
+    <ID>LongParameterList:UpdateUserOperationExecutor.kt$UpdateUserOperationExecutor$( private val _userBackend: IUserBackendService, private val _identityModelStore: IdentityModelStore, private val _propertiesModelStore: PropertiesModelStore, private val _buildUserService: IRebuildUserService, private val _newRecordState: NewRecordsState, private val _consistencyManager: IConsistencyManager, private val _jwtTokenStore: JwtTokenStore, private val _identityVerificationService: IdentityVerificationService, )</ID>
     <ID>LongParameterList:UserSwitcher.kt$UserSwitcher$( private val preferencesService: IPreferencesService, private val operationRepo: IOperationRepo, private val services: ServiceProvider, private val idManager: IDManager = IDManager, private val identityModelStore: IdentityModelStore, private val propertiesModelStore: PropertiesModelStore, private val subscriptionModelStore: SubscriptionModelStore, private val configModel: ConfigModel, private val oneSignalUtils: OneSignalUtils = OneSignalUtils, private val carrierName: String? = null, private val deviceOS: String? = null, private val androidUtils: AndroidUtils = AndroidUtils, private val appContextProvider: () -> Context, )</ID>
     <ID>LoopWithTooManyJumpStatements:ModelStore.kt$ModelStore$for (index in jsonArray.length() - 1 downTo 0) { val newModel = create(jsonArray.getJSONObject(index)) ?: continue /* * NOTE: Migration fix for bug introduced in 5.1.12 * The following check is intended for the operation model store. * When the call to this method moved out of the operation model store's initializer, * duplicate operations could be cached. * See https://github.com/OneSignal/OneSignal-Android-SDK/pull/2099 */ val hasExisting = models.any { it.id == newModel.id } if (hasExisting) { Logging.debug("ModelStore&lt;$name>: load - operation.id: ${newModel.id} already exists in the store.") continue } models.add(0, newModel) // listen for changes to this model newModel.subscribe(this) }</ID>
     <ID>MagicNumber:ApplicationService.kt$ApplicationService$50</ID>
@@ -266,6 +279,7 @@
     <ID>MagicNumber:TrackGooglePurchase.kt$TrackGooglePurchase.Companion$4</ID>
     <ID>MagicNumber:TrackGooglePurchase.kt$TrackGooglePurchase.Companion$99</ID>
     <ID>MagicNumber:UpdateUserOperationExecutor.kt$UpdateUserOperationExecutor$404</ID>
+    <ID>MatchingDeclarationName:ExecutorsIvExtensions.kt$IvBackendParams</ID>
     <ID>MemberNameEqualsClassName:OneSignal.kt$OneSignal$private val oneSignal: IOneSignal by lazy { OneSignalImp() }</ID>
     <ID>NestedBlockDepth:IdentityOperationExecutor.kt$IdentityOperationExecutor$override suspend fun execute(operations: List&lt;Operation>): ExecutionResponse</ID>
     <ID>NestedBlockDepth:InfluenceManager.kt$InfluenceManager$private fun attemptSessionUpgrade( entryAction: AppEntryAction, directId: String? = null, )</ID>
@@ -287,8 +301,9 @@
     <ID>RethrowCaughtException:OSDatabase.kt$OSDatabase$throw e</ID>
     <ID>ReturnCount:AppIdResolution.kt$fun resolveAppId( inputAppId: String?, configModel: ConfigModel, preferencesService: IPreferencesService, ): AppIdResolution</ID>
     <ID>ReturnCount:BackgroundManager.kt$BackgroundManager$override fun cancelRunBackgroundServices(): Boolean</ID>
-    <ID>ReturnCount:OneSignalImp.kt$OneSignalImp$private fun internalInit( context: Context, appId: String?, ): Boolean</ID>
     <ID>ReturnCount:ConfigModel.kt$ConfigModel$override fun createModelForProperty( property: String, jsonObject: JSONObject, ): Model?</ID>
+    <ID>ReturnCount:ExecutorsIvExtensions.kt$internal fun resolveIvBackendParams( op: Operation, onesignalId: String, jwtTokenStore: JwtTokenStore, ivBehaviorActive: Boolean, ): IvBackendParams</ID>
+    <ID>ReturnCount:ExecutorsIvExtensions.kt$internal fun resolveIvJwt( op: Operation, jwtTokenStore: JwtTokenStore, ivBehaviorActive: Boolean, ): String?</ID>
     <ID>ReturnCount:FeatureFlagsBackendService.kt$FeatureFlagsBackendService$override suspend fun fetchRemoteFeatureFlags(appId: String): RemoteFeatureFlagsFetchOutcome</ID>
     <ID>ReturnCount:HttpClient.kt$HttpClient$private suspend fun makeRequest( url: String, method: String?, jsonBody: JSONObject?, timeout: Int, headers: OptionalHeaders?, ): HttpResponse</ID>
     <ID>ReturnCount:IdentityOperationExecutor.kt$IdentityOperationExecutor$override suspend fun execute(operations: List&lt;Operation>): ExecutionResponse</ID>
@@ -301,10 +316,11 @@
     <ID>ReturnCount:Model.kt$Model$protected fun getOptIntProperty( name: String, create: (() -> Int?)? = null, ): Int?</ID>
     <ID>ReturnCount:Model.kt$Model$protected fun getOptLongProperty( name: String, create: (() -> Long?)? = null, ): Long?</ID>
     <ID>ReturnCount:Model.kt$Model$protected inline fun &lt;reified T : Enum&lt;T>> getOptEnumProperty(name: String): T?</ID>
+    <ID>ReturnCount:OneSignalImp.kt$OneSignalImp$private fun internalInit( context: Context, appId: String?, ): Boolean</ID>
     <ID>ReturnCount:OperationModelStore.kt$OperationModelStore$override fun create(jsonObject: JSONObject?): Operation?</ID>
+    <ID>ReturnCount:OperationModelStore.kt$OperationModelStore$private fun isValidOperation(jsonObject: JSONObject): Boolean</ID>
     <ID>ReturnCount:OperationRepoIvExtensions.kt$internal fun OperationRepo.handleFailUnauthorized( startingOp: OperationRepo.OperationQueueItem, ops: List&lt;OperationRepo.OperationQueueItem>, jwtTokenStore: JwtTokenStore, ivBehaviorActive: Boolean, ): Boolean</ID>
     <ID>ReturnCount:OperationRepoIvExtensions.kt$internal fun OperationRepo.hasValidJwtIfRequired( jwtTokenStore: JwtTokenStore, op: com.onesignal.core.internal.operations.Operation, ivBehaviorActive: Boolean, ): Boolean</ID>
-    <ID>ReturnCount:OperationModelStore.kt$OperationModelStore$private fun isValidOperation(jsonObject: JSONObject): Boolean</ID>
     <ID>ReturnCount:OutcomeEventsController.kt$OutcomeEventsController$private suspend fun sendAndCreateOutcomeEvent( name: String, weight: Float, // Note: this is optional sessionTime: Long, influences: List&lt;Influence>, ): OutcomeEvent?</ID>
     <ID>ReturnCount:OutcomeEventsController.kt$OutcomeEventsController$private suspend fun sendUniqueOutcomeEvent( name: String, sessionInfluences: List&lt;Influence>, ): OutcomeEvent?</ID>
     <ID>ReturnCount:PermissionsViewModel.kt$PermissionsViewModel$private fun shouldShowSettings( permission: String, shouldShowRationaleAfter: Boolean, ): Boolean</ID>
@@ -329,11 +345,13 @@
     <ID>SwallowedException:JSONUtils.kt$JSONUtils$t: Throwable</ID>
     <ID>SwallowedException:PermissionsActivity.kt$PermissionsActivity$e: ClassNotFoundException</ID>
     <ID>SwallowedException:PreferencesService.kt$PreferencesService$ex: Exception</ID>
+    <ID>SwallowedException:PreferencesService.kt$PreferencesService$t: Throwable</ID>
     <ID>SwallowedException:SyncJobService.kt$SyncJobService$e: Exception</ID>
     <ID>SwallowedException:TrackGooglePurchase.kt$TrackGooglePurchase.Companion$t: Throwable</ID>
     <ID>ThrowsCount:OneSignalImp.kt$OneSignalImp$private suspend fun waitUntilInitInternal(operationName: String? = null)</ID>
     <ID>TooGenericExceptionCaught:AndroidUtils.kt$AndroidUtils$e: Throwable</ID>
     <ID>TooGenericExceptionCaught:DeviceUtils.kt$DeviceUtils$t: Throwable</ID>
+    <ID>TooGenericExceptionCaught:FeatureFlagsRefreshService.kt$FeatureFlagsRefreshService$e: Exception</ID>
     <ID>TooGenericExceptionCaught:HttpClient.kt$HttpClient$e: Throwable</ID>
     <ID>TooGenericExceptionCaught:HttpClient.kt$HttpClient$t: Throwable</ID>
     <ID>TooGenericExceptionCaught:JSONUtils.kt$JSONUtils$t: Throwable</ID>
@@ -343,6 +361,7 @@
     <ID>TooGenericExceptionCaught:PreferenceStoreFix.kt$PreferenceStoreFix$e: Throwable</ID>
     <ID>TooGenericExceptionCaught:PreferencesService.kt$PreferencesService$e: Throwable</ID>
     <ID>TooGenericExceptionCaught:PreferencesService.kt$PreferencesService$ex: Exception</ID>
+    <ID>TooGenericExceptionCaught:PreferencesService.kt$PreferencesService$t: Throwable</ID>
     <ID>TooGenericExceptionCaught:SyncJobService.kt$SyncJobService$e: Exception</ID>
     <ID>TooGenericExceptionCaught:ThreadUtils.kt$e: Exception</ID>
     <ID>TooGenericExceptionCaught:TrackGooglePurchase.kt$TrackGooglePurchase$e: Throwable</ID>
@@ -421,10 +440,6 @@
     <ID>UndocumentedPublicClass:IOperationExecutor.kt$ExecutionResponse</ID>
     <ID>UndocumentedPublicClass:IOperationExecutor.kt$ExecutionResult</ID>
     <ID>UndocumentedPublicClass:IOutcomeEvent.kt$IOutcomeEvent</ID>
-    <ID>UndocumentedPublicClass:IParamsBackendService.kt$FCMParamsObject</ID>
-    <ID>UndocumentedPublicClass:IParamsBackendService.kt$IParamsBackendService</ID>
-    <ID>UndocumentedPublicClass:IParamsBackendService.kt$InfluenceParamsObject</ID>
-    <ID>UndocumentedPublicClass:IParamsBackendService.kt$ParamsObject</ID>
     <ID>UndocumentedPublicClass:IPreferencesService.kt$PreferenceOneSignalKeys</ID>
     <ID>UndocumentedPublicClass:IPreferencesService.kt$PreferencePlayerPurchasesKeys</ID>
     <ID>UndocumentedPublicClass:IPreferencesService.kt$PreferenceStores</ID>
@@ -557,8 +572,6 @@
     <ID>UndocumentedPublicFunction:Logging.kt$Logging$@JvmStatic fun warn( message: String, throwable: Throwable? = null, )</ID>
     <ID>UndocumentedPublicFunction:Logging.kt$Logging$fun addListener(listener: ILogListener)</ID>
     <ID>UndocumentedPublicFunction:Logging.kt$Logging$fun removeListener(listener: ILogListener)</ID>
-    <ID>UndocumentedPublicFunction:LoginHelper.kt$LoginHelper$suspend fun login( externalId: String, jwtBearerToken: String? = null, )</ID>
-    <ID>UndocumentedPublicFunction:LogoutHelper.kt$LogoutHelper$fun logout()</ID>
     <ID>UndocumentedPublicFunction:Model.kt$Model$fun &lt;T> setListProperty( name: String, value: List&lt;T>, tag: String = ModelChangeTags.NORMAL, forceChange: Boolean = false, )</ID>
     <ID>UndocumentedPublicFunction:Model.kt$Model$fun &lt;T> setMapModelProperty( name: String, value: MapModel&lt;T>, tag: String = ModelChangeTags.NORMAL, forceChange: Boolean = false, )</ID>
     <ID>UndocumentedPublicFunction:Model.kt$Model$fun &lt;T> setOptListProperty( name: String, value: List&lt;T>?, tag: String = ModelChangeTags.NORMAL, forceChange: Boolean = false, )</ID>

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/http/impl/HttpClient.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/http/impl/HttpClient.kt
@@ -159,17 +159,10 @@ internal class HttpClient(
                         con.doOutput = true
                     }
 
-                    logHTTPSent(con.requestMethod, con.url, jsonBody, con.requestProperties)
-
-                    if (jsonBody != null) {
-                        val strJsonBody = JSONUtils.toUnescapedEUIDString(jsonBody)
-                        val sendBytes = strJsonBody.toByteArray(charset("UTF-8"))
-                        con.setFixedLengthStreamingMode(sendBytes.size)
-                        val outputStream = con.outputStream
-                        outputStream.write(sendBytes)
-                    }
-
-                    // H E A D E R S
+                    // H E A D E R S — must be set before any body write below. `getOutputStream()`
+                    // (and `setFixedLengthStreamingMode`) commit the request line + headers to the
+                    // wire; `setRequestProperty` after that point either throws IllegalStateException
+                    // or is silently dropped, depending on the HttpURLConnection implementation.
 
                     if (headers?.cacheKey != null) {
                         val eTag =
@@ -197,6 +190,16 @@ internal class HttpClient(
 
                     if (headers?.jwt != null) {
                         con.setRequestProperty("Authorization", "Bearer ${headers.jwt}")
+                    }
+
+                    logHTTPSent(con.requestMethod, con.url, jsonBody, con.requestProperties)
+
+                    if (jsonBody != null) {
+                        val strJsonBody = JSONUtils.toUnescapedEUIDString(jsonBody)
+                        val sendBytes = strJsonBody.toByteArray(charset("UTF-8"))
+                        con.setFixedLengthStreamingMode(sendBytes.size)
+                        val outputStream = con.outputStream
+                        outputStream.write(sendBytes)
                     }
 
                     // Network request is made from getResponseCode()

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/http/impl/HttpClient.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/http/impl/HttpClient.kt
@@ -195,6 +195,10 @@ internal class HttpClient(
                         con.setRequestProperty("OneSignal-Session-Duration", headers.sessionDuration.toString())
                     }
 
+                    if (headers?.jwt != null) {
+                        con.setRequestProperty("Authorization", "Bearer ${headers.jwt}")
+                    }
+
                     // Network request is made from getResponseCode()
                     httpResponse = con.responseCode
 
@@ -325,7 +329,11 @@ internal class HttpClient(
         jsonBody: JSONObject?,
         headers: Map<String, List<String>>,
     ) {
-        val headersStr = headers.entries.joinToString()
+        // Redact Authorization so JWTs never reach logs even if this call moves below the header block.
+        val headersStr =
+            headers.entries.joinToString {
+                if (it.key.equals("Authorization", ignoreCase = true)) "${it.key}=[REDACTED]" else it.toString()
+            }
         val methodStr = method ?: "GET"
         val bodyStr = if (jsonBody != null) JSONUtils.toUnescapedEUIDString(jsonBody) else null
         Logging.debug("HttpClient: Request Sent = $methodStr $url - Body: $bodyStr - Headers: $headersStr")

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/http/impl/HttpClient.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/http/impl/HttpClient.kt
@@ -332,11 +332,7 @@ internal class HttpClient(
         jsonBody: JSONObject?,
         headers: Map<String, List<String>>,
     ) {
-        // Redact Authorization so JWTs never reach logs even if this call moves below the header block.
-        val headersStr =
-            headers.entries.joinToString {
-                if (it.key.equals("Authorization", ignoreCase = true)) "${it.key}=[REDACTED]" else it.toString()
-            }
+        val headersStr = headers.entries.joinToString()
         val methodStr = method ?: "GET"
         val bodyStr = if (jsonBody != null) JSONUtils.toUnescapedEUIDString(jsonBody) else null
         Logging.debug("HttpClient: Request Sent = $methodStr $url - Body: $bodyStr - Headers: $headersStr")

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/http/impl/OptionalHeaders.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/http/impl/OptionalHeaders.kt
@@ -17,4 +17,9 @@ data class OptionalHeaders(
      * Used to track delay between session start and request
      */
     val sessionDuration: Long? = null,
+    /**
+     * JWT bearer token for identity verification. When non-null, sent as
+     * `Authorization: Bearer <jwt>` on the request.
+     */
+    val jwt: String? = null,
 )

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/backend/IIdentityBackendService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/backend/IIdentityBackendService.kt
@@ -18,6 +18,7 @@ interface IIdentityBackendService {
         aliasLabel: String,
         aliasValue: String,
         identities: Map<String, String>,
+        jwt: String? = null,
     ): Map<String, String>
 
     /**
@@ -35,6 +36,7 @@ interface IIdentityBackendService {
         aliasLabel: String,
         aliasValue: String,
         aliasLabelToDelete: String,
+        jwt: String? = null,
     )
 }
 

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/backend/ISubscriptionBackendService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/backend/ISubscriptionBackendService.kt
@@ -22,6 +22,7 @@ interface ISubscriptionBackendService {
         aliasLabel: String,
         aliasValue: String,
         subscription: SubscriptionObject,
+        jwt: String? = null,
     ): Pair<String, RywData?>?
 
     /**
@@ -35,6 +36,7 @@ interface ISubscriptionBackendService {
         appId: String,
         subscriptionId: String,
         subscription: SubscriptionObject,
+        jwt: String? = null,
     ): RywData?
 
     /**
@@ -46,6 +48,7 @@ interface ISubscriptionBackendService {
     suspend fun deleteSubscription(
         appId: String,
         subscriptionId: String,
+        jwt: String? = null,
     )
 
     /**
@@ -61,10 +64,14 @@ interface ISubscriptionBackendService {
         subscriptionId: String,
         aliasLabel: String,
         aliasValue: String,
+        jwt: String? = null,
     )
 
     /**
      * Given an existing subscription, retrieve all identities associated to it.
+     *
+     * Note: this endpoint is not used when `jwt_required == true`; the v4→v5 migration path it
+     * supports is explicitly blocked under IV. See [LoginUserFromSubscriptionOperationExecutor].
      *
      * @param appId The ID of the OneSignal application this subscription exists under.
      * @param subscriptionId The ID of the subscription to retrieve identities for.

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/backend/IUserBackendService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/backend/IUserBackendService.kt
@@ -24,6 +24,7 @@ interface IUserBackendService {
         identities: Map<String, String>,
         subscriptions: List<SubscriptionObject>,
         properties: Map<String, String>,
+        jwt: String? = null,
     ): CreateUserResponse
     // TODO: Change to send only the push subscription, optimally
 
@@ -48,6 +49,7 @@ interface IUserBackendService {
         properties: PropertiesObject,
         refreshDeviceMetadata: Boolean,
         propertyiesDelta: PropertiesDeltasObject,
+        jwt: String? = null,
     ): RywData?
 
     /**
@@ -65,6 +67,7 @@ interface IUserBackendService {
         appId: String,
         aliasLabel: String,
         aliasValue: String,
+        jwt: String? = null,
     ): CreateUserResponse
 }
 

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/backend/impl/IdentityBackendService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/backend/impl/IdentityBackendService.kt
@@ -4,6 +4,7 @@ import com.onesignal.common.exceptions.BackendException
 import com.onesignal.common.putMap
 import com.onesignal.common.toMap
 import com.onesignal.core.internal.http.IHttpClient
+import com.onesignal.core.internal.http.impl.OptionalHeaders
 import com.onesignal.user.internal.backend.IIdentityBackendService
 import org.json.JSONObject
 
@@ -15,12 +16,14 @@ internal class IdentityBackendService(
         aliasLabel: String,
         aliasValue: String,
         identities: Map<String, String>,
+        jwt: String?,
     ): Map<String, String> {
         val requestJSONObject =
             JSONObject()
                 .put("identity", JSONObject().putMap(identities))
 
-        val response = _httpClient.patch("apps/$appId/users/by/$aliasLabel/$aliasValue/identity", requestJSONObject)
+        val response =
+            _httpClient.patch("apps/$appId/users/by/$aliasLabel/$aliasValue/identity", requestJSONObject, OptionalHeaders(jwt = jwt))
 
         if (!response.isSuccess) {
             throw BackendException(response.statusCode, response.payload, response.retryAfterSeconds)
@@ -36,8 +39,10 @@ internal class IdentityBackendService(
         aliasLabel: String,
         aliasValue: String,
         aliasLabelToDelete: String,
+        jwt: String?,
     ) {
-        val response = _httpClient.delete("apps/$appId/users/by/$aliasLabel/$aliasValue/identity/$aliasLabelToDelete")
+        val response =
+            _httpClient.delete("apps/$appId/users/by/$aliasLabel/$aliasValue/identity/$aliasLabelToDelete", OptionalHeaders(jwt = jwt))
 
         if (!response.isSuccess) {
             throw BackendException(response.statusCode, response.payload, response.retryAfterSeconds)

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/backend/impl/SubscriptionBackendService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/backend/impl/SubscriptionBackendService.kt
@@ -7,6 +7,7 @@ import com.onesignal.common.safeLong
 import com.onesignal.common.safeString
 import com.onesignal.common.toMap
 import com.onesignal.core.internal.http.IHttpClient
+import com.onesignal.core.internal.http.impl.OptionalHeaders
 import com.onesignal.user.internal.backend.ISubscriptionBackendService
 import com.onesignal.user.internal.backend.SubscriptionObject
 import org.json.JSONObject
@@ -19,11 +20,13 @@ internal class SubscriptionBackendService(
         aliasLabel: String,
         aliasValue: String,
         subscription: SubscriptionObject,
+        jwt: String?,
     ): Pair<String, RywData?>? {
         val jsonSubscription = JSONConverter.convertToJSON(subscription)
         val requestJSON = JSONObject().put("subscription", jsonSubscription)
 
-        val response = _httpClient.post("apps/$appId/users/by/$aliasLabel/$aliasValue/subscriptions", requestJSON)
+        val response =
+            _httpClient.post("apps/$appId/users/by/$aliasLabel/$aliasValue/subscriptions", requestJSON, OptionalHeaders(jwt = jwt))
 
         if (!response.isSuccess) {
             throw BackendException(response.statusCode, response.payload, response.retryAfterSeconds)
@@ -50,12 +53,13 @@ internal class SubscriptionBackendService(
         appId: String,
         subscriptionId: String,
         subscription: SubscriptionObject,
+        jwt: String?,
     ): RywData? {
         val requestJSON =
             JSONObject()
                 .put("subscription", JSONConverter.convertToJSON(subscription))
 
-        val response = _httpClient.patch("apps/$appId/subscriptions/$subscriptionId", requestJSON)
+        val response = _httpClient.patch("apps/$appId/subscriptions/$subscriptionId", requestJSON, OptionalHeaders(jwt = jwt))
 
         if (!response.isSuccess) {
             throw BackendException(response.statusCode, response.payload, response.retryAfterSeconds)
@@ -76,8 +80,9 @@ internal class SubscriptionBackendService(
     override suspend fun deleteSubscription(
         appId: String,
         subscriptionId: String,
+        jwt: String?,
     ) {
-        val response = _httpClient.delete("apps/$appId/subscriptions/$subscriptionId")
+        val response = _httpClient.delete("apps/$appId/subscriptions/$subscriptionId", OptionalHeaders(jwt = jwt))
 
         if (!response.isSuccess) {
             throw BackendException(response.statusCode, response.payload, response.retryAfterSeconds)
@@ -89,12 +94,13 @@ internal class SubscriptionBackendService(
         subscriptionId: String,
         aliasLabel: String,
         aliasValue: String,
+        jwt: String?,
     ) {
         val requestJSON =
             JSONObject()
                 .put("identity", JSONObject().put(aliasLabel, aliasValue))
 
-        val response = _httpClient.patch("apps/$appId/subscriptions/$subscriptionId/owner", requestJSON)
+        val response = _httpClient.patch("apps/$appId/subscriptions/$subscriptionId/owner", requestJSON, OptionalHeaders(jwt = jwt))
 
         if (!response.isSuccess) {
             throw BackendException(response.statusCode, response.payload, response.retryAfterSeconds)

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/backend/impl/UserBackendService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/backend/impl/UserBackendService.kt
@@ -6,6 +6,7 @@ import com.onesignal.common.putMap
 import com.onesignal.common.safeLong
 import com.onesignal.common.safeString
 import com.onesignal.core.internal.http.IHttpClient
+import com.onesignal.core.internal.http.impl.OptionalHeaders
 import com.onesignal.user.internal.backend.CreateUserResponse
 import com.onesignal.user.internal.backend.IUserBackendService
 import com.onesignal.user.internal.backend.PropertiesDeltasObject
@@ -21,6 +22,7 @@ internal class UserBackendService(
         identities: Map<String, String>,
         subscriptions: List<SubscriptionObject>,
         properties: Map<String, String>,
+        jwt: String?,
     ): CreateUserResponse {
         val requestJSON = JSONObject()
 
@@ -39,7 +41,7 @@ internal class UserBackendService(
 
         requestJSON.put("refresh_device_metadata", true)
 
-        val response = _httpClient.post("apps/$appId/users", requestJSON)
+        val response = _httpClient.post("apps/$appId/users", requestJSON, OptionalHeaders(jwt = jwt))
 
         if (!response.isSuccess) {
             throw BackendException(response.statusCode, response.payload, response.retryAfterSeconds)
@@ -55,6 +57,7 @@ internal class UserBackendService(
         properties: PropertiesObject,
         refreshDeviceMetadata: Boolean,
         propertyiesDelta: PropertiesDeltasObject,
+        jwt: String?,
     ): RywData? {
         val jsonObject =
             JSONObject()
@@ -68,7 +71,7 @@ internal class UserBackendService(
             jsonObject.put("deltas", JSONConverter.convertToJSON(propertyiesDelta))
         }
 
-        val response = _httpClient.patch("apps/$appId/users/by/$aliasLabel/$aliasValue", jsonObject)
+        val response = _httpClient.patch("apps/$appId/users/by/$aliasLabel/$aliasValue", jsonObject, OptionalHeaders(jwt = jwt))
 
         if (!response.isSuccess) {
             throw BackendException(response.statusCode, response.payload, response.retryAfterSeconds)
@@ -90,8 +93,9 @@ internal class UserBackendService(
         appId: String,
         aliasLabel: String,
         aliasValue: String,
+        jwt: String?,
     ): CreateUserResponse {
-        val response = _httpClient.get("apps/$appId/users/by/$aliasLabel/$aliasValue")
+        val response = _httpClient.get("apps/$appId/users/by/$aliasLabel/$aliasValue", OptionalHeaders(jwt = jwt))
 
         if (!response.isSuccess) {
             throw BackendException(response.statusCode, response.payload, response.retryAfterSeconds)

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/customEvents/ICustomEventBackendService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/customEvents/ICustomEventBackendService.kt
@@ -20,5 +20,6 @@ interface ICustomEventBackendService {
         eventName: String,
         eventProperties: String?,
         metadata: CustomEventMetadata,
+        jwt: String? = null,
     ): ExecutionResponse
 }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/customEvents/impl/CustomEventBackendService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/customEvents/impl/CustomEventBackendService.kt
@@ -3,6 +3,7 @@ package com.onesignal.user.internal.customEvents.impl
 import com.onesignal.common.DateUtils
 import com.onesignal.common.exceptions.BackendException
 import com.onesignal.core.internal.http.IHttpClient
+import com.onesignal.core.internal.http.impl.OptionalHeaders
 import com.onesignal.core.internal.operations.ExecutionResponse
 import com.onesignal.core.internal.operations.ExecutionResult
 import com.onesignal.user.internal.customEvents.ICustomEventBackendService
@@ -21,6 +22,7 @@ internal class CustomEventBackendService(
         eventName: String,
         eventProperties: String?,
         metadata: CustomEventMetadata,
+        jwt: String?,
     ): ExecutionResponse {
         val body = JSONObject()
         body.put("name", eventName)
@@ -42,7 +44,7 @@ internal class CustomEventBackendService(
         body.put("payload", payload)
         val jsonObject = JSONObject().put("events", JSONArray().put(body))
 
-        val response = httpClient.post("apps/$appId/custom_events", jsonObject)
+        val response = httpClient.post("apps/$appId/custom_events", jsonObject, OptionalHeaders(jwt = jwt))
 
         if (!response.isSuccess) {
             throw BackendException(response.statusCode, response.payload, response.retryAfterSeconds)

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/jwt/JwtTokenStore.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/jwt/JwtTokenStore.kt
@@ -76,7 +76,7 @@ internal class JwtTokenStore(
             updates.fire { listener ->
                 runCatching { listener.onJwtInvalidated(externalId) }
                     .onFailure { ex ->
-                        Logging.warn("JwtTokenStore: subscriber threw on onJwtInvalidated for externalId=$externalId: ${ex.message}")
+                        Logging.warn("JwtTokenStore: subscriber threw on onJwtInvalidated for externalId=$externalId", ex)
                     }
             }
         }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/jwt/JwtTokenStore.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/jwt/JwtTokenStore.kt
@@ -76,7 +76,7 @@ internal class JwtTokenStore(
             updates.fire { listener ->
                 runCatching { listener.onJwtInvalidated(externalId) }
                     .onFailure { ex ->
-                        Logging.warn("JwtTokenStore: subscriber threw on onJwtInvalidated for externalId=$externalId", ex)
+                        Logging.warn("JwtTokenStore: subscriber threw on onJwtInvalidated for externalId=$externalId: ${ex.message}")
                     }
             }
         }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/CustomEventOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/CustomEventOperationExecutor.kt
@@ -13,12 +13,15 @@ import com.onesignal.core.internal.operations.IOperationExecutor
 import com.onesignal.core.internal.operations.Operation
 import com.onesignal.user.internal.customEvents.ICustomEventBackendService
 import com.onesignal.user.internal.customEvents.impl.CustomEventMetadata
+import com.onesignal.user.internal.jwt.IdentityVerificationGates
+import com.onesignal.user.internal.jwt.JwtTokenStore
 import com.onesignal.user.internal.operations.TrackCustomEventOperation
 
 internal class CustomEventOperationExecutor(
     private val customEventBackendService: ICustomEventBackendService,
     private val applicationService: IApplicationService,
     private val deviceService: IDeviceService,
+    private val jwtTokenStore: JwtTokenStore,
 ) : IOperationExecutor {
     override val operations: List<String>
         get() = listOf(CUSTOM_EVENT)
@@ -40,6 +43,7 @@ internal class CustomEventOperationExecutor(
         try {
             when (operation) {
                 is TrackCustomEventOperation -> {
+                    val jwt = if (IdentityVerificationGates.newCodePathsRun) resolveIvJwt(operation, jwtTokenStore) else null
                     customEventBackendService.sendCustomEvent(
                         operation.appId,
                         operation.onesignalId,
@@ -48,6 +52,7 @@ internal class CustomEventOperationExecutor(
                         operation.eventName,
                         operation.eventProperties,
                         eventMetadataJson,
+                        jwt,
                     )
                 }
             }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/CustomEventOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/CustomEventOperationExecutor.kt
@@ -68,6 +68,8 @@ internal class CustomEventOperationExecutor(
             return when (responseType) {
                 NetworkUtils.ResponseStatusType.RETRYABLE ->
                     ExecutionResponse(ExecutionResult.FAIL_RETRY, retryAfterSeconds = ex.retryAfterSeconds)
+                NetworkUtils.ResponseStatusType.UNAUTHORIZED ->
+                    ExecutionResponse(ExecutionResult.FAIL_UNAUTHORIZED, retryAfterSeconds = ex.retryAfterSeconds)
                 else ->
                     ExecutionResponse(ExecutionResult.FAIL_NORETRY)
             }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/CustomEventOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/CustomEventOperationExecutor.kt
@@ -6,6 +6,7 @@ import com.onesignal.common.NetworkUtils
 import com.onesignal.common.OneSignalUtils
 import com.onesignal.common.exceptions.BackendException
 import com.onesignal.core.internal.application.IApplicationService
+import com.onesignal.core.internal.config.impl.IdentityVerificationService
 import com.onesignal.core.internal.device.IDeviceService
 import com.onesignal.core.internal.operations.ExecutionResponse
 import com.onesignal.core.internal.operations.ExecutionResult
@@ -13,7 +14,6 @@ import com.onesignal.core.internal.operations.IOperationExecutor
 import com.onesignal.core.internal.operations.Operation
 import com.onesignal.user.internal.customEvents.ICustomEventBackendService
 import com.onesignal.user.internal.customEvents.impl.CustomEventMetadata
-import com.onesignal.user.internal.jwt.IdentityVerificationGates
 import com.onesignal.user.internal.jwt.JwtTokenStore
 import com.onesignal.user.internal.operations.TrackCustomEventOperation
 
@@ -22,6 +22,7 @@ internal class CustomEventOperationExecutor(
     private val applicationService: IApplicationService,
     private val deviceService: IDeviceService,
     private val jwtTokenStore: JwtTokenStore,
+    private val identityVerificationService: IdentityVerificationService,
 ) : IOperationExecutor {
     override val operations: List<String>
         get() = listOf(CUSTOM_EVENT)
@@ -43,7 +44,12 @@ internal class CustomEventOperationExecutor(
         try {
             when (operation) {
                 is TrackCustomEventOperation -> {
-                    val jwt = if (IdentityVerificationGates.newCodePathsRun) resolveIvJwt(operation, jwtTokenStore) else null
+                    val jwt =
+                        if (identityVerificationService.newCodePathsRun) {
+                            resolveIvJwt(operation, jwtTokenStore, identityVerificationService.ivBehaviorActive)
+                        } else {
+                            null
+                        }
                     customEventBackendService.sendCustomEvent(
                         operation.appId,
                         operation.onesignalId,

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/CustomEventOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/CustomEventOperationExecutor.kt
@@ -44,12 +44,7 @@ internal class CustomEventOperationExecutor(
         try {
             when (operation) {
                 is TrackCustomEventOperation -> {
-                    val jwt =
-                        if (identityVerificationService.newCodePathsRun) {
-                            resolveIvJwt(operation, jwtTokenStore, identityVerificationService.ivBehaviorActive)
-                        } else {
-                            null
-                        }
+                    val jwt = resolveJwt(operation, jwtTokenStore, identityVerificationService)
                     customEventBackendService.sendCustomEvent(
                         operation.appId,
                         operation.onesignalId,

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/ExecutorsIvExtensions.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/ExecutorsIvExtensions.kt
@@ -3,15 +3,16 @@ package com.onesignal.user.internal.operations.impl.executors
 import com.onesignal.core.internal.operations.Operation
 import com.onesignal.debug.internal.logging.Logging
 import com.onesignal.user.internal.backend.IdentityConstants
-import com.onesignal.user.internal.jwt.IdentityVerificationGates
 import com.onesignal.user.internal.jwt.JwtTokenStore
 
 /**
  * IV-specific parameter resolution for operation executors. Base-class call sites dispatch via
- * `if (IdentityVerificationGates.newCodePathsRun) resolveIvBackendParams(...) else IvBackendParams.legacyFor(...)`;
- * the inner [IdentityVerificationGates.ivBehaviorActive] check keeps Phase 3 users (new code path
- * on, IV behavior off) on legacy alias/jwt values so they exercise the dispatch without any
- * behavioral change.
+ * `if (newCodePathsRun) resolveIvBackendParams(...) else IvBackendParams.legacyFor(...)`;
+ * the inner `ivBehaviorActive` check keeps Phase 3 users (new code path on, IV behavior off)
+ * on legacy alias/jwt values so they exercise the dispatch without any behavioral change.
+ *
+ * `ivBehaviorActive` is passed in by the executor (read from the injected
+ * `IdentityVerificationService`) — extension functions are not classes and cannot inject.
  */
 
 /** Alias + JWT triplet passed into backend calls. */
@@ -28,7 +29,7 @@ internal data class IvBackendParams(
 
 /**
  * Resolves alias + JWT for a backend call. Intended to be called only when
- * [IdentityVerificationGates.newCodePathsRun] is true; base-class dispatch handles the outer gate.
+ * `newCodePathsRun` is true; base-class dispatch handles the outer gate.
  *
  * - IV behavior inactive (Phase 3) → legacy values; no alias switch, no JWT attach.
  * - IV behavior active + op has externalId → `external_id` alias + JWT from [JwtTokenStore].
@@ -42,8 +43,9 @@ internal fun resolveIvBackendParams(
     op: Operation,
     onesignalId: String,
     jwtTokenStore: JwtTokenStore,
+    ivBehaviorActive: Boolean,
 ): IvBackendParams {
-    if (!IdentityVerificationGates.ivBehaviorActive) return IvBackendParams.legacyFor(onesignalId)
+    if (!ivBehaviorActive) return IvBackendParams.legacyFor(onesignalId)
     val externalId = op.externalId
     if (externalId == null) {
         Logging.error("IV active but op has null externalId; falling back to onesignal_id")
@@ -59,8 +61,9 @@ internal fun resolveIvBackendParams(
 internal fun resolveIvJwt(
     op: Operation,
     jwtTokenStore: JwtTokenStore,
+    ivBehaviorActive: Boolean,
 ): String? {
-    if (!IdentityVerificationGates.ivBehaviorActive) return null
+    if (!ivBehaviorActive) return null
     val externalId = op.externalId ?: return null
     return jwtTokenStore.getJwt(externalId)
 }
@@ -68,7 +71,7 @@ internal fun resolveIvJwt(
 /**
  * LoginUserFromSubscription path is blocked under IV — the backend endpoint the v4→v5 upgrade path
  * relies on is not allowed when `jwt_required == true`. Returns `true` when the executor should
- * short-circuit to `FAIL_NORETRY`. Called only when [IdentityVerificationGates.newCodePathsRun]
- * is true; Phase 3 users (behavior inactive) fall through and use the legacy migration path.
+ * short-circuit to `FAIL_NORETRY`. Called only when `newCodePathsRun` is true; Phase 3 users
+ * (behavior inactive) fall through and use the legacy migration path.
  */
-internal fun shouldFailLoginUserFromSubscription(): Boolean = IdentityVerificationGates.ivBehaviorActive
+internal fun shouldFailLoginUserFromSubscription(ivBehaviorActive: Boolean): Boolean = ivBehaviorActive

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/ExecutorsIvExtensions.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/ExecutorsIvExtensions.kt
@@ -1,0 +1,74 @@
+package com.onesignal.user.internal.operations.impl.executors
+
+import com.onesignal.core.internal.operations.Operation
+import com.onesignal.debug.internal.logging.Logging
+import com.onesignal.user.internal.backend.IdentityConstants
+import com.onesignal.user.internal.jwt.IdentityVerificationGates
+import com.onesignal.user.internal.jwt.JwtTokenStore
+
+/**
+ * IV-specific parameter resolution for operation executors. Base-class call sites dispatch via
+ * `if (IdentityVerificationGates.newCodePathsRun) resolveIvBackendParams(...) else IvBackendParams.legacyFor(...)`;
+ * the inner [IdentityVerificationGates.ivBehaviorActive] check keeps Phase 3 users (new code path
+ * on, IV behavior off) on legacy alias/jwt values so they exercise the dispatch without any
+ * behavioral change.
+ */
+
+/** Alias + JWT triplet passed into backend calls. */
+internal data class IvBackendParams(
+    val aliasLabel: String,
+    val aliasValue: String,
+    val jwt: String?,
+) {
+    companion object {
+        /** Values used when the new code path is off or IV behavior is inactive. Byte-for-byte identical to pre-IV behavior. */
+        fun legacyFor(onesignalId: String) = IvBackendParams(IdentityConstants.ONESIGNAL_ID, onesignalId, null)
+    }
+}
+
+/**
+ * Resolves alias + JWT for a backend call. Intended to be called only when
+ * [IdentityVerificationGates.newCodePathsRun] is true; base-class dispatch handles the outer gate.
+ *
+ * - IV behavior inactive (Phase 3) → legacy values; no alias switch, no JWT attach.
+ * - IV behavior active + op has externalId → `external_id` alias + JWT from [JwtTokenStore].
+ *   Note: `hasValidJwtIfRequired` already keeps anon ops and missing-JWT ops out of dispatch while
+ *   IV is active, so the null-externalId / missing-JWT branches below are defensive only.
+ *
+ * [onesignalId] is passed explicitly because the base [Operation] class doesn't expose it;
+ * concrete executors all have their own onesignalId field on the operation they're about to send.
+ */
+internal fun resolveIvBackendParams(
+    op: Operation,
+    onesignalId: String,
+    jwtTokenStore: JwtTokenStore,
+): IvBackendParams {
+    if (!IdentityVerificationGates.ivBehaviorActive) return IvBackendParams.legacyFor(onesignalId)
+    val externalId = op.externalId
+    if (externalId == null) {
+        Logging.error("IV active but op has null externalId; falling back to onesignal_id")
+        return IvBackendParams.legacyFor(onesignalId)
+    }
+    return IvBackendParams(IdentityConstants.EXTERNAL_ID, externalId, jwtTokenStore.getJwt(externalId))
+}
+
+/**
+ * Resolves a JWT-only parameter (used by endpoints that don't take alias label/value, e.g.
+ * subscription update/delete, custom events). Same inner gating as [resolveIvBackendParams].
+ */
+internal fun resolveIvJwt(
+    op: Operation,
+    jwtTokenStore: JwtTokenStore,
+): String? {
+    if (!IdentityVerificationGates.ivBehaviorActive) return null
+    val externalId = op.externalId ?: return null
+    return jwtTokenStore.getJwt(externalId)
+}
+
+/**
+ * LoginUserFromSubscription path is blocked under IV — the backend endpoint the v4→v5 upgrade path
+ * relies on is not allowed when `jwt_required == true`. Returns `true` when the executor should
+ * short-circuit to `FAIL_NORETRY`. Called only when [IdentityVerificationGates.newCodePathsRun]
+ * is true; Phase 3 users (behavior inactive) fall through and use the legacy migration path.
+ */
+internal fun shouldFailLoginUserFromSubscription(): Boolean = IdentityVerificationGates.ivBehaviorActive

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/ExecutorsIvExtensions.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/ExecutorsIvExtensions.kt
@@ -1,5 +1,6 @@
 package com.onesignal.user.internal.operations.impl.executors
 
+import com.onesignal.core.internal.config.impl.IdentityVerificationService
 import com.onesignal.core.internal.operations.Operation
 import com.onesignal.debug.internal.logging.Logging
 import com.onesignal.user.internal.backend.IdentityConstants
@@ -28,8 +29,28 @@ internal data class IvBackendParams(
 }
 
 /**
+ * Combined outer + inner gate for executors that just want "the right alias/JWT for this op."
+ * Replaces the call-site `if (newCodePathsRun) resolveIvBackendParams(...) else legacyFor(...)`
+ * boilerplate. Phase 1 (newCodePathsRun=false) skips the new code path entirely and returns
+ * legacy values directly, preserving the rollout-safety property that Phase 1 traffic does not
+ * exercise the IV resolution code.
+ */
+internal fun resolveBackendParams(
+    op: Operation,
+    onesignalId: String,
+    jwtTokenStore: JwtTokenStore,
+    identityVerificationService: IdentityVerificationService,
+): IvBackendParams =
+    if (identityVerificationService.newCodePathsRun) {
+        resolveIvBackendParams(op, onesignalId, jwtTokenStore, identityVerificationService.ivBehaviorActive)
+    } else {
+        IvBackendParams.legacyFor(onesignalId)
+    }
+
+/**
  * Resolves alias + JWT for a backend call. Intended to be called only when
- * `newCodePathsRun` is true; base-class dispatch handles the outer gate.
+ * `newCodePathsRun` is true; base-class dispatch handles the outer gate. Most executors should
+ * call [resolveBackendParams] which encapsulates the outer gate.
  *
  * - IV behavior inactive (Phase 3) → legacy values; no alias switch, no JWT attach.
  * - IV behavior active + op has externalId → `external_id` alias + JWT from [JwtTokenStore].
@@ -55,8 +76,27 @@ internal fun resolveIvBackendParams(
 }
 
 /**
+ * Combined outer + inner gate for executors that need only a JWT (no alias switch). Replaces
+ * the call-site `if (newCodePathsRun) resolveIvJwt(...) else null` boilerplate. Phase 1
+ * (newCodePathsRun=false) skips the new code path entirely and returns null directly,
+ * preserving the rollout-safety property that Phase 1 traffic does not exercise IV resolution.
+ */
+internal fun resolveJwt(
+    op: Operation,
+    jwtTokenStore: JwtTokenStore,
+    identityVerificationService: IdentityVerificationService,
+): String? =
+    if (identityVerificationService.newCodePathsRun) {
+        resolveIvJwt(op, jwtTokenStore, identityVerificationService.ivBehaviorActive)
+    } else {
+        null
+    }
+
+/**
  * Resolves a JWT-only parameter (used by endpoints that don't take alias label/value, e.g.
  * subscription update/delete, custom events). Same inner gating as [resolveIvBackendParams].
+ * Intended to be called only when `newCodePathsRun` is true; most executors should call
+ * [resolveJwt] which encapsulates the outer gate.
  */
 internal fun resolveIvJwt(
     op: Operation,

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/IdentityOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/IdentityOperationExecutor.kt
@@ -3,6 +3,7 @@ package com.onesignal.user.internal.operations.impl.executors
 import com.onesignal.common.NetworkUtils
 import com.onesignal.common.exceptions.BackendException
 import com.onesignal.common.modeling.ModelChangeTags
+import com.onesignal.core.internal.config.impl.IdentityVerificationService
 import com.onesignal.core.internal.operations.ExecutionResponse
 import com.onesignal.core.internal.operations.ExecutionResult
 import com.onesignal.core.internal.operations.IOperationExecutor
@@ -11,7 +12,6 @@ import com.onesignal.debug.internal.logging.Logging
 import com.onesignal.user.internal.backend.IIdentityBackendService
 import com.onesignal.user.internal.builduser.IRebuildUserService
 import com.onesignal.user.internal.identity.IdentityModelStore
-import com.onesignal.user.internal.jwt.IdentityVerificationGates
 import com.onesignal.user.internal.jwt.JwtTokenStore
 import com.onesignal.user.internal.operations.DeleteAliasOperation
 import com.onesignal.user.internal.operations.SetAliasOperation
@@ -23,6 +23,7 @@ internal class IdentityOperationExecutor(
     private val _buildUserService: IRebuildUserService,
     private val _newRecordState: NewRecordsState,
     private val _jwtTokenStore: JwtTokenStore,
+    private val _identityVerificationService: IdentityVerificationService,
 ) : IOperationExecutor {
     override val operations: List<String>
         get() = listOf(SET_ALIAS, DELETE_ALIAS)
@@ -47,8 +48,8 @@ internal class IdentityOperationExecutor(
 
         if (lastOperation is SetAliasOperation) {
             val params =
-                if (IdentityVerificationGates.newCodePathsRun) {
-                    resolveIvBackendParams(lastOperation, lastOperation.onesignalId, _jwtTokenStore)
+                if (_identityVerificationService.newCodePathsRun) {
+                    resolveIvBackendParams(lastOperation, lastOperation.onesignalId, _jwtTokenStore, _identityVerificationService.ivBehaviorActive)
                 } else {
                     IvBackendParams.legacyFor(lastOperation.onesignalId)
                 }
@@ -97,8 +98,8 @@ internal class IdentityOperationExecutor(
             }
         } else if (lastOperation is DeleteAliasOperation) {
             val params =
-                if (IdentityVerificationGates.newCodePathsRun) {
-                    resolveIvBackendParams(lastOperation, lastOperation.onesignalId, _jwtTokenStore)
+                if (_identityVerificationService.newCodePathsRun) {
+                    resolveIvBackendParams(lastOperation, lastOperation.onesignalId, _jwtTokenStore, _identityVerificationService.ivBehaviorActive)
                 } else {
                     IvBackendParams.legacyFor(lastOperation.onesignalId)
                 }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/IdentityOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/IdentityOperationExecutor.kt
@@ -9,9 +9,10 @@ import com.onesignal.core.internal.operations.IOperationExecutor
 import com.onesignal.core.internal.operations.Operation
 import com.onesignal.debug.internal.logging.Logging
 import com.onesignal.user.internal.backend.IIdentityBackendService
-import com.onesignal.user.internal.backend.IdentityConstants
 import com.onesignal.user.internal.builduser.IRebuildUserService
 import com.onesignal.user.internal.identity.IdentityModelStore
+import com.onesignal.user.internal.jwt.IdentityVerificationGates
+import com.onesignal.user.internal.jwt.JwtTokenStore
 import com.onesignal.user.internal.operations.DeleteAliasOperation
 import com.onesignal.user.internal.operations.SetAliasOperation
 import com.onesignal.user.internal.operations.impl.states.NewRecordsState
@@ -21,6 +22,7 @@ internal class IdentityOperationExecutor(
     private val _identityModelStore: IdentityModelStore,
     private val _buildUserService: IRebuildUserService,
     private val _newRecordState: NewRecordsState,
+    private val _jwtTokenStore: JwtTokenStore,
 ) : IOperationExecutor {
     override val operations: List<String>
         get() = listOf(SET_ALIAS, DELETE_ALIAS)
@@ -44,12 +46,19 @@ internal class IdentityOperationExecutor(
         val lastOperation = operations.last()
 
         if (lastOperation is SetAliasOperation) {
+            val params =
+                if (IdentityVerificationGates.newCodePathsRun) {
+                    resolveIvBackendParams(lastOperation, lastOperation.onesignalId, _jwtTokenStore)
+                } else {
+                    IvBackendParams.legacyFor(lastOperation.onesignalId)
+                }
             try {
                 _identityBackend.setAlias(
                     lastOperation.appId,
-                    IdentityConstants.ONESIGNAL_ID,
-                    lastOperation.onesignalId,
+                    params.aliasLabel,
+                    params.aliasValue,
                     mapOf(lastOperation.label to lastOperation.value),
+                    params.jwt,
                 )
 
                 // ensure the now created alias is in the model as long as the user is still current.
@@ -87,12 +96,19 @@ internal class IdentityOperationExecutor(
                 }
             }
         } else if (lastOperation is DeleteAliasOperation) {
+            val params =
+                if (IdentityVerificationGates.newCodePathsRun) {
+                    resolveIvBackendParams(lastOperation, lastOperation.onesignalId, _jwtTokenStore)
+                } else {
+                    IvBackendParams.legacyFor(lastOperation.onesignalId)
+                }
             try {
                 _identityBackend.deleteAlias(
                     lastOperation.appId,
-                    IdentityConstants.ONESIGNAL_ID,
-                    lastOperation.onesignalId,
+                    params.aliasLabel,
+                    params.aliasValue,
                     lastOperation.label,
+                    params.jwt,
                 )
 
                 // ensure the now deleted alias is not in the model as long as the user is still current.

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/IdentityOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/IdentityOperationExecutor.kt
@@ -47,12 +47,7 @@ internal class IdentityOperationExecutor(
         val lastOperation = operations.last()
 
         if (lastOperation is SetAliasOperation) {
-            val params =
-                if (_identityVerificationService.newCodePathsRun) {
-                    resolveIvBackendParams(lastOperation, lastOperation.onesignalId, _jwtTokenStore, _identityVerificationService.ivBehaviorActive)
-                } else {
-                    IvBackendParams.legacyFor(lastOperation.onesignalId)
-                }
+            val params = resolveBackendParams(lastOperation, lastOperation.onesignalId, _jwtTokenStore, _identityVerificationService)
             try {
                 _identityBackend.setAlias(
                     lastOperation.appId,
@@ -97,12 +92,7 @@ internal class IdentityOperationExecutor(
                 }
             }
         } else if (lastOperation is DeleteAliasOperation) {
-            val params =
-                if (_identityVerificationService.newCodePathsRun) {
-                    resolveIvBackendParams(lastOperation, lastOperation.onesignalId, _jwtTokenStore, _identityVerificationService.ivBehaviorActive)
-                } else {
-                    IvBackendParams.legacyFor(lastOperation.onesignalId)
-                }
+            val params = resolveBackendParams(lastOperation, lastOperation.onesignalId, _jwtTokenStore, _identityVerificationService)
             try {
                 _identityBackend.deleteAlias(
                     lastOperation.appId,

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/LoginUserFromSubscriptionOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/LoginUserFromSubscriptionOperationExecutor.kt
@@ -3,6 +3,7 @@ package com.onesignal.user.internal.operations.impl.executors
 import com.onesignal.common.NetworkUtils
 import com.onesignal.common.exceptions.BackendException
 import com.onesignal.common.modeling.ModelChangeTags
+import com.onesignal.core.internal.config.impl.IdentityVerificationService
 import com.onesignal.core.internal.operations.ExecutionResponse
 import com.onesignal.core.internal.operations.ExecutionResult
 import com.onesignal.core.internal.operations.IOperationExecutor
@@ -11,7 +12,6 @@ import com.onesignal.debug.internal.logging.Logging
 import com.onesignal.user.internal.backend.ISubscriptionBackendService
 import com.onesignal.user.internal.backend.IdentityConstants
 import com.onesignal.user.internal.identity.IdentityModelStore
-import com.onesignal.user.internal.jwt.IdentityVerificationGates
 import com.onesignal.user.internal.operations.LoginUserFromSubscriptionOperation
 import com.onesignal.user.internal.operations.RefreshUserOperation
 import com.onesignal.user.internal.properties.PropertiesModel
@@ -21,6 +21,7 @@ internal class LoginUserFromSubscriptionOperationExecutor(
     private val _subscriptionBackend: ISubscriptionBackendService,
     private val _identityModelStore: IdentityModelStore,
     private val _propertiesModelStore: PropertiesModelStore,
+    private val _identityVerificationService: IdentityVerificationService,
 ) : IOperationExecutor {
     override val operations: List<String>
         get() = listOf(LOGIN_USER_FROM_SUBSCRIPTION_USER)
@@ -30,7 +31,7 @@ internal class LoginUserFromSubscriptionOperationExecutor(
 
         // The getIdentityFromSubscription endpoint isn't allowed when `jwt_required == true`; the
         // v4→v5 migration path this executor exists for only applies to non-IV apps. Drop on IV.
-        if (IdentityVerificationGates.newCodePathsRun && shouldFailLoginUserFromSubscription()) {
+        if (_identityVerificationService.newCodePathsRun && shouldFailLoginUserFromSubscription(_identityVerificationService.ivBehaviorActive)) {
             Logging.warn("LoginUserFromSubscriptionOperation is not supported when identity verification is enabled. Dropping.")
             return ExecutionResponse(ExecutionResult.FAIL_NORETRY)
         }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/LoginUserFromSubscriptionOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/LoginUserFromSubscriptionOperationExecutor.kt
@@ -11,6 +11,7 @@ import com.onesignal.debug.internal.logging.Logging
 import com.onesignal.user.internal.backend.ISubscriptionBackendService
 import com.onesignal.user.internal.backend.IdentityConstants
 import com.onesignal.user.internal.identity.IdentityModelStore
+import com.onesignal.user.internal.jwt.IdentityVerificationGates
 import com.onesignal.user.internal.operations.LoginUserFromSubscriptionOperation
 import com.onesignal.user.internal.operations.RefreshUserOperation
 import com.onesignal.user.internal.properties.PropertiesModel
@@ -26,6 +27,13 @@ internal class LoginUserFromSubscriptionOperationExecutor(
 
     override suspend fun execute(operations: List<Operation>): ExecutionResponse {
         Logging.debug("LoginUserFromSubscriptionOperationExecutor(operation: $operations)")
+
+        // The getIdentityFromSubscription endpoint isn't allowed when `jwt_required == true`; the
+        // v4→v5 migration path this executor exists for only applies to non-IV apps. Drop on IV.
+        if (IdentityVerificationGates.newCodePathsRun && shouldFailLoginUserFromSubscription()) {
+            Logging.warn("LoginUserFromSubscriptionOperation is not supported when identity verification is enabled. Dropping.")
+            return ExecutionResponse(ExecutionResult.FAIL_NORETRY)
+        }
 
         if (operations.size > 1) {
             throw Exception("Only supports one operation! Attempted operations:\n$operations")

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/LoginUserOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/LoginUserOperationExecutor.kt
@@ -77,10 +77,18 @@ internal class LoginUserOperationExecutor(
         if (!containsSubscriptionOperation && loginUserOp.externalId == null) {
             return ExecutionResponse(ExecutionResult.FAIL_NORETRY)
         }
-        if (loginUserOp.existingOnesignalId == null || loginUserOp.externalId == null) {
+        if (loginUserOp.existingOnesignalId == null || loginUserOp.externalId == null ||
+            IdentityVerificationGates.ivBehaviorActive
+        ) {
             // When there is no existing user to attempt to associate with the externalId provided, we go right to
             // createUser.  If there is no externalId provided this is an insert, if there is this will be an
             // "upsert with retrieval" as the user may already exist.
+            //
+            // Under IV, also skip the optimistic SetAliasOperation: that inline op identifies the
+            // target user by `onesignal_id = existingOnesignalId`, but IV's alias-resolution would
+            // rewrite the call to identify by the new (not-yet-registered) `external_id`, producing
+            // a 404 or idempotent success against the wrong user. createUser's identities-map path
+            // handles the merge correctly through backend upsert semantics.
             return createUser(loginUserOp, operations)
         } else {
             // before we create a user we attempt to associate the user defined by existingOnesignalId with the

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/LoginUserOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/LoginUserOperationExecutor.kt
@@ -24,6 +24,8 @@ import com.onesignal.user.internal.backend.IdentityConstants
 import com.onesignal.user.internal.backend.SubscriptionObject
 import com.onesignal.user.internal.backend.SubscriptionObjectType
 import com.onesignal.user.internal.identity.IdentityModelStore
+import com.onesignal.user.internal.jwt.IdentityVerificationGates
+import com.onesignal.user.internal.jwt.JwtTokenStore
 import com.onesignal.user.internal.operations.CreateSubscriptionOperation
 import com.onesignal.user.internal.operations.DeleteSubscriptionOperation
 import com.onesignal.user.internal.operations.LoginUserOperation
@@ -47,6 +49,7 @@ internal class LoginUserOperationExecutor(
     private val _subscriptionsModelStore: SubscriptionModelStore,
     private val _configModelStore: ConfigModelStore,
     private val _languageContext: ILanguageContext,
+    private val _jwtTokenStore: JwtTokenStore,
 ) : IOperationExecutor {
     override val operations: List<String>
         get() = listOf(LOGIN_USER)
@@ -169,7 +172,9 @@ internal class LoginUserOperationExecutor(
 
         try {
             val subscriptionList = subscriptions.toList()
-            val response = _userBackend.createUser(createUserOperation.appId, identities, subscriptionList.map { it.second }, properties)
+            val jwt = if (IdentityVerificationGates.newCodePathsRun) resolveIvJwt(createUserOperation, _jwtTokenStore) else null
+            val response =
+                _userBackend.createUser(createUserOperation.appId, identities, subscriptionList.map { it.second }, properties, jwt)
             val idTranslations = mutableMapOf<String, String>()
             // Add the "local-to-backend" ID translation to the IdentifierTranslator for any operations that were
             // *not* executed but still reference the locally-generated IDs.

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/LoginUserOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/LoginUserOperationExecutor.kt
@@ -12,6 +12,7 @@ import com.onesignal.common.exceptions.BackendException
 import com.onesignal.common.modeling.ModelChangeTags
 import com.onesignal.core.internal.application.IApplicationService
 import com.onesignal.core.internal.config.ConfigModelStore
+import com.onesignal.core.internal.config.impl.IdentityVerificationService
 import com.onesignal.core.internal.device.IDeviceService
 import com.onesignal.core.internal.language.ILanguageContext
 import com.onesignal.core.internal.operations.ExecutionResponse
@@ -24,7 +25,6 @@ import com.onesignal.user.internal.backend.IdentityConstants
 import com.onesignal.user.internal.backend.SubscriptionObject
 import com.onesignal.user.internal.backend.SubscriptionObjectType
 import com.onesignal.user.internal.identity.IdentityModelStore
-import com.onesignal.user.internal.jwt.IdentityVerificationGates
 import com.onesignal.user.internal.jwt.JwtTokenStore
 import com.onesignal.user.internal.operations.CreateSubscriptionOperation
 import com.onesignal.user.internal.operations.DeleteSubscriptionOperation
@@ -50,6 +50,7 @@ internal class LoginUserOperationExecutor(
     private val _configModelStore: ConfigModelStore,
     private val _languageContext: ILanguageContext,
     private val _jwtTokenStore: JwtTokenStore,
+    private val _identityVerificationService: IdentityVerificationService,
 ) : IOperationExecutor {
     override val operations: List<String>
         get() = listOf(LOGIN_USER)
@@ -78,7 +79,7 @@ internal class LoginUserOperationExecutor(
             return ExecutionResponse(ExecutionResult.FAIL_NORETRY)
         }
         if (loginUserOp.existingOnesignalId == null || loginUserOp.externalId == null ||
-            IdentityVerificationGates.ivBehaviorActive
+            _identityVerificationService.ivBehaviorActive
         ) {
             // When there is no existing user to attempt to associate with the externalId provided, we go right to
             // createUser.  If there is no externalId provided this is an insert, if there is this will be an
@@ -180,7 +181,12 @@ internal class LoginUserOperationExecutor(
 
         try {
             val subscriptionList = subscriptions.toList()
-            val jwt = if (IdentityVerificationGates.newCodePathsRun) resolveIvJwt(createUserOperation, _jwtTokenStore) else null
+            val jwt =
+                if (_identityVerificationService.newCodePathsRun) {
+                    resolveIvJwt(createUserOperation, _jwtTokenStore, _identityVerificationService.ivBehaviorActive)
+                } else {
+                    null
+                }
             val response =
                 _userBackend.createUser(createUserOperation.appId, identities, subscriptionList.map { it.second }, properties, jwt)
             val idTranslations = mutableMapOf<String, String>()

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/LoginUserOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/LoginUserOperationExecutor.kt
@@ -181,12 +181,7 @@ internal class LoginUserOperationExecutor(
 
         try {
             val subscriptionList = subscriptions.toList()
-            val jwt =
-                if (_identityVerificationService.newCodePathsRun) {
-                    resolveIvJwt(createUserOperation, _jwtTokenStore, _identityVerificationService.ivBehaviorActive)
-                } else {
-                    null
-                }
+            val jwt = resolveJwt(createUserOperation, _jwtTokenStore, _identityVerificationService)
             val response =
                 _userBackend.createUser(createUserOperation.appId, identities, subscriptionList.map { it.second }, properties, jwt)
             val idTranslations = mutableMapOf<String, String>()

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/RefreshUserOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/RefreshUserOperationExecutor.kt
@@ -12,11 +12,12 @@ import com.onesignal.core.internal.operations.Operation
 import com.onesignal.debug.LogLevel
 import com.onesignal.debug.internal.logging.Logging
 import com.onesignal.user.internal.backend.IUserBackendService
-import com.onesignal.user.internal.backend.IdentityConstants
 import com.onesignal.user.internal.backend.SubscriptionObjectType
 import com.onesignal.user.internal.builduser.IRebuildUserService
 import com.onesignal.user.internal.identity.IdentityModel
 import com.onesignal.user.internal.identity.IdentityModelStore
+import com.onesignal.user.internal.jwt.IdentityVerificationGates
+import com.onesignal.user.internal.jwt.JwtTokenStore
 import com.onesignal.user.internal.operations.RefreshUserOperation
 import com.onesignal.user.internal.operations.impl.states.NewRecordsState
 import com.onesignal.user.internal.properties.PropertiesModel
@@ -34,6 +35,7 @@ internal class RefreshUserOperationExecutor(
     private val _configModelStore: ConfigModelStore,
     private val _buildUserService: IRebuildUserService,
     private val _newRecordState: NewRecordsState,
+    private val _jwtTokenStore: JwtTokenStore,
 ) : IOperationExecutor {
     override val operations: List<String>
         get() = listOf(REFRESH_USER)
@@ -54,12 +56,19 @@ internal class RefreshUserOperationExecutor(
     }
 
     private suspend fun getUser(op: RefreshUserOperation): ExecutionResponse {
+        val params =
+            if (IdentityVerificationGates.newCodePathsRun) {
+                resolveIvBackendParams(op, op.onesignalId, _jwtTokenStore)
+            } else {
+                IvBackendParams.legacyFor(op.onesignalId)
+            }
         try {
             val response =
                 _userBackend.getUser(
                     op.appId,
-                    IdentityConstants.ONESIGNAL_ID,
-                    op.onesignalId,
+                    params.aliasLabel,
+                    params.aliasValue,
+                    params.jwt,
                 )
 
             if (op.onesignalId != _identityModelStore.model.onesignalId) {

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/RefreshUserOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/RefreshUserOperationExecutor.kt
@@ -5,6 +5,7 @@ import com.onesignal.common.TimeUtils
 import com.onesignal.common.exceptions.BackendException
 import com.onesignal.common.modeling.ModelChangeTags
 import com.onesignal.core.internal.config.ConfigModelStore
+import com.onesignal.core.internal.config.impl.IdentityVerificationService
 import com.onesignal.core.internal.operations.ExecutionResponse
 import com.onesignal.core.internal.operations.ExecutionResult
 import com.onesignal.core.internal.operations.IOperationExecutor
@@ -16,7 +17,6 @@ import com.onesignal.user.internal.backend.SubscriptionObjectType
 import com.onesignal.user.internal.builduser.IRebuildUserService
 import com.onesignal.user.internal.identity.IdentityModel
 import com.onesignal.user.internal.identity.IdentityModelStore
-import com.onesignal.user.internal.jwt.IdentityVerificationGates
 import com.onesignal.user.internal.jwt.JwtTokenStore
 import com.onesignal.user.internal.operations.RefreshUserOperation
 import com.onesignal.user.internal.operations.impl.states.NewRecordsState
@@ -36,6 +36,7 @@ internal class RefreshUserOperationExecutor(
     private val _buildUserService: IRebuildUserService,
     private val _newRecordState: NewRecordsState,
     private val _jwtTokenStore: JwtTokenStore,
+    private val _identityVerificationService: IdentityVerificationService,
 ) : IOperationExecutor {
     override val operations: List<String>
         get() = listOf(REFRESH_USER)
@@ -57,8 +58,8 @@ internal class RefreshUserOperationExecutor(
 
     private suspend fun getUser(op: RefreshUserOperation): ExecutionResponse {
         val params =
-            if (IdentityVerificationGates.newCodePathsRun) {
-                resolveIvBackendParams(op, op.onesignalId, _jwtTokenStore)
+            if (_identityVerificationService.newCodePathsRun) {
+                resolveIvBackendParams(op, op.onesignalId, _jwtTokenStore, _identityVerificationService.ivBehaviorActive)
             } else {
                 IvBackendParams.legacyFor(op.onesignalId)
             }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/RefreshUserOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/RefreshUserOperationExecutor.kt
@@ -57,12 +57,7 @@ internal class RefreshUserOperationExecutor(
     }
 
     private suspend fun getUser(op: RefreshUserOperation): ExecutionResponse {
-        val params =
-            if (_identityVerificationService.newCodePathsRun) {
-                resolveIvBackendParams(op, op.onesignalId, _jwtTokenStore, _identityVerificationService.ivBehaviorActive)
-            } else {
-                IvBackendParams.legacyFor(op.onesignalId)
-            }
+        val params = resolveBackendParams(op, op.onesignalId, _jwtTokenStore, _identityVerificationService)
         try {
             val response =
                 _userBackend.getUser(

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/SubscriptionOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/SubscriptionOperationExecutor.kt
@@ -213,6 +213,8 @@ internal class SubscriptionOperationExecutor(
             return when (responseType) {
                 NetworkUtils.ResponseStatusType.RETRYABLE ->
                     ExecutionResponse(ExecutionResult.FAIL_RETRY, retryAfterSeconds = ex.retryAfterSeconds)
+                NetworkUtils.ResponseStatusType.UNAUTHORIZED ->
+                    ExecutionResponse(ExecutionResult.FAIL_UNAUTHORIZED, retryAfterSeconds = ex.retryAfterSeconds)
                 NetworkUtils.ResponseStatusType.MISSING -> {
                     if (ex.statusCode == 404 &&
                         listOf(
@@ -270,6 +272,8 @@ internal class SubscriptionOperationExecutor(
             return when (responseType) {
                 NetworkUtils.ResponseStatusType.RETRYABLE ->
                     ExecutionResponse(ExecutionResult.FAIL_RETRY, retryAfterSeconds = ex.retryAfterSeconds)
+                NetworkUtils.ResponseStatusType.UNAUTHORIZED ->
+                    ExecutionResponse(ExecutionResult.FAIL_UNAUTHORIZED, retryAfterSeconds = ex.retryAfterSeconds)
                 else ->
                     ExecutionResponse(ExecutionResult.FAIL_NORETRY)
             }
@@ -318,6 +322,8 @@ internal class SubscriptionOperationExecutor(
                 }
                 NetworkUtils.ResponseStatusType.RETRYABLE ->
                     ExecutionResponse(ExecutionResult.FAIL_RETRY, retryAfterSeconds = ex.retryAfterSeconds)
+                NetworkUtils.ResponseStatusType.UNAUTHORIZED ->
+                    ExecutionResponse(ExecutionResult.FAIL_UNAUTHORIZED, retryAfterSeconds = ex.retryAfterSeconds)
                 else ->
                     ExecutionResponse(ExecutionResult.FAIL_NORETRY)
             }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/SubscriptionOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/SubscriptionOperationExecutor.kt
@@ -14,6 +14,7 @@ import com.onesignal.common.exceptions.BackendException
 import com.onesignal.common.modeling.ModelChangeTags
 import com.onesignal.core.internal.application.IApplicationService
 import com.onesignal.core.internal.config.ConfigModelStore
+import com.onesignal.core.internal.config.impl.IdentityVerificationService
 import com.onesignal.core.internal.device.IDeviceService
 import com.onesignal.core.internal.operations.ExecutionResponse
 import com.onesignal.core.internal.operations.ExecutionResult
@@ -25,7 +26,6 @@ import com.onesignal.user.internal.backend.ISubscriptionBackendService
 import com.onesignal.user.internal.backend.SubscriptionObject
 import com.onesignal.user.internal.backend.SubscriptionObjectType
 import com.onesignal.user.internal.builduser.IRebuildUserService
-import com.onesignal.user.internal.jwt.IdentityVerificationGates
 import com.onesignal.user.internal.jwt.JwtTokenStore
 import com.onesignal.user.internal.operations.CreateSubscriptionOperation
 import com.onesignal.user.internal.operations.DeleteSubscriptionOperation
@@ -46,6 +46,7 @@ internal class SubscriptionOperationExecutor(
     private val _newRecordState: NewRecordsState,
     private val _consistencyManager: IConsistencyManager,
     private val _jwtTokenStore: JwtTokenStore,
+    private val _identityVerificationService: IdentityVerificationService,
 ) : IOperationExecutor {
     override val operations: List<String>
         get() = listOf(CREATE_SUBSCRIPTION, UPDATE_SUBSCRIPTION, DELETE_SUBSCRIPTION, TRANSFER_SUBSCRIPTION)
@@ -110,8 +111,8 @@ internal class SubscriptionOperationExecutor(
                 )
 
             val params =
-                if (IdentityVerificationGates.newCodePathsRun) {
-                    resolveIvBackendParams(createOperation, createOperation.onesignalId, _jwtTokenStore)
+                if (_identityVerificationService.newCodePathsRun) {
+                    resolveIvBackendParams(createOperation, createOperation.onesignalId, _jwtTokenStore, _identityVerificationService.ivBehaviorActive)
                 } else {
                     IvBackendParams.legacyFor(createOperation.onesignalId)
                 }
@@ -199,7 +200,12 @@ internal class SubscriptionOperationExecutor(
                     AndroidUtils.getAppVersion(_applicationService.appContext),
                 )
 
-            val jwt = if (IdentityVerificationGates.newCodePathsRun) resolveIvJwt(lastOperation, _jwtTokenStore) else null
+            val jwt =
+                if (_identityVerificationService.newCodePathsRun) {
+                    resolveIvJwt(lastOperation, _jwtTokenStore, _identityVerificationService.ivBehaviorActive)
+                } else {
+                    null
+                }
             val rywData = _subscriptionBackend.updateSubscription(lastOperation.appId, lastOperation.subscriptionId, subscription, jwt)
 
             if (rywData != null) {
@@ -253,8 +259,8 @@ internal class SubscriptionOperationExecutor(
     // TODO: whenever the end-user changes users, we need to add the read-your-write token here, currently no code to handle the re-fetch IAMs
     private suspend fun transferSubscription(startingOperation: TransferSubscriptionOperation): ExecutionResponse {
         val params =
-            if (IdentityVerificationGates.newCodePathsRun) {
-                resolveIvBackendParams(startingOperation, startingOperation.onesignalId, _jwtTokenStore)
+            if (_identityVerificationService.newCodePathsRun) {
+                resolveIvBackendParams(startingOperation, startingOperation.onesignalId, _jwtTokenStore, _identityVerificationService.ivBehaviorActive)
             } else {
                 IvBackendParams.legacyFor(startingOperation.onesignalId)
             }
@@ -297,7 +303,12 @@ internal class SubscriptionOperationExecutor(
     }
 
     private suspend fun deleteSubscription(op: DeleteSubscriptionOperation): ExecutionResponse {
-        val jwt = if (IdentityVerificationGates.newCodePathsRun) resolveIvJwt(op, _jwtTokenStore) else null
+        val jwt =
+            if (_identityVerificationService.newCodePathsRun) {
+                resolveIvJwt(op, _jwtTokenStore, _identityVerificationService.ivBehaviorActive)
+            } else {
+                null
+            }
         try {
             _subscriptionBackend.deleteSubscription(op.appId, op.subscriptionId, jwt)
 

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/SubscriptionOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/SubscriptionOperationExecutor.kt
@@ -22,10 +22,11 @@ import com.onesignal.core.internal.operations.Operation
 import com.onesignal.debug.LogLevel
 import com.onesignal.debug.internal.logging.Logging
 import com.onesignal.user.internal.backend.ISubscriptionBackendService
-import com.onesignal.user.internal.backend.IdentityConstants
 import com.onesignal.user.internal.backend.SubscriptionObject
 import com.onesignal.user.internal.backend.SubscriptionObjectType
 import com.onesignal.user.internal.builduser.IRebuildUserService
+import com.onesignal.user.internal.jwt.IdentityVerificationGates
+import com.onesignal.user.internal.jwt.JwtTokenStore
 import com.onesignal.user.internal.operations.CreateSubscriptionOperation
 import com.onesignal.user.internal.operations.DeleteSubscriptionOperation
 import com.onesignal.user.internal.operations.TransferSubscriptionOperation
@@ -44,6 +45,7 @@ internal class SubscriptionOperationExecutor(
     private val _buildUserService: IRebuildUserService,
     private val _newRecordState: NewRecordsState,
     private val _consistencyManager: IConsistencyManager,
+    private val _jwtTokenStore: JwtTokenStore,
 ) : IOperationExecutor {
     override val operations: List<String>
         get() = listOf(CREATE_SUBSCRIPTION, UPDATE_SUBSCRIPTION, DELETE_SUBSCRIPTION, TRANSFER_SUBSCRIPTION)
@@ -107,12 +109,19 @@ internal class SubscriptionOperationExecutor(
                     AndroidUtils.getAppVersion(_applicationService.appContext),
                 )
 
+            val params =
+                if (IdentityVerificationGates.newCodePathsRun) {
+                    resolveIvBackendParams(createOperation, createOperation.onesignalId, _jwtTokenStore)
+                } else {
+                    IvBackendParams.legacyFor(createOperation.onesignalId)
+                }
             val result =
                 _subscriptionBackend.createSubscription(
                     createOperation.appId,
-                    IdentityConstants.ONESIGNAL_ID,
-                    createOperation.onesignalId,
+                    params.aliasLabel,
+                    params.aliasValue,
                     subscription,
+                    params.jwt,
                 ) ?: return ExecutionResponse(ExecutionResult.SUCCESS)
 
             val backendSubscriptionId = result.first
@@ -190,7 +199,8 @@ internal class SubscriptionOperationExecutor(
                     AndroidUtils.getAppVersion(_applicationService.appContext),
                 )
 
-            val rywData = _subscriptionBackend.updateSubscription(lastOperation.appId, lastOperation.subscriptionId, subscription)
+            val jwt = if (IdentityVerificationGates.newCodePathsRun) resolveIvJwt(lastOperation, _jwtTokenStore) else null
+            val rywData = _subscriptionBackend.updateSubscription(lastOperation.appId, lastOperation.subscriptionId, subscription, jwt)
 
             if (rywData != null) {
                 _consistencyManager.setRywData(startingOperation.onesignalId, IamFetchRywTokenKey.SUBSCRIPTION, rywData)
@@ -240,12 +250,19 @@ internal class SubscriptionOperationExecutor(
 
     // TODO: whenever the end-user changes users, we need to add the read-your-write token here, currently no code to handle the re-fetch IAMs
     private suspend fun transferSubscription(startingOperation: TransferSubscriptionOperation): ExecutionResponse {
+        val params =
+            if (IdentityVerificationGates.newCodePathsRun) {
+                resolveIvBackendParams(startingOperation, startingOperation.onesignalId, _jwtTokenStore)
+            } else {
+                IvBackendParams.legacyFor(startingOperation.onesignalId)
+            }
         try {
             _subscriptionBackend.transferSubscription(
                 startingOperation.appId,
                 startingOperation.subscriptionId,
-                IdentityConstants.ONESIGNAL_ID,
-                startingOperation.onesignalId,
+                params.aliasLabel,
+                params.aliasValue,
+                params.jwt,
             )
         } catch (ex: BackendException) {
             val responseType = NetworkUtils.getResponseStatusType(ex.statusCode)
@@ -276,8 +293,9 @@ internal class SubscriptionOperationExecutor(
     }
 
     private suspend fun deleteSubscription(op: DeleteSubscriptionOperation): ExecutionResponse {
+        val jwt = if (IdentityVerificationGates.newCodePathsRun) resolveIvJwt(op, _jwtTokenStore) else null
         try {
-            _subscriptionBackend.deleteSubscription(op.appId, op.subscriptionId)
+            _subscriptionBackend.deleteSubscription(op.appId, op.subscriptionId, jwt)
 
             // remove the subscription model as a HYDRATE in case for some reason it still exists.
             _subscriptionModelStore.remove(op.subscriptionId, ModelChangeTags.HYDRATE)

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/SubscriptionOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/SubscriptionOperationExecutor.kt
@@ -110,12 +110,7 @@ internal class SubscriptionOperationExecutor(
                     AndroidUtils.getAppVersion(_applicationService.appContext),
                 )
 
-            val params =
-                if (_identityVerificationService.newCodePathsRun) {
-                    resolveIvBackendParams(createOperation, createOperation.onesignalId, _jwtTokenStore, _identityVerificationService.ivBehaviorActive)
-                } else {
-                    IvBackendParams.legacyFor(createOperation.onesignalId)
-                }
+            val params = resolveBackendParams(createOperation, createOperation.onesignalId, _jwtTokenStore, _identityVerificationService)
             val result =
                 _subscriptionBackend.createSubscription(
                     createOperation.appId,
@@ -200,12 +195,7 @@ internal class SubscriptionOperationExecutor(
                     AndroidUtils.getAppVersion(_applicationService.appContext),
                 )
 
-            val jwt =
-                if (_identityVerificationService.newCodePathsRun) {
-                    resolveIvJwt(lastOperation, _jwtTokenStore, _identityVerificationService.ivBehaviorActive)
-                } else {
-                    null
-                }
+            val jwt = resolveJwt(lastOperation, _jwtTokenStore, _identityVerificationService)
             val rywData = _subscriptionBackend.updateSubscription(lastOperation.appId, lastOperation.subscriptionId, subscription, jwt)
 
             if (rywData != null) {
@@ -258,12 +248,7 @@ internal class SubscriptionOperationExecutor(
 
     // TODO: whenever the end-user changes users, we need to add the read-your-write token here, currently no code to handle the re-fetch IAMs
     private suspend fun transferSubscription(startingOperation: TransferSubscriptionOperation): ExecutionResponse {
-        val params =
-            if (_identityVerificationService.newCodePathsRun) {
-                resolveIvBackendParams(startingOperation, startingOperation.onesignalId, _jwtTokenStore, _identityVerificationService.ivBehaviorActive)
-            } else {
-                IvBackendParams.legacyFor(startingOperation.onesignalId)
-            }
+        val params = resolveBackendParams(startingOperation, startingOperation.onesignalId, _jwtTokenStore, _identityVerificationService)
         try {
             _subscriptionBackend.transferSubscription(
                 startingOperation.appId,
@@ -303,12 +288,7 @@ internal class SubscriptionOperationExecutor(
     }
 
     private suspend fun deleteSubscription(op: DeleteSubscriptionOperation): ExecutionResponse {
-        val jwt =
-            if (_identityVerificationService.newCodePathsRun) {
-                resolveIvJwt(op, _jwtTokenStore, _identityVerificationService.ivBehaviorActive)
-            } else {
-                null
-            }
+        val jwt = resolveJwt(op, _jwtTokenStore, _identityVerificationService)
         try {
             _subscriptionBackend.deleteSubscription(op.appId, op.subscriptionId, jwt)
 

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/UpdateUserOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/UpdateUserOperationExecutor.kt
@@ -6,6 +6,7 @@ import com.onesignal.common.consistency.enums.IamFetchRywTokenKey
 import com.onesignal.common.consistency.models.IConsistencyManager
 import com.onesignal.common.exceptions.BackendException
 import com.onesignal.common.modeling.ModelChangeTags
+import com.onesignal.core.internal.config.impl.IdentityVerificationService
 import com.onesignal.core.internal.operations.ExecutionResponse
 import com.onesignal.core.internal.operations.ExecutionResult
 import com.onesignal.core.internal.operations.IOperationExecutor
@@ -18,7 +19,6 @@ import com.onesignal.user.internal.backend.PropertiesObject
 import com.onesignal.user.internal.backend.PurchaseObject
 import com.onesignal.user.internal.builduser.IRebuildUserService
 import com.onesignal.user.internal.identity.IdentityModelStore
-import com.onesignal.user.internal.jwt.IdentityVerificationGates
 import com.onesignal.user.internal.jwt.JwtTokenStore
 import com.onesignal.user.internal.operations.DeleteTagOperation
 import com.onesignal.user.internal.operations.SetPropertyOperation
@@ -37,6 +37,7 @@ internal class UpdateUserOperationExecutor(
     private val _newRecordState: NewRecordsState,
     private val _consistencyManager: IConsistencyManager,
     private val _jwtTokenStore: JwtTokenStore,
+    private val _identityVerificationService: IdentityVerificationService,
 ) : IOperationExecutor {
     override val operations: List<String>
         get() = listOf(SET_TAG, DELETE_TAG, SET_PROPERTY, TRACK_SESSION_START, TRACK_SESSION_END, TRACK_PURCHASE)
@@ -143,8 +144,8 @@ internal class UpdateUserOperationExecutor(
             // pulling externalId from `operations.first()` is safe and represents the batch.
             val firstOp = operations.first()
             val params =
-                if (IdentityVerificationGates.newCodePathsRun) {
-                    resolveIvBackendParams(firstOp, onesignalId, _jwtTokenStore)
+                if (_identityVerificationService.newCodePathsRun) {
+                    resolveIvBackendParams(firstOp, onesignalId, _jwtTokenStore, _identityVerificationService.ivBehaviorActive)
                 } else {
                     IvBackendParams.legacyFor(onesignalId)
                 }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/UpdateUserOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/UpdateUserOperationExecutor.kt
@@ -13,12 +13,13 @@ import com.onesignal.core.internal.operations.Operation
 import com.onesignal.debug.LogLevel
 import com.onesignal.debug.internal.logging.Logging
 import com.onesignal.user.internal.backend.IUserBackendService
-import com.onesignal.user.internal.backend.IdentityConstants
 import com.onesignal.user.internal.backend.PropertiesDeltasObject
 import com.onesignal.user.internal.backend.PropertiesObject
 import com.onesignal.user.internal.backend.PurchaseObject
 import com.onesignal.user.internal.builduser.IRebuildUserService
 import com.onesignal.user.internal.identity.IdentityModelStore
+import com.onesignal.user.internal.jwt.IdentityVerificationGates
+import com.onesignal.user.internal.jwt.JwtTokenStore
 import com.onesignal.user.internal.operations.DeleteTagOperation
 import com.onesignal.user.internal.operations.SetPropertyOperation
 import com.onesignal.user.internal.operations.SetTagOperation
@@ -35,6 +36,7 @@ internal class UpdateUserOperationExecutor(
     private val _buildUserService: IRebuildUserService,
     private val _newRecordState: NewRecordsState,
     private val _consistencyManager: IConsistencyManager,
+    private val _jwtTokenStore: JwtTokenStore,
 ) : IOperationExecutor {
     override val operations: List<String>
         get() = listOf(SET_TAG, DELETE_TAG, SET_PROPERTY, TRACK_SESSION_START, TRACK_SESSION_END, TRACK_PURCHASE)
@@ -137,15 +139,25 @@ internal class UpdateUserOperationExecutor(
         }
 
         if (appId != null && onesignalId != null) {
+            // Grouped update ops all belong to the same user (queue grouping is per-user), so
+            // pulling externalId from `operations.first()` is safe and represents the batch.
+            val firstOp = operations.first()
+            val params =
+                if (IdentityVerificationGates.newCodePathsRun) {
+                    resolveIvBackendParams(firstOp, onesignalId, _jwtTokenStore)
+                } else {
+                    IvBackendParams.legacyFor(onesignalId)
+                }
             try {
                 val rywData =
                     _userBackend.updateUser(
                         appId,
-                        IdentityConstants.ONESIGNAL_ID,
-                        onesignalId,
+                        params.aliasLabel,
+                        params.aliasValue,
                         propertiesObject,
                         refreshDeviceMetadata,
                         deltasObject,
+                        params.jwt,
                     )
 
                 if (rywData != null) {

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/UpdateUserOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/UpdateUserOperationExecutor.kt
@@ -143,12 +143,7 @@ internal class UpdateUserOperationExecutor(
             // Grouped update ops all belong to the same user (queue grouping is per-user), so
             // pulling externalId from `operations.first()` is safe and represents the batch.
             val firstOp = operations.first()
-            val params =
-                if (_identityVerificationService.newCodePathsRun) {
-                    resolveIvBackendParams(firstOp, onesignalId, _jwtTokenStore, _identityVerificationService.ivBehaviorActive)
-                } else {
-                    IvBackendParams.legacyFor(onesignalId)
-                }
+            val params = resolveBackendParams(firstOp, onesignalId, _jwtTokenStore, _identityVerificationService)
             try {
                 val rywData =
                     _userBackend.updateUser(

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/http/HttpClientTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/http/HttpClientTests.kt
@@ -255,4 +255,32 @@ class HttpClientTests : FunSpec({
         response2 shouldBe null
         response3 shouldNotBe null
     }
+
+    test("Authorization header is set when OptionalHeaders.jwt is provided") {
+        // Given
+        val mocks = Mocks()
+
+        // When
+        mocks.httpClient.get("URL", OptionalHeaders(jwt = "abc.def.ghi"))
+        mocks.httpClient.post("URL", JSONObject(), OptionalHeaders(jwt = "abc.def.ghi"))
+
+        // Then
+        for (connection in mocks.factory.connections) {
+            connection.getRequestProperty("Authorization") shouldBe "Bearer abc.def.ghi"
+        }
+    }
+
+    test("Authorization header is NOT set when OptionalHeaders.jwt is null") {
+        // Given
+        val mocks = Mocks()
+
+        // When
+        mocks.httpClient.get("URL", OptionalHeaders(jwt = null))
+        mocks.httpClient.post("URL", JSONObject())
+
+        // Then
+        for (connection in mocks.factory.connections) {
+            connection.getRequestProperty("Authorization") shouldBe null
+        }
+    }
 })

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/http/HttpClientTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/http/HttpClientTests.kt
@@ -283,4 +283,20 @@ class HttpClientTests : FunSpec({
             connection.getRequestProperty("Authorization") shouldBe null
         }
     }
+
+    test("POST + JWT does not throw (headers must be set before body write)") {
+        // Given: MockHttpURLConnection now throws IllegalStateException if setRequestProperty is
+        // called after connect()/getOutputStream()/getResponseCode (matching real Android behavior).
+        // This test fails if the HttpClient regresses to setting Authorization after the body write.
+        val mocks = Mocks()
+        mocks.response.status = 200
+        mocks.response.responseBody = "{}"
+
+        // When
+        val response = mocks.httpClient.post("URL", JSONObject().put("k", "v"), OptionalHeaders(jwt = "the-jwt"))
+
+        // Then: the request completed without the mock throwing, and the header actually stuck.
+        response.throwable shouldBe null
+        mocks.factory.connections.last().getRequestProperty("Authorization") shouldBe "Bearer the-jwt"
+    }
 })

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/http/MockHttpConnectionFactory.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/http/MockHttpConnectionFactory.kt
@@ -32,6 +32,13 @@ internal class MockHttpConnectionFactory(
         url: URL?,
         private val mockResponse: MockResponse,
     ) : HttpURLConnection(url) {
+        // Real HttpURLConnection (both stock JDK and Android's OkHttp-backed impl) commits the
+        // request line + headers to the wire when `getOutputStream()` / `setFixedLengthStreamingMode`
+        // is used to stream a body, and rejects `setRequestProperty` afterward. The stock mock
+        // lets headers be set at any time, which hides header-ordering bugs. Simulate the real
+        // contract so HttpClientTests will fail fast if headers are set after the body begins.
+        private var headersCommitted: Boolean = false
+
         override fun disconnect() {}
 
         override fun usingProxy(): Boolean {
@@ -40,6 +47,14 @@ internal class MockHttpConnectionFactory(
 
         @Throws(IOException::class)
         override fun connect() {
+            headersCommitted = true
+        }
+
+        override fun setRequestProperty(key: String, value: String?) {
+            if (headersCommitted) {
+                throw IllegalStateException("Cannot set request property '$key' after connection is made")
+            }
+            super.setRequestProperty(key, value)
         }
 
         override fun getHeaderField(name: String): String? {
@@ -48,6 +63,7 @@ internal class MockHttpConnectionFactory(
 
         @Throws(IOException::class)
         override fun getResponseCode(): Int {
+            headersCommitted = true
             if (mockResponse.mockRequestTime != null) {
                 try {
                     Thread.sleep(mockResponse.mockRequestTime!!)
@@ -60,6 +76,7 @@ internal class MockHttpConnectionFactory(
         }
 
         override fun getOutputStream(): OutputStream {
+            headersCommitted = true
             return NullOutputStream()
         }
 

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/debug/internal/LoggingTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/debug/internal/LoggingTests.kt
@@ -22,14 +22,30 @@ infix fun <T : Collection<String>> T.shouldHaveEachItemEndWith(expected: Array<S
 }
 
 class LoggingTests : FunSpec({
+    // Track every listener registered in a test so we can clear them in afterEach.
+    // Without this, leaked listeners survive across test classes in the same JVM and any
+    // later test that triggers Logging.warn(msg, throwable) crashes on the unmocked
+    // android.util.Log.getStackTraceString call inside callLogListeners.
+    val registered = mutableListOf<ILogListener>()
+    fun register(listener: ILogListener): ILogListener {
+        registered.add(listener)
+        Logging.addListener(listener)
+        return listener
+    }
+
     beforeAny {
         Logging.logLevel = LogLevel.NONE
+    }
+
+    afterEach {
+        registered.forEach { Logging.removeListener(it) }
+        registered.clear()
     }
 
     test("addListener") {
         // Given
         val listener = TestLogLister()
-        Logging.addListener(listener)
+        register(listener)
 
         // When
         Logging.debug("test")
@@ -41,8 +57,8 @@ class LoggingTests : FunSpec({
     test("addListener twice") {
         // Given
         val listener = TestLogLister()
-        Logging.addListener(listener)
-        Logging.addListener(listener)
+        register(listener)
+        register(listener)
 
         // When
         Logging.debug("test")
@@ -54,7 +70,7 @@ class LoggingTests : FunSpec({
     test("removeListener") {
         // Given
         val listener = TestLogLister()
-        Logging.addListener(listener)
+        register(listener)
         Logging.removeListener(listener)
 
         // When
@@ -67,7 +83,7 @@ class LoggingTests : FunSpec({
     test("removeListener twice") {
         // Given
         val listener = TestLogLister()
-        Logging.addListener(listener)
+        register(listener)
         Logging.removeListener(listener)
         Logging.removeListener(listener)
 
@@ -81,7 +97,8 @@ class LoggingTests : FunSpec({
     test("addListener nested") {
         // Given
         val nestedListener = TestLogLister()
-        Logging.addListener { Logging.addListener(nestedListener) }
+        val outerListener = ILogListener { register(nestedListener) }
+        register(outerListener)
 
         // When
         Logging.debug("test")
@@ -101,7 +118,7 @@ class LoggingTests : FunSpec({
             // Remove self from listeners
             Logging.removeListener(listener)
         }
-        Logging.addListener(listener)
+        register(listener)
 
         // When
         Logging.debug("test")

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/backend/CustomEventBackendServiceTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/backend/CustomEventBackendServiceTests.kt
@@ -35,7 +35,7 @@ class CustomEventBackendServiceTests : FunSpec({
     test("track event") {
         // Given
         val spyHttpClient = mockk<IHttpClient>()
-        coEvery { spyHttpClient.post(any(), any()) } returns HttpResponse(202, "")
+        coEvery { spyHttpClient.post(any(), any(), any()) } returns HttpResponse(202, "")
         val customEventBackendService = CustomEventBackendService(spyHttpClient)
 
         // When
@@ -80,6 +80,7 @@ class CustomEventBackendServiceTests : FunSpec({
                     payload.getJSONObject("os_sdk").toString() shouldBeEqual metadata.toJSONObject().toString()
                     payload.getString("proKey1") shouldBeEqual "proVal1"
                 },
+                any(),
             )
         }
     }

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/backend/IdentityBackendServiceTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/backend/IdentityBackendServiceTests.kt
@@ -21,7 +21,7 @@ class IdentityBackendServiceTests : FunSpec({
         val aliasLabel = "onesignal_id"
         val aliasValue = "11111111-1111-1111-1111-111111111111"
         val spyHttpClient = mockk<IHttpClient>()
-        coEvery { spyHttpClient.patch(any(), any()) } returns HttpResponse(200, "{ identity: { aliasKey1: \"aliasValue1\"} }")
+        coEvery { spyHttpClient.patch(any(), any(), any()) } returns HttpResponse(200, "{ identity: { aliasKey1: \"aliasValue1\"} }")
         val identityBackendService = IdentityBackendService(spyHttpClient)
         val identities = mapOf("aliasKey1" to "aliasValue1")
 
@@ -38,6 +38,7 @@ class IdentityBackendServiceTests : FunSpec({
                     it.getJSONObject("identity").has("aliasKey1") shouldBe true
                     it.getJSONObject("identity").getString("aliasKey1") shouldBe "aliasValue1"
                 },
+                any(),
             )
         }
     }
@@ -48,7 +49,7 @@ class IdentityBackendServiceTests : FunSpec({
         val aliasValue = "11111111-1111-1111-1111-111111111111"
         val aliasToDelete = "aliasKey1"
         val spyHttpClient = mockk<IHttpClient>()
-        coEvery { spyHttpClient.delete(any()) } returns HttpResponse(200, "")
+        coEvery { spyHttpClient.delete(any(), any()) } returns HttpResponse(200, "")
         val identityBackendService = IdentityBackendService(spyHttpClient)
 
         // When
@@ -56,7 +57,7 @@ class IdentityBackendServiceTests : FunSpec({
 
         // Then
         coVerify {
-            spyHttpClient.delete("apps/appId/users/by/$aliasLabel/$aliasValue/identity/$aliasToDelete")
+            spyHttpClient.delete("apps/appId/users/by/$aliasLabel/$aliasValue/identity/$aliasToDelete", any())
         }
     }
 })

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/backend/SubscriptionBackendServiceTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/backend/SubscriptionBackendServiceTests.kt
@@ -27,7 +27,7 @@ class SubscriptionBackendServiceTests : FunSpec({
         val aliasLabel = "onesignal_id"
         val aliasValue = "11111111-1111-1111-1111-111111111111"
         val spyHttpClient = mockk<IHttpClient>()
-        coEvery { spyHttpClient.post(any(), any()) } returns HttpResponse(202, "{ \"subscription\": { id: \"subscriptionId\" }, \"ryw_token\": \"123\"}")
+        coEvery { spyHttpClient.post(any(), any(), any()) } returns HttpResponse(202, "{ \"subscription\": { id: \"subscriptionId\" }, \"ryw_token\": \"123\"}")
         val subscriptionBackendService = SubscriptionBackendService(spyHttpClient)
 
         // When
@@ -55,6 +55,7 @@ class SubscriptionBackendServiceTests : FunSpec({
                     sub.getBoolean("enabled") shouldBe true
                     sub.getInt("notification_types") shouldBe 1
                 },
+                any(),
             )
         }
     }
@@ -64,7 +65,7 @@ class SubscriptionBackendServiceTests : FunSpec({
         val aliasLabel = "onesignal_id"
         val aliasValue = "11111111-1111-1111-1111-111111111111"
         val spyHttpClient = mockk<IHttpClient>()
-        coEvery { spyHttpClient.post(any(), any()) } returns HttpResponse(404, "NOT FOUND")
+        coEvery { spyHttpClient.post(any(), any(), any()) } returns HttpResponse(404, "NOT FOUND")
         val subscriptionBackendService = SubscriptionBackendService(spyHttpClient)
 
         // When
@@ -100,6 +101,7 @@ class SubscriptionBackendServiceTests : FunSpec({
                     sub.getBoolean("enabled") shouldBe true
                     sub.getInt("notification_types") shouldBe 1
                 },
+                any(),
             )
         }
     }

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/backend/UserBackendServiceTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/backend/UserBackendServiceTests.kt
@@ -22,7 +22,7 @@ class UserBackendServiceTests : FunSpec({
     test("create user with nothing throws an exception") {
         // Given
         val spyHttpClient = mockk<IHttpClient>()
-        coEvery { spyHttpClient.post(any(), any()) } returns HttpResponse(403, "FORBIDDEN")
+        coEvery { spyHttpClient.post(any(), any(), any()) } returns HttpResponse(403, "FORBIDDEN")
         val userBackendService = UserBackendService(spyHttpClient)
         val identities = mapOf<String, String>()
         val properties = mapOf<String, String>()
@@ -44,7 +44,7 @@ class UserBackendServiceTests : FunSpec({
         val osId = "11111111-1111-1111-1111-111111111111"
         val spyHttpClient = mockk<IHttpClient>()
         coEvery {
-            spyHttpClient.post(any(), any())
+            spyHttpClient.post(any(), any(), any())
         } returns HttpResponse(202, "{identity:{onesignal_id: \"$osId\", aliasLabel1: \"aliasValue1\"}, properties:{timezone_id: \"testTimeZone\", language: \"testLanguage\"}}")
         val userBackendService = UserBackendService(spyHttpClient)
         val identities = mapOf("aliasLabel1" to "aliasValue1")
@@ -70,6 +70,7 @@ class UserBackendServiceTests : FunSpec({
                     it.has("properties") shouldBe true
                     it.has("subscriptions") shouldBe false
                 },
+                any(),
             )
         }
     }
@@ -79,7 +80,7 @@ class UserBackendServiceTests : FunSpec({
         val osId = "11111111-1111-1111-1111-111111111111"
         val spyHttpClient = mockk<IHttpClient>()
         coEvery {
-            spyHttpClient.post(any(), any())
+            spyHttpClient.post(any(), any(), any())
         } returns HttpResponse(202, "{identity:{onesignal_id: \"$osId\"}, subscriptions:[{id:\"subscriptionId1\", type:\"AndroidPush\"}], properties:{timezone_id: \"testTimeZone\", language: \"testLanguage\"}}")
         val userBackendService = UserBackendService(spyHttpClient)
         val identities = mapOf<String, String>()
@@ -109,6 +110,7 @@ class UserBackendServiceTests : FunSpec({
                     it.getJSONArray("subscriptions").getJSONObject(0).has("type") shouldBe true
                     it.getJSONArray("subscriptions").getJSONObject(0).getString("type") shouldBe "AndroidPush"
                 },
+                any(),
             )
         }
     }
@@ -118,7 +120,7 @@ class UserBackendServiceTests : FunSpec({
         val aliasLabel = "onesignal_id"
         val aliasValue = "11111111-1111-1111-1111-111111111111"
         val spyHttpClient = mockk<IHttpClient>()
-        coEvery { spyHttpClient.patch(any(), any()) } returns HttpResponse(202, "{properties: { tags: {tagKey1: tagValue1}}}")
+        coEvery { spyHttpClient.patch(any(), any(), any()) } returns HttpResponse(202, "{properties: { tags: {tagKey1: tagValue1}}}")
         val userBackendService = UserBackendService(spyHttpClient)
         val properties = PropertiesObject(tags = mapOf("tagkey1" to "tagValue1"))
         val propertiesDelta = PropertiesDeltasObject()
@@ -136,6 +138,7 @@ class UserBackendServiceTests : FunSpec({
                     it.getJSONObject("properties").getJSONObject("tags").has("tagkey1") shouldBe true
                     it.getJSONObject("properties").getJSONObject("tags").getString("tagkey1") shouldBe "tagValue1"
                 },
+                any(),
             )
         }
     }
@@ -145,7 +148,7 @@ class UserBackendServiceTests : FunSpec({
         val aliasLabel = "onesignal_id"
         val aliasValue = "11111111-1111-1111-1111-111111111111"
         val spyHttpClient = mockk<IHttpClient>()
-        coEvery { spyHttpClient.patch(any(), any()) } returns HttpResponse(202, "{properties: { tags: {tagKey1: tagValue1}}}")
+        coEvery { spyHttpClient.patch(any(), any(), any()) } returns HttpResponse(202, "{properties: { tags: {tagKey1: tagValue1}}}")
         val userBackendService = UserBackendService(spyHttpClient)
         val properties = PropertiesObject(language = "newLanguage")
         val propertiesDelta = PropertiesDeltasObject()
@@ -162,6 +165,7 @@ class UserBackendServiceTests : FunSpec({
                     it.getJSONObject("properties").has("language") shouldBe true
                     it.getJSONObject("properties").getString("language") shouldBe "newLanguage"
                 },
+                any(),
             )
         }
     }
@@ -171,7 +175,7 @@ class UserBackendServiceTests : FunSpec({
         val aliasLabel = "onesignal_id"
         val aliasValue = "11111111-1111-1111-1111-111111111111"
         val spyHttpClient = mockk<IHttpClient>()
-        coEvery { spyHttpClient.patch(any(), any()) } returns HttpResponse(202, "{properties: { timezone_id: \"America/New_York\"}}")
+        coEvery { spyHttpClient.patch(any(), any(), any()) } returns HttpResponse(202, "{properties: { timezone_id: \"America/New_York\"}}")
         val userBackendService = UserBackendService(spyHttpClient)
         val properties = PropertiesObject(timezoneId = "America/New_York")
         val propertiesDelta = PropertiesDeltasObject()
@@ -188,6 +192,7 @@ class UserBackendServiceTests : FunSpec({
                     it.getJSONObject("properties").has("timezone_id") shouldBe true
                     it.getJSONObject("properties").getString("timezone_id") shouldBe "America/New_York"
                 },
+                any(),
             )
         }
     }
@@ -197,7 +202,7 @@ class UserBackendServiceTests : FunSpec({
         val aliasLabel = "onesignal_id"
         val aliasValue = "11111111-1111-1111-1111-111111111111"
         val spyHttpClient = mockk<IHttpClient>()
-        coEvery { spyHttpClient.patch(any(), any()) } returns HttpResponse(202, "{properties: { country: \"TV\"}}")
+        coEvery { spyHttpClient.patch(any(), any(), any()) } returns HttpResponse(202, "{properties: { country: \"TV\"}}")
         val userBackendService = UserBackendService(spyHttpClient)
         val properties = PropertiesObject(country = "TV")
         val propertiesDelta = PropertiesDeltasObject()
@@ -214,6 +219,7 @@ class UserBackendServiceTests : FunSpec({
                     it.getJSONObject("properties").has("country") shouldBe true
                     it.getJSONObject("properties").getString("country") shouldBe "TV"
                 },
+                any(),
             )
         }
     }
@@ -223,7 +229,7 @@ class UserBackendServiceTests : FunSpec({
         val aliasLabel = "onesignal_id"
         val aliasValue = "11111111-1111-1111-1111-111111111111"
         val spyHttpClient = mockk<IHttpClient>()
-        coEvery { spyHttpClient.patch(any(), any()) } returns HttpResponse(202, "{properties: { lat: 12.34, long: 45.67}}")
+        coEvery { spyHttpClient.patch(any(), any(), any()) } returns HttpResponse(202, "{properties: { lat: 12.34, long: 45.67}}")
         val userBackendService = UserBackendService(spyHttpClient)
         val properties = PropertiesObject(latitude = 12.34, longitude = 45.67)
         val propertiesDelta = PropertiesDeltasObject()
@@ -242,6 +248,7 @@ class UserBackendServiceTests : FunSpec({
                     it.getJSONObject("properties").has("long") shouldBe true
                     it.getJSONObject("properties").getDouble("long") shouldBe 45.67
                 },
+                any(),
             )
         }
     }
@@ -251,7 +258,7 @@ class UserBackendServiceTests : FunSpec({
         val aliasLabel = "onesignal_id"
         val aliasValue = "11111111-1111-1111-1111-111111111111"
         val spyHttpClient = mockk<IHttpClient>()
-        coEvery { spyHttpClient.patch(any(), any()) } returns HttpResponse(202, "{properties: {} }")
+        coEvery { spyHttpClient.patch(any(), any(), any()) } returns HttpResponse(202, "{properties: {} }")
         val userBackendService = UserBackendService(spyHttpClient)
         val properties = PropertiesObject(tags = mapOf("tagkey1" to "tagValue1"))
         val propertiesDelta = PropertiesDeltasObject()
@@ -266,6 +273,7 @@ class UserBackendServiceTests : FunSpec({
                 withArg {
                     it.getBoolean("refresh_device_metadata") shouldBe true
                 },
+                any(),
             )
         }
     }
@@ -275,7 +283,7 @@ class UserBackendServiceTests : FunSpec({
         val aliasLabel = "onesignal_id"
         val aliasValue = "11111111-1111-1111-1111-111111111111"
         val spyHttpClient = mockk<IHttpClient>()
-        coEvery { spyHttpClient.patch(any(), any()) } returns HttpResponse(202, "{properties: {} }")
+        coEvery { spyHttpClient.patch(any(), any(), any()) } returns HttpResponse(202, "{properties: {} }")
         val userBackendService = UserBackendService(spyHttpClient)
         val properties = PropertiesObject(tags = mapOf("tagkey1" to "tagValue1"))
         val propertiesDelta = PropertiesDeltasObject()
@@ -290,6 +298,7 @@ class UserBackendServiceTests : FunSpec({
                 withArg {
                     it.getBoolean("refresh_device_metadata") shouldBe false
                 },
+                any(),
             )
         }
     }
@@ -299,7 +308,7 @@ class UserBackendServiceTests : FunSpec({
         val aliasLabel = "onesignal_id"
         val aliasValue = "11111111-1111-1111-1111-111111111111"
         val spyHttpClient = mockk<IHttpClient>()
-        coEvery { spyHttpClient.patch(any(), any()) } returns HttpResponse(202, "{properties: { }}")
+        coEvery { spyHttpClient.patch(any(), any(), any()) } returns HttpResponse(202, "{properties: { }}")
         val userBackendService = UserBackendService(spyHttpClient)
         val properties = PropertiesObject()
         val propertiesDelta = PropertiesDeltasObject(sessionTime = 1111, sessionCount = 1)
@@ -318,6 +327,7 @@ class UserBackendServiceTests : FunSpec({
                     it.getJSONObject("deltas").has("session_count") shouldBe true
                     it.getJSONObject("deltas").getInt("session_count") shouldBe 1
                 },
+                any(),
             )
         }
     }
@@ -327,7 +337,7 @@ class UserBackendServiceTests : FunSpec({
         val aliasLabel = "onesignal_id"
         val aliasValue = "11111111-1111-1111-1111-111111111111"
         val spyHttpClient = mockk<IHttpClient>()
-        coEvery { spyHttpClient.patch(any(), any()) } returns HttpResponse(202, "{properties: { }}")
+        coEvery { spyHttpClient.patch(any(), any(), any()) } returns HttpResponse(202, "{properties: { }}")
         val userBackendService = UserBackendService(spyHttpClient)
         val properties = PropertiesObject()
         val propertiesDelta =
@@ -366,6 +376,7 @@ class UserBackendServiceTests : FunSpec({
                     it.getJSONObject("deltas").getJSONArray("purchases").getJSONObject(1).has("amount") shouldBe true
                     it.getJSONObject("deltas").getJSONArray("purchases").getJSONObject(1).getDouble("amount") shouldBe 4444
                 },
+                any(),
             )
         }
     }
@@ -375,7 +386,7 @@ class UserBackendServiceTests : FunSpec({
         val aliasLabel = "onesignal_id"
         val aliasValue = "11111111-1111-1111-1111-111111111111"
         val spyHttpClient = mockk<IHttpClient>()
-        coEvery { spyHttpClient.patch(any(), any()) } returns HttpResponse(404, "NOT FOUND")
+        coEvery { spyHttpClient.patch(any(), any(), any()) } returns HttpResponse(404, "NOT FOUND")
         val userBackendService = UserBackendService(spyHttpClient)
         val properties = PropertiesObject(tags = mapOf("tagkey1" to "tagValue1"))
         val propertiesDelta = PropertiesDeltasObject()
@@ -396,7 +407,7 @@ class UserBackendServiceTests : FunSpec({
         val aliasLabel = "onesignal_id"
         val aliasValue = "11111111-1111-1111-1111-111111111111"
         val spyHttpClient = mockk<IHttpClient>()
-        coEvery { spyHttpClient.patch(any(), any()) } returns HttpResponse(403, "FORBIDDEN")
+        coEvery { spyHttpClient.patch(any(), any(), any()) } returns HttpResponse(403, "FORBIDDEN")
         val userBackendService = UserBackendService(spyHttpClient)
         val properties = PropertiesObject(tags = mapOf("tagkey1" to "tagValue1"))
         val propertiesDelta = PropertiesDeltasObject()

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/CustomEventOperationExecutorTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/CustomEventOperationExecutorTests.kt
@@ -9,6 +9,7 @@ import com.onesignal.core.internal.operations.ExecutionResult
 import com.onesignal.core.internal.operations.Operation
 import com.onesignal.mocks.MockHelper
 import com.onesignal.user.internal.customEvents.ICustomEventBackendService
+import com.onesignal.user.internal.operations.ExecutorMocks.Companion.getJwtTokenStore
 import com.onesignal.user.internal.operations.impl.executors.CustomEventOperationExecutor
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.equals.shouldBeEqual
@@ -23,7 +24,7 @@ class CustomEventOperationExecutorTests : FunSpec({
     test("execution of track event operation") {
         // Given
         val mockCustomEventBackendService = mockk<ICustomEventBackendService>()
-        coEvery { mockCustomEventBackendService.sendCustomEvent(any(), any(), any(), any(), any(), any(), any()) } returns ExecutionResponse(ExecutionResult.SUCCESS)
+        coEvery { mockCustomEventBackendService.sendCustomEvent(any(), any(), any(), any(), any(), any(), any(), any()) } returns ExecutionResponse(ExecutionResult.SUCCESS)
 
         val mockApplicationService = MockHelper.applicationService()
         val mockContext = mockk<Context>(relaxed = true)
@@ -36,7 +37,7 @@ class CustomEventOperationExecutorTests : FunSpec({
         val properties = JSONObject().put("key", "value").toString()
 
         val customEventOperationExecutor =
-            CustomEventOperationExecutor(mockCustomEventBackendService, mockApplicationService, mockDeviceService)
+            CustomEventOperationExecutor(mockCustomEventBackendService, mockApplicationService, mockDeviceService, getJwtTokenStore())
         val operations = listOf<Operation>(TrackCustomEventOperation("appId", "onesignalId", null, 1, "event-name", properties))
 
         // When
@@ -60,6 +61,7 @@ class CustomEventOperationExecutorTests : FunSpec({
                     it.deviceModel shouldBe deviceMode
                     it.deviceOS shouldBe deviceOS
                 },
+                null,
             )
         }
     }

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/CustomEventOperationExecutorTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/CustomEventOperationExecutorTests.kt
@@ -3,6 +3,7 @@ package com.onesignal.user.internal.operations
 import android.content.Context
 import android.os.Build
 import com.onesignal.common.OneSignalUtils
+import com.onesignal.common.exceptions.BackendException
 import com.onesignal.core.internal.device.IDeviceService
 import com.onesignal.core.internal.operations.ExecutionResponse
 import com.onesignal.core.internal.operations.ExecutionResult
@@ -65,5 +66,37 @@ class CustomEventOperationExecutorTests : FunSpec({
                 null,
             )
         }
+    }
+
+    test("track event returns FAIL_UNAUTHORIZED on 401 so JWT gets invalidated under IV") {
+        // Given
+        val mockCustomEventBackendService = mockk<ICustomEventBackendService>()
+        coEvery { mockCustomEventBackendService.sendCustomEvent(any(), any(), any(), any(), any(), any(), any(), any()) } throws
+            BackendException(401, "UNAUTHORIZED", retryAfterSeconds = 5)
+
+        val mockApplicationService = MockHelper.applicationService()
+        every { mockApplicationService.appContext } returns mockk<Context>(relaxed = true)
+        val mockDeviceService = MockHelper.deviceService()
+        every { mockDeviceService.deviceType } returns IDeviceService.DeviceType.Android
+
+        val customEventOperationExecutor =
+            CustomEventOperationExecutor(
+                mockCustomEventBackendService,
+                mockApplicationService,
+                mockDeviceService,
+                getJwtTokenStore(),
+                getIdentityVerificationService(newCodePathsRun = true, ivBehaviorActive = true),
+            )
+        val operations =
+            listOf<Operation>(
+                TrackCustomEventOperation("appId", "onesignalId", "ext-1", 1, "event-name", JSONObject().toString()),
+            )
+
+        // When
+        val response = customEventOperationExecutor.execute(operations)
+
+        // Then — must be FAIL_UNAUTHORIZED so OperationRepo.handleFailUnauthorized fires.
+        response.result shouldBe ExecutionResult.FAIL_UNAUTHORIZED
+        response.retryAfterSeconds shouldBe 5
     }
 })

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/CustomEventOperationExecutorTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/CustomEventOperationExecutorTests.kt
@@ -9,6 +9,7 @@ import com.onesignal.core.internal.operations.ExecutionResult
 import com.onesignal.core.internal.operations.Operation
 import com.onesignal.mocks.MockHelper
 import com.onesignal.user.internal.customEvents.ICustomEventBackendService
+import com.onesignal.user.internal.operations.ExecutorMocks.Companion.getIdentityVerificationService
 import com.onesignal.user.internal.operations.ExecutorMocks.Companion.getJwtTokenStore
 import com.onesignal.user.internal.operations.impl.executors.CustomEventOperationExecutor
 import io.kotest.core.spec.style.FunSpec
@@ -37,7 +38,7 @@ class CustomEventOperationExecutorTests : FunSpec({
         val properties = JSONObject().put("key", "value").toString()
 
         val customEventOperationExecutor =
-            CustomEventOperationExecutor(mockCustomEventBackendService, mockApplicationService, mockDeviceService, getJwtTokenStore())
+            CustomEventOperationExecutor(mockCustomEventBackendService, mockApplicationService, mockDeviceService, getJwtTokenStore(), getIdentityVerificationService())
         val operations = listOf<Operation>(TrackCustomEventOperation("appId", "onesignalId", null, 1, "event-name", properties))
 
         // When

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/ExecutorMocks.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/ExecutorMocks.kt
@@ -1,11 +1,14 @@
 package com.onesignal.user.internal.operations
 
 import com.onesignal.core.internal.config.ConfigModelStore
+import com.onesignal.core.internal.config.impl.IdentityVerificationService
 import com.onesignal.core.internal.time.impl.Time
 import com.onesignal.mocks.MockHelper
 import com.onesignal.mocks.MockPreferencesService
 import com.onesignal.user.internal.jwt.JwtTokenStore
 import com.onesignal.user.internal.operations.impl.states.NewRecordsState
+import io.mockk.every
+import io.mockk.mockk
 
 class ExecutorMocks {
     companion object {
@@ -13,5 +16,16 @@ class ExecutorMocks {
 
         /** Real (empty) JWT store backed by a mock preferences service. `getJwt` returns null for all keys. */
         internal fun getJwtTokenStore() = JwtTokenStore(MockPreferencesService())
+
+        /** Mocked [IdentityVerificationService] with both gates returning false by default — IV inactive, new code paths off. */
+        internal fun getIdentityVerificationService(
+            newCodePathsRun: Boolean = false,
+            ivBehaviorActive: Boolean = false,
+        ): IdentityVerificationService {
+            val mock = mockk<IdentityVerificationService>(relaxed = true)
+            every { mock.newCodePathsRun } returns newCodePathsRun
+            every { mock.ivBehaviorActive } returns ivBehaviorActive
+            return mock
+        }
     }
 }

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/ExecutorMocks.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/ExecutorMocks.kt
@@ -3,10 +3,15 @@ package com.onesignal.user.internal.operations
 import com.onesignal.core.internal.config.ConfigModelStore
 import com.onesignal.core.internal.time.impl.Time
 import com.onesignal.mocks.MockHelper
+import com.onesignal.mocks.MockPreferencesService
+import com.onesignal.user.internal.jwt.JwtTokenStore
 import com.onesignal.user.internal.operations.impl.states.NewRecordsState
 
 class ExecutorMocks {
     companion object {
         fun getNewRecordState(configModelStore: ConfigModelStore = MockHelper.configModelStore()) = NewRecordsState(Time(), configModelStore)
+
+        /** Real (empty) JWT store backed by a mock preferences service. `getJwt` returns null for all keys. */
+        internal fun getJwtTokenStore() = JwtTokenStore(MockPreferencesService())
     }
 }

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/ExecutorsIvExtensionsTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/ExecutorsIvExtensionsTests.kt
@@ -1,0 +1,121 @@
+package com.onesignal.user.internal.operations
+
+import com.onesignal.debug.LogLevel
+import com.onesignal.debug.internal.logging.Logging
+import com.onesignal.mocks.MockPreferencesService
+import com.onesignal.user.internal.backend.IdentityConstants
+import com.onesignal.user.internal.jwt.IdentityVerificationGates
+import com.onesignal.user.internal.jwt.JwtRequirement
+import com.onesignal.user.internal.jwt.JwtTokenStore
+import com.onesignal.user.internal.operations.impl.executors.IvBackendParams
+import com.onesignal.user.internal.operations.impl.executors.resolveIvBackendParams
+import com.onesignal.user.internal.operations.impl.executors.resolveIvJwt
+import com.onesignal.user.internal.operations.impl.executors.shouldFailLoginUserFromSubscription
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class ExecutorsIvExtensionsTests : FunSpec({
+    beforeAny {
+        Logging.logLevel = LogLevel.NONE
+    }
+
+    afterEach {
+        IdentityVerificationGates.update(false, JwtRequirement.UNKNOWN, "test-teardown")
+    }
+
+    test("resolveIvBackendParams returns legacy values when ivBehaviorActive is false (Phase 3)") {
+        // Given: new code path on but behavior inactive
+        IdentityVerificationGates.update(true, JwtRequirement.NOT_REQUIRED, "test")
+        val jwtStore = JwtTokenStore(MockPreferencesService())
+        jwtStore.putJwt("ext-1", "jwt-value")
+        val op = LoginUserOperation("app", "os-1", "ext-1", null)
+
+        // When
+        val params = resolveIvBackendParams(op, "os-1", jwtStore)
+
+        // Then: onesignal_id alias, no JWT
+        params shouldBe IvBackendParams(IdentityConstants.ONESIGNAL_ID, "os-1", null)
+    }
+
+    test("resolveIvBackendParams returns external_id alias + JWT when IV active and externalId present") {
+        // Given
+        IdentityVerificationGates.update(false, JwtRequirement.REQUIRED, "test")
+        val jwtStore = JwtTokenStore(MockPreferencesService())
+        jwtStore.putJwt("ext-1", "jwt-value")
+        val op = LoginUserOperation("app", "os-1", "ext-1", null)
+
+        // When
+        val params = resolveIvBackendParams(op, "os-1", jwtStore)
+
+        // Then
+        params shouldBe IvBackendParams(IdentityConstants.EXTERNAL_ID, "ext-1", "jwt-value")
+    }
+
+    test("resolveIvBackendParams falls back to onesignal_id when IV active but externalId null (defensive)") {
+        // Given: IV active, op has no externalId (shouldn't happen per hasValidJwtIfRequired gating)
+        IdentityVerificationGates.update(false, JwtRequirement.REQUIRED, "test")
+        val jwtStore = JwtTokenStore(MockPreferencesService())
+        val op = LoginUserOperation("app", "os-1", null, null)
+
+        // When
+        val params = resolveIvBackendParams(op, "os-1", jwtStore)
+
+        // Then
+        params shouldBe IvBackendParams(IdentityConstants.ONESIGNAL_ID, "os-1", null)
+    }
+
+    test("resolveIvBackendParams returns null JWT when IV active but no JWT stored (defensive)") {
+        // Given: IV active, externalId set, but no JWT in store
+        IdentityVerificationGates.update(false, JwtRequirement.REQUIRED, "test")
+        val jwtStore = JwtTokenStore(MockPreferencesService())
+        val op = LoginUserOperation("app", "os-1", "ext-1", null)
+
+        // When
+        val params = resolveIvBackendParams(op, "os-1", jwtStore)
+
+        // Then: alias still switches to external_id but jwt is null
+        params shouldBe IvBackendParams(IdentityConstants.EXTERNAL_ID, "ext-1", null)
+    }
+
+    test("resolveIvJwt returns null when ivBehaviorActive is false") {
+        // Given
+        IdentityVerificationGates.update(true, JwtRequirement.NOT_REQUIRED, "test")
+        val jwtStore = JwtTokenStore(MockPreferencesService())
+        jwtStore.putJwt("ext-1", "jwt-value")
+        val op = LoginUserOperation("app", "os-1", "ext-1", null)
+
+        // When / Then
+        resolveIvJwt(op, jwtStore) shouldBe null
+    }
+
+    test("resolveIvJwt returns stored JWT when IV active and externalId present") {
+        // Given
+        IdentityVerificationGates.update(false, JwtRequirement.REQUIRED, "test")
+        val jwtStore = JwtTokenStore(MockPreferencesService())
+        jwtStore.putJwt("ext-1", "jwt-value")
+        val op = LoginUserOperation("app", "os-1", "ext-1", null)
+
+        // When / Then
+        resolveIvJwt(op, jwtStore) shouldBe "jwt-value"
+    }
+
+    test("resolveIvJwt returns null when IV active but op is anonymous") {
+        // Given
+        IdentityVerificationGates.update(false, JwtRequirement.REQUIRED, "test")
+        val jwtStore = JwtTokenStore(MockPreferencesService())
+        val op = LoginUserOperation("app", "os-1", null, null)
+
+        // When / Then
+        resolveIvJwt(op, jwtStore) shouldBe null
+    }
+
+    test("shouldFailLoginUserFromSubscription returns false when ivBehaviorActive is false") {
+        IdentityVerificationGates.update(true, JwtRequirement.NOT_REQUIRED, "test")
+        shouldFailLoginUserFromSubscription() shouldBe false
+    }
+
+    test("shouldFailLoginUserFromSubscription returns true when ivBehaviorActive is true") {
+        IdentityVerificationGates.update(false, JwtRequirement.REQUIRED, "test")
+        shouldFailLoginUserFromSubscription() shouldBe true
+    }
+})

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/ExecutorsIvExtensionsTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/ExecutorsIvExtensionsTests.kt
@@ -4,8 +4,6 @@ import com.onesignal.debug.LogLevel
 import com.onesignal.debug.internal.logging.Logging
 import com.onesignal.mocks.MockPreferencesService
 import com.onesignal.user.internal.backend.IdentityConstants
-import com.onesignal.user.internal.jwt.IdentityVerificationGates
-import com.onesignal.user.internal.jwt.JwtRequirement
 import com.onesignal.user.internal.jwt.JwtTokenStore
 import com.onesignal.user.internal.operations.impl.executors.IvBackendParams
 import com.onesignal.user.internal.operations.impl.executors.resolveIvBackendParams
@@ -19,19 +17,14 @@ class ExecutorsIvExtensionsTests : FunSpec({
         Logging.logLevel = LogLevel.NONE
     }
 
-    afterEach {
-        IdentityVerificationGates.update(false, JwtRequirement.UNKNOWN, "test-teardown")
-    }
-
     test("resolveIvBackendParams returns legacy values when ivBehaviorActive is false (Phase 3)") {
         // Given: new code path on but behavior inactive
-        IdentityVerificationGates.update(true, JwtRequirement.NOT_REQUIRED, "test")
         val jwtStore = JwtTokenStore(MockPreferencesService())
         jwtStore.putJwt("ext-1", "jwt-value")
         val op = LoginUserOperation("app", "os-1", "ext-1", null)
 
         // When
-        val params = resolveIvBackendParams(op, "os-1", jwtStore)
+        val params = resolveIvBackendParams(op, "os-1", jwtStore, ivBehaviorActive = false)
 
         // Then: onesignal_id alias, no JWT
         params shouldBe IvBackendParams(IdentityConstants.ONESIGNAL_ID, "os-1", null)
@@ -39,13 +32,12 @@ class ExecutorsIvExtensionsTests : FunSpec({
 
     test("resolveIvBackendParams returns external_id alias + JWT when IV active and externalId present") {
         // Given
-        IdentityVerificationGates.update(false, JwtRequirement.REQUIRED, "test")
         val jwtStore = JwtTokenStore(MockPreferencesService())
         jwtStore.putJwt("ext-1", "jwt-value")
         val op = LoginUserOperation("app", "os-1", "ext-1", null)
 
         // When
-        val params = resolveIvBackendParams(op, "os-1", jwtStore)
+        val params = resolveIvBackendParams(op, "os-1", jwtStore, ivBehaviorActive = true)
 
         // Then
         params shouldBe IvBackendParams(IdentityConstants.EXTERNAL_ID, "ext-1", "jwt-value")
@@ -53,12 +45,11 @@ class ExecutorsIvExtensionsTests : FunSpec({
 
     test("resolveIvBackendParams falls back to onesignal_id when IV active but externalId null (defensive)") {
         // Given: IV active, op has no externalId (shouldn't happen per hasValidJwtIfRequired gating)
-        IdentityVerificationGates.update(false, JwtRequirement.REQUIRED, "test")
         val jwtStore = JwtTokenStore(MockPreferencesService())
         val op = LoginUserOperation("app", "os-1", null, null)
 
         // When
-        val params = resolveIvBackendParams(op, "os-1", jwtStore)
+        val params = resolveIvBackendParams(op, "os-1", jwtStore, ivBehaviorActive = true)
 
         // Then
         params shouldBe IvBackendParams(IdentityConstants.ONESIGNAL_ID, "os-1", null)
@@ -66,56 +57,44 @@ class ExecutorsIvExtensionsTests : FunSpec({
 
     test("resolveIvBackendParams returns null JWT when IV active but no JWT stored (defensive)") {
         // Given: IV active, externalId set, but no JWT in store
-        IdentityVerificationGates.update(false, JwtRequirement.REQUIRED, "test")
         val jwtStore = JwtTokenStore(MockPreferencesService())
         val op = LoginUserOperation("app", "os-1", "ext-1", null)
 
         // When
-        val params = resolveIvBackendParams(op, "os-1", jwtStore)
+        val params = resolveIvBackendParams(op, "os-1", jwtStore, ivBehaviorActive = true)
 
         // Then: alias still switches to external_id but jwt is null
         params shouldBe IvBackendParams(IdentityConstants.EXTERNAL_ID, "ext-1", null)
     }
 
     test("resolveIvJwt returns null when ivBehaviorActive is false") {
-        // Given
-        IdentityVerificationGates.update(true, JwtRequirement.NOT_REQUIRED, "test")
         val jwtStore = JwtTokenStore(MockPreferencesService())
         jwtStore.putJwt("ext-1", "jwt-value")
         val op = LoginUserOperation("app", "os-1", "ext-1", null)
 
-        // When / Then
-        resolveIvJwt(op, jwtStore) shouldBe null
+        resolveIvJwt(op, jwtStore, ivBehaviorActive = false) shouldBe null
     }
 
     test("resolveIvJwt returns stored JWT when IV active and externalId present") {
-        // Given
-        IdentityVerificationGates.update(false, JwtRequirement.REQUIRED, "test")
         val jwtStore = JwtTokenStore(MockPreferencesService())
         jwtStore.putJwt("ext-1", "jwt-value")
         val op = LoginUserOperation("app", "os-1", "ext-1", null)
 
-        // When / Then
-        resolveIvJwt(op, jwtStore) shouldBe "jwt-value"
+        resolveIvJwt(op, jwtStore, ivBehaviorActive = true) shouldBe "jwt-value"
     }
 
     test("resolveIvJwt returns null when IV active but op is anonymous") {
-        // Given
-        IdentityVerificationGates.update(false, JwtRequirement.REQUIRED, "test")
         val jwtStore = JwtTokenStore(MockPreferencesService())
         val op = LoginUserOperation("app", "os-1", null, null)
 
-        // When / Then
-        resolveIvJwt(op, jwtStore) shouldBe null
+        resolveIvJwt(op, jwtStore, ivBehaviorActive = true) shouldBe null
     }
 
     test("shouldFailLoginUserFromSubscription returns false when ivBehaviorActive is false") {
-        IdentityVerificationGates.update(true, JwtRequirement.NOT_REQUIRED, "test")
-        shouldFailLoginUserFromSubscription() shouldBe false
+        shouldFailLoginUserFromSubscription(ivBehaviorActive = false) shouldBe false
     }
 
     test("shouldFailLoginUserFromSubscription returns true when ivBehaviorActive is true") {
-        IdentityVerificationGates.update(false, JwtRequirement.REQUIRED, "test")
-        shouldFailLoginUserFromSubscription() shouldBe true
+        shouldFailLoginUserFromSubscription(ivBehaviorActive = true) shouldBe true
     }
 })

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/IdentityOperationExecutorTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/IdentityOperationExecutorTests.kt
@@ -5,15 +5,14 @@ import com.onesignal.common.modeling.ModelChangeTags
 import com.onesignal.core.internal.operations.ExecutionResult
 import com.onesignal.core.internal.operations.Operation
 import com.onesignal.mocks.MockHelper
+import com.onesignal.mocks.MockPreferencesService
 import com.onesignal.user.internal.backend.IIdentityBackendService
 import com.onesignal.user.internal.backend.IdentityConstants
-import com.onesignal.mocks.MockPreferencesService
 import com.onesignal.user.internal.builduser.IRebuildUserService
 import com.onesignal.user.internal.identity.IdentityModel
 import com.onesignal.user.internal.identity.IdentityModelStore
-import com.onesignal.user.internal.jwt.IdentityVerificationGates
-import com.onesignal.user.internal.jwt.JwtRequirement
 import com.onesignal.user.internal.jwt.JwtTokenStore
+import com.onesignal.user.internal.operations.ExecutorMocks.Companion.getIdentityVerificationService
 import com.onesignal.user.internal.operations.ExecutorMocks.Companion.getJwtTokenStore
 import com.onesignal.user.internal.operations.ExecutorMocks.Companion.getNewRecordState
 import com.onesignal.user.internal.operations.impl.executors.IdentityOperationExecutor
@@ -44,7 +43,7 @@ class IdentityOperationExecutorTests : FunSpec({
         val mockBuildUserService = mockk<IRebuildUserService>()
 
         val identityOperationExecutor =
-            IdentityOperationExecutor(mockIdentityBackendService, mockIdentityModelStore, mockBuildUserService, getNewRecordState(), getJwtTokenStore())
+            IdentityOperationExecutor(mockIdentityBackendService, mockIdentityModelStore, mockBuildUserService, getNewRecordState(), getJwtTokenStore(), getIdentityVerificationService())
         val operations = listOf<Operation>(SetAliasOperation("appId", "onesignalId", null, "aliasKey1", "aliasValue1"))
 
         // When
@@ -74,7 +73,7 @@ class IdentityOperationExecutorTests : FunSpec({
         val mockBuildUserService = mockk<IRebuildUserService>()
 
         val identityOperationExecutor =
-            IdentityOperationExecutor(mockIdentityBackendService, mockIdentityModelStore, mockBuildUserService, getNewRecordState(), getJwtTokenStore())
+            IdentityOperationExecutor(mockIdentityBackendService, mockIdentityModelStore, mockBuildUserService, getNewRecordState(), getJwtTokenStore(), getIdentityVerificationService())
         val operations = listOf<Operation>(SetAliasOperation("appId", "onesignalId", null, "aliasKey1", "aliasValue1"))
 
         // When
@@ -95,7 +94,7 @@ class IdentityOperationExecutorTests : FunSpec({
         val mockBuildUserService = mockk<IRebuildUserService>()
 
         val identityOperationExecutor =
-            IdentityOperationExecutor(mockIdentityBackendService, mockIdentityModelStore, mockBuildUserService, getNewRecordState(), getJwtTokenStore())
+            IdentityOperationExecutor(mockIdentityBackendService, mockIdentityModelStore, mockBuildUserService, getNewRecordState(), getJwtTokenStore(), getIdentityVerificationService())
         val operations = listOf<Operation>(SetAliasOperation("appId", "onesignalId", null, "aliasKey1", "aliasValue1"))
 
         // When
@@ -116,7 +115,7 @@ class IdentityOperationExecutorTests : FunSpec({
         every { mockBuildUserService.getRebuildOperationsIfCurrentUser(any(), any()) } returns null
 
         val identityOperationExecutor =
-            IdentityOperationExecutor(mockIdentityBackendService, mockIdentityModelStore, mockBuildUserService, getNewRecordState(), getJwtTokenStore())
+            IdentityOperationExecutor(mockIdentityBackendService, mockIdentityModelStore, mockBuildUserService, getNewRecordState(), getJwtTokenStore(), getIdentityVerificationService())
         val operations = listOf<Operation>(SetAliasOperation("appId", "onesignalId", null, "aliasKey1", "aliasValue1"))
 
         // When
@@ -139,7 +138,7 @@ class IdentityOperationExecutorTests : FunSpec({
         val mockConfigModelStore = MockHelper.configModelStore().also { it.model.opRepoPostCreateRetryUpTo = 1_000 }
         val newRecordState = getNewRecordState(mockConfigModelStore).also { it.add("onesignalId") }
         val identityOperationExecutor =
-            IdentityOperationExecutor(mockIdentityBackendService, mockIdentityModelStore, mockBuildUserService, newRecordState, getJwtTokenStore())
+            IdentityOperationExecutor(mockIdentityBackendService, mockIdentityModelStore, mockBuildUserService, newRecordState, getJwtTokenStore(), getIdentityVerificationService())
         val operations = listOf<Operation>(SetAliasOperation("appId", "onesignalId", null, "aliasKey1", "aliasValue1"))
 
         // When
@@ -165,7 +164,7 @@ class IdentityOperationExecutorTests : FunSpec({
         val mockBuildUserService = mockk<IRebuildUserService>()
 
         val identityOperationExecutor =
-            IdentityOperationExecutor(mockIdentityBackendService, mockIdentityModelStore, mockBuildUserService, getNewRecordState(), getJwtTokenStore())
+            IdentityOperationExecutor(mockIdentityBackendService, mockIdentityModelStore, mockBuildUserService, getNewRecordState(), getJwtTokenStore(), getIdentityVerificationService())
         val operations = listOf<Operation>(DeleteAliasOperation("appId", "onesignalId", null, "aliasKey1"))
 
         // When
@@ -188,7 +187,7 @@ class IdentityOperationExecutorTests : FunSpec({
         val mockBuildUserService = mockk<IRebuildUserService>()
 
         val identityOperationExecutor =
-            IdentityOperationExecutor(mockIdentityBackendService, mockIdentityModelStore, mockBuildUserService, getNewRecordState(), getJwtTokenStore())
+            IdentityOperationExecutor(mockIdentityBackendService, mockIdentityModelStore, mockBuildUserService, getNewRecordState(), getJwtTokenStore(), getIdentityVerificationService())
         val operations = listOf<Operation>(DeleteAliasOperation("appId", "onesignalId", null, "aliasKey1"))
 
         // When
@@ -208,7 +207,7 @@ class IdentityOperationExecutorTests : FunSpec({
         val mockBuildUserService = mockk<IRebuildUserService>()
 
         val identityOperationExecutor =
-            IdentityOperationExecutor(mockIdentityBackendService, mockIdentityModelStore, mockBuildUserService, getNewRecordState(), getJwtTokenStore())
+            IdentityOperationExecutor(mockIdentityBackendService, mockIdentityModelStore, mockBuildUserService, getNewRecordState(), getJwtTokenStore(), getIdentityVerificationService())
         val operations = listOf<Operation>(DeleteAliasOperation("appId", "onesignalId", null, "aliasKey1"))
 
         // When
@@ -230,7 +229,7 @@ class IdentityOperationExecutorTests : FunSpec({
         val mockBuildUserService = mockk<IRebuildUserService>()
 
         val identityOperationExecutor =
-            IdentityOperationExecutor(mockIdentityBackendService, mockIdentityModelStore, mockBuildUserService, getNewRecordState(), getJwtTokenStore())
+            IdentityOperationExecutor(mockIdentityBackendService, mockIdentityModelStore, mockBuildUserService, getNewRecordState(), getJwtTokenStore(), getIdentityVerificationService())
         val operations = listOf<Operation>(DeleteAliasOperation("appId", "onesignalId", null, "aliasKey1"))
 
         // When
@@ -255,7 +254,7 @@ class IdentityOperationExecutorTests : FunSpec({
         val mockConfigModelStore = MockHelper.configModelStore().also { it.model.opRepoPostCreateRetryUpTo = 1_000 }
         val newRecordState = getNewRecordState(mockConfigModelStore).also { it.add("onesignalId") }
         val identityOperationExecutor =
-            IdentityOperationExecutor(mockIdentityBackendService, mockIdentityModelStore, mockBuildUserService, newRecordState, getJwtTokenStore())
+            IdentityOperationExecutor(mockIdentityBackendService, mockIdentityModelStore, mockBuildUserService, newRecordState, getJwtTokenStore(), getIdentityVerificationService())
         val operations = listOf<Operation>(DeleteAliasOperation("appId", "onesignalId", null, "aliasKey1"))
 
         // When
@@ -267,86 +266,82 @@ class IdentityOperationExecutorTests : FunSpec({
 
     test("set alias uses external_id alias and attaches JWT when IV active") {
         // Given
-        IdentityVerificationGates.update(false, JwtRequirement.REQUIRED, "test")
-        try {
-            val mockIdentityBackendService = mockk<IIdentityBackendService>()
-            coEvery { mockIdentityBackendService.setAlias(any(), any(), any(), any(), any()) } returns mapOf()
+        val mockIdentityBackendService = mockk<IIdentityBackendService>()
+        coEvery { mockIdentityBackendService.setAlias(any(), any(), any(), any(), any()) } returns mapOf()
 
-            val mockIdentityModel = mockk<IdentityModel>()
-            every { mockIdentityModel.onesignalId } returns "onesignalId"
-            every { mockIdentityModel.setStringProperty(any(), any(), any()) } just runs
+        val mockIdentityModel = mockk<IdentityModel>()
+        every { mockIdentityModel.onesignalId } returns "onesignalId"
+        every { mockIdentityModel.setStringProperty(any(), any(), any()) } just runs
 
-            val mockIdentityModelStore = mockk<IdentityModelStore>()
-            every { mockIdentityModelStore.model } returns mockIdentityModel
+        val mockIdentityModelStore = mockk<IdentityModelStore>()
+        every { mockIdentityModelStore.model } returns mockIdentityModel
 
-            val mockBuildUserService = mockk<IRebuildUserService>()
+        val mockBuildUserService = mockk<IRebuildUserService>()
 
-            val jwtStore = JwtTokenStore(MockPreferencesService())
-            jwtStore.putJwt("ext-1", "the-jwt")
+        val jwtStore = JwtTokenStore(MockPreferencesService())
+        jwtStore.putJwt("ext-1", "the-jwt")
 
-            val identityOperationExecutor =
-                IdentityOperationExecutor(mockIdentityBackendService, mockIdentityModelStore, mockBuildUserService, getNewRecordState(), jwtStore)
-            val operations = listOf<Operation>(SetAliasOperation("appId", "onesignalId", "ext-1", "aliasKey1", "aliasValue1"))
+        val identityOperationExecutor =
+            IdentityOperationExecutor(
+                mockIdentityBackendService, mockIdentityModelStore, mockBuildUserService, getNewRecordState(), jwtStore,
+                getIdentityVerificationService(newCodePathsRun = true, ivBehaviorActive = true),
+            )
+        val operations = listOf<Operation>(SetAliasOperation("appId", "onesignalId", "ext-1", "aliasKey1", "aliasValue1"))
 
-            // When
-            val response = identityOperationExecutor.execute(operations)
+        // When
+        val response = identityOperationExecutor.execute(operations)
 
-            // Then
-            response.result shouldBe ExecutionResult.SUCCESS
-            coVerify(exactly = 1) {
-                mockIdentityBackendService.setAlias(
-                    "appId",
-                    IdentityConstants.EXTERNAL_ID,
-                    "ext-1",
-                    mapOf("aliasKey1" to "aliasValue1"),
-                    "the-jwt",
-                )
-            }
-        } finally {
-            IdentityVerificationGates.update(false, JwtRequirement.UNKNOWN, "test-teardown")
+        // Then
+        response.result shouldBe ExecutionResult.SUCCESS
+        coVerify(exactly = 1) {
+            mockIdentityBackendService.setAlias(
+                "appId",
+                IdentityConstants.EXTERNAL_ID,
+                "ext-1",
+                mapOf("aliasKey1" to "aliasValue1"),
+                "the-jwt",
+            )
         }
     }
 
     test("set alias keeps onesignal_id alias and null JWT in Phase 3 (newCodePathsRun + ivBehaviorActive=false)") {
         // Given: new code path on but IV behavior off — extension runs but must return legacy values
-        IdentityVerificationGates.update(true, JwtRequirement.NOT_REQUIRED, "test")
-        try {
-            val mockIdentityBackendService = mockk<IIdentityBackendService>()
-            coEvery { mockIdentityBackendService.setAlias(any(), any(), any(), any(), any()) } returns mapOf()
+        val mockIdentityBackendService = mockk<IIdentityBackendService>()
+        coEvery { mockIdentityBackendService.setAlias(any(), any(), any(), any(), any()) } returns mapOf()
 
-            val mockIdentityModel = mockk<IdentityModel>()
-            every { mockIdentityModel.onesignalId } returns "onesignalId"
-            every { mockIdentityModel.setStringProperty(any(), any(), any()) } just runs
+        val mockIdentityModel = mockk<IdentityModel>()
+        every { mockIdentityModel.onesignalId } returns "onesignalId"
+        every { mockIdentityModel.setStringProperty(any(), any(), any()) } just runs
 
-            val mockIdentityModelStore = mockk<IdentityModelStore>()
-            every { mockIdentityModelStore.model } returns mockIdentityModel
+        val mockIdentityModelStore = mockk<IdentityModelStore>()
+        every { mockIdentityModelStore.model } returns mockIdentityModel
 
-            val mockBuildUserService = mockk<IRebuildUserService>()
+        val mockBuildUserService = mockk<IRebuildUserService>()
 
-            val jwtStore = JwtTokenStore(MockPreferencesService())
-            // A JWT is stored; Phase 3 must NOT attach it.
-            jwtStore.putJwt("ext-1", "the-jwt")
+        val jwtStore = JwtTokenStore(MockPreferencesService())
+        // A JWT is stored; Phase 3 must NOT attach it.
+        jwtStore.putJwt("ext-1", "the-jwt")
 
-            val identityOperationExecutor =
-                IdentityOperationExecutor(mockIdentityBackendService, mockIdentityModelStore, mockBuildUserService, getNewRecordState(), jwtStore)
-            val operations = listOf<Operation>(SetAliasOperation("appId", "onesignalId", "ext-1", "aliasKey1", "aliasValue1"))
+        val identityOperationExecutor =
+            IdentityOperationExecutor(
+                mockIdentityBackendService, mockIdentityModelStore, mockBuildUserService, getNewRecordState(), jwtStore,
+                getIdentityVerificationService(newCodePathsRun = true, ivBehaviorActive = false),
+            )
+        val operations = listOf<Operation>(SetAliasOperation("appId", "onesignalId", "ext-1", "aliasKey1", "aliasValue1"))
 
-            // When
-            val response = identityOperationExecutor.execute(operations)
+        // When
+        val response = identityOperationExecutor.execute(operations)
 
-            // Then: onesignal_id alias, null JWT
-            response.result shouldBe ExecutionResult.SUCCESS
-            coVerify(exactly = 1) {
-                mockIdentityBackendService.setAlias(
-                    "appId",
-                    IdentityConstants.ONESIGNAL_ID,
-                    "onesignalId",
-                    mapOf("aliasKey1" to "aliasValue1"),
-                    null,
-                )
-            }
-        } finally {
-            IdentityVerificationGates.update(false, JwtRequirement.UNKNOWN, "test-teardown")
+        // Then: onesignal_id alias, null JWT
+        response.result shouldBe ExecutionResult.SUCCESS
+        coVerify(exactly = 1) {
+            mockIdentityBackendService.setAlias(
+                "appId",
+                IdentityConstants.ONESIGNAL_ID,
+                "onesignalId",
+                mapOf("aliasKey1" to "aliasValue1"),
+                null,
+            )
         }
     }
 })

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/IdentityOperationExecutorTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/IdentityOperationExecutorTests.kt
@@ -7,9 +7,14 @@ import com.onesignal.core.internal.operations.Operation
 import com.onesignal.mocks.MockHelper
 import com.onesignal.user.internal.backend.IIdentityBackendService
 import com.onesignal.user.internal.backend.IdentityConstants
+import com.onesignal.mocks.MockPreferencesService
 import com.onesignal.user.internal.builduser.IRebuildUserService
 import com.onesignal.user.internal.identity.IdentityModel
 import com.onesignal.user.internal.identity.IdentityModelStore
+import com.onesignal.user.internal.jwt.IdentityVerificationGates
+import com.onesignal.user.internal.jwt.JwtRequirement
+import com.onesignal.user.internal.jwt.JwtTokenStore
+import com.onesignal.user.internal.operations.ExecutorMocks.Companion.getJwtTokenStore
 import com.onesignal.user.internal.operations.ExecutorMocks.Companion.getNewRecordState
 import com.onesignal.user.internal.operations.impl.executors.IdentityOperationExecutor
 import io.kotest.core.spec.style.FunSpec
@@ -39,7 +44,7 @@ class IdentityOperationExecutorTests : FunSpec({
         val mockBuildUserService = mockk<IRebuildUserService>()
 
         val identityOperationExecutor =
-            IdentityOperationExecutor(mockIdentityBackendService, mockIdentityModelStore, mockBuildUserService, getNewRecordState())
+            IdentityOperationExecutor(mockIdentityBackendService, mockIdentityModelStore, mockBuildUserService, getNewRecordState(), getJwtTokenStore())
         val operations = listOf<Operation>(SetAliasOperation("appId", "onesignalId", null, "aliasKey1", "aliasValue1"))
 
         // When
@@ -69,7 +74,7 @@ class IdentityOperationExecutorTests : FunSpec({
         val mockBuildUserService = mockk<IRebuildUserService>()
 
         val identityOperationExecutor =
-            IdentityOperationExecutor(mockIdentityBackendService, mockIdentityModelStore, mockBuildUserService, getNewRecordState())
+            IdentityOperationExecutor(mockIdentityBackendService, mockIdentityModelStore, mockBuildUserService, getNewRecordState(), getJwtTokenStore())
         val operations = listOf<Operation>(SetAliasOperation("appId", "onesignalId", null, "aliasKey1", "aliasValue1"))
 
         // When
@@ -90,7 +95,7 @@ class IdentityOperationExecutorTests : FunSpec({
         val mockBuildUserService = mockk<IRebuildUserService>()
 
         val identityOperationExecutor =
-            IdentityOperationExecutor(mockIdentityBackendService, mockIdentityModelStore, mockBuildUserService, getNewRecordState())
+            IdentityOperationExecutor(mockIdentityBackendService, mockIdentityModelStore, mockBuildUserService, getNewRecordState(), getJwtTokenStore())
         val operations = listOf<Operation>(SetAliasOperation("appId", "onesignalId", null, "aliasKey1", "aliasValue1"))
 
         // When
@@ -111,7 +116,7 @@ class IdentityOperationExecutorTests : FunSpec({
         every { mockBuildUserService.getRebuildOperationsIfCurrentUser(any(), any()) } returns null
 
         val identityOperationExecutor =
-            IdentityOperationExecutor(mockIdentityBackendService, mockIdentityModelStore, mockBuildUserService, getNewRecordState())
+            IdentityOperationExecutor(mockIdentityBackendService, mockIdentityModelStore, mockBuildUserService, getNewRecordState(), getJwtTokenStore())
         val operations = listOf<Operation>(SetAliasOperation("appId", "onesignalId", null, "aliasKey1", "aliasValue1"))
 
         // When
@@ -134,7 +139,7 @@ class IdentityOperationExecutorTests : FunSpec({
         val mockConfigModelStore = MockHelper.configModelStore().also { it.model.opRepoPostCreateRetryUpTo = 1_000 }
         val newRecordState = getNewRecordState(mockConfigModelStore).also { it.add("onesignalId") }
         val identityOperationExecutor =
-            IdentityOperationExecutor(mockIdentityBackendService, mockIdentityModelStore, mockBuildUserService, newRecordState)
+            IdentityOperationExecutor(mockIdentityBackendService, mockIdentityModelStore, mockBuildUserService, newRecordState, getJwtTokenStore())
         val operations = listOf<Operation>(SetAliasOperation("appId", "onesignalId", null, "aliasKey1", "aliasValue1"))
 
         // When
@@ -160,7 +165,7 @@ class IdentityOperationExecutorTests : FunSpec({
         val mockBuildUserService = mockk<IRebuildUserService>()
 
         val identityOperationExecutor =
-            IdentityOperationExecutor(mockIdentityBackendService, mockIdentityModelStore, mockBuildUserService, getNewRecordState())
+            IdentityOperationExecutor(mockIdentityBackendService, mockIdentityModelStore, mockBuildUserService, getNewRecordState(), getJwtTokenStore())
         val operations = listOf<Operation>(DeleteAliasOperation("appId", "onesignalId", null, "aliasKey1"))
 
         // When
@@ -183,7 +188,7 @@ class IdentityOperationExecutorTests : FunSpec({
         val mockBuildUserService = mockk<IRebuildUserService>()
 
         val identityOperationExecutor =
-            IdentityOperationExecutor(mockIdentityBackendService, mockIdentityModelStore, mockBuildUserService, getNewRecordState())
+            IdentityOperationExecutor(mockIdentityBackendService, mockIdentityModelStore, mockBuildUserService, getNewRecordState(), getJwtTokenStore())
         val operations = listOf<Operation>(DeleteAliasOperation("appId", "onesignalId", null, "aliasKey1"))
 
         // When
@@ -203,7 +208,7 @@ class IdentityOperationExecutorTests : FunSpec({
         val mockBuildUserService = mockk<IRebuildUserService>()
 
         val identityOperationExecutor =
-            IdentityOperationExecutor(mockIdentityBackendService, mockIdentityModelStore, mockBuildUserService, getNewRecordState())
+            IdentityOperationExecutor(mockIdentityBackendService, mockIdentityModelStore, mockBuildUserService, getNewRecordState(), getJwtTokenStore())
         val operations = listOf<Operation>(DeleteAliasOperation("appId", "onesignalId", null, "aliasKey1"))
 
         // When
@@ -225,7 +230,7 @@ class IdentityOperationExecutorTests : FunSpec({
         val mockBuildUserService = mockk<IRebuildUserService>()
 
         val identityOperationExecutor =
-            IdentityOperationExecutor(mockIdentityBackendService, mockIdentityModelStore, mockBuildUserService, getNewRecordState())
+            IdentityOperationExecutor(mockIdentityBackendService, mockIdentityModelStore, mockBuildUserService, getNewRecordState(), getJwtTokenStore())
         val operations = listOf<Operation>(DeleteAliasOperation("appId", "onesignalId", null, "aliasKey1"))
 
         // When
@@ -250,7 +255,7 @@ class IdentityOperationExecutorTests : FunSpec({
         val mockConfigModelStore = MockHelper.configModelStore().also { it.model.opRepoPostCreateRetryUpTo = 1_000 }
         val newRecordState = getNewRecordState(mockConfigModelStore).also { it.add("onesignalId") }
         val identityOperationExecutor =
-            IdentityOperationExecutor(mockIdentityBackendService, mockIdentityModelStore, mockBuildUserService, newRecordState)
+            IdentityOperationExecutor(mockIdentityBackendService, mockIdentityModelStore, mockBuildUserService, newRecordState, getJwtTokenStore())
         val operations = listOf<Operation>(DeleteAliasOperation("appId", "onesignalId", null, "aliasKey1"))
 
         // When
@@ -258,5 +263,90 @@ class IdentityOperationExecutorTests : FunSpec({
 
         // Then
         response.result shouldBe ExecutionResult.FAIL_RETRY
+    }
+
+    test("set alias uses external_id alias and attaches JWT when IV active") {
+        // Given
+        IdentityVerificationGates.update(false, JwtRequirement.REQUIRED, "test")
+        try {
+            val mockIdentityBackendService = mockk<IIdentityBackendService>()
+            coEvery { mockIdentityBackendService.setAlias(any(), any(), any(), any(), any()) } returns mapOf()
+
+            val mockIdentityModel = mockk<IdentityModel>()
+            every { mockIdentityModel.onesignalId } returns "onesignalId"
+            every { mockIdentityModel.setStringProperty(any(), any(), any()) } just runs
+
+            val mockIdentityModelStore = mockk<IdentityModelStore>()
+            every { mockIdentityModelStore.model } returns mockIdentityModel
+
+            val mockBuildUserService = mockk<IRebuildUserService>()
+
+            val jwtStore = JwtTokenStore(MockPreferencesService())
+            jwtStore.putJwt("ext-1", "the-jwt")
+
+            val identityOperationExecutor =
+                IdentityOperationExecutor(mockIdentityBackendService, mockIdentityModelStore, mockBuildUserService, getNewRecordState(), jwtStore)
+            val operations = listOf<Operation>(SetAliasOperation("appId", "onesignalId", "ext-1", "aliasKey1", "aliasValue1"))
+
+            // When
+            val response = identityOperationExecutor.execute(operations)
+
+            // Then
+            response.result shouldBe ExecutionResult.SUCCESS
+            coVerify(exactly = 1) {
+                mockIdentityBackendService.setAlias(
+                    "appId",
+                    IdentityConstants.EXTERNAL_ID,
+                    "ext-1",
+                    mapOf("aliasKey1" to "aliasValue1"),
+                    "the-jwt",
+                )
+            }
+        } finally {
+            IdentityVerificationGates.update(false, JwtRequirement.UNKNOWN, "test-teardown")
+        }
+    }
+
+    test("set alias keeps onesignal_id alias and null JWT in Phase 3 (newCodePathsRun + ivBehaviorActive=false)") {
+        // Given: new code path on but IV behavior off — extension runs but must return legacy values
+        IdentityVerificationGates.update(true, JwtRequirement.NOT_REQUIRED, "test")
+        try {
+            val mockIdentityBackendService = mockk<IIdentityBackendService>()
+            coEvery { mockIdentityBackendService.setAlias(any(), any(), any(), any(), any()) } returns mapOf()
+
+            val mockIdentityModel = mockk<IdentityModel>()
+            every { mockIdentityModel.onesignalId } returns "onesignalId"
+            every { mockIdentityModel.setStringProperty(any(), any(), any()) } just runs
+
+            val mockIdentityModelStore = mockk<IdentityModelStore>()
+            every { mockIdentityModelStore.model } returns mockIdentityModel
+
+            val mockBuildUserService = mockk<IRebuildUserService>()
+
+            val jwtStore = JwtTokenStore(MockPreferencesService())
+            // A JWT is stored; Phase 3 must NOT attach it.
+            jwtStore.putJwt("ext-1", "the-jwt")
+
+            val identityOperationExecutor =
+                IdentityOperationExecutor(mockIdentityBackendService, mockIdentityModelStore, mockBuildUserService, getNewRecordState(), jwtStore)
+            val operations = listOf<Operation>(SetAliasOperation("appId", "onesignalId", "ext-1", "aliasKey1", "aliasValue1"))
+
+            // When
+            val response = identityOperationExecutor.execute(operations)
+
+            // Then: onesignal_id alias, null JWT
+            response.result shouldBe ExecutionResult.SUCCESS
+            coVerify(exactly = 1) {
+                mockIdentityBackendService.setAlias(
+                    "appId",
+                    IdentityConstants.ONESIGNAL_ID,
+                    "onesignalId",
+                    mapOf("aliasKey1" to "aliasValue1"),
+                    null,
+                )
+            }
+        } finally {
+            IdentityVerificationGates.update(false, JwtRequirement.UNKNOWN, "test-teardown")
+        }
     }
 })

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/LoginUserOperationExecutorTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/LoginUserOperationExecutorTests.kt
@@ -3,6 +3,7 @@ package com.onesignal.user.internal.operations
 import br.com.colman.kotest.android.extensions.robolectric.RobolectricTest
 import com.onesignal.common.exceptions.BackendException
 import com.onesignal.core.internal.operations.ExecutionResponse
+import com.onesignal.user.internal.operations.ExecutorMocks.Companion.getJwtTokenStore
 import com.onesignal.core.internal.operations.ExecutionResult
 import com.onesignal.core.internal.operations.Operation
 import com.onesignal.mocks.AndroidMockHelper
@@ -77,6 +78,7 @@ class LoginUserOperationExecutorTests : FunSpec({
                 mockSubscriptionsModelStore,
                 MockHelper.configModelStore(),
                 MockHelper.languageContext(),
+                getJwtTokenStore(),
             )
         val operations =
             listOf<Operation>(
@@ -121,6 +123,7 @@ class LoginUserOperationExecutorTests : FunSpec({
                 mockSubscriptionsModelStore,
                 MockHelper.configModelStore(),
                 MockHelper.languageContext(),
+                getJwtTokenStore(),
             )
         val operations =
             listOf<Operation>(
@@ -149,7 +152,7 @@ class LoginUserOperationExecutorTests : FunSpec({
         val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
 
         val loginUserOperationExecutor =
-            LoginUserOperationExecutor(mockIdentityOperationExecutor, AndroidMockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext())
+            LoginUserOperationExecutor(mockIdentityOperationExecutor, AndroidMockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext(), getJwtTokenStore())
         val operations =
             listOf<Operation>(
                 LoginUserOperation(appId, localOneSignalId, null, null),
@@ -177,7 +180,7 @@ class LoginUserOperationExecutorTests : FunSpec({
         val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
 
         val loginUserOperationExecutor =
-            LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext())
+            LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext(), getJwtTokenStore())
         val operations = listOf<Operation>(LoginUserOperation(appId, localOneSignalId, "externalId", null))
 
         // When
@@ -215,6 +218,7 @@ class LoginUserOperationExecutorTests : FunSpec({
                 mockSubscriptionsModelStore,
                 MockHelper.configModelStore(),
                 MockHelper.languageContext(),
+                getJwtTokenStore(),
             )
         val operations = listOf<Operation>(LoginUserOperation(appId, localOneSignalId, "externalId", null))
 
@@ -243,7 +247,7 @@ class LoginUserOperationExecutorTests : FunSpec({
         val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
 
         val loginUserOperationExecutor =
-            LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext())
+            LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext(), getJwtTokenStore())
         val operations = listOf<Operation>(LoginUserOperation(appId, localOneSignalId, "externalId", "existingOneSignalId"))
 
         // When
@@ -279,7 +283,7 @@ class LoginUserOperationExecutorTests : FunSpec({
         val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
 
         val loginUserOperationExecutor =
-            LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext())
+            LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext(), getJwtTokenStore())
         val operations = listOf<Operation>(LoginUserOperation(appId, localOneSignalId, "externalId", "existingOneSignalId"))
 
         // When
@@ -315,7 +319,7 @@ class LoginUserOperationExecutorTests : FunSpec({
         val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
 
         val loginUserOperationExecutor =
-            LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext())
+            LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext(), getJwtTokenStore())
         val operations = listOf<Operation>(LoginUserOperation(appId, localOneSignalId, "externalId", "existingOneSignalId"))
 
         // When
@@ -353,7 +357,7 @@ class LoginUserOperationExecutorTests : FunSpec({
         val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
 
         val loginUserOperationExecutor =
-            LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext())
+            LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext(), getJwtTokenStore())
         val operations = listOf<Operation>(LoginUserOperation(appId, localOneSignalId, "externalId", "existingOneSignalId"))
 
         // When
@@ -404,6 +408,7 @@ class LoginUserOperationExecutorTests : FunSpec({
                 mockSubscriptionsModelStore,
                 MockHelper.configModelStore(),
                 MockHelper.languageContext(),
+                getJwtTokenStore(),
             )
         val operations =
             listOf<Operation>(
@@ -508,6 +513,7 @@ class LoginUserOperationExecutorTests : FunSpec({
                 mockSubscriptionsModelStore,
                 MockHelper.configModelStore(),
                 MockHelper.languageContext(),
+                getJwtTokenStore(),
             )
         val operations =
             listOf<Operation>(
@@ -596,6 +602,7 @@ class LoginUserOperationExecutorTests : FunSpec({
                 mockSubscriptionsModelStore,
                 MockHelper.configModelStore(),
                 MockHelper.languageContext(),
+                getJwtTokenStore(),
             )
         val operations =
             listOf<Operation>(
@@ -670,6 +677,7 @@ class LoginUserOperationExecutorTests : FunSpec({
                 mockSubscriptionsModelStore,
                 MockHelper.configModelStore(),
                 MockHelper.languageContext(),
+                getJwtTokenStore(),
             )
         val operations =
             listOf<Operation>(
@@ -735,6 +743,7 @@ class LoginUserOperationExecutorTests : FunSpec({
                 mockSubscriptionsModelStore,
                 MockHelper.configModelStore(),
                 MockHelper.languageContext(),
+                getJwtTokenStore(),
             )
         // anonymous Login request
         val operations = listOf<Operation>(LoginUserOperation(appId, localOneSignalId, null, null))
@@ -781,6 +790,7 @@ class LoginUserOperationExecutorTests : FunSpec({
                 mockSubscriptionsModelStore,
                 MockHelper.configModelStore(),
                 MockHelper.languageContext(),
+                getJwtTokenStore(),
             )
 
         // send PUSH then EMAIL (local IDs 1,2) — order differs from backend response
@@ -845,6 +855,7 @@ class LoginUserOperationExecutorTests : FunSpec({
                 mockSubscriptionsModelStore,
                 configModelStore,
                 MockHelper.languageContext(),
+                getJwtTokenStore(),
             )
 
         val ops =

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/LoginUserOperationExecutorTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/LoginUserOperationExecutorTests.kt
@@ -3,9 +3,6 @@ package com.onesignal.user.internal.operations
 import br.com.colman.kotest.android.extensions.robolectric.RobolectricTest
 import com.onesignal.common.exceptions.BackendException
 import com.onesignal.core.internal.operations.ExecutionResponse
-import com.onesignal.user.internal.jwt.IdentityVerificationGates
-import com.onesignal.user.internal.jwt.JwtRequirement
-import com.onesignal.user.internal.operations.ExecutorMocks.Companion.getJwtTokenStore
 import com.onesignal.core.internal.operations.ExecutionResult
 import com.onesignal.core.internal.operations.Operation
 import com.onesignal.mocks.AndroidMockHelper
@@ -17,6 +14,8 @@ import com.onesignal.user.internal.backend.PropertiesObject
 import com.onesignal.user.internal.backend.SubscriptionObject
 import com.onesignal.user.internal.backend.SubscriptionObjectType
 import com.onesignal.user.internal.identity.IdentityModel
+import com.onesignal.user.internal.operations.ExecutorMocks.Companion.getIdentityVerificationService
+import com.onesignal.user.internal.operations.ExecutorMocks.Companion.getJwtTokenStore
 import com.onesignal.user.internal.operations.impl.executors.IdentityOperationExecutor
 import com.onesignal.user.internal.operations.impl.executors.LoginUserOperationExecutor
 import com.onesignal.user.internal.properties.PropertiesModel
@@ -80,7 +79,7 @@ class LoginUserOperationExecutorTests : FunSpec({
                 mockSubscriptionsModelStore,
                 MockHelper.configModelStore(),
                 MockHelper.languageContext(),
-                getJwtTokenStore(),
+                getJwtTokenStore(), getIdentityVerificationService(),
             )
         val operations =
             listOf<Operation>(
@@ -125,7 +124,7 @@ class LoginUserOperationExecutorTests : FunSpec({
                 mockSubscriptionsModelStore,
                 MockHelper.configModelStore(),
                 MockHelper.languageContext(),
-                getJwtTokenStore(),
+                getJwtTokenStore(), getIdentityVerificationService(),
             )
         val operations =
             listOf<Operation>(
@@ -154,7 +153,7 @@ class LoginUserOperationExecutorTests : FunSpec({
         val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
 
         val loginUserOperationExecutor =
-            LoginUserOperationExecutor(mockIdentityOperationExecutor, AndroidMockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext(), getJwtTokenStore())
+            LoginUserOperationExecutor(mockIdentityOperationExecutor, AndroidMockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext(), getJwtTokenStore(), getIdentityVerificationService())
         val operations =
             listOf<Operation>(
                 LoginUserOperation(appId, localOneSignalId, null, null),
@@ -182,7 +181,7 @@ class LoginUserOperationExecutorTests : FunSpec({
         val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
 
         val loginUserOperationExecutor =
-            LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext(), getJwtTokenStore())
+            LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext(), getJwtTokenStore(), getIdentityVerificationService())
         val operations = listOf<Operation>(LoginUserOperation(appId, localOneSignalId, "externalId", null))
 
         // When
@@ -220,7 +219,7 @@ class LoginUserOperationExecutorTests : FunSpec({
                 mockSubscriptionsModelStore,
                 MockHelper.configModelStore(),
                 MockHelper.languageContext(),
-                getJwtTokenStore(),
+                getJwtTokenStore(), getIdentityVerificationService(),
             )
         val operations = listOf<Operation>(LoginUserOperation(appId, localOneSignalId, "externalId", null))
 
@@ -249,7 +248,7 @@ class LoginUserOperationExecutorTests : FunSpec({
         val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
 
         val loginUserOperationExecutor =
-            LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext(), getJwtTokenStore())
+            LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext(), getJwtTokenStore(), getIdentityVerificationService())
         val operations = listOf<Operation>(LoginUserOperation(appId, localOneSignalId, "externalId", "existingOneSignalId"))
 
         // When
@@ -285,7 +284,7 @@ class LoginUserOperationExecutorTests : FunSpec({
         val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
 
         val loginUserOperationExecutor =
-            LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext(), getJwtTokenStore())
+            LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext(), getJwtTokenStore(), getIdentityVerificationService())
         val operations = listOf<Operation>(LoginUserOperation(appId, localOneSignalId, "externalId", "existingOneSignalId"))
 
         // When
@@ -321,7 +320,7 @@ class LoginUserOperationExecutorTests : FunSpec({
         val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
 
         val loginUserOperationExecutor =
-            LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext(), getJwtTokenStore())
+            LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext(), getJwtTokenStore(), getIdentityVerificationService())
         val operations = listOf<Operation>(LoginUserOperation(appId, localOneSignalId, "externalId", "existingOneSignalId"))
 
         // When
@@ -359,7 +358,7 @@ class LoginUserOperationExecutorTests : FunSpec({
         val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
 
         val loginUserOperationExecutor =
-            LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext(), getJwtTokenStore())
+            LoginUserOperationExecutor(mockIdentityOperationExecutor, MockHelper.applicationService(), MockHelper.deviceService(), mockUserBackendService, mockIdentityModelStore, mockPropertiesModelStore, mockSubscriptionsModelStore, MockHelper.configModelStore(), MockHelper.languageContext(), getJwtTokenStore(), getIdentityVerificationService())
         val operations = listOf<Operation>(LoginUserOperation(appId, localOneSignalId, "externalId", "existingOneSignalId"))
 
         // When
@@ -410,7 +409,7 @@ class LoginUserOperationExecutorTests : FunSpec({
                 mockSubscriptionsModelStore,
                 MockHelper.configModelStore(),
                 MockHelper.languageContext(),
-                getJwtTokenStore(),
+                getJwtTokenStore(), getIdentityVerificationService(),
             )
         val operations =
             listOf<Operation>(
@@ -515,7 +514,7 @@ class LoginUserOperationExecutorTests : FunSpec({
                 mockSubscriptionsModelStore,
                 MockHelper.configModelStore(),
                 MockHelper.languageContext(),
-                getJwtTokenStore(),
+                getJwtTokenStore(), getIdentityVerificationService(),
             )
         val operations =
             listOf<Operation>(
@@ -604,7 +603,7 @@ class LoginUserOperationExecutorTests : FunSpec({
                 mockSubscriptionsModelStore,
                 MockHelper.configModelStore(),
                 MockHelper.languageContext(),
-                getJwtTokenStore(),
+                getJwtTokenStore(), getIdentityVerificationService(),
             )
         val operations =
             listOf<Operation>(
@@ -679,7 +678,7 @@ class LoginUserOperationExecutorTests : FunSpec({
                 mockSubscriptionsModelStore,
                 MockHelper.configModelStore(),
                 MockHelper.languageContext(),
-                getJwtTokenStore(),
+                getJwtTokenStore(), getIdentityVerificationService(),
             )
         val operations =
             listOf<Operation>(
@@ -745,7 +744,7 @@ class LoginUserOperationExecutorTests : FunSpec({
                 mockSubscriptionsModelStore,
                 MockHelper.configModelStore(),
                 MockHelper.languageContext(),
-                getJwtTokenStore(),
+                getJwtTokenStore(), getIdentityVerificationService(),
             )
         // anonymous Login request
         val operations = listOf<Operation>(LoginUserOperation(appId, localOneSignalId, null, null))
@@ -792,7 +791,7 @@ class LoginUserOperationExecutorTests : FunSpec({
                 mockSubscriptionsModelStore,
                 MockHelper.configModelStore(),
                 MockHelper.languageContext(),
-                getJwtTokenStore(),
+                getJwtTokenStore(), getIdentityVerificationService(),
             )
 
         // send PUSH then EMAIL (local IDs 1,2) — order differs from backend response
@@ -857,7 +856,7 @@ class LoginUserOperationExecutorTests : FunSpec({
                 mockSubscriptionsModelStore,
                 configModelStore,
                 MockHelper.languageContext(),
-                getJwtTokenStore(),
+                getJwtTokenStore(), getIdentityVerificationService(),
             )
 
         val ops =
@@ -887,64 +886,60 @@ class LoginUserOperationExecutorTests : FunSpec({
         // Given: IV active. Under legacy or Phase 3 this input would hit the optimistic-merge
         // SetAliasOperation path; under IV we must skip that because IdentityOperationExecutor
         // would resolve alias to (external_id, newExternalId) and target the wrong user.
-        IdentityVerificationGates.update(false, JwtRequirement.REQUIRED, "test")
-        try {
-            val mockUserBackendService = mockk<IUserBackendService>()
-            coEvery { mockUserBackendService.createUser(any(), any(), any(), any(), any()) } returns
-                CreateUserResponse(
-                    mapOf(IdentityConstants.ONESIGNAL_ID to remoteOneSignalId),
-                    PropertiesObject(),
-                    listOf(),
-                )
+        val mockUserBackendService = mockk<IUserBackendService>()
+        coEvery { mockUserBackendService.createUser(any(), any(), any(), any(), any()) } returns
+            CreateUserResponse(
+                mapOf(IdentityConstants.ONESIGNAL_ID to remoteOneSignalId),
+                PropertiesObject(),
+                listOf(),
+            )
 
-            // Strict mock: if the optimistic-merge path is reached, the test fails because no
-            // `execute` stub is registered on IdentityOperationExecutor.
-            val mockIdentityOperationExecutor = mockk<IdentityOperationExecutor>()
+        // Strict mock: if the optimistic-merge path is reached, the test fails because no
+        // `execute` stub is registered on IdentityOperationExecutor.
+        val mockIdentityOperationExecutor = mockk<IdentityOperationExecutor>()
 
-            val mockIdentityModelStore = MockHelper.identityModelStore()
-            val mockPropertiesModelStore = MockHelper.propertiesModelStore()
-            val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
+        val mockIdentityModelStore = MockHelper.identityModelStore()
+        val mockPropertiesModelStore = MockHelper.propertiesModelStore()
+        val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
 
-            val loginUserOperationExecutor =
-                LoginUserOperationExecutor(
-                    mockIdentityOperationExecutor,
-                    AndroidMockHelper.applicationService(),
-                    MockHelper.deviceService(),
-                    mockUserBackendService,
-                    mockIdentityModelStore,
-                    mockPropertiesModelStore,
-                    mockSubscriptionsModelStore,
-                    MockHelper.configModelStore(),
-                    MockHelper.languageContext(),
-                    getJwtTokenStore(),
-                )
+        val loginUserOperationExecutor =
+            LoginUserOperationExecutor(
+                mockIdentityOperationExecutor,
+                AndroidMockHelper.applicationService(),
+                MockHelper.deviceService(),
+                mockUserBackendService,
+                mockIdentityModelStore,
+                mockPropertiesModelStore,
+                mockSubscriptionsModelStore,
+                MockHelper.configModelStore(),
+                MockHelper.languageContext(),
+                getJwtTokenStore(),
+                getIdentityVerificationService(newCodePathsRun = true, ivBehaviorActive = true),
+            )
 
-            // LoginUserOperation has existingOnesignalId AND externalId — the input shape that
-            // triggers the optimistic-merge branch under legacy.
-            val operations =
-                listOf<Operation>(
-                    LoginUserOperation(appId, localOneSignalId, "new-external-id", "existing-osid"),
-                )
+        // LoginUserOperation has existingOnesignalId AND externalId — the input shape that
+        // triggers the optimistic-merge branch under legacy.
+        val operations =
+            listOf<Operation>(
+                LoginUserOperation(appId, localOneSignalId, "new-external-id", "existing-osid"),
+            )
 
-            // When
-            val response = loginUserOperationExecutor.execute(operations)
+        // When
+        val response = loginUserOperationExecutor.execute(operations)
 
-            // Then
-            response.result shouldBe ExecutionResult.SUCCESS
-            coVerify(exactly = 1) {
-                mockUserBackendService.createUser(
-                    appId,
-                    mapOf(IdentityConstants.EXTERNAL_ID to "new-external-id"),
-                    any(),
-                    any(),
-                    any(),
-                )
-            }
-            // IdentityOperationExecutor must NOT be invoked (strict mock enforces this via kotest's
-            // unstubbed-call failure; coVerify(exactly = 0) makes the expectation explicit).
-            coVerify(exactly = 0) { mockIdentityOperationExecutor.execute(any()) }
-        } finally {
-            IdentityVerificationGates.update(false, JwtRequirement.UNKNOWN, "test-teardown")
+        // Then
+        response.result shouldBe ExecutionResult.SUCCESS
+        coVerify(exactly = 1) {
+            mockUserBackendService.createUser(
+                appId,
+                mapOf(IdentityConstants.EXTERNAL_ID to "new-external-id"),
+                any(),
+                any(),
+                any(),
+            )
         }
+        // IdentityOperationExecutor must NOT be invoked (strict mock enforces this via kotest's
+        // unstubbed-call failure; coVerify(exactly = 0) makes the expectation explicit).
+        coVerify(exactly = 0) { mockIdentityOperationExecutor.execute(any()) }
     }
 })

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/LoginUserOperationExecutorTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/LoginUserOperationExecutorTests.kt
@@ -3,6 +3,8 @@ package com.onesignal.user.internal.operations
 import br.com.colman.kotest.android.extensions.robolectric.RobolectricTest
 import com.onesignal.common.exceptions.BackendException
 import com.onesignal.core.internal.operations.ExecutionResponse
+import com.onesignal.user.internal.jwt.IdentityVerificationGates
+import com.onesignal.user.internal.jwt.JwtRequirement
 import com.onesignal.user.internal.operations.ExecutorMocks.Companion.getJwtTokenStore
 import com.onesignal.core.internal.operations.ExecutionResult
 import com.onesignal.core.internal.operations.Operation
@@ -879,5 +881,70 @@ class LoginUserOperationExecutorTests : FunSpec({
         // pushSubscriptionId should be updated from local to remote id
         configModelStore.model.pushSubscriptionId shouldBe remoteSubscriptionId1
         coVerify(exactly = 1) { mockUserBackendService.createUser(appId, mapOf(), any(), any()) }
+    }
+
+    test("IV active: loginUser with existingOnesignalId + externalId goes straight to createUser, skipping optimistic SetAliasOperation") {
+        // Given: IV active. Under legacy or Phase 3 this input would hit the optimistic-merge
+        // SetAliasOperation path; under IV we must skip that because IdentityOperationExecutor
+        // would resolve alias to (external_id, newExternalId) and target the wrong user.
+        IdentityVerificationGates.update(false, JwtRequirement.REQUIRED, "test")
+        try {
+            val mockUserBackendService = mockk<IUserBackendService>()
+            coEvery { mockUserBackendService.createUser(any(), any(), any(), any(), any()) } returns
+                CreateUserResponse(
+                    mapOf(IdentityConstants.ONESIGNAL_ID to remoteOneSignalId),
+                    PropertiesObject(),
+                    listOf(),
+                )
+
+            // Strict mock: if the optimistic-merge path is reached, the test fails because no
+            // `execute` stub is registered on IdentityOperationExecutor.
+            val mockIdentityOperationExecutor = mockk<IdentityOperationExecutor>()
+
+            val mockIdentityModelStore = MockHelper.identityModelStore()
+            val mockPropertiesModelStore = MockHelper.propertiesModelStore()
+            val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
+
+            val loginUserOperationExecutor =
+                LoginUserOperationExecutor(
+                    mockIdentityOperationExecutor,
+                    AndroidMockHelper.applicationService(),
+                    MockHelper.deviceService(),
+                    mockUserBackendService,
+                    mockIdentityModelStore,
+                    mockPropertiesModelStore,
+                    mockSubscriptionsModelStore,
+                    MockHelper.configModelStore(),
+                    MockHelper.languageContext(),
+                    getJwtTokenStore(),
+                )
+
+            // LoginUserOperation has existingOnesignalId AND externalId — the input shape that
+            // triggers the optimistic-merge branch under legacy.
+            val operations =
+                listOf<Operation>(
+                    LoginUserOperation(appId, localOneSignalId, "new-external-id", "existing-osid"),
+                )
+
+            // When
+            val response = loginUserOperationExecutor.execute(operations)
+
+            // Then
+            response.result shouldBe ExecutionResult.SUCCESS
+            coVerify(exactly = 1) {
+                mockUserBackendService.createUser(
+                    appId,
+                    mapOf(IdentityConstants.EXTERNAL_ID to "new-external-id"),
+                    any(),
+                    any(),
+                    any(),
+                )
+            }
+            // IdentityOperationExecutor must NOT be invoked (strict mock enforces this via kotest's
+            // unstubbed-call failure; coVerify(exactly = 0) makes the expectation explicit).
+            coVerify(exactly = 0) { mockIdentityOperationExecutor.execute(any()) }
+        } finally {
+            IdentityVerificationGates.update(false, JwtRequirement.UNKNOWN, "test-teardown")
+        }
     }
 })

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/RefreshUserOperationExecutorTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/RefreshUserOperationExecutorTests.kt
@@ -14,6 +14,7 @@ import com.onesignal.user.internal.backend.SubscriptionObject
 import com.onesignal.user.internal.backend.SubscriptionObjectType
 import com.onesignal.user.internal.builduser.IRebuildUserService
 import com.onesignal.user.internal.identity.IdentityModel
+import com.onesignal.user.internal.operations.ExecutorMocks.Companion.getJwtTokenStore
 import com.onesignal.user.internal.operations.ExecutorMocks.Companion.getNewRecordState
 import com.onesignal.user.internal.operations.impl.executors.RefreshUserOperationExecutor
 import com.onesignal.user.internal.properties.PropertiesModel
@@ -107,6 +108,7 @@ class RefreshUserOperationExecutorTests : FunSpec({
                 mockConfigModelStore,
                 mockBuildUserService,
                 getNewRecordState(),
+                getJwtTokenStore(),
             )
 
         val operations = listOf<Operation>(RefreshUserOperation(appId, remoteOneSignalId, null))
@@ -191,6 +193,7 @@ class RefreshUserOperationExecutorTests : FunSpec({
                 MockHelper.configModelStore(),
                 mockBuildUserService,
                 getNewRecordState(),
+                getJwtTokenStore(),
             )
 
         val operations = listOf<Operation>(RefreshUserOperation(appId, remoteOneSignalId, null))
@@ -230,6 +233,7 @@ class RefreshUserOperationExecutorTests : FunSpec({
                 MockHelper.configModelStore(),
                 mockBuildUserService,
                 getNewRecordState(),
+                getJwtTokenStore(),
             )
 
         val operations = listOf<Operation>(RefreshUserOperation(appId, remoteOneSignalId, null))
@@ -265,6 +269,7 @@ class RefreshUserOperationExecutorTests : FunSpec({
                 MockHelper.configModelStore(),
                 mockBuildUserService,
                 getNewRecordState(),
+                getJwtTokenStore(),
             )
 
         val operations = listOf<Operation>(RefreshUserOperation(appId, remoteOneSignalId, null))
@@ -300,6 +305,7 @@ class RefreshUserOperationExecutorTests : FunSpec({
                 MockHelper.configModelStore(),
                 mockBuildUserService,
                 getNewRecordState(),
+                getJwtTokenStore(),
             )
 
         val operations = listOf<Operation>(RefreshUserOperation(appId, remoteOneSignalId, null))
@@ -337,6 +343,7 @@ class RefreshUserOperationExecutorTests : FunSpec({
                 MockHelper.configModelStore(),
                 mockBuildUserService,
                 newRecordState,
+                getJwtTokenStore(),
             )
 
         val operations = listOf<Operation>(RefreshUserOperation(appId, remoteOneSignalId, null))

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/RefreshUserOperationExecutorTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/RefreshUserOperationExecutorTests.kt
@@ -14,6 +14,7 @@ import com.onesignal.user.internal.backend.SubscriptionObject
 import com.onesignal.user.internal.backend.SubscriptionObjectType
 import com.onesignal.user.internal.builduser.IRebuildUserService
 import com.onesignal.user.internal.identity.IdentityModel
+import com.onesignal.user.internal.operations.ExecutorMocks.Companion.getIdentityVerificationService
 import com.onesignal.user.internal.operations.ExecutorMocks.Companion.getJwtTokenStore
 import com.onesignal.user.internal.operations.ExecutorMocks.Companion.getNewRecordState
 import com.onesignal.user.internal.operations.impl.executors.RefreshUserOperationExecutor
@@ -108,7 +109,7 @@ class RefreshUserOperationExecutorTests : FunSpec({
                 mockConfigModelStore,
                 mockBuildUserService,
                 getNewRecordState(),
-                getJwtTokenStore(),
+                getJwtTokenStore(), getIdentityVerificationService(),
             )
 
         val operations = listOf<Operation>(RefreshUserOperation(appId, remoteOneSignalId, null))
@@ -193,7 +194,7 @@ class RefreshUserOperationExecutorTests : FunSpec({
                 MockHelper.configModelStore(),
                 mockBuildUserService,
                 getNewRecordState(),
-                getJwtTokenStore(),
+                getJwtTokenStore(), getIdentityVerificationService(),
             )
 
         val operations = listOf<Operation>(RefreshUserOperation(appId, remoteOneSignalId, null))
@@ -233,7 +234,7 @@ class RefreshUserOperationExecutorTests : FunSpec({
                 MockHelper.configModelStore(),
                 mockBuildUserService,
                 getNewRecordState(),
-                getJwtTokenStore(),
+                getJwtTokenStore(), getIdentityVerificationService(),
             )
 
         val operations = listOf<Operation>(RefreshUserOperation(appId, remoteOneSignalId, null))
@@ -269,7 +270,7 @@ class RefreshUserOperationExecutorTests : FunSpec({
                 MockHelper.configModelStore(),
                 mockBuildUserService,
                 getNewRecordState(),
-                getJwtTokenStore(),
+                getJwtTokenStore(), getIdentityVerificationService(),
             )
 
         val operations = listOf<Operation>(RefreshUserOperation(appId, remoteOneSignalId, null))
@@ -305,7 +306,7 @@ class RefreshUserOperationExecutorTests : FunSpec({
                 MockHelper.configModelStore(),
                 mockBuildUserService,
                 getNewRecordState(),
-                getJwtTokenStore(),
+                getJwtTokenStore(), getIdentityVerificationService(),
             )
 
         val operations = listOf<Operation>(RefreshUserOperation(appId, remoteOneSignalId, null))
@@ -343,7 +344,7 @@ class RefreshUserOperationExecutorTests : FunSpec({
                 MockHelper.configModelStore(),
                 mockBuildUserService,
                 newRecordState,
-                getJwtTokenStore(),
+                getJwtTokenStore(), getIdentityVerificationService(),
             )
 
         val operations = listOf<Operation>(RefreshUserOperation(appId, remoteOneSignalId, null))

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/SubscriptionOperationExecutorTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/SubscriptionOperationExecutorTests.kt
@@ -13,6 +13,8 @@ import com.onesignal.user.internal.backend.ISubscriptionBackendService
 import com.onesignal.user.internal.backend.IdentityConstants
 import com.onesignal.user.internal.backend.SubscriptionObjectType
 import com.onesignal.user.internal.builduser.IRebuildUserService
+import com.onesignal.user.internal.jwt.IdentityVerificationGates
+import com.onesignal.user.internal.jwt.JwtRequirement
 import com.onesignal.user.internal.operations.ExecutorMocks.Companion.getJwtTokenStore
 import com.onesignal.user.internal.operations.ExecutorMocks.Companion.getNewRecordState
 import com.onesignal.user.internal.operations.impl.executors.SubscriptionOperationExecutor
@@ -852,6 +854,114 @@ class SubscriptionOperationExecutorTests :
             // Then
             coVerify(exactly = 1) {
                 mockConsistencyManager.setRywData(remoteOneSignalId, IamFetchRywTokenKey.SUBSCRIPTION, rywData)
+            }
+        }
+
+        test("update subscription returns FAIL_UNAUTHORIZED on 401 so JWT gets invalidated under IV") {
+            // Given
+            IdentityVerificationGates.update(false, JwtRequirement.REQUIRED, "test")
+            try {
+                val mockSubscriptionBackendService = mockk<ISubscriptionBackendService>()
+                coEvery { mockSubscriptionBackendService.updateSubscription(any(), any(), any(), any()) } throws
+                    BackendException(401, "UNAUTHORIZED", retryAfterSeconds = 5)
+
+                val subscriptionOperationExecutor =
+                    SubscriptionOperationExecutor(
+                        mockSubscriptionBackendService,
+                        MockHelper.deviceService(),
+                        AndroidMockHelper.applicationService(),
+                        mockk<SubscriptionModelStore>(),
+                        MockHelper.configModelStore(),
+                        mockk<IRebuildUserService>(),
+                        getNewRecordState(),
+                        mockConsistencyManager,
+                        getJwtTokenStore(),
+                    )
+                val operations =
+                    listOf<Operation>(
+                        UpdateSubscriptionOperation(
+                            appId, remoteOneSignalId, "ext-1", remoteSubscriptionId,
+                            SubscriptionType.PUSH, true, "pushToken2", SubscriptionStatus.SUBSCRIBED,
+                        ),
+                    )
+
+                // When
+                val response = subscriptionOperationExecutor.execute(operations)
+
+                // Then — must be FAIL_UNAUTHORIZED so OperationRepo.handleFailUnauthorized fires.
+                response.result shouldBe ExecutionResult.FAIL_UNAUTHORIZED
+                response.retryAfterSeconds shouldBe 5
+            } finally {
+                IdentityVerificationGates.update(false, JwtRequirement.UNKNOWN, "test-teardown")
+            }
+        }
+
+        test("delete subscription returns FAIL_UNAUTHORIZED on 401 so JWT gets invalidated under IV") {
+            // Given
+            IdentityVerificationGates.update(false, JwtRequirement.REQUIRED, "test")
+            try {
+                val mockSubscriptionBackendService = mockk<ISubscriptionBackendService>()
+                coEvery { mockSubscriptionBackendService.deleteSubscription(any(), any(), any()) } throws
+                    BackendException(401, "UNAUTHORIZED", retryAfterSeconds = 5)
+
+                val subscriptionOperationExecutor =
+                    SubscriptionOperationExecutor(
+                        mockSubscriptionBackendService,
+                        MockHelper.deviceService(),
+                        AndroidMockHelper.applicationService(),
+                        mockk<SubscriptionModelStore>(),
+                        MockHelper.configModelStore(),
+                        mockk<IRebuildUserService>(),
+                        getNewRecordState(),
+                        mockConsistencyManager,
+                        getJwtTokenStore(),
+                    )
+                val operations =
+                    listOf<Operation>(DeleteSubscriptionOperation(appId, remoteOneSignalId, "ext-1", remoteSubscriptionId))
+
+                // When
+                val response = subscriptionOperationExecutor.execute(operations)
+
+                // Then
+                response.result shouldBe ExecutionResult.FAIL_UNAUTHORIZED
+                response.retryAfterSeconds shouldBe 5
+            } finally {
+                IdentityVerificationGates.update(false, JwtRequirement.UNKNOWN, "test-teardown")
+            }
+        }
+
+        test("transfer subscription returns FAIL_UNAUTHORIZED on 401 so JWT gets invalidated under IV") {
+            // Given
+            IdentityVerificationGates.update(false, JwtRequirement.REQUIRED, "test")
+            try {
+                val mockSubscriptionBackendService = mockk<ISubscriptionBackendService>()
+                coEvery {
+                    mockSubscriptionBackendService.transferSubscription(any(), any(), any(), any(), any())
+                } throws BackendException(403, "FORBIDDEN", retryAfterSeconds = 5)
+
+                val subscriptionOperationExecutor =
+                    SubscriptionOperationExecutor(
+                        mockSubscriptionBackendService,
+                        MockHelper.deviceService(),
+                        AndroidMockHelper.applicationService(),
+                        mockk<SubscriptionModelStore>(),
+                        MockHelper.configModelStore(),
+                        mockk<IRebuildUserService>(),
+                        getNewRecordState(),
+                        mockConsistencyManager,
+                        getJwtTokenStore(),
+                    )
+                val operations =
+                    listOf<Operation>(TransferSubscriptionOperation(appId, remoteOneSignalId, "ext-1", remoteSubscriptionId))
+
+                // When
+                val response = subscriptionOperationExecutor.execute(operations)
+
+                // Then
+                response.result shouldBe ExecutionResult.FAIL_UNAUTHORIZED
+                response.retryAfterSeconds shouldBe 5
+            } finally {
+                IdentityVerificationGates.update(false, JwtRequirement.UNKNOWN, "test-teardown")
             }
         }
     })

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/SubscriptionOperationExecutorTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/SubscriptionOperationExecutorTests.kt
@@ -13,6 +13,7 @@ import com.onesignal.user.internal.backend.ISubscriptionBackendService
 import com.onesignal.user.internal.backend.IdentityConstants
 import com.onesignal.user.internal.backend.SubscriptionObjectType
 import com.onesignal.user.internal.builduser.IRebuildUserService
+import com.onesignal.user.internal.operations.ExecutorMocks.Companion.getJwtTokenStore
 import com.onesignal.user.internal.operations.ExecutorMocks.Companion.getNewRecordState
 import com.onesignal.user.internal.operations.impl.executors.SubscriptionOperationExecutor
 import com.onesignal.user.internal.subscriptions.SubscriptionModel
@@ -68,6 +69,7 @@ class SubscriptionOperationExecutorTests :
                     mockBuildUserService,
                     getNewRecordState(),
                     mockConsistencyManager,
+                    getJwtTokenStore(),
                 )
 
             val operations =
@@ -129,6 +131,7 @@ class SubscriptionOperationExecutorTests :
                     mockBuildUserService,
                     getNewRecordState(),
                     mockConsistencyManager,
+                    getJwtTokenStore(),
                 )
 
             val operations =
@@ -180,6 +183,7 @@ class SubscriptionOperationExecutorTests :
                     mockBuildUserService,
                     getNewRecordState(),
                     mockConsistencyManager,
+                    getJwtTokenStore(),
                 )
 
             val operations =
@@ -236,6 +240,7 @@ class SubscriptionOperationExecutorTests :
                     mockBuildUserService,
                     getNewRecordState(),
                     mockConsistencyManager,
+                    getJwtTokenStore(),
                 )
 
             val operations =
@@ -292,6 +297,7 @@ class SubscriptionOperationExecutorTests :
                     mockBuildUserService,
                     newRecordState,
                     mockConsistencyManager,
+                    getJwtTokenStore(),
                 )
 
             val operations =
@@ -336,6 +342,7 @@ class SubscriptionOperationExecutorTests :
                     mockBuildUserService,
                     getNewRecordState(),
                     mockConsistencyManager,
+                    getJwtTokenStore(),
                 )
 
             val operations =
@@ -383,6 +390,7 @@ class SubscriptionOperationExecutorTests :
                     mockBuildUserService,
                     getNewRecordState(),
                     mockConsistencyManager,
+                    getJwtTokenStore(),
                 )
 
             val operations =
@@ -455,6 +463,7 @@ class SubscriptionOperationExecutorTests :
                     mockBuildUserService,
                     getNewRecordState(),
                     mockConsistencyManager,
+                    getJwtTokenStore(),
                 )
 
             val operations =
@@ -518,6 +527,7 @@ class SubscriptionOperationExecutorTests :
                     mockBuildUserService,
                     getNewRecordState(),
                     mockConsistencyManager,
+                    getJwtTokenStore(),
                 )
 
             val operations =
@@ -571,6 +581,7 @@ class SubscriptionOperationExecutorTests :
                     mockBuildUserService,
                     getNewRecordState(),
                     mockConsistencyManager,
+                    getJwtTokenStore(),
                 )
 
             val operations =
@@ -626,6 +637,7 @@ class SubscriptionOperationExecutorTests :
                     mockBuildUserService,
                     newRecordState,
                     mockConsistencyManager,
+                    getJwtTokenStore(),
                 )
 
             val operations =
@@ -669,6 +681,7 @@ class SubscriptionOperationExecutorTests :
                     mockBuildUserService,
                     getNewRecordState(),
                     mockConsistencyManager,
+                    getJwtTokenStore(),
                 )
 
             val operations =
@@ -703,6 +716,7 @@ class SubscriptionOperationExecutorTests :
                     mockBuildUserService,
                     getNewRecordState(),
                     mockConsistencyManager,
+                    getJwtTokenStore(),
                 )
 
             val operations =
@@ -738,6 +752,7 @@ class SubscriptionOperationExecutorTests :
                     mockBuildUserService,
                     getNewRecordState(),
                     mockConsistencyManager,
+                    getJwtTokenStore(),
                 )
 
             val operations =
@@ -773,6 +788,7 @@ class SubscriptionOperationExecutorTests :
                     mockBuildUserService,
                     newRecordState,
                     mockConsistencyManager,
+                    getJwtTokenStore(),
                 )
 
             val operations =
@@ -814,6 +830,7 @@ class SubscriptionOperationExecutorTests :
                     mockBuildUserService,
                     getNewRecordState(),
                     mockConsistencyManager,
+                    getJwtTokenStore(),
                 )
 
             val operations =

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/SubscriptionOperationExecutorTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/SubscriptionOperationExecutorTests.kt
@@ -13,8 +13,7 @@ import com.onesignal.user.internal.backend.ISubscriptionBackendService
 import com.onesignal.user.internal.backend.IdentityConstants
 import com.onesignal.user.internal.backend.SubscriptionObjectType
 import com.onesignal.user.internal.builduser.IRebuildUserService
-import com.onesignal.user.internal.jwt.IdentityVerificationGates
-import com.onesignal.user.internal.jwt.JwtRequirement
+import com.onesignal.user.internal.operations.ExecutorMocks.Companion.getIdentityVerificationService
 import com.onesignal.user.internal.operations.ExecutorMocks.Companion.getJwtTokenStore
 import com.onesignal.user.internal.operations.ExecutorMocks.Companion.getNewRecordState
 import com.onesignal.user.internal.operations.impl.executors.SubscriptionOperationExecutor
@@ -71,7 +70,7 @@ class SubscriptionOperationExecutorTests :
                     mockBuildUserService,
                     getNewRecordState(),
                     mockConsistencyManager,
-                    getJwtTokenStore(),
+                    getJwtTokenStore(), getIdentityVerificationService(),
                 )
 
             val operations =
@@ -133,7 +132,7 @@ class SubscriptionOperationExecutorTests :
                     mockBuildUserService,
                     getNewRecordState(),
                     mockConsistencyManager,
-                    getJwtTokenStore(),
+                    getJwtTokenStore(), getIdentityVerificationService(),
                 )
 
             val operations =
@@ -185,7 +184,7 @@ class SubscriptionOperationExecutorTests :
                     mockBuildUserService,
                     getNewRecordState(),
                     mockConsistencyManager,
-                    getJwtTokenStore(),
+                    getJwtTokenStore(), getIdentityVerificationService(),
                 )
 
             val operations =
@@ -242,7 +241,7 @@ class SubscriptionOperationExecutorTests :
                     mockBuildUserService,
                     getNewRecordState(),
                     mockConsistencyManager,
-                    getJwtTokenStore(),
+                    getJwtTokenStore(), getIdentityVerificationService(),
                 )
 
             val operations =
@@ -299,7 +298,7 @@ class SubscriptionOperationExecutorTests :
                     mockBuildUserService,
                     newRecordState,
                     mockConsistencyManager,
-                    getJwtTokenStore(),
+                    getJwtTokenStore(), getIdentityVerificationService(),
                 )
 
             val operations =
@@ -344,7 +343,7 @@ class SubscriptionOperationExecutorTests :
                     mockBuildUserService,
                     getNewRecordState(),
                     mockConsistencyManager,
-                    getJwtTokenStore(),
+                    getJwtTokenStore(), getIdentityVerificationService(),
                 )
 
             val operations =
@@ -392,7 +391,7 @@ class SubscriptionOperationExecutorTests :
                     mockBuildUserService,
                     getNewRecordState(),
                     mockConsistencyManager,
-                    getJwtTokenStore(),
+                    getJwtTokenStore(), getIdentityVerificationService(),
                 )
 
             val operations =
@@ -465,7 +464,7 @@ class SubscriptionOperationExecutorTests :
                     mockBuildUserService,
                     getNewRecordState(),
                     mockConsistencyManager,
-                    getJwtTokenStore(),
+                    getJwtTokenStore(), getIdentityVerificationService(),
                 )
 
             val operations =
@@ -529,7 +528,7 @@ class SubscriptionOperationExecutorTests :
                     mockBuildUserService,
                     getNewRecordState(),
                     mockConsistencyManager,
-                    getJwtTokenStore(),
+                    getJwtTokenStore(), getIdentityVerificationService(),
                 )
 
             val operations =
@@ -583,7 +582,7 @@ class SubscriptionOperationExecutorTests :
                     mockBuildUserService,
                     getNewRecordState(),
                     mockConsistencyManager,
-                    getJwtTokenStore(),
+                    getJwtTokenStore(), getIdentityVerificationService(),
                 )
 
             val operations =
@@ -639,7 +638,7 @@ class SubscriptionOperationExecutorTests :
                     mockBuildUserService,
                     newRecordState,
                     mockConsistencyManager,
-                    getJwtTokenStore(),
+                    getJwtTokenStore(), getIdentityVerificationService(),
                 )
 
             val operations =
@@ -683,7 +682,7 @@ class SubscriptionOperationExecutorTests :
                     mockBuildUserService,
                     getNewRecordState(),
                     mockConsistencyManager,
-                    getJwtTokenStore(),
+                    getJwtTokenStore(), getIdentityVerificationService(),
                 )
 
             val operations =
@@ -718,7 +717,7 @@ class SubscriptionOperationExecutorTests :
                     mockBuildUserService,
                     getNewRecordState(),
                     mockConsistencyManager,
-                    getJwtTokenStore(),
+                    getJwtTokenStore(), getIdentityVerificationService(),
                 )
 
             val operations =
@@ -754,7 +753,7 @@ class SubscriptionOperationExecutorTests :
                     mockBuildUserService,
                     getNewRecordState(),
                     mockConsistencyManager,
-                    getJwtTokenStore(),
+                    getJwtTokenStore(), getIdentityVerificationService(),
                 )
 
             val operations =
@@ -790,7 +789,7 @@ class SubscriptionOperationExecutorTests :
                     mockBuildUserService,
                     newRecordState,
                     mockConsistencyManager,
-                    getJwtTokenStore(),
+                    getJwtTokenStore(), getIdentityVerificationService(),
                 )
 
             val operations =
@@ -832,7 +831,7 @@ class SubscriptionOperationExecutorTests :
                     mockBuildUserService,
                     getNewRecordState(),
                     mockConsistencyManager,
-                    getJwtTokenStore(),
+                    getJwtTokenStore(), getIdentityVerificationService(),
                 )
 
             val operations =
@@ -859,109 +858,97 @@ class SubscriptionOperationExecutorTests :
 
         test("update subscription returns FAIL_UNAUTHORIZED on 401 so JWT gets invalidated under IV") {
             // Given
-            IdentityVerificationGates.update(false, JwtRequirement.REQUIRED, "test")
-            try {
-                val mockSubscriptionBackendService = mockk<ISubscriptionBackendService>()
-                coEvery { mockSubscriptionBackendService.updateSubscription(any(), any(), any(), any()) } throws
-                    BackendException(401, "UNAUTHORIZED", retryAfterSeconds = 5)
+            val mockSubscriptionBackendService = mockk<ISubscriptionBackendService>()
+            coEvery { mockSubscriptionBackendService.updateSubscription(any(), any(), any(), any()) } throws
+                BackendException(401, "UNAUTHORIZED", retryAfterSeconds = 5)
 
-                val subscriptionOperationExecutor =
-                    SubscriptionOperationExecutor(
-                        mockSubscriptionBackendService,
-                        MockHelper.deviceService(),
-                        AndroidMockHelper.applicationService(),
-                        mockk<SubscriptionModelStore>(),
-                        MockHelper.configModelStore(),
-                        mockk<IRebuildUserService>(),
-                        getNewRecordState(),
-                        mockConsistencyManager,
-                        getJwtTokenStore(),
-                    )
-                val operations =
-                    listOf<Operation>(
-                        UpdateSubscriptionOperation(
-                            appId, remoteOneSignalId, "ext-1", remoteSubscriptionId,
-                            SubscriptionType.PUSH, true, "pushToken2", SubscriptionStatus.SUBSCRIBED,
-                        ),
-                    )
+            val subscriptionOperationExecutor =
+                SubscriptionOperationExecutor(
+                    mockSubscriptionBackendService,
+                    MockHelper.deviceService(),
+                    AndroidMockHelper.applicationService(),
+                    mockk<SubscriptionModelStore>(),
+                    MockHelper.configModelStore(),
+                    mockk<IRebuildUserService>(),
+                    getNewRecordState(),
+                    mockConsistencyManager,
+                    getJwtTokenStore(),
+                    getIdentityVerificationService(newCodePathsRun = true, ivBehaviorActive = true),
+                )
+            val operations =
+                listOf<Operation>(
+                    UpdateSubscriptionOperation(
+                        appId, remoteOneSignalId, "ext-1", remoteSubscriptionId,
+                        SubscriptionType.PUSH, true, "pushToken2", SubscriptionStatus.SUBSCRIBED,
+                    ),
+                )
 
-                // When
-                val response = subscriptionOperationExecutor.execute(operations)
+            // When
+            val response = subscriptionOperationExecutor.execute(operations)
 
-                // Then — must be FAIL_UNAUTHORIZED so OperationRepo.handleFailUnauthorized fires.
-                response.result shouldBe ExecutionResult.FAIL_UNAUTHORIZED
-                response.retryAfterSeconds shouldBe 5
-            } finally {
-                IdentityVerificationGates.update(false, JwtRequirement.UNKNOWN, "test-teardown")
-            }
+            // Then — must be FAIL_UNAUTHORIZED so OperationRepo.handleFailUnauthorized fires.
+            response.result shouldBe ExecutionResult.FAIL_UNAUTHORIZED
+            response.retryAfterSeconds shouldBe 5
         }
 
         test("delete subscription returns FAIL_UNAUTHORIZED on 401 so JWT gets invalidated under IV") {
             // Given
-            IdentityVerificationGates.update(false, JwtRequirement.REQUIRED, "test")
-            try {
-                val mockSubscriptionBackendService = mockk<ISubscriptionBackendService>()
-                coEvery { mockSubscriptionBackendService.deleteSubscription(any(), any(), any()) } throws
-                    BackendException(401, "UNAUTHORIZED", retryAfterSeconds = 5)
+            val mockSubscriptionBackendService = mockk<ISubscriptionBackendService>()
+            coEvery { mockSubscriptionBackendService.deleteSubscription(any(), any(), any()) } throws
+                BackendException(401, "UNAUTHORIZED", retryAfterSeconds = 5)
 
-                val subscriptionOperationExecutor =
-                    SubscriptionOperationExecutor(
-                        mockSubscriptionBackendService,
-                        MockHelper.deviceService(),
-                        AndroidMockHelper.applicationService(),
-                        mockk<SubscriptionModelStore>(),
-                        MockHelper.configModelStore(),
-                        mockk<IRebuildUserService>(),
-                        getNewRecordState(),
-                        mockConsistencyManager,
-                        getJwtTokenStore(),
-                    )
-                val operations =
-                    listOf<Operation>(DeleteSubscriptionOperation(appId, remoteOneSignalId, "ext-1", remoteSubscriptionId))
+            val subscriptionOperationExecutor =
+                SubscriptionOperationExecutor(
+                    mockSubscriptionBackendService,
+                    MockHelper.deviceService(),
+                    AndroidMockHelper.applicationService(),
+                    mockk<SubscriptionModelStore>(),
+                    MockHelper.configModelStore(),
+                    mockk<IRebuildUserService>(),
+                    getNewRecordState(),
+                    mockConsistencyManager,
+                    getJwtTokenStore(),
+                    getIdentityVerificationService(newCodePathsRun = true, ivBehaviorActive = true),
+                )
+            val operations =
+                listOf<Operation>(DeleteSubscriptionOperation(appId, remoteOneSignalId, "ext-1", remoteSubscriptionId))
 
-                // When
-                val response = subscriptionOperationExecutor.execute(operations)
+            // When
+            val response = subscriptionOperationExecutor.execute(operations)
 
-                // Then
-                response.result shouldBe ExecutionResult.FAIL_UNAUTHORIZED
-                response.retryAfterSeconds shouldBe 5
-            } finally {
-                IdentityVerificationGates.update(false, JwtRequirement.UNKNOWN, "test-teardown")
-            }
+            // Then
+            response.result shouldBe ExecutionResult.FAIL_UNAUTHORIZED
+            response.retryAfterSeconds shouldBe 5
         }
 
         test("transfer subscription returns FAIL_UNAUTHORIZED on 401 so JWT gets invalidated under IV") {
             // Given
-            IdentityVerificationGates.update(false, JwtRequirement.REQUIRED, "test")
-            try {
-                val mockSubscriptionBackendService = mockk<ISubscriptionBackendService>()
-                coEvery {
-                    mockSubscriptionBackendService.transferSubscription(any(), any(), any(), any(), any())
-                } throws BackendException(403, "FORBIDDEN", retryAfterSeconds = 5)
+            val mockSubscriptionBackendService = mockk<ISubscriptionBackendService>()
+            coEvery {
+                mockSubscriptionBackendService.transferSubscription(any(), any(), any(), any(), any())
+            } throws BackendException(403, "FORBIDDEN", retryAfterSeconds = 5)
 
-                val subscriptionOperationExecutor =
-                    SubscriptionOperationExecutor(
-                        mockSubscriptionBackendService,
-                        MockHelper.deviceService(),
-                        AndroidMockHelper.applicationService(),
-                        mockk<SubscriptionModelStore>(),
-                        MockHelper.configModelStore(),
-                        mockk<IRebuildUserService>(),
-                        getNewRecordState(),
-                        mockConsistencyManager,
-                        getJwtTokenStore(),
-                    )
-                val operations =
-                    listOf<Operation>(TransferSubscriptionOperation(appId, remoteOneSignalId, "ext-1", remoteSubscriptionId))
+            val subscriptionOperationExecutor =
+                SubscriptionOperationExecutor(
+                    mockSubscriptionBackendService,
+                    MockHelper.deviceService(),
+                    AndroidMockHelper.applicationService(),
+                    mockk<SubscriptionModelStore>(),
+                    MockHelper.configModelStore(),
+                    mockk<IRebuildUserService>(),
+                    getNewRecordState(),
+                    mockConsistencyManager,
+                    getJwtTokenStore(),
+                    getIdentityVerificationService(newCodePathsRun = true, ivBehaviorActive = true),
+                )
+            val operations =
+                listOf<Operation>(TransferSubscriptionOperation(appId, remoteOneSignalId, "ext-1", remoteSubscriptionId))
 
-                // When
-                val response = subscriptionOperationExecutor.execute(operations)
+            // When
+            val response = subscriptionOperationExecutor.execute(operations)
 
-                // Then
-                response.result shouldBe ExecutionResult.FAIL_UNAUTHORIZED
-                response.retryAfterSeconds shouldBe 5
-            } finally {
-                IdentityVerificationGates.update(false, JwtRequirement.UNKNOWN, "test-teardown")
-            }
+            // Then
+            response.result shouldBe ExecutionResult.FAIL_UNAUTHORIZED
+            response.retryAfterSeconds shouldBe 5
         }
     })

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/UpdateUserOperationExecutorTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/UpdateUserOperationExecutorTests.kt
@@ -10,6 +10,7 @@ import com.onesignal.mocks.MockHelper
 import com.onesignal.user.internal.backend.IUserBackendService
 import com.onesignal.user.internal.backend.IdentityConstants
 import com.onesignal.user.internal.builduser.IRebuildUserService
+import com.onesignal.user.internal.operations.ExecutorMocks.Companion.getJwtTokenStore
 import com.onesignal.user.internal.operations.ExecutorMocks.Companion.getNewRecordState
 import com.onesignal.user.internal.operations.impl.executors.UpdateUserOperationExecutor
 import com.onesignal.user.internal.properties.PropertiesModel
@@ -56,6 +57,7 @@ class UpdateUserOperationExecutorTests :
                     mockBuildUserService,
                     getNewRecordState(),
                     mockConsistencyManager,
+                    getJwtTokenStore(),
                 )
             val operations = listOf<Operation>(SetTagOperation(appId, remoteOneSignalId, null, "tagKey1", "tagValue1"))
 
@@ -96,6 +98,7 @@ class UpdateUserOperationExecutorTests :
                     mockBuildUserService,
                     getNewRecordState(),
                     mockConsistencyManager,
+                    getJwtTokenStore(),
                 )
             val operations =
                 listOf<Operation>(
@@ -158,6 +161,7 @@ class UpdateUserOperationExecutorTests :
                     mockBuildUserService,
                     getNewRecordState(),
                     mockConsistencyManager,
+                    getJwtTokenStore(),
                 )
             val operations =
                 listOf<Operation>(
@@ -203,6 +207,7 @@ class UpdateUserOperationExecutorTests :
                     mockBuildUserService,
                     getNewRecordState(),
                     mockConsistencyManager,
+                    getJwtTokenStore(),
                 )
             val operations =
                 listOf<Operation>(
@@ -269,6 +274,7 @@ class UpdateUserOperationExecutorTests :
                     mockBuildUserService,
                     getNewRecordState(),
                     mockConsistencyManager,
+                    getJwtTokenStore(),
                 )
             val operations =
                 listOf<Operation>(
@@ -317,6 +323,7 @@ class UpdateUserOperationExecutorTests :
                     mockBuildUserService,
                     getNewRecordState(),
                     mockConsistencyManager,
+                    getJwtTokenStore(),
                 )
             val operations = listOf(SetTagOperation(appId, remoteOneSignalId, null, "tagKey1", "tagValue1"))
 
@@ -350,6 +357,7 @@ class UpdateUserOperationExecutorTests :
                     mockBuildUserService,
                     newRecordState,
                     mockConsistencyManager,
+                    getJwtTokenStore(),
                 )
             val operations = listOf(SetTagOperation(appId, remoteOneSignalId, null, "tagKey1", "tagValue1"))
 
@@ -380,6 +388,7 @@ class UpdateUserOperationExecutorTests :
                     mockBuildUserService,
                     getNewRecordState(),
                     mockConsistencyManager,
+                    getJwtTokenStore(),
                 )
 
             val operations =

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/UpdateUserOperationExecutorTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/UpdateUserOperationExecutorTests.kt
@@ -10,6 +10,7 @@ import com.onesignal.mocks.MockHelper
 import com.onesignal.user.internal.backend.IUserBackendService
 import com.onesignal.user.internal.backend.IdentityConstants
 import com.onesignal.user.internal.builduser.IRebuildUserService
+import com.onesignal.user.internal.operations.ExecutorMocks.Companion.getIdentityVerificationService
 import com.onesignal.user.internal.operations.ExecutorMocks.Companion.getJwtTokenStore
 import com.onesignal.user.internal.operations.ExecutorMocks.Companion.getNewRecordState
 import com.onesignal.user.internal.operations.impl.executors.UpdateUserOperationExecutor
@@ -57,7 +58,7 @@ class UpdateUserOperationExecutorTests :
                     mockBuildUserService,
                     getNewRecordState(),
                     mockConsistencyManager,
-                    getJwtTokenStore(),
+                    getJwtTokenStore(), getIdentityVerificationService(),
                 )
             val operations = listOf<Operation>(SetTagOperation(appId, remoteOneSignalId, null, "tagKey1", "tagValue1"))
 
@@ -98,7 +99,7 @@ class UpdateUserOperationExecutorTests :
                     mockBuildUserService,
                     getNewRecordState(),
                     mockConsistencyManager,
-                    getJwtTokenStore(),
+                    getJwtTokenStore(), getIdentityVerificationService(),
                 )
             val operations =
                 listOf<Operation>(
@@ -161,7 +162,7 @@ class UpdateUserOperationExecutorTests :
                     mockBuildUserService,
                     getNewRecordState(),
                     mockConsistencyManager,
-                    getJwtTokenStore(),
+                    getJwtTokenStore(), getIdentityVerificationService(),
                 )
             val operations =
                 listOf<Operation>(
@@ -207,7 +208,7 @@ class UpdateUserOperationExecutorTests :
                     mockBuildUserService,
                     getNewRecordState(),
                     mockConsistencyManager,
-                    getJwtTokenStore(),
+                    getJwtTokenStore(), getIdentityVerificationService(),
                 )
             val operations =
                 listOf<Operation>(
@@ -274,7 +275,7 @@ class UpdateUserOperationExecutorTests :
                     mockBuildUserService,
                     getNewRecordState(),
                     mockConsistencyManager,
-                    getJwtTokenStore(),
+                    getJwtTokenStore(), getIdentityVerificationService(),
                 )
             val operations =
                 listOf<Operation>(
@@ -323,7 +324,7 @@ class UpdateUserOperationExecutorTests :
                     mockBuildUserService,
                     getNewRecordState(),
                     mockConsistencyManager,
-                    getJwtTokenStore(),
+                    getJwtTokenStore(), getIdentityVerificationService(),
                 )
             val operations = listOf(SetTagOperation(appId, remoteOneSignalId, null, "tagKey1", "tagValue1"))
 
@@ -357,7 +358,7 @@ class UpdateUserOperationExecutorTests :
                     mockBuildUserService,
                     newRecordState,
                     mockConsistencyManager,
-                    getJwtTokenStore(),
+                    getJwtTokenStore(), getIdentityVerificationService(),
                 )
             val operations = listOf(SetTagOperation(appId, remoteOneSignalId, null, "tagKey1", "tagValue1"))
 
@@ -388,7 +389,7 @@ class UpdateUserOperationExecutorTests :
                     mockBuildUserService,
                     getNewRecordState(),
                     mockConsistencyManager,
-                    getJwtTokenStore(),
+                    getJwtTokenStore(), getIdentityVerificationService(),
                 )
 
             val operations =


### PR DESCRIPTION
Fourth of six PRs re-implementing Identity Verification (IV) on the `feat/identity_verification_feature_flagged_major_release` integration branch.

Stack: #2623 → #2624 → #2625 → **this** → (5/6) → (6/6)

## What this PR does

Plumbs the JWT all the way from storage to the HTTP wire, and wraps all seven user-facing operation executors in the new-code-path extension pattern established in #2625.

### HTTP layer (unconditional plumbing)
- `OptionalHeaders.jwt: String?` field.
- `HttpClient` sets `Authorization: Bearer <jwt>` when non-null.

### Backend service signatures
- `jwt: String? = null` default param added to 10 methods across 4 services:
  - `IIdentityBackendService.setAlias` / `deleteAlias`
  - `IUserBackendService.createUser` / `updateUser` / `getUser`
  - `ISubscriptionBackendService.createSubscription` / `updateSubscription` / `deleteSubscription` / `transferSubscription`
  - `ICustomEventBackendService.sendCustomEvent`
- Each impl threads `jwt` into `OptionalHeaders`. Existing callers unchanged.
- **Excluded**: `getIdentityFromSubscription`. That endpoint is not allowed when `jwt_required=true`; `LoginUserFromSubscriptionOperationExecutor` already returns `FAIL_NORETRY` under IV, so the call never reaches the backend service on the IV path. KDoc added to document this.

### Executor gating — extension pattern
New file `ExecutorsIvExtensions.kt` exposes:
- `IvBackendParams(aliasLabel, aliasValue, jwt)` with `legacyFor(onesignalId)` factory.
- `resolveIvBackendParams(op, onesignalId, jwtTokenStore)` — alias + JWT for backend calls.
- `resolveIvJwt(op, jwtTokenStore)` — JWT-only for calls that don't take alias label/value.
- `shouldFailLoginUserFromSubscription()` — IV-active predicate.

Each helper short-circuits on `IdentityVerificationGates.ivBehaviorActive == false`. Base-class dispatch sites gate on `IdentityVerificationGates.newCodePathsRun`, so:
- Phase 1 (`newCodePathsRun=false`): extensions never called; executors byte-for-byte identical to today.
- Phase 3 (`newCodePathsRun=true`, `ivBehaviorActive=false`): extensions run and return legacy values; new code path exercised without IV behavior — validates structural changes.
- IV active: alias switches to `external_id`, JWT attaches.

Seven executors wired:
| Executor | Resolution |
|---|---|
| `LoginUserOperationExecutor` | `resolveIvJwt` (createUser uses identities map, no alias) |
| `IdentityOperationExecutor` | `resolveIvBackendParams` (setAlias / deleteAlias) |
| `SubscriptionOperationExecutor.createSubscription` | `resolveIvBackendParams` |
| `SubscriptionOperationExecutor.updateSubscription` / `deleteSubscription` | `resolveIvJwt` |
| `SubscriptionOperationExecutor.transferSubscription` | `resolveIvBackendParams` |
| `UpdateUserOperationExecutor` | `resolveIvBackendParams` (externalId pulled from `operations.first()`; grouped ops share user) |
| `RefreshUserOperationExecutor` | `resolveIvBackendParams` |
| `LoginUserFromSubscriptionOperationExecutor` | `shouldFailLoginUserFromSubscription` → `FAIL_NORETRY` |
| `CustomEventOperationExecutor` | `resolveIvJwt` |

DI auto-wires `JwtTokenStore` into executors through constructor reflection — no module changes needed (store was registered in #2623).

### Tests
- New `ExecutorsIvExtensionsTests` — 9 focused unit tests across Phase 1 / Phase 3 / IV-active for both `resolveIvBackendParams` and `resolveIvJwt`, plus `shouldFailLoginUserFromSubscription`.
- New `HttpClientTests` cases — Authorization header set iff `OptionalHeaders.jwt != null`.
- New `IdentityOperationExecutorTests` cases — IV-active and Phase 3 end-to-end verifies that the correct alias + JWT reach the backend mock.
- Updated existing test mocks in 4 backend test files + 6 executor test files to match new three-arg HTTP calls / new constructor params.
- New `ExecutorMocks.getJwtTokenStore()` helper (real empty `JwtTokenStore` backed by `MockPreferencesService`).

## Test plan
- [x] `./gradlew :OneSignal:core:testDebugUnitTest` — 814 pass / 2 fail (both pre-existing `SDKInitTests` failures, unrelated; reproduced on baseline).
- [x] `:OneSignal:in-app-messages`, `:OneSignal:notifications`, `:OneSignal:location` all compile clean.
- [ ] Manual smoke: verify `Authorization: Bearer <jwt>` is present on network requests when a customer has `jwt_required=true` (will be testable once PR 5 wires the public `login(externalId, jwt)` API).

## Out of scope (deferred to PR 5)
- IAM / `InAppBackendService` JWT integration
- RYW plumbing on `CreateUserResponse` / `JSONConverter`
- IAM 401/403 retry via `IJwtUpdateListener`
- `JwtTokenStore.pruneToExternalIds` caller (logout path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)