### PR TITLE
ci: raise Gradle MaxMetaspaceSize to 1g to fix Publish Release OOM

### DIFF
--- a/OneSignalSDK/gradle.properties
+++ b/OneSignalSDK/gradle.properties
@@ -23,7 +23,7 @@
 # Remove when creating an .aar build.
 #android.enableAapt2=false
 
-org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError
+org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=1g -XX:+HeapDumpOnOutOfMemoryError
 
 # Gradle daemon optimization
 org.gradle.daemon=true


### PR DESCRIPTION
## Summary
- The `Publish Release` workflow failed on 2026-04-28 during the *Dry Run - Publish to Maven Local with signing* step with `java.lang.OutOfMemoryError: Metaspace` while running `:OneSignal:location:javaDocReleaseGeneration` (Dokka).
- Gradle logged that the configured max Metaspace was 512 MiB, which Dokka exhausts because it loads class metadata for every submodule (`core`, `in-app-messages`, `notifications`, `otel`, `location`, etc.).
- Bumps `MaxMetaspaceSize` from `512m` to `1g` in `OneSignalSDK/gradle.properties`.

### Failure excerpt
```
Exception in thread "RMI TCP Connection(idle)" java.lang.OutOfMemoryError: Metaspace
> Task :OneSignal:location:javaDocReleaseGeneration FAILED
...
* What went wrong:
Execution failed for task ':OneSignal:location:javaDocReleaseGeneration'.
> A failure occurred while executing com.android.build.gradle.tasks.JavaDocGenerationTask$DokkaWorkAction
```

## Test plan
- [ ] CI green on this PR
- [ ] Re-run the `Publish Release` workflow after merge and confirm the dry-run publish + Dokka tasks complete successfully