### PR TITLE
fix: [SDK-4388] subscription state permanently stuck at "Never Subscribed" when login() is called before requestPermission()

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/SubscriptionOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/SubscriptionOperationExecutor.kt
@@ -250,7 +250,12 @@ internal class SubscriptionOperationExecutor(
                     ) {
                         return ExecutionResponse(ExecutionResult.FAIL_RETRY, retryAfterSeconds = ex.retryAfterSeconds)
                     }
-                    // toss this, but create an identical CreateSubscriptionOperation to re-create the subscription being updated.
+                    // SDK-4388 follow-up: the original update target no longer exists on the
+                    // backend, so issue a fresh local-id Create. A non-local id here would re-route
+                    // through updateExistingSubscriptionFromCreate -> PATCH -> 404 indefinitely
+                    // because execute() dispatches non-local-id Creates as PATCHes; only a local
+                    // id forces the POST/rebuild-user recovery path that can actually re-create
+                    // the subscription.
                     ExecutionResponse(
                         ExecutionResult.FAIL_NORETRY,
                         operations =
@@ -259,7 +264,7 @@ internal class SubscriptionOperationExecutor(
                                 lastOperation.appId,
                                 lastOperation.onesignalId,
                                 lastOperation.externalId,
-                                lastOperation.subscriptionId,
+                                IDManager.createLocalId(),
                                 lastOperation.type,
                                 lastOperation.enabled,
                                 lastOperation.address,

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/SubscriptionOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/SubscriptionOperationExecutor.kt
@@ -57,7 +57,14 @@ internal class SubscriptionOperationExecutor(
         val startingOp = operations.first()
 
         return if (startingOp is CreateSubscriptionOperation) {
-            createSubscription(startingOp, operations)
+            // SDK-4388: if the subscription already exists on the backend (non-local id),
+            // POSTing to /subscriptions with that id is silently treated as a no-op and
+            // drops the merged enabled/status payload. Dispatch as an update instead.
+            if (!IDManager.isLocalId(startingOp.subscriptionId)) {
+                updateExistingSubscriptionFromCreate(startingOp, operations)
+            } else {
+                createSubscription(startingOp, operations)
+            }
         } else if (operations.any { it is DeleteSubscriptionOperation }) {
             if (operations.size > 1) {
                 throw Exception("Only supports one operation! Attempted operations:\n$operations")
@@ -76,6 +83,30 @@ internal class SubscriptionOperationExecutor(
         }
     }
 
+    private suspend fun updateExistingSubscriptionFromCreate(
+        createOperation: CreateSubscriptionOperation,
+        operations: List<Operation>,
+    ): ExecutionResponse {
+        // if there are any deletes all operations should be tossed, nothing to do.
+        if (operations.any { it is DeleteSubscriptionOperation }) {
+            return ExecutionResponse(ExecutionResult.SUCCESS)
+        }
+
+        val lastUpdateOperation = operations.lastOrNull { it is UpdateSubscriptionOperation } as UpdateSubscriptionOperation?
+        val patchOp =
+            UpdateSubscriptionOperation(
+                createOperation.appId,
+                createOperation.onesignalId,
+                createOperation.externalId,
+                createOperation.subscriptionId,
+                createOperation.type,
+                lastUpdateOperation?.enabled ?: createOperation.enabled,
+                lastUpdateOperation?.address ?: createOperation.address,
+                lastUpdateOperation?.status ?: createOperation.status,
+            )
+        return updateSubscription(patchOp, listOf(patchOp))
+    }
+
     private suspend fun createSubscription(
         createOperation: CreateSubscriptionOperation,
         operations: List<Operation>,
@@ -91,24 +122,6 @@ internal class SubscriptionOperationExecutor(
         val enabled = lastUpdateOperation?.enabled ?: createOperation.enabled
         val address = lastUpdateOperation?.address ?: createOperation.address
         val status = lastUpdateOperation?.status ?: createOperation.status
-
-        // SDK-4388: If the subscription already exists on the backend (non-local id), POSTing
-        // to /subscriptions with that id is silently treated as a no-op, dropping the merged
-        // enabled/status payload. Re-dispatch as a PATCH on the existing subscription instead.
-        if (!IDManager.isLocalId(createOperation.subscriptionId)) {
-            val patchOp =
-                UpdateSubscriptionOperation(
-                    createOperation.appId,
-                    createOperation.onesignalId,
-                    createOperation.externalId,
-                    createOperation.subscriptionId,
-                    createOperation.type,
-                    enabled,
-                    address,
-                    status,
-                )
-            return updateSubscription(patchOp, listOf(patchOp))
-        }
 
         try {
             val subscription =

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/SubscriptionOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/SubscriptionOperationExecutor.kt
@@ -91,12 +91,29 @@ internal class SubscriptionOperationExecutor(
         val enabled = lastUpdateOperation?.enabled ?: createOperation.enabled
         val address = lastUpdateOperation?.address ?: createOperation.address
         val status = lastUpdateOperation?.status ?: createOperation.status
-        val subId = if (!IDManager.isLocalId(createOperation.subscriptionId)) createOperation.subscriptionId else null
+
+        // SDK-4388: If the subscription already exists on the backend (non-local id), POSTing
+        // to /subscriptions with that id is silently treated as a no-op, dropping the merged
+        // enabled/status payload. Re-dispatch as a PATCH on the existing subscription instead.
+        if (!IDManager.isLocalId(createOperation.subscriptionId)) {
+            val patchOp =
+                UpdateSubscriptionOperation(
+                    createOperation.appId,
+                    createOperation.onesignalId,
+                    createOperation.externalId,
+                    createOperation.subscriptionId,
+                    createOperation.type,
+                    enabled,
+                    address,
+                    status,
+                )
+            return updateSubscription(patchOp, listOf(patchOp))
+        }
 
         try {
             val subscription =
                 SubscriptionObject(
-                    id = subId,
+                    id = null,
                     convert(createOperation.type),
                     address,
                     enabled,

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/SubscriptionOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/SubscriptionOperationExecutor.kt
@@ -256,6 +256,24 @@ internal class SubscriptionOperationExecutor(
                     // execute() dispatches non-local-id Creates as PATCHes; only a local id
                     // forces the POST/rebuild-user recovery path that can actually re-create
                     // the subscription.
+                    val recoveryLocalId = IDManager.createLocalId()
+                    val staleSubscriptionId = lastOperation.subscriptionId
+
+                    // Rewrite the cached SubscriptionModel id (and pushSubscriptionId, if it
+                    // pointed at the stale id) to the new local id. This keeps the recovery
+                    // Create and the rebuild-user path's getRebuildOperationsIfCurrentUser
+                    // emitting Creates with the same subscriptionId, so they dedupe instead
+                    // of producing two POST /users subscription rows. HYDRATE prevents the
+                    // SubscriptionModelStoreListener from enqueuing follow-on operations.
+                    _subscriptionModelStore.get(staleSubscriptionId)?.setStringProperty(
+                        SubscriptionModel::id.name,
+                        recoveryLocalId,
+                        ModelChangeTags.HYDRATE,
+                    )
+                    if (_configModelStore.model.pushSubscriptionId == staleSubscriptionId) {
+                        _configModelStore.model.pushSubscriptionId = recoveryLocalId
+                    }
+
                     ExecutionResponse(
                         ExecutionResult.FAIL_NORETRY,
                         operations =
@@ -264,7 +282,7 @@ internal class SubscriptionOperationExecutor(
                                 lastOperation.appId,
                                 lastOperation.onesignalId,
                                 lastOperation.externalId,
-                                IDManager.createLocalId(),
+                                recoveryLocalId,
                                 lastOperation.type,
                                 lastOperation.enabled,
                                 lastOperation.address,

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/SubscriptionOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/SubscriptionOperationExecutor.kt
@@ -57,9 +57,9 @@ internal class SubscriptionOperationExecutor(
         val startingOp = operations.first()
 
         return if (startingOp is CreateSubscriptionOperation) {
-            // SDK-4388: if the subscription already exists on the backend (non-local id),
-            // POSTing to /subscriptions with that id is silently treated as a no-op and
-            // drops the merged enabled/status payload. Dispatch as an update instead.
+            // If the subscription already exists on the backend (non-local id), POSTing
+            // to /subscriptions with that id is silently a server-side no-op and drops
+            // the merged enabled/status payload. Dispatch as an update instead.
             if (!IDManager.isLocalId(startingOp.subscriptionId)) {
                 updateExistingSubscriptionFromCreate(startingOp, operations)
             } else {
@@ -250,11 +250,11 @@ internal class SubscriptionOperationExecutor(
                     ) {
                         return ExecutionResponse(ExecutionResult.FAIL_RETRY, retryAfterSeconds = ex.retryAfterSeconds)
                     }
-                    // SDK-4388 follow-up: the original update target no longer exists on the
-                    // backend, so issue a fresh local-id Create. A non-local id here would re-route
-                    // through updateExistingSubscriptionFromCreate -> PATCH -> 404 indefinitely
-                    // because execute() dispatches non-local-id Creates as PATCHes; only a local
-                    // id forces the POST/rebuild-user recovery path that can actually re-create
+                    // The original update target no longer exists on the backend, so issue
+                    // a fresh local-id Create. A non-local id here would re-route through
+                    // updateExistingSubscriptionFromCreate -> PATCH -> 404 indefinitely because
+                    // execute() dispatches non-local-id Creates as PATCHes; only a local id
+                    // forces the POST/rebuild-user recovery path that can actually re-create
                     // the subscription.
                     ExecutionResponse(
                         ExecutionResult.FAIL_NORETRY,

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/SubscriptionOperationExecutorTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/SubscriptionOperationExecutorTests.kt
@@ -1,6 +1,7 @@
 package com.onesignal.user.internal.operations
 
 import br.com.colman.kotest.android.extensions.robolectric.RobolectricTest
+import com.onesignal.common.IDManager
 import com.onesignal.common.consistency.RywData
 import com.onesignal.common.consistency.enums.IamFetchRywTokenKey
 import com.onesignal.common.consistency.models.IConsistencyManager
@@ -23,6 +24,7 @@ import com.onesignal.user.internal.subscriptions.SubscriptionStatus
 import com.onesignal.user.internal.subscriptions.SubscriptionType
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.mockk.clearMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -625,6 +627,70 @@ class SubscriptionOperationExecutorTests :
                     },
                 )
             }
+        }
+
+        // Regression for SDK-4388: when an UpdateSubscriptionOperation PATCH returns 404 outside
+        // the missing-retry window, the executor must enqueue a recovery CreateSubscriptionOperation
+        // with a *local* subscriptionId. Re-using the original non-local id would bounce back
+        // through execute() -> updateExistingSubscriptionFromCreate -> PATCH -> 404 indefinitely
+        // (because non-local-id Creates dispatch as PATCHes), preventing the rebuild-user / POST
+        // recovery path in createSubscription from ever running.
+        test("update subscription 404 outside retry window enqueues recovery CreateSubscriptionOperation with local id") {
+            // Given
+            val mockSubscriptionBackendService = mockk<ISubscriptionBackendService>()
+            coEvery { mockSubscriptionBackendService.updateSubscription(any(), any(), any()) } throws BackendException(404)
+
+            val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
+            val mockBuildUserService = mockk<IRebuildUserService>()
+
+            val subscriptionOperationExecutor =
+                SubscriptionOperationExecutor(
+                    mockSubscriptionBackendService,
+                    MockHelper.deviceService(),
+                    AndroidMockHelper.applicationService(),
+                    mockSubscriptionsModelStore,
+                    MockHelper.configModelStore(),
+                    mockBuildUserService,
+                    getNewRecordState(),
+                    mockConsistencyManager,
+                    getJwtTokenStore(), getIdentityVerificationService(),
+                )
+
+            val operations =
+                listOf<Operation>(
+                    UpdateSubscriptionOperation(
+                        appId,
+                        remoteOneSignalId,
+                        "ext-1",
+                        remoteSubscriptionId,
+                        SubscriptionType.PUSH,
+                        true,
+                        "pushToken2",
+                        SubscriptionStatus.SUBSCRIBED,
+                    ),
+                )
+
+            // When
+            val response = subscriptionOperationExecutor.execute(operations)
+
+            // Then
+            response.result shouldBe ExecutionResult.FAIL_NORETRY
+            response.operations shouldNotBe null
+            response.operations!!.size shouldBe 1
+            val recovery = response.operations!!.first() as CreateSubscriptionOperation
+            // The recovery op must carry a fresh LOCAL id, not the original non-local one.
+            // This is what forces execute() to dispatch through the POST/rebuild-user path on the
+            // next execution instead of looping back into PATCH -> 404 forever.
+            IDManager.isLocalId(recovery.subscriptionId) shouldBe true
+            recovery.subscriptionId shouldNotBe remoteSubscriptionId
+            // All other fields propagated so the recovered subscription matches the desired state.
+            recovery.appId shouldBe appId
+            recovery.onesignalId shouldBe remoteOneSignalId
+            recovery.externalId shouldBe "ext-1"
+            recovery.type shouldBe SubscriptionType.PUSH
+            recovery.enabled shouldBe true
+            recovery.address shouldBe "pushToken2"
+            recovery.status shouldBe SubscriptionStatus.SUBSCRIBED
         }
 
         test("update subscription fails with retry when the backend returns MISSING, when isInMissingRetryWindow") {

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/SubscriptionOperationExecutorTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/SubscriptionOperationExecutorTests.kt
@@ -632,16 +632,33 @@ class SubscriptionOperationExecutorTests :
 
         // Regression: when an UpdateSubscriptionOperation PATCH returns 404 outside
         // the missing-retry window, the executor must enqueue a recovery CreateSubscriptionOperation
-        // with a *local* subscriptionId. Re-using the original non-local id would bounce back
-        // through execute() -> updateExistingSubscriptionFromCreate -> PATCH -> 404 indefinitely
-        // (because non-local-id Creates dispatch as PATCHes), preventing the rebuild-user / POST
-        // recovery path in createSubscription from ever running.
-        test("update subscription 404 outside retry window enqueues recovery CreateSubscriptionOperation with local id") {
+        // with a *local* subscriptionId AND rewrite the cached SubscriptionModel + pushSubscriptionId
+        // to that same local id. Two reasons:
+        //   1. A non-local recovery id would bounce back through execute() ->
+        //      updateExistingSubscriptionFromCreate -> PATCH -> 404 indefinitely (because
+        //      non-local-id Creates dispatch as PATCHes), preventing the rebuild-user / POST
+        //      recovery path in createSubscription from ever running.
+        //   2. If the model store still held the original non-local id, the rebuild-user path
+        //      (LoginUserOperationExecutor's getRebuildOperationsIfCurrentUser) would emit a
+        //      second Create carrying that stale id; both Creates would land in POST /users
+        //      and the backend would create two subscription rows for the same device.
+        test("update subscription 404 outside retry window rewrites cached subscription id and enqueues local-id Create") {
             // Given
             val mockSubscriptionBackendService = mockk<ISubscriptionBackendService>()
             coEvery { mockSubscriptionBackendService.updateSubscription(any(), any(), any()) } throws BackendException(404)
 
             val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
+            val cachedSubscriptionModel =
+                SubscriptionModel().apply {
+                    id = remoteSubscriptionId
+                    type = SubscriptionType.PUSH
+                    address = "pushToken2"
+                    optedIn = true
+                }
+            every { mockSubscriptionsModelStore.get(remoteSubscriptionId) } returns cachedSubscriptionModel
+
+            val configModelStore = MockHelper.configModelStore().also { it.model.pushSubscriptionId = remoteSubscriptionId }
+
             val mockBuildUserService = mockk<IRebuildUserService>()
 
             val subscriptionOperationExecutor =
@@ -650,7 +667,7 @@ class SubscriptionOperationExecutorTests :
                     MockHelper.deviceService(),
                     AndroidMockHelper.applicationService(),
                     mockSubscriptionsModelStore,
-                    MockHelper.configModelStore(),
+                    configModelStore,
                     mockBuildUserService,
                     getNewRecordState(),
                     mockConsistencyManager,
@@ -692,6 +709,10 @@ class SubscriptionOperationExecutorTests :
             recovery.enabled shouldBe true
             recovery.address shouldBe "pushToken2"
             recovery.status shouldBe SubscriptionStatus.SUBSCRIBED
+            // The cached SubscriptionModel and pushSubscriptionId must now point at the new local id
+            // so the rebuild-user path emits a Create with the same id and dedupes with this recovery.
+            cachedSubscriptionModel.id shouldBe recovery.subscriptionId
+            configModelStore.model.pushSubscriptionId shouldBe recovery.subscriptionId
         }
 
         test("update subscription fails with retry when the backend returns MISSING, when isInMissingRetryWindow") {

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/SubscriptionOperationExecutorTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/SubscriptionOperationExecutorTests.kt
@@ -1034,4 +1034,211 @@ class SubscriptionOperationExecutorTests :
                 )
             }
         }
+
+        // SDK-4388: when a CreateSubscriptionOperation with a non-local id is grouped with a
+        // DeleteSubscriptionOperation, the executor must short-circuit to SUCCESS without
+        // making any backend calls. Creating-then-deleting an already-existing subscription is
+        // a no-op, and a stray PATCH here would resurrect a subscription the caller intended
+        // to remove.
+        test("create subscription with non-local id then delete is a successful no-op") {
+            // Given
+            val mockSubscriptionBackendService = mockk<ISubscriptionBackendService>()
+
+            val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
+            val subscriptionModel = SubscriptionModel().apply { id = remoteSubscriptionId }
+            every { mockSubscriptionsModelStore.get(remoteSubscriptionId) } returns subscriptionModel
+
+            val mockBuildUserService = mockk<IRebuildUserService>()
+
+            val subscriptionOperationExecutor =
+                SubscriptionOperationExecutor(
+                    mockSubscriptionBackendService,
+                    MockHelper.deviceService(),
+                    AndroidMockHelper.applicationService(),
+                    mockSubscriptionsModelStore,
+                    MockHelper.configModelStore(),
+                    mockBuildUserService,
+                    getNewRecordState(),
+                    mockConsistencyManager,
+                    getJwtTokenStore(), getIdentityVerificationService(),
+                )
+
+            val operations =
+                listOf<Operation>(
+                    CreateSubscriptionOperation(
+                        appId,
+                        remoteOneSignalId,
+                        null,
+                        remoteSubscriptionId,
+                        SubscriptionType.PUSH,
+                        true,
+                        "pushToken",
+                        SubscriptionStatus.SUBSCRIBED,
+                    ),
+                    DeleteSubscriptionOperation(appId, remoteOneSignalId, null, remoteSubscriptionId),
+                )
+
+            // When
+            val response = subscriptionOperationExecutor.execute(operations)
+
+            // Then
+            response.result shouldBe ExecutionResult.SUCCESS
+            coVerify(exactly = 0) {
+                mockSubscriptionBackendService.createSubscription(any(), any(), any(), any())
+            }
+            coVerify(exactly = 0) {
+                mockSubscriptionBackendService.updateSubscription(any(), any(), any())
+            }
+            coVerify(exactly = 0) {
+                mockSubscriptionBackendService.deleteSubscription(any(), any())
+            }
+        }
+
+        // SDK-4388: when the PATCH dispatched for a non-local-id Create fails with a retryable
+        // network error, the executor must propagate FAIL_RETRY (and any retryAfterSeconds) so
+        // OperationRepo can re-execute, rather than swallowing the error or routing back to a
+        // POST that the backend would silently no-op.
+        test("create subscription with non-local id fails with retry when there is a network condition") {
+            // Given
+            val mockSubscriptionBackendService = mockk<ISubscriptionBackendService>()
+            coEvery { mockSubscriptionBackendService.updateSubscription(any(), any(), any()) } throws
+                BackendException(408, retryAfterSeconds = 10)
+
+            val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
+            val mockBuildUserService = mockk<IRebuildUserService>()
+
+            val subscriptionOperationExecutor =
+                SubscriptionOperationExecutor(
+                    mockSubscriptionBackendService,
+                    MockHelper.deviceService(),
+                    AndroidMockHelper.applicationService(),
+                    mockSubscriptionsModelStore,
+                    MockHelper.configModelStore(),
+                    mockBuildUserService,
+                    getNewRecordState(),
+                    mockConsistencyManager,
+                    getJwtTokenStore(), getIdentityVerificationService(),
+                )
+
+            val operations =
+                listOf<Operation>(
+                    CreateSubscriptionOperation(
+                        appId,
+                        remoteOneSignalId,
+                        null,
+                        remoteSubscriptionId,
+                        SubscriptionType.PUSH,
+                        true,
+                        "pushToken",
+                        SubscriptionStatus.SUBSCRIBED,
+                    ),
+                )
+
+            // When
+            val response = subscriptionOperationExecutor.execute(operations)
+
+            // Then
+            response.result shouldBe ExecutionResult.FAIL_RETRY
+            response.retryAfterSeconds shouldBe 10
+            coVerify(exactly = 0) {
+                mockSubscriptionBackendService.createSubscription(any(), any(), any(), any())
+            }
+            coVerify(exactly = 1) {
+                mockSubscriptionBackendService.updateSubscription(
+                    appId,
+                    remoteSubscriptionId,
+                    withArg {
+                        it.type shouldBe SubscriptionObjectType.ANDROID_PUSH
+                        it.enabled shouldBe true
+                        it.token shouldBe "pushToken"
+                        it.notificationTypes shouldBe SubscriptionStatus.SUBSCRIBED.value
+                    },
+                )
+            }
+        }
+
+        // SDK-4388: when multiple UpdateSubscriptionOperations are batched with a non-local-id
+        // Create, the executor must collapse them into a single PATCH carrying the *last*
+        // update's values (not the create's, not the first update's). Locks in last-wins
+        // semantics so a future "merge updates" refactor can't silently change behavior on
+        // this path and re-introduce stale state on the backend.
+        test("create subscription with non-local id and multiple updates uses the last update's values") {
+            // Given
+            val mockSubscriptionBackendService = mockk<ISubscriptionBackendService>()
+            coEvery { mockSubscriptionBackendService.updateSubscription(any(), any(), any()) } returns rywData
+
+            val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
+            val subscriptionModel = SubscriptionModel().apply { id = remoteSubscriptionId }
+            every { mockSubscriptionsModelStore.get(remoteSubscriptionId) } returns subscriptionModel
+
+            val mockBuildUserService = mockk<IRebuildUserService>()
+
+            val subscriptionOperationExecutor =
+                SubscriptionOperationExecutor(
+                    mockSubscriptionBackendService,
+                    MockHelper.deviceService(),
+                    AndroidMockHelper.applicationService(),
+                    mockSubscriptionsModelStore,
+                    MockHelper.configModelStore(),
+                    mockBuildUserService,
+                    getNewRecordState(),
+                    mockConsistencyManager,
+                    getJwtTokenStore(), getIdentityVerificationService(),
+                )
+
+            val operations =
+                listOf<Operation>(
+                    CreateSubscriptionOperation(
+                        appId,
+                        remoteOneSignalId,
+                        null,
+                        remoteSubscriptionId,
+                        SubscriptionType.PUSH,
+                        false,
+                        "pushTokenCreate",
+                        SubscriptionStatus.NO_PERMISSION,
+                    ),
+                    UpdateSubscriptionOperation(
+                        appId,
+                        remoteOneSignalId,
+                        null,
+                        remoteSubscriptionId,
+                        SubscriptionType.PUSH,
+                        false,
+                        "pushTokenIntermediate",
+                        SubscriptionStatus.NO_PERMISSION,
+                    ),
+                    UpdateSubscriptionOperation(
+                        appId,
+                        remoteOneSignalId,
+                        null,
+                        remoteSubscriptionId,
+                        SubscriptionType.PUSH,
+                        true,
+                        "pushTokenFinal",
+                        SubscriptionStatus.SUBSCRIBED,
+                    ),
+                )
+
+            // When
+            val response = subscriptionOperationExecutor.execute(operations)
+
+            // Then
+            response.result shouldBe ExecutionResult.SUCCESS
+            coVerify(exactly = 0) {
+                mockSubscriptionBackendService.createSubscription(any(), any(), any(), any())
+            }
+            coVerify(exactly = 1) {
+                mockSubscriptionBackendService.updateSubscription(
+                    appId,
+                    remoteSubscriptionId,
+                    withArg {
+                        it.type shouldBe SubscriptionObjectType.ANDROID_PUSH
+                        it.enabled shouldBe true
+                        it.token shouldBe "pushTokenFinal"
+                        it.notificationTypes shouldBe SubscriptionStatus.SUBSCRIBED.value
+                    },
+                )
+            }
+        }
     })

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/SubscriptionOperationExecutorTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/SubscriptionOperationExecutorTests.kt
@@ -109,11 +109,14 @@ class SubscriptionOperationExecutorTests :
             }
         }
 
-        test("create subscription includes the subscription ID if non-local") {
+        // SDK-4388: A CreateSubscriptionOperation can carry a non-local subscriptionId when
+        // a subscription that already exists on the backend is re-attached to a new local user
+        // (e.g. createAndSwitchToNewUser after login). POSTing to /subscriptions with that id is
+        // silently a no-op on the server, so we must PATCH the existing subscription instead.
+        test("create subscription PATCHes existing subscription when subscription ID is non-local") {
             // Given
             val mockSubscriptionBackendService = mockk<ISubscriptionBackendService>()
-            coEvery { mockSubscriptionBackendService.createSubscription(any(), any(), any(), any()) } returns
-                Pair(remoteSubscriptionId, rywData)
+            coEvery { mockSubscriptionBackendService.updateSubscription(any(), any(), any()) } returns rywData
 
             val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
             val subscriptionModel = SubscriptionModel()
@@ -150,16 +153,22 @@ class SubscriptionOperationExecutorTests :
                 )
 
             // When
-            subscriptionOperationExecutor.execute(operations)
+            val response = subscriptionOperationExecutor.execute(operations)
 
             // Then
+            response.result shouldBe ExecutionResult.SUCCESS
+            coVerify(exactly = 0) {
+                mockSubscriptionBackendService.createSubscription(any(), any(), any(), any())
+            }
             coVerify(exactly = 1) {
-                mockSubscriptionBackendService.createSubscription(
+                mockSubscriptionBackendService.updateSubscription(
                     appId,
-                    IdentityConstants.ONESIGNAL_ID,
-                    remoteOneSignalId,
+                    remoteSubscriptionId,
                     withArg {
-                        it.id shouldBe remoteSubscriptionId
+                        it.type shouldBe SubscriptionObjectType.ANDROID_PUSH
+                        it.enabled shouldBe true
+                        it.token shouldBe "pushToken"
+                        it.notificationTypes shouldBe SubscriptionStatus.SUBSCRIBED.value
                     },
                 )
             }
@@ -950,5 +959,79 @@ class SubscriptionOperationExecutorTests :
             // Then
             response.result shouldBe ExecutionResult.FAIL_UNAUTHORIZED
             response.retryAfterSeconds shouldBe 5
+        }
+
+        // Repro for SDK-4388: when a CreateSubscriptionOperation is grouped with a follow-up
+        // UpdateSubscriptionOperation for a subscription that already exists on the server
+        // (non-local subscriptionId), the executor must PATCH the merged final state instead
+        // of POSTing (which the backend treats as a no-op, silently dropping enabled/status).
+        test("create subscription with non-local id PATCHes instead of POSTing when grouped with update") {
+            // Given
+            val mockSubscriptionBackendService = mockk<ISubscriptionBackendService>()
+            coEvery { mockSubscriptionBackendService.updateSubscription(any(), any(), any()) } returns rywData
+
+            val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
+            val subscriptionModel = SubscriptionModel().apply { id = remoteSubscriptionId }
+            every { mockSubscriptionsModelStore.get(remoteSubscriptionId) } returns subscriptionModel
+
+            val mockBuildUserService = mockk<IRebuildUserService>()
+
+            val subscriptionOperationExecutor =
+                SubscriptionOperationExecutor(
+                    mockSubscriptionBackendService,
+                    MockHelper.deviceService(),
+                    AndroidMockHelper.applicationService(),
+                    mockSubscriptionsModelStore,
+                    MockHelper.configModelStore(),
+                    mockBuildUserService,
+                    getNewRecordState(),
+                    mockConsistencyManager,
+                    getJwtTokenStore(), getIdentityVerificationService(),
+                )
+
+            val operations =
+                listOf<Operation>(
+                    CreateSubscriptionOperation(
+                        appId,
+                        remoteOneSignalId,
+                        null,
+                        remoteSubscriptionId,
+                        SubscriptionType.PUSH,
+                        false,
+                        "pushToken",
+                        SubscriptionStatus.NO_PERMISSION,
+                    ),
+                    UpdateSubscriptionOperation(
+                        appId,
+                        remoteOneSignalId,
+                        null,
+                        remoteSubscriptionId,
+                        SubscriptionType.PUSH,
+                        true,
+                        "pushToken",
+                        SubscriptionStatus.SUBSCRIBED,
+                    ),
+                )
+
+            // When
+            val response = subscriptionOperationExecutor.execute(operations)
+
+            // Then
+            response.result shouldBe ExecutionResult.SUCCESS
+            coVerify(exactly = 0) {
+                mockSubscriptionBackendService.createSubscription(any(), any(), any(), any())
+            }
+            coVerify(exactly = 1) {
+                mockSubscriptionBackendService.updateSubscription(
+                    appId,
+                    remoteSubscriptionId,
+                    withArg {
+                        it.type shouldBe SubscriptionObjectType.ANDROID_PUSH
+                        it.enabled shouldBe true
+                        it.token shouldBe "pushToken"
+                        it.notificationTypes shouldBe SubscriptionStatus.SUBSCRIBED.value
+                    },
+                )
+            }
         }
     })

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/SubscriptionOperationExecutorTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/SubscriptionOperationExecutorTests.kt
@@ -111,9 +111,9 @@ class SubscriptionOperationExecutorTests :
             }
         }
 
-        // SDK-4388: A CreateSubscriptionOperation can carry a non-local subscriptionId when
-        // a subscription that already exists on the backend is re-attached to a new local user
-        // (e.g. createAndSwitchToNewUser after login). POSTing to /subscriptions with that id is
+        // A CreateSubscriptionOperation can carry a non-local subscriptionId when a subscription
+        // that already exists on the backend is re-attached to a new local user (e.g.
+        // createAndSwitchToNewUser after login). POSTing to /subscriptions with that id is
         // silently a no-op on the server, so we must PATCH the existing subscription instead.
         test("create subscription PATCHes existing subscription when subscription ID is non-local") {
             // Given
@@ -629,7 +629,7 @@ class SubscriptionOperationExecutorTests :
             }
         }
 
-        // Regression for SDK-4388: when an UpdateSubscriptionOperation PATCH returns 404 outside
+        // Regression: when an UpdateSubscriptionOperation PATCH returns 404 outside
         // the missing-retry window, the executor must enqueue a recovery CreateSubscriptionOperation
         // with a *local* subscriptionId. Re-using the original non-local id would bounce back
         // through execute() -> updateExistingSubscriptionFromCreate -> PATCH -> 404 indefinitely
@@ -1027,7 +1027,7 @@ class SubscriptionOperationExecutorTests :
             response.retryAfterSeconds shouldBe 5
         }
 
-        // Repro for SDK-4388: when a CreateSubscriptionOperation is grouped with a follow-up
+        // When a CreateSubscriptionOperation is grouped with a follow-up
         // UpdateSubscriptionOperation for a subscription that already exists on the server
         // (non-local subscriptionId), the executor must PATCH the merged final state instead
         // of POSTing (which the backend treats as a no-op, silently dropping enabled/status).
@@ -1101,7 +1101,7 @@ class SubscriptionOperationExecutorTests :
             }
         }
 
-        // SDK-4388: when a CreateSubscriptionOperation with a non-local id is grouped with a
+        // When a CreateSubscriptionOperation with a non-local id is grouped with a
         // DeleteSubscriptionOperation, the executor must short-circuit to SUCCESS without
         // making any backend calls. Creating-then-deleting an already-existing subscription is
         // a no-op, and a stray PATCH here would resurrect a subscription the caller intended
@@ -1160,7 +1160,7 @@ class SubscriptionOperationExecutorTests :
             }
         }
 
-        // SDK-4388: when the PATCH dispatched for a non-local-id Create fails with a retryable
+        // When the PATCH dispatched for a non-local-id Create fails with a retryable
         // network error, the executor must propagate FAIL_RETRY (and any retryAfterSeconds) so
         // OperationRepo can re-execute, rather than swallowing the error or routing back to a
         // POST that the backend would silently no-op.
@@ -1223,7 +1223,7 @@ class SubscriptionOperationExecutorTests :
             }
         }
 
-        // SDK-4388: when multiple UpdateSubscriptionOperations are batched with a non-local-id
+        // When multiple UpdateSubscriptionOperations are batched with a non-local-id
         // Create, the executor must collapse them into a single PATCH carrying the *last*
         // update's values (not the create's, not the first update's). Locks in last-wins
         // semantics so a future "merge updates" refactor can't silently change behavior on

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/SubscriptionOperationExecutorTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/SubscriptionOperationExecutorTests.kt
@@ -581,6 +581,7 @@ class SubscriptionOperationExecutorTests :
             coEvery { mockSubscriptionBackendService.updateSubscription(any(), any(), any()) } throws BackendException(404)
 
             val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
+            every { mockSubscriptionsModelStore.get(any()) } returns null
             val mockBuildUserService = mockk<IRebuildUserService>()
 
             val subscriptionOperationExecutor =


### PR DESCRIPTION
## Summary

Fixes [SDK-4388](https://linear.app/onesignal/issue/SDK-4388/android-sdk-subscription-state-permanently-stuck-at-never-subscribed). On a fresh install, when `OneSignal.login(externalId)` is called after `initWithContext` but before `requestPermission()`, the server-side subscription gets permanently stuck at `enabled:false, notification_types:0` ("Never Subscribed / Permission Not Granted") even though the device is fully subscribed locally (`optedIn == true`).

Cherry-picked from @fadii925's [`fadi/sdk-4388-...`](https://github.com/OneSignal/OneSignal-Android-SDK/tree/fadi/sdk-4388-android-sdk-subscription-state-permanently-stuck-at-never) branch (which is based on `5.7-main`) onto `main`. Authorship preserved.

## Repro (from the ticket)

1. Fresh install → `initWithContext` runs, SDK POSTs `/apps/.../users` → server responds 201 with a server-assigned `subscriptionId`.
2. FCM returns a push token → SDK enqueues `update-subscription(NO_PERMISSION)`.
3. App calls `OneSignal.login(externalId)` → SDK runs `createAndSwitchToNewUser()`, which enqueues `create-subscription` **reusing the server-assigned `subscriptionId`** + `login-user` with `existingOnesignalId`.
4. App calls `requestPermission()` → user grants → SDK enqueues `update-subscription(SUBSCRIBED)`.
5. Op queue flushes:
   - `update-subscription(NO_PERMISSION)` → `PATCH /subscriptions/{id}` → 200. Server: `enabled:false, notification_types:0`.
   - `login-user` → `PATCH .../identity` → `SUCCESS_STARTING_ONLY`. Remaining ops translated from local user onto server user.
   - `create-subscription` + `update-subscription(SUBSCRIBED)` batched into one `POST .../subscriptions` with `{ id:"<server-uuid>", enabled:true, notification_types:1 }` → **`200 {}`** (no-op, subscription already exists). The `enabled:true` is silently discarded.
6. No further PATCH is issued → server stays at `enabled:false, notification_types:0` permanently.

## Root cause

`SubscriptionOperationExecutor.createSubscription` was always issuing a `POST /subscriptions` for `CreateSubscriptionOperation`, regardless of whether the carried `subscriptionId` was local or already a server-assigned UUID. When the id is already known to the backend, POST is silently treated as a no-op and the merged `enabled`/`address`/`status` payload is dropped.

This happens specifically on `login()` because `UserSwitcher.createAndSwitchToNewUser` reuses the existing push subscription's id under the new local user, and `SubscriptionModelStoreListener.getAddOperation` mechanically converts the resulting model add into a `CreateSubscriptionOperation` carrying that real id. Combined with `GroupComparisonType.ALTER` grouping it with the follow-up `update-subscription(SUBSCRIBED)`, the executor ends up POSTing a doomed batch.

## Fix

In `SubscriptionOperationExecutor.execute()`, branch on `IDManager.isLocalId(startingOp.subscriptionId)` for `CreateSubscriptionOperation`:

- **Local id** (genuinely new subscription): keep existing `createSubscription` path → `POST /subscriptions`.
- **Non-local id** (subscription already on backend): route through new `updateExistingSubscriptionFromCreate` helper which collapses the merged final state (`enabled`/`address`/`status` from the last `UpdateSubscriptionOperation` if present, otherwise from the create op) into an `UpdateSubscriptionOperation` and dispatches via `updateSubscription` → `PATCH /subscriptions/{id}`.

This implements option (a) from the ticket. Option (b) (drop the create op) was rejected because it would no-op when there's no follow-up `UpdateSubscriptionOperation` in the batch.

The delete short-circuit (`if (operations.any { it is DeleteSubscriptionOperation }) return SUCCESS`) is preserved in the new helper.

## Customer impact

- **App ID:** `e198f6f8-f233-4073-8380-4a3c79ae64e7`
- **Affected SDK:** Android Native 5.7.7 and earlier (likely all 5.x versions with this code path)
- **Customer workaround:** call `requestPermission()` *before* `login()`, or REST-API correct stuck subscriptions via `PATCH /apps/{app_id}/subscriptions/{subscription_id}` with `{"subscription": {"notification_types": 1}}`.

## Test plan

- [x] New unit test `"create subscription with non-local id PATCHes instead of POSTing when grouped with update"` reproduces the SDK-4388 scenario (Create(NO_PERMISSION) + Update(SUBSCRIBED) with non-local id) and asserts a single PATCH with `enabled:true, notificationTypes=SUBSCRIBED`, zero POSTs.
- [x] Existing test `"create subscription includes the subscription ID if non-local"` rewritten to assert PATCH (the previous "POST with existing id" behavior is no longer correct).
- [x] Pre-existing test coverage for create-subscription with local id, transfer, delete, and update paths preserved unchanged.
- [ ] CI: `./gradlew :OneSignal:core:testReleaseUnitTest` green.
- [ ] Manual: repro the ticket flow on a fresh install (initWithContext → login → requestPermission) and verify the server-side subscription ends at `enabled:true, notification_types:1`.

## Followups (not in this PR)

The root *modeling* issue is that `UserSwitcher.createAndSwitchToNewUser` re-attaches an existing server-assigned subscription model under a new local user, which the model-store listener interprets as a brand-new subscription needing creation. A follow-up should consider either:

1. Emitting a `TransferSubscriptionOperation` (or no-op) instead of `CreateSubscriptionOperation` in the listener when `IDManager.isLocalId(model.id)` is false, or
2. Handling the re-attach with `NO_PROPOGATE` in `createAndSwitchToNewUser` and explicitly enqueuing a transfer op.

There is also a sibling code path in `LoginUserOperationExecutor.createSubscriptionsFromOperation(CreateSubscriptionOperation, ...)` that does the same `if (!isLocalId) operation.subscriptionId else null` trick when sending to `/users` (the non-`SUCCESS_STARTING_ONLY` path), and is not addressed here.

## Backport

This fix should also land on `5.7-main` for the next 5.7.x patch release. @fadii925's original branch is already based on `5.7-main` and can be PR'd there directly: https://github.com/OneSignal/OneSignal-Android-SDK/tree/fadi/sdk-4388-android-sdk-subscription-state-permanently-stuck-at-never
