### PR TITLE
fix: [SDK-4474] self-heal SDK-4388-stuck push subscriptions on session start

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/RefreshUserOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/RefreshUserOperationExecutor.kt
@@ -224,7 +224,7 @@ internal class RefreshUserOperationExecutor(
             return null
         }
 
-        Logging.warn(
+        Logging.info(
             "RefreshUserOperationExecutor: push subscription $pushSubscriptionId diverged from server " +
                 "(server enabled=${serverSubscription.enabled} notificationTypes=${serverSubscription.notificationTypes}; " +
                 "local opted-in and SUBSCRIBED). Enqueuing follow-up update-subscription op to re-assert local " +

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/RefreshUserOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/RefreshUserOperationExecutor.kt
@@ -107,7 +107,7 @@ internal class RefreshUserOperationExecutor(
             val pushSubscriptionIdFromConfig = _configModelStore.model.pushSubscriptionId
 
             val subscriptionModels = mutableListOf<SubscriptionModel>()
-            var pushSelfHealOperation: UpdateSubscriptionOperation? = null
+            var pushSelfHealOperationForStuckSubscription: UpdateSubscriptionOperation? = null
             for (subscription in response.subscriptions) {
                 val subscriptionModel = SubscriptionModel()
                 subscriptionModel.id = subscription.id!!
@@ -135,7 +135,7 @@ internal class RefreshUserOperationExecutor(
                 // so we don't want to cache these subscriptions from the backend.
                 if (subscriptionModel.type != SubscriptionType.PUSH) {
                     subscriptionModels.add(subscriptionModel)
-                } else if (subscription.id == pushSubscriptionIdFromConfig && pushSelfHealOperation == null) {
+                } else if (subscription.id == pushSubscriptionIdFromConfig && pushSelfHealOperationForStuckSubscription == null) {
                     // Self-heal for users stuck at "Never Subscribed". Older SDK builds dispatched
                     // the merged create-subscription + update-subscription(SUBSCRIBED) batch as a
                     // POST /subscriptions carrying the already-existing server-side id; the server
@@ -147,7 +147,7 @@ internal class RefreshUserOperationExecutor(
                     // re-assert local truth via PATCH. "Device is the source of truth" is the
                     // existing policy for push; this just enforces it across the wire when the
                     // server has drifted out of sync.
-                    pushSelfHealOperation = buildPushSelfHealOperationForStuckSubscription(op, subscription, pushSubscriptionIdFromConfig)
+                    pushSelfHealOperationForStuckSubscription = buildPushSelfHealOperationForStuckSubscription(op, subscription, pushSubscriptionIdFromConfig)
                 }
             }
 
@@ -167,7 +167,7 @@ internal class RefreshUserOperationExecutor(
 
             return ExecutionResponse(
                 ExecutionResult.SUCCESS,
-                operations = pushSelfHealOperation?.let { listOf<Operation>(it) },
+                operations = pushSelfHealOperationForStuckSubscription?.let { listOf<Operation>(it) },
             )
         } catch (ex: BackendException) {
             val responseType = NetworkUtils.getResponseStatusType(ex.statusCode)

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/RefreshUserOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/RefreshUserOperationExecutor.kt
@@ -207,7 +207,6 @@ internal class RefreshUserOperationExecutor(
      * Caller has already verified that [serverSubscription.id] matches the cached
      * `pushSubscriptionId`, so this method only inspects the local model + server flags.
      */
-    @Suppress("ReturnCount")
     private fun buildPushSelfHealOperationForStuckSubscription(
         op: RefreshUserOperation,
         serverSubscription: SubscriptionObject,
@@ -220,27 +219,28 @@ internal class RefreshUserOperationExecutor(
 
         val (localEnabled, localStatus) = SubscriptionModelStoreListener.getSubscriptionEnabledAndStatus(cachedPushSubscriptionModel)
         val serverEnabled = (serverSubscription.enabled == true) && ((serverSubscription.notificationTypes ?: 0) > 0)
-        if (!localEnabled || serverEnabled) {
-            return null
+        val divergent = localEnabled && !serverEnabled
+
+        return if (divergent) {
+            Logging.info(
+                "RefreshUserOperationExecutor: push subscription $pushSubscriptionId diverged from server " +
+                    "(server enabled=${serverSubscription.enabled} notificationTypes=${serverSubscription.notificationTypes}; " +
+                    "local opted-in and SUBSCRIBED). Enqueuing follow-up update-subscription op to re-assert local " +
+                    "truth via PATCH /subscriptions/{id}. See SDK-4388 / SDK-4474.",
+            )
+            UpdateSubscriptionOperation(
+                op.appId,
+                op.onesignalId,
+                _identityModelStore.model.externalId,
+                pushSubscriptionId,
+                cachedPushSubscriptionModel.type,
+                localEnabled,
+                cachedPushSubscriptionModel.address,
+                localStatus,
+            )
+        } else {
+            null
         }
-
-        Logging.info(
-            "RefreshUserOperationExecutor: push subscription $pushSubscriptionId diverged from server " +
-                "(server enabled=${serverSubscription.enabled} notificationTypes=${serverSubscription.notificationTypes}; " +
-                "local opted-in and SUBSCRIBED). Enqueuing follow-up update-subscription op to re-assert local " +
-                "truth via PATCH /subscriptions/{id}. See SDK-4388 / SDK-4474.",
-        )
-
-        return UpdateSubscriptionOperation(
-            op.appId,
-            op.onesignalId,
-            _identityModelStore.model.externalId,
-            pushSubscriptionId,
-            cachedPushSubscriptionModel.type,
-            localEnabled,
-            cachedPushSubscriptionModel.address,
-            localStatus,
-        )
     }
 
     companion object {

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/RefreshUserOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/RefreshUserOperationExecutor.kt
@@ -13,12 +13,15 @@ import com.onesignal.core.internal.operations.Operation
 import com.onesignal.debug.LogLevel
 import com.onesignal.debug.internal.logging.Logging
 import com.onesignal.user.internal.backend.IUserBackendService
+import com.onesignal.user.internal.backend.SubscriptionObject
 import com.onesignal.user.internal.backend.SubscriptionObjectType
 import com.onesignal.user.internal.builduser.IRebuildUserService
 import com.onesignal.user.internal.identity.IdentityModel
 import com.onesignal.user.internal.identity.IdentityModelStore
 import com.onesignal.user.internal.jwt.JwtTokenStore
 import com.onesignal.user.internal.operations.RefreshUserOperation
+import com.onesignal.user.internal.operations.UpdateSubscriptionOperation
+import com.onesignal.user.internal.operations.impl.listeners.SubscriptionModelStoreListener
 import com.onesignal.user.internal.operations.impl.states.NewRecordsState
 import com.onesignal.user.internal.properties.PropertiesModel
 import com.onesignal.user.internal.properties.PropertiesModelStore
@@ -98,7 +101,13 @@ internal class RefreshUserOperationExecutor(
             // No longer hydrate timezone from remote, set locally
             propertiesModel.timezone = TimeUtils.getTimeZoneId()
 
+            // Retrieve the push subscription ID from the backend configuration model store. Used
+            // both for re-attaching the locally-cached push model below and for the SDK-4474
+            // self-heal divergence check inside the loop.
+            val pushSubscriptionIdFromConfig = _configModelStore.model.pushSubscriptionId
+
             val subscriptionModels = mutableListOf<SubscriptionModel>()
+            var pushSelfHealOperation: UpdateSubscriptionOperation? = null
             for (subscription in response.subscriptions) {
                 val subscriptionModel = SubscriptionModel()
                 subscriptionModel.id = subscription.id!!
@@ -126,10 +135,22 @@ internal class RefreshUserOperationExecutor(
                 // so we don't want to cache these subscriptions from the backend.
                 if (subscriptionModel.type != SubscriptionType.PUSH) {
                     subscriptionModels.add(subscriptionModel)
+                } else if (subscription.id == pushSubscriptionIdFromConfig && pushSelfHealOperation == null) {
+                    // SDK-4474 self-heal for SDK-4388 victims. The buggy
+                    // SubscriptionOperationExecutor in older SDK builds dispatched the merged
+                    // create-subscription + update-subscription(SUBSCRIBED) batch as a POST
+                    // /subscriptions carrying the already-existing server-side id; the server
+                    // responded 200 {} (no-op) and the local op queue was emptied, leaving the
+                    // server stuck at enabled:false / notification_types:0. Once that user
+                    // upgrades to a fixed SDK build, nothing in the queue triggers the fix path.
+                    //
+                    // Detect the divergence here (every session start runs RefreshUser) and
+                    // re-assert local truth via PATCH. "Device is the source of truth" is the
+                    // existing policy for push; this just enforces it across the wire when the
+                    // server has drifted out of sync.
+                    pushSelfHealOperation = buildPushSelfHealOperationOrNull(op, subscription, pushSubscriptionIdFromConfig)
                 }
             }
-            // Retrieve the push subscription ID from the backend configuration model store
-            val pushSubscriptionIdFromConfig = _configModelStore.model.pushSubscriptionId
 
             if (pushSubscriptionIdFromConfig != null) {
                 // Retrieve the push subscription model from the model store
@@ -145,7 +166,10 @@ internal class RefreshUserOperationExecutor(
             _propertiesModelStore.replace(propertiesModel, ModelChangeTags.HYDRATE)
             _subscriptionsModelStore.replaceAll(subscriptionModels, ModelChangeTags.HYDRATE)
 
-            return ExecutionResponse(ExecutionResult.SUCCESS)
+            return ExecutionResponse(
+                ExecutionResult.SUCCESS,
+                operations = pushSelfHealOperation?.let { listOf<Operation>(it) },
+            )
         } catch (ex: BackendException) {
             val responseType = NetworkUtils.getResponseStatusType(ex.statusCode)
 
@@ -173,6 +197,50 @@ internal class RefreshUserOperationExecutor(
                     ExecutionResponse(ExecutionResult.FAIL_NORETRY)
             }
         }
+    }
+
+    /**
+     * SDK-4474 self-heal builder. Returns an [UpdateSubscriptionOperation] iff the cached
+     * push subscription model resolves to enabled-and-opted-in but the server response
+     * recorded the same id as disabled. Returns null otherwise (no divergence — no-op).
+     *
+     * Caller has already verified that [serverSubscription.id] matches the cached
+     * `pushSubscriptionId`, so this method only inspects the local model + server flags.
+     */
+    @Suppress("ReturnCount")
+    private fun buildPushSelfHealOperationOrNull(
+        op: RefreshUserOperation,
+        serverSubscription: SubscriptionObject,
+        pushSubscriptionId: String,
+    ): UpdateSubscriptionOperation? {
+        val cachedPushSubscriptionModel = _subscriptionsModelStore.get(pushSubscriptionId)
+        if (cachedPushSubscriptionModel == null || cachedPushSubscriptionModel.type != SubscriptionType.PUSH) {
+            return null
+        }
+
+        val (localEnabled, localStatus) = SubscriptionModelStoreListener.getSubscriptionEnabledAndStatus(cachedPushSubscriptionModel)
+        val serverEnabled = (serverSubscription.enabled == true) && ((serverSubscription.notificationTypes ?: 0) > 0)
+        if (!localEnabled || serverEnabled) {
+            return null
+        }
+
+        Logging.warn(
+            "RefreshUserOperationExecutor: push subscription $pushSubscriptionId diverged from server " +
+                "(server enabled=${serverSubscription.enabled} notificationTypes=${serverSubscription.notificationTypes}; " +
+                "local opted-in and SUBSCRIBED). Enqueuing follow-up update-subscription op to re-assert local " +
+                "truth via PATCH /subscriptions/{id}. See SDK-4388 / SDK-4474.",
+        )
+
+        return UpdateSubscriptionOperation(
+            op.appId,
+            op.onesignalId,
+            _identityModelStore.model.externalId,
+            pushSubscriptionId,
+            cachedPushSubscriptionModel.type,
+            localEnabled,
+            cachedPushSubscriptionModel.address,
+            localStatus,
+        )
     }
 
     companion object {

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/RefreshUserOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/RefreshUserOperationExecutor.kt
@@ -148,7 +148,7 @@ internal class RefreshUserOperationExecutor(
                     // re-assert local truth via PATCH. "Device is the source of truth" is the
                     // existing policy for push; this just enforces it across the wire when the
                     // server has drifted out of sync.
-                    pushSelfHealOperation = buildPushSelfHealOperationOrNull(op, subscription, pushSubscriptionIdFromConfig)
+                    pushSelfHealOperation = buildPushSelfHealOperationForStuckSubscription(op, subscription, pushSubscriptionIdFromConfig)
                 }
             }
 
@@ -208,7 +208,7 @@ internal class RefreshUserOperationExecutor(
      * `pushSubscriptionId`, so this method only inspects the local model + server flags.
      */
     @Suppress("ReturnCount")
-    private fun buildPushSelfHealOperationOrNull(
+    private fun buildPushSelfHealOperationForStuckSubscription(
         op: RefreshUserOperation,
         serverSubscription: SubscriptionObject,
         pushSubscriptionId: String,

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/RefreshUserOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/RefreshUserOperationExecutor.kt
@@ -102,7 +102,7 @@ internal class RefreshUserOperationExecutor(
             propertiesModel.timezone = TimeUtils.getTimeZoneId()
 
             // Retrieve the push subscription ID from the backend configuration model store. Used
-            // both for re-attaching the locally-cached push model below and for the SDK-4474
+            // both for re-attaching the locally-cached push model below and for the push
             // self-heal divergence check inside the loop.
             val pushSubscriptionIdFromConfig = _configModelStore.model.pushSubscriptionId
 
@@ -136,10 +136,9 @@ internal class RefreshUserOperationExecutor(
                 if (subscriptionModel.type != SubscriptionType.PUSH) {
                     subscriptionModels.add(subscriptionModel)
                 } else if (subscription.id == pushSubscriptionIdFromConfig && pushSelfHealOperation == null) {
-                    // SDK-4474 self-heal for SDK-4388 victims. The buggy
-                    // SubscriptionOperationExecutor in older SDK builds dispatched the merged
-                    // create-subscription + update-subscription(SUBSCRIBED) batch as a POST
-                    // /subscriptions carrying the already-existing server-side id; the server
+                    // Self-heal for users stuck at "Never Subscribed". Older SDK builds dispatched
+                    // the merged create-subscription + update-subscription(SUBSCRIBED) batch as a
+                    // POST /subscriptions carrying the already-existing server-side id; the server
                     // responded 200 {} (no-op) and the local op queue was emptied, leaving the
                     // server stuck at enabled:false / notification_types:0. Once that user
                     // upgrades to a fixed SDK build, nothing in the queue triggers the fix path.
@@ -200,9 +199,9 @@ internal class RefreshUserOperationExecutor(
     }
 
     /**
-     * SDK-4474 self-heal builder. Returns an [UpdateSubscriptionOperation] iff the cached
-     * push subscription model resolves to enabled-and-opted-in but the server response
-     * recorded the same id as disabled. Returns null otherwise (no divergence — no-op).
+     * Push self-heal builder. Returns an [UpdateSubscriptionOperation] iff the cached push
+     * subscription model resolves to enabled-and-opted-in but the server response recorded
+     * the same id as disabled. Returns null otherwise (no divergence — no-op).
      *
      * Caller has already verified that [serverSubscription.id] matches the cached
      * `pushSubscriptionId`, so this method only inspects the local model + server flags.
@@ -226,7 +225,7 @@ internal class RefreshUserOperationExecutor(
                 "RefreshUserOperationExecutor: push subscription $pushSubscriptionId diverged from server " +
                     "(server enabled=${serverSubscription.enabled} notificationTypes=${serverSubscription.notificationTypes}; " +
                     "local opted-in and SUBSCRIBED). Enqueuing follow-up update-subscription op to re-assert local " +
-                    "truth via PATCH /subscriptions/{id}. See SDK-4388 / SDK-4474.",
+                    "truth via PATCH /subscriptions/{id}.",
             )
             UpdateSubscriptionOperation(
                 op.appId,

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/SubscriptionOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/SubscriptionOperationExecutor.kt
@@ -250,7 +250,12 @@ internal class SubscriptionOperationExecutor(
                     ) {
                         return ExecutionResponse(ExecutionResult.FAIL_RETRY, retryAfterSeconds = ex.retryAfterSeconds)
                     }
-                    // toss this, but create an identical CreateSubscriptionOperation to re-create the subscription being updated.
+                    // SDK-4388 follow-up: the original update target no longer exists on the
+                    // backend, so issue a fresh local-id Create. A non-local id here would re-route
+                    // through updateExistingSubscriptionFromCreate -> PATCH -> 404 indefinitely
+                    // because execute() dispatches non-local-id Creates as PATCHes; only a local
+                    // id forces the POST/rebuild-user recovery path that can actually re-create
+                    // the subscription.
                     ExecutionResponse(
                         ExecutionResult.FAIL_NORETRY,
                         operations =
@@ -259,7 +264,7 @@ internal class SubscriptionOperationExecutor(
                                 lastOperation.appId,
                                 lastOperation.onesignalId,
                                 lastOperation.externalId,
-                                lastOperation.subscriptionId,
+                                IDManager.createLocalId(),
                                 lastOperation.type,
                                 lastOperation.enabled,
                                 lastOperation.address,

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/SubscriptionOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/SubscriptionOperationExecutor.kt
@@ -57,7 +57,14 @@ internal class SubscriptionOperationExecutor(
         val startingOp = operations.first()
 
         return if (startingOp is CreateSubscriptionOperation) {
-            createSubscription(startingOp, operations)
+            // SDK-4388: if the subscription already exists on the backend (non-local id),
+            // POSTing to /subscriptions with that id is silently treated as a no-op and
+            // drops the merged enabled/status payload. Dispatch as an update instead.
+            if (!IDManager.isLocalId(startingOp.subscriptionId)) {
+                updateExistingSubscriptionFromCreate(startingOp, operations)
+            } else {
+                createSubscription(startingOp, operations)
+            }
         } else if (operations.any { it is DeleteSubscriptionOperation }) {
             if (operations.size > 1) {
                 throw Exception("Only supports one operation! Attempted operations:\n$operations")
@@ -76,6 +83,30 @@ internal class SubscriptionOperationExecutor(
         }
     }
 
+    private suspend fun updateExistingSubscriptionFromCreate(
+        createOperation: CreateSubscriptionOperation,
+        operations: List<Operation>,
+    ): ExecutionResponse {
+        // if there are any deletes all operations should be tossed, nothing to do.
+        if (operations.any { it is DeleteSubscriptionOperation }) {
+            return ExecutionResponse(ExecutionResult.SUCCESS)
+        }
+
+        val lastUpdateOperation = operations.lastOrNull { it is UpdateSubscriptionOperation } as UpdateSubscriptionOperation?
+        val patchOp =
+            UpdateSubscriptionOperation(
+                createOperation.appId,
+                createOperation.onesignalId,
+                createOperation.externalId,
+                createOperation.subscriptionId,
+                createOperation.type,
+                lastUpdateOperation?.enabled ?: createOperation.enabled,
+                lastUpdateOperation?.address ?: createOperation.address,
+                lastUpdateOperation?.status ?: createOperation.status,
+            )
+        return updateSubscription(patchOp, listOf(patchOp))
+    }
+
     private suspend fun createSubscription(
         createOperation: CreateSubscriptionOperation,
         operations: List<Operation>,
@@ -91,24 +122,6 @@ internal class SubscriptionOperationExecutor(
         val enabled = lastUpdateOperation?.enabled ?: createOperation.enabled
         val address = lastUpdateOperation?.address ?: createOperation.address
         val status = lastUpdateOperation?.status ?: createOperation.status
-
-        // SDK-4388: If the subscription already exists on the backend (non-local id), POSTing
-        // to /subscriptions with that id is silently treated as a no-op, dropping the merged
-        // enabled/status payload. Re-dispatch as a PATCH on the existing subscription instead.
-        if (!IDManager.isLocalId(createOperation.subscriptionId)) {
-            val patchOp =
-                UpdateSubscriptionOperation(
-                    createOperation.appId,
-                    createOperation.onesignalId,
-                    createOperation.externalId,
-                    createOperation.subscriptionId,
-                    createOperation.type,
-                    enabled,
-                    address,
-                    status,
-                )
-            return updateSubscription(patchOp, listOf(patchOp))
-        }
 
         try {
             val subscription =

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/SubscriptionOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/SubscriptionOperationExecutor.kt
@@ -91,12 +91,29 @@ internal class SubscriptionOperationExecutor(
         val enabled = lastUpdateOperation?.enabled ?: createOperation.enabled
         val address = lastUpdateOperation?.address ?: createOperation.address
         val status = lastUpdateOperation?.status ?: createOperation.status
-        val subId = if (!IDManager.isLocalId(createOperation.subscriptionId)) createOperation.subscriptionId else null
+
+        // SDK-4388: If the subscription already exists on the backend (non-local id), POSTing
+        // to /subscriptions with that id is silently treated as a no-op, dropping the merged
+        // enabled/status payload. Re-dispatch as a PATCH on the existing subscription instead.
+        if (!IDManager.isLocalId(createOperation.subscriptionId)) {
+            val patchOp =
+                UpdateSubscriptionOperation(
+                    createOperation.appId,
+                    createOperation.onesignalId,
+                    createOperation.externalId,
+                    createOperation.subscriptionId,
+                    createOperation.type,
+                    enabled,
+                    address,
+                    status,
+                )
+            return updateSubscription(patchOp, listOf(patchOp))
+        }
 
         try {
             val subscription =
                 SubscriptionObject(
-                    id = subId,
+                    id = null,
                     convert(createOperation.type),
                     address,
                     enabled,

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/SubscriptionOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/SubscriptionOperationExecutor.kt
@@ -256,6 +256,24 @@ internal class SubscriptionOperationExecutor(
                     // execute() dispatches non-local-id Creates as PATCHes; only a local id
                     // forces the POST/rebuild-user recovery path that can actually re-create
                     // the subscription.
+                    val recoveryLocalId = IDManager.createLocalId()
+                    val staleSubscriptionId = lastOperation.subscriptionId
+
+                    // Rewrite the cached SubscriptionModel id (and pushSubscriptionId, if it
+                    // pointed at the stale id) to the new local id. This keeps the recovery
+                    // Create and the rebuild-user path's getRebuildOperationsIfCurrentUser
+                    // emitting Creates with the same subscriptionId, so they dedupe instead
+                    // of producing two POST /users subscription rows. HYDRATE prevents the
+                    // SubscriptionModelStoreListener from enqueuing follow-on operations.
+                    _subscriptionModelStore.get(staleSubscriptionId)?.setStringProperty(
+                        SubscriptionModel::id.name,
+                        recoveryLocalId,
+                        ModelChangeTags.HYDRATE,
+                    )
+                    if (_configModelStore.model.pushSubscriptionId == staleSubscriptionId) {
+                        _configModelStore.model.pushSubscriptionId = recoveryLocalId
+                    }
+
                     ExecutionResponse(
                         ExecutionResult.FAIL_NORETRY,
                         operations =
@@ -264,7 +282,7 @@ internal class SubscriptionOperationExecutor(
                                 lastOperation.appId,
                                 lastOperation.onesignalId,
                                 lastOperation.externalId,
-                                IDManager.createLocalId(),
+                                recoveryLocalId,
                                 lastOperation.type,
                                 lastOperation.enabled,
                                 lastOperation.address,

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/SubscriptionOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/SubscriptionOperationExecutor.kt
@@ -57,9 +57,9 @@ internal class SubscriptionOperationExecutor(
         val startingOp = operations.first()
 
         return if (startingOp is CreateSubscriptionOperation) {
-            // SDK-4388: if the subscription already exists on the backend (non-local id),
-            // POSTing to /subscriptions with that id is silently treated as a no-op and
-            // drops the merged enabled/status payload. Dispatch as an update instead.
+            // If the subscription already exists on the backend (non-local id), POSTing
+            // to /subscriptions with that id is silently a server-side no-op and drops
+            // the merged enabled/status payload. Dispatch as an update instead.
             if (!IDManager.isLocalId(startingOp.subscriptionId)) {
                 updateExistingSubscriptionFromCreate(startingOp, operations)
             } else {
@@ -250,11 +250,11 @@ internal class SubscriptionOperationExecutor(
                     ) {
                         return ExecutionResponse(ExecutionResult.FAIL_RETRY, retryAfterSeconds = ex.retryAfterSeconds)
                     }
-                    // SDK-4388 follow-up: the original update target no longer exists on the
-                    // backend, so issue a fresh local-id Create. A non-local id here would re-route
-                    // through updateExistingSubscriptionFromCreate -> PATCH -> 404 indefinitely
-                    // because execute() dispatches non-local-id Creates as PATCHes; only a local
-                    // id forces the POST/rebuild-user recovery path that can actually re-create
+                    // The original update target no longer exists on the backend, so issue
+                    // a fresh local-id Create. A non-local id here would re-route through
+                    // updateExistingSubscriptionFromCreate -> PATCH -> 404 indefinitely because
+                    // execute() dispatches non-local-id Creates as PATCHes; only a local id
+                    // forces the POST/rebuild-user recovery path that can actually re-create
                     // the subscription.
                     ExecutionResponse(
                         ExecutionResult.FAIL_NORETRY,

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/RefreshUserOperationExecutorTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/RefreshUserOperationExecutorTests.kt
@@ -61,8 +61,10 @@ class RefreshUserOperationExecutorTests : FunSpec({
                 mapOf(IdentityConstants.ONESIGNAL_ID to remoteOneSignalId, "aliasLabel1" to "aliasValue1"),
                 PropertiesObject(country = remoteCountry, language = remoteLanguage, timezoneId = remoteTimeZone, tags = remoteTags),
                 listOf(
-                    SubscriptionObject(existingSubscriptionId1, SubscriptionObjectType.ANDROID_PUSH, enabled = true, token = "on-backend-push-token"),
-                    SubscriptionObject(remoteSubscriptionId1, SubscriptionObjectType.ANDROID_PUSH, enabled = true, token = "pushToken2"),
+                    // notificationTypes = 1 keeps server-side view healthy so the SDK-4474
+                    // self-heal divergence check is a no-op for this happy-path test.
+                    SubscriptionObject(existingSubscriptionId1, SubscriptionObjectType.ANDROID_PUSH, enabled = true, notificationTypes = 1, token = "on-backend-push-token"),
+                    SubscriptionObject(remoteSubscriptionId1, SubscriptionObjectType.ANDROID_PUSH, enabled = true, notificationTypes = 1, token = "pushToken2"),
                     SubscriptionObject(remoteSubscriptionId2, SubscriptionObjectType.EMAIL, token = "name@company.com"),
                 ),
             )

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/RefreshUserOperationExecutorTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/RefreshUserOperationExecutorTests.kt
@@ -5,6 +5,8 @@ import com.onesignal.common.exceptions.BackendException
 import com.onesignal.common.modeling.ModelChangeTags
 import com.onesignal.core.internal.operations.ExecutionResult
 import com.onesignal.core.internal.operations.Operation
+import com.onesignal.debug.LogLevel
+import com.onesignal.debug.internal.logging.Logging
 import com.onesignal.mocks.MockHelper
 import com.onesignal.user.internal.backend.CreateUserResponse
 import com.onesignal.user.internal.backend.IUserBackendService
@@ -18,6 +20,7 @@ import com.onesignal.user.internal.operations.ExecutorMocks.Companion.getIdentit
 import com.onesignal.user.internal.operations.ExecutorMocks.Companion.getJwtTokenStore
 import com.onesignal.user.internal.operations.ExecutorMocks.Companion.getNewRecordState
 import com.onesignal.user.internal.operations.impl.executors.RefreshUserOperationExecutor
+import com.onesignal.user.internal.operations.impl.executors.SubscriptionOperationExecutor
 import com.onesignal.user.internal.properties.PropertiesModel
 import com.onesignal.user.internal.subscriptions.SubscriptionModel
 import com.onesignal.user.internal.subscriptions.SubscriptionModelStore
@@ -321,6 +324,171 @@ class RefreshUserOperationExecutorTests : FunSpec({
         coVerify(exactly = 1) {
             mockUserBackendService.getUser(appId, IdentityConstants.ONESIGNAL_ID, remoteOneSignalId)
         }
+    }
+
+    // SDK-4474 self-heal divergence detection. Verifies that when the device-cached push
+    // subscription resolves to enabled-and-opted-in but the GET /users response returns the
+    // same subscription as disabled (the SDK-4388 stuck state), RefreshUserOperationExecutor
+    // emits a follow-up UpdateSubscriptionOperation to re-assert local truth via PATCH.
+    fun buildSelfHealHarness(
+        serverPushEnabled: Boolean,
+        serverNotificationTypes: Int?,
+        localOptedIn: Boolean,
+        localStatus: SubscriptionStatus,
+        localAddress: String,
+    ): Triple<RefreshUserOperationExecutor, SubscriptionModel, IUserBackendService> {
+        val mockUserBackendService = mockk<IUserBackendService>()
+        coEvery { mockUserBackendService.getUser(appId, IdentityConstants.ONESIGNAL_ID, remoteOneSignalId) } returns
+            CreateUserResponse(
+                mapOf(IdentityConstants.ONESIGNAL_ID to remoteOneSignalId),
+                PropertiesObject(),
+                listOf(
+                    SubscriptionObject(
+                        existingSubscriptionId1,
+                        SubscriptionObjectType.ANDROID_PUSH,
+                        enabled = serverPushEnabled,
+                        notificationTypes = serverNotificationTypes,
+                        token = "on-backend-push-token",
+                    ),
+                ),
+            )
+
+        val mockIdentityModelStore = MockHelper.identityModelStore()
+        val mockIdentityModel = IdentityModel()
+        mockIdentityModel.onesignalId = remoteOneSignalId
+        every { mockIdentityModelStore.model } returns mockIdentityModel
+        every { mockIdentityModelStore.replace(any(), any()) } just runs
+
+        val mockPropertiesModelStore = MockHelper.propertiesModelStore()
+        val mockPropertiesModel = PropertiesModel()
+        mockPropertiesModel.onesignalId = remoteOneSignalId
+        every { mockPropertiesModelStore.model } returns mockPropertiesModel
+        every { mockPropertiesModelStore.replace(any(), any()) } just runs
+
+        val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
+        every { mockSubscriptionsModelStore.replaceAll(any(), any()) } just runs
+
+        val cachedPushSubscriptionModel = SubscriptionModel()
+        cachedPushSubscriptionModel.id = existingSubscriptionId1
+        cachedPushSubscriptionModel.type = SubscriptionType.PUSH
+        cachedPushSubscriptionModel.address = localAddress
+        cachedPushSubscriptionModel.status = localStatus
+        cachedPushSubscriptionModel.optedIn = localOptedIn
+        every { mockSubscriptionsModelStore.get(existingSubscriptionId1) } returns cachedPushSubscriptionModel
+
+        val mockConfigModelStore =
+            MockHelper.configModelStore {
+                it.pushSubscriptionId = existingSubscriptionId1
+            }
+
+        val executor =
+            RefreshUserOperationExecutor(
+                mockUserBackendService,
+                mockIdentityModelStore,
+                mockPropertiesModelStore,
+                mockSubscriptionsModelStore,
+                mockConfigModelStore,
+                mockk<IRebuildUserService>(),
+                getNewRecordState(),
+                getJwtTokenStore(), getIdentityVerificationService(),
+            )
+
+        return Triple(executor, cachedPushSubscriptionModel, mockUserBackendService)
+    }
+
+    test("SDK-4474 self-heal: enqueues follow-up update-subscription op when server is stuck-disabled but local is enabled") {
+        // Given: server view says push is disabled (the SDK-4388 stuck state), local view says enabled
+        val (executor, _, _) =
+            buildSelfHealHarness(
+                serverPushEnabled = false,
+                serverNotificationTypes = 0,
+                localOptedIn = true,
+                localStatus = SubscriptionStatus.SUBSCRIBED,
+                localAddress = onDevicePushToken,
+            )
+
+        // Suppress logcat output for the self-heal WARN line so the unmocked android.util.Log
+        // in robolectric-free unit tests doesn't blow up. Restored in finally.
+        val originalLogLevel = Logging.logLevel
+        Logging.logLevel = LogLevel.NONE
+        try {
+            // When
+            val response = executor.execute(listOf(RefreshUserOperation(appId, remoteOneSignalId, null)))
+
+            // Then a single UpdateSubscriptionOperation is returned to the op repo
+            response.result shouldBe ExecutionResult.SUCCESS
+            response.operations?.count() shouldBe 1
+            val followup = response.operations!![0]
+            (followup is UpdateSubscriptionOperation) shouldBe true
+            followup as UpdateSubscriptionOperation
+            followup.name shouldBe SubscriptionOperationExecutor.UPDATE_SUBSCRIPTION
+            followup.appId shouldBe appId
+            followup.onesignalId shouldBe remoteOneSignalId
+            followup.subscriptionId shouldBe existingSubscriptionId1
+            followup.type shouldBe SubscriptionType.PUSH
+            followup.enabled shouldBe true
+            followup.address shouldBe onDevicePushToken
+            followup.status shouldBe SubscriptionStatus.SUBSCRIBED
+        } finally {
+            Logging.logLevel = originalLogLevel
+        }
+    }
+
+    test("SDK-4474 self-heal: does NOT enqueue follow-up op when server matches local (healthy push subscription)") {
+        // Given: server already enabled and notificationTypes=1, local also enabled
+        val (executor, _, _) =
+            buildSelfHealHarness(
+                serverPushEnabled = true,
+                serverNotificationTypes = 1,
+                localOptedIn = true,
+                localStatus = SubscriptionStatus.SUBSCRIBED,
+                localAddress = onDevicePushToken,
+            )
+
+        // When
+        val response = executor.execute(listOf(RefreshUserOperation(appId, remoteOneSignalId, null)))
+
+        // Then no follow-up ops emitted
+        response.result shouldBe ExecutionResult.SUCCESS
+        response.operations shouldBe null
+    }
+
+    test("SDK-4474 self-heal: does NOT enqueue follow-up op when local is opted out (UNSUBSCRIBE is intentional)") {
+        // Given: server is disabled, but so is local (user explicitly opted out)
+        val (executor, _, _) =
+            buildSelfHealHarness(
+                serverPushEnabled = false,
+                serverNotificationTypes = -2,
+                localOptedIn = false,
+                localStatus = SubscriptionStatus.SUBSCRIBED,
+                localAddress = onDevicePushToken,
+            )
+
+        // When
+        val response = executor.execute(listOf(RefreshUserOperation(appId, remoteOneSignalId, null)))
+
+        // Then no follow-up — opt-out is the user's intent, not divergence
+        response.result shouldBe ExecutionResult.SUCCESS
+        response.operations shouldBe null
+    }
+
+    test("SDK-4474 self-heal: does NOT enqueue follow-up op when local has NO_PERMISSION (OS-level disable is real)") {
+        // Given: server disabled, local also has no notification permission
+        val (executor, _, _) =
+            buildSelfHealHarness(
+                serverPushEnabled = false,
+                serverNotificationTypes = 0,
+                localOptedIn = true,
+                localStatus = SubscriptionStatus.NO_PERMISSION,
+                localAddress = onDevicePushToken,
+            )
+
+        // When
+        val response = executor.execute(listOf(RefreshUserOperation(appId, remoteOneSignalId, null)))
+
+        // Then no follow-up — OS denies notifications, server's view is correct
+        response.result shouldBe ExecutionResult.SUCCESS
+        response.operations shouldBe null
     }
 
     test("refresh user is retried when backend returns MISSING, but isInMissingRetryWindow") {

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/RefreshUserOperationExecutorTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/RefreshUserOperationExecutorTests.kt
@@ -64,7 +64,7 @@ class RefreshUserOperationExecutorTests : FunSpec({
                 mapOf(IdentityConstants.ONESIGNAL_ID to remoteOneSignalId, "aliasLabel1" to "aliasValue1"),
                 PropertiesObject(country = remoteCountry, language = remoteLanguage, timezoneId = remoteTimeZone, tags = remoteTags),
                 listOf(
-                    // notificationTypes = 1 keeps server-side view healthy so the SDK-4474
+                    // notificationTypes = 1 keeps server-side view healthy so the push
                     // self-heal divergence check is a no-op for this happy-path test.
                     SubscriptionObject(existingSubscriptionId1, SubscriptionObjectType.ANDROID_PUSH, enabled = true, notificationTypes = 1, token = "on-backend-push-token"),
                     SubscriptionObject(remoteSubscriptionId1, SubscriptionObjectType.ANDROID_PUSH, enabled = true, notificationTypes = 1, token = "pushToken2"),
@@ -326,10 +326,11 @@ class RefreshUserOperationExecutorTests : FunSpec({
         }
     }
 
-    // SDK-4474 self-heal divergence detection. Verifies that when the device-cached push
+    // Push self-heal divergence detection. Verifies that when the device-cached push
     // subscription resolves to enabled-and-opted-in but the GET /users response returns the
-    // same subscription as disabled (the SDK-4388 stuck state), RefreshUserOperationExecutor
-    // emits a follow-up UpdateSubscriptionOperation to re-assert local truth via PATCH.
+    // same subscription as disabled (the "Never Subscribed" stuck state),
+    // RefreshUserOperationExecutor emits a follow-up UpdateSubscriptionOperation to re-assert
+    // local truth via PATCH.
     fun buildSelfHealHarness(
         serverPushEnabled: Boolean,
         serverNotificationTypes: Int?,
@@ -396,8 +397,8 @@ class RefreshUserOperationExecutorTests : FunSpec({
         return Triple(executor, cachedPushSubscriptionModel, mockUserBackendService)
     }
 
-    test("SDK-4474 self-heal: enqueues follow-up update-subscription op when server is stuck-disabled but local is enabled") {
-        // Given: server view says push is disabled (the SDK-4388 stuck state), local view says enabled
+    test("push self-heal: enqueues follow-up update-subscription op when server is stuck-disabled but local is enabled") {
+        // Given: server view says push is disabled (the stuck state), local view says enabled
         val (executor, _, _) =
             buildSelfHealHarness(
                 serverPushEnabled = false,
@@ -434,7 +435,7 @@ class RefreshUserOperationExecutorTests : FunSpec({
         }
     }
 
-    test("SDK-4474 self-heal: does NOT enqueue follow-up op when server matches local (healthy push subscription)") {
+    test("push self-heal: does NOT enqueue follow-up op when server matches local (healthy push subscription)") {
         // Given: server already enabled and notificationTypes=1, local also enabled
         val (executor, _, _) =
             buildSelfHealHarness(
@@ -453,7 +454,7 @@ class RefreshUserOperationExecutorTests : FunSpec({
         response.operations shouldBe null
     }
 
-    test("SDK-4474 self-heal: does NOT enqueue follow-up op when local is opted out (UNSUBSCRIBE is intentional)") {
+    test("push self-heal: does NOT enqueue follow-up op when local is opted out (UNSUBSCRIBE is intentional)") {
         // Given: server is disabled, but so is local (user explicitly opted out)
         val (executor, _, _) =
             buildSelfHealHarness(
@@ -472,7 +473,7 @@ class RefreshUserOperationExecutorTests : FunSpec({
         response.operations shouldBe null
     }
 
-    test("SDK-4474 self-heal: does NOT enqueue follow-up op when local has NO_PERMISSION (OS-level disable is real)") {
+    test("push self-heal: does NOT enqueue follow-up op when local has NO_PERMISSION (OS-level disable is real)") {
         // Given: server disabled, local also has no notification permission
         val (executor, _, _) =
             buildSelfHealHarness(

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/SubscriptionOperationExecutorTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/SubscriptionOperationExecutorTests.kt
@@ -1,6 +1,7 @@
 package com.onesignal.user.internal.operations
 
 import br.com.colman.kotest.android.extensions.robolectric.RobolectricTest
+import com.onesignal.common.IDManager
 import com.onesignal.common.consistency.RywData
 import com.onesignal.common.consistency.enums.IamFetchRywTokenKey
 import com.onesignal.common.consistency.models.IConsistencyManager
@@ -23,6 +24,7 @@ import com.onesignal.user.internal.subscriptions.SubscriptionStatus
 import com.onesignal.user.internal.subscriptions.SubscriptionType
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.mockk.clearMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -625,6 +627,70 @@ class SubscriptionOperationExecutorTests :
                     },
                 )
             }
+        }
+
+        // Regression for SDK-4388: when an UpdateSubscriptionOperation PATCH returns 404 outside
+        // the missing-retry window, the executor must enqueue a recovery CreateSubscriptionOperation
+        // with a *local* subscriptionId. Re-using the original non-local id would bounce back
+        // through execute() -> updateExistingSubscriptionFromCreate -> PATCH -> 404 indefinitely
+        // (because non-local-id Creates dispatch as PATCHes), preventing the rebuild-user / POST
+        // recovery path in createSubscription from ever running.
+        test("update subscription 404 outside retry window enqueues recovery CreateSubscriptionOperation with local id") {
+            // Given
+            val mockSubscriptionBackendService = mockk<ISubscriptionBackendService>()
+            coEvery { mockSubscriptionBackendService.updateSubscription(any(), any(), any()) } throws BackendException(404)
+
+            val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
+            val mockBuildUserService = mockk<IRebuildUserService>()
+
+            val subscriptionOperationExecutor =
+                SubscriptionOperationExecutor(
+                    mockSubscriptionBackendService,
+                    MockHelper.deviceService(),
+                    AndroidMockHelper.applicationService(),
+                    mockSubscriptionsModelStore,
+                    MockHelper.configModelStore(),
+                    mockBuildUserService,
+                    getNewRecordState(),
+                    mockConsistencyManager,
+                    getJwtTokenStore(), getIdentityVerificationService(),
+                )
+
+            val operations =
+                listOf<Operation>(
+                    UpdateSubscriptionOperation(
+                        appId,
+                        remoteOneSignalId,
+                        "ext-1",
+                        remoteSubscriptionId,
+                        SubscriptionType.PUSH,
+                        true,
+                        "pushToken2",
+                        SubscriptionStatus.SUBSCRIBED,
+                    ),
+                )
+
+            // When
+            val response = subscriptionOperationExecutor.execute(operations)
+
+            // Then
+            response.result shouldBe ExecutionResult.FAIL_NORETRY
+            response.operations shouldNotBe null
+            response.operations!!.size shouldBe 1
+            val recovery = response.operations!!.first() as CreateSubscriptionOperation
+            // The recovery op must carry a fresh LOCAL id, not the original non-local one.
+            // This is what forces execute() to dispatch through the POST/rebuild-user path on the
+            // next execution instead of looping back into PATCH -> 404 forever.
+            IDManager.isLocalId(recovery.subscriptionId) shouldBe true
+            recovery.subscriptionId shouldNotBe remoteSubscriptionId
+            // All other fields propagated so the recovered subscription matches the desired state.
+            recovery.appId shouldBe appId
+            recovery.onesignalId shouldBe remoteOneSignalId
+            recovery.externalId shouldBe "ext-1"
+            recovery.type shouldBe SubscriptionType.PUSH
+            recovery.enabled shouldBe true
+            recovery.address shouldBe "pushToken2"
+            recovery.status shouldBe SubscriptionStatus.SUBSCRIBED
         }
 
         test("update subscription fails with retry when the backend returns MISSING, when isInMissingRetryWindow") {

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/SubscriptionOperationExecutorTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/SubscriptionOperationExecutorTests.kt
@@ -632,16 +632,33 @@ class SubscriptionOperationExecutorTests :
 
         // Regression: when an UpdateSubscriptionOperation PATCH returns 404 outside
         // the missing-retry window, the executor must enqueue a recovery CreateSubscriptionOperation
-        // with a *local* subscriptionId. Re-using the original non-local id would bounce back
-        // through execute() -> updateExistingSubscriptionFromCreate -> PATCH -> 404 indefinitely
-        // (because non-local-id Creates dispatch as PATCHes), preventing the rebuild-user / POST
-        // recovery path in createSubscription from ever running.
-        test("update subscription 404 outside retry window enqueues recovery CreateSubscriptionOperation with local id") {
+        // with a *local* subscriptionId AND rewrite the cached SubscriptionModel + pushSubscriptionId
+        // to that same local id. Two reasons:
+        //   1. A non-local recovery id would bounce back through execute() ->
+        //      updateExistingSubscriptionFromCreate -> PATCH -> 404 indefinitely (because
+        //      non-local-id Creates dispatch as PATCHes), preventing the rebuild-user / POST
+        //      recovery path in createSubscription from ever running.
+        //   2. If the model store still held the original non-local id, the rebuild-user path
+        //      (LoginUserOperationExecutor's getRebuildOperationsIfCurrentUser) would emit a
+        //      second Create carrying that stale id; both Creates would land in POST /users
+        //      and the backend would create two subscription rows for the same device.
+        test("update subscription 404 outside retry window rewrites cached subscription id and enqueues local-id Create") {
             // Given
             val mockSubscriptionBackendService = mockk<ISubscriptionBackendService>()
             coEvery { mockSubscriptionBackendService.updateSubscription(any(), any(), any()) } throws BackendException(404)
 
             val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
+            val cachedSubscriptionModel =
+                SubscriptionModel().apply {
+                    id = remoteSubscriptionId
+                    type = SubscriptionType.PUSH
+                    address = "pushToken2"
+                    optedIn = true
+                }
+            every { mockSubscriptionsModelStore.get(remoteSubscriptionId) } returns cachedSubscriptionModel
+
+            val configModelStore = MockHelper.configModelStore().also { it.model.pushSubscriptionId = remoteSubscriptionId }
+
             val mockBuildUserService = mockk<IRebuildUserService>()
 
             val subscriptionOperationExecutor =
@@ -650,7 +667,7 @@ class SubscriptionOperationExecutorTests :
                     MockHelper.deviceService(),
                     AndroidMockHelper.applicationService(),
                     mockSubscriptionsModelStore,
-                    MockHelper.configModelStore(),
+                    configModelStore,
                     mockBuildUserService,
                     getNewRecordState(),
                     mockConsistencyManager,
@@ -692,6 +709,10 @@ class SubscriptionOperationExecutorTests :
             recovery.enabled shouldBe true
             recovery.address shouldBe "pushToken2"
             recovery.status shouldBe SubscriptionStatus.SUBSCRIBED
+            // The cached SubscriptionModel and pushSubscriptionId must now point at the new local id
+            // so the rebuild-user path emits a Create with the same id and dedupes with this recovery.
+            cachedSubscriptionModel.id shouldBe recovery.subscriptionId
+            configModelStore.model.pushSubscriptionId shouldBe recovery.subscriptionId
         }
 
         test("update subscription fails with retry when the backend returns MISSING, when isInMissingRetryWindow") {

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/SubscriptionOperationExecutorTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/SubscriptionOperationExecutorTests.kt
@@ -1034,4 +1034,211 @@ class SubscriptionOperationExecutorTests :
                 )
             }
         }
+
+        // SDK-4388: when a CreateSubscriptionOperation with a non-local id is grouped with a
+        // DeleteSubscriptionOperation, the executor must short-circuit to SUCCESS without
+        // making any backend calls. Creating-then-deleting an already-existing subscription is
+        // a no-op, and a stray PATCH here would resurrect a subscription the caller intended
+        // to remove.
+        test("create subscription with non-local id then delete is a successful no-op") {
+            // Given
+            val mockSubscriptionBackendService = mockk<ISubscriptionBackendService>()
+
+            val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
+            val subscriptionModel = SubscriptionModel().apply { id = remoteSubscriptionId }
+            every { mockSubscriptionsModelStore.get(remoteSubscriptionId) } returns subscriptionModel
+
+            val mockBuildUserService = mockk<IRebuildUserService>()
+
+            val subscriptionOperationExecutor =
+                SubscriptionOperationExecutor(
+                    mockSubscriptionBackendService,
+                    MockHelper.deviceService(),
+                    AndroidMockHelper.applicationService(),
+                    mockSubscriptionsModelStore,
+                    MockHelper.configModelStore(),
+                    mockBuildUserService,
+                    getNewRecordState(),
+                    mockConsistencyManager,
+                    getJwtTokenStore(), getIdentityVerificationService(),
+                )
+
+            val operations =
+                listOf<Operation>(
+                    CreateSubscriptionOperation(
+                        appId,
+                        remoteOneSignalId,
+                        null,
+                        remoteSubscriptionId,
+                        SubscriptionType.PUSH,
+                        true,
+                        "pushToken",
+                        SubscriptionStatus.SUBSCRIBED,
+                    ),
+                    DeleteSubscriptionOperation(appId, remoteOneSignalId, null, remoteSubscriptionId),
+                )
+
+            // When
+            val response = subscriptionOperationExecutor.execute(operations)
+
+            // Then
+            response.result shouldBe ExecutionResult.SUCCESS
+            coVerify(exactly = 0) {
+                mockSubscriptionBackendService.createSubscription(any(), any(), any(), any())
+            }
+            coVerify(exactly = 0) {
+                mockSubscriptionBackendService.updateSubscription(any(), any(), any())
+            }
+            coVerify(exactly = 0) {
+                mockSubscriptionBackendService.deleteSubscription(any(), any())
+            }
+        }
+
+        // SDK-4388: when the PATCH dispatched for a non-local-id Create fails with a retryable
+        // network error, the executor must propagate FAIL_RETRY (and any retryAfterSeconds) so
+        // OperationRepo can re-execute, rather than swallowing the error or routing back to a
+        // POST that the backend would silently no-op.
+        test("create subscription with non-local id fails with retry when there is a network condition") {
+            // Given
+            val mockSubscriptionBackendService = mockk<ISubscriptionBackendService>()
+            coEvery { mockSubscriptionBackendService.updateSubscription(any(), any(), any()) } throws
+                BackendException(408, retryAfterSeconds = 10)
+
+            val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
+            val mockBuildUserService = mockk<IRebuildUserService>()
+
+            val subscriptionOperationExecutor =
+                SubscriptionOperationExecutor(
+                    mockSubscriptionBackendService,
+                    MockHelper.deviceService(),
+                    AndroidMockHelper.applicationService(),
+                    mockSubscriptionsModelStore,
+                    MockHelper.configModelStore(),
+                    mockBuildUserService,
+                    getNewRecordState(),
+                    mockConsistencyManager,
+                    getJwtTokenStore(), getIdentityVerificationService(),
+                )
+
+            val operations =
+                listOf<Operation>(
+                    CreateSubscriptionOperation(
+                        appId,
+                        remoteOneSignalId,
+                        null,
+                        remoteSubscriptionId,
+                        SubscriptionType.PUSH,
+                        true,
+                        "pushToken",
+                        SubscriptionStatus.SUBSCRIBED,
+                    ),
+                )
+
+            // When
+            val response = subscriptionOperationExecutor.execute(operations)
+
+            // Then
+            response.result shouldBe ExecutionResult.FAIL_RETRY
+            response.retryAfterSeconds shouldBe 10
+            coVerify(exactly = 0) {
+                mockSubscriptionBackendService.createSubscription(any(), any(), any(), any())
+            }
+            coVerify(exactly = 1) {
+                mockSubscriptionBackendService.updateSubscription(
+                    appId,
+                    remoteSubscriptionId,
+                    withArg {
+                        it.type shouldBe SubscriptionObjectType.ANDROID_PUSH
+                        it.enabled shouldBe true
+                        it.token shouldBe "pushToken"
+                        it.notificationTypes shouldBe SubscriptionStatus.SUBSCRIBED.value
+                    },
+                )
+            }
+        }
+
+        // SDK-4388: when multiple UpdateSubscriptionOperations are batched with a non-local-id
+        // Create, the executor must collapse them into a single PATCH carrying the *last*
+        // update's values (not the create's, not the first update's). Locks in last-wins
+        // semantics so a future "merge updates" refactor can't silently change behavior on
+        // this path and re-introduce stale state on the backend.
+        test("create subscription with non-local id and multiple updates uses the last update's values") {
+            // Given
+            val mockSubscriptionBackendService = mockk<ISubscriptionBackendService>()
+            coEvery { mockSubscriptionBackendService.updateSubscription(any(), any(), any()) } returns rywData
+
+            val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
+            val subscriptionModel = SubscriptionModel().apply { id = remoteSubscriptionId }
+            every { mockSubscriptionsModelStore.get(remoteSubscriptionId) } returns subscriptionModel
+
+            val mockBuildUserService = mockk<IRebuildUserService>()
+
+            val subscriptionOperationExecutor =
+                SubscriptionOperationExecutor(
+                    mockSubscriptionBackendService,
+                    MockHelper.deviceService(),
+                    AndroidMockHelper.applicationService(),
+                    mockSubscriptionsModelStore,
+                    MockHelper.configModelStore(),
+                    mockBuildUserService,
+                    getNewRecordState(),
+                    mockConsistencyManager,
+                    getJwtTokenStore(), getIdentityVerificationService(),
+                )
+
+            val operations =
+                listOf<Operation>(
+                    CreateSubscriptionOperation(
+                        appId,
+                        remoteOneSignalId,
+                        null,
+                        remoteSubscriptionId,
+                        SubscriptionType.PUSH,
+                        false,
+                        "pushTokenCreate",
+                        SubscriptionStatus.NO_PERMISSION,
+                    ),
+                    UpdateSubscriptionOperation(
+                        appId,
+                        remoteOneSignalId,
+                        null,
+                        remoteSubscriptionId,
+                        SubscriptionType.PUSH,
+                        false,
+                        "pushTokenIntermediate",
+                        SubscriptionStatus.NO_PERMISSION,
+                    ),
+                    UpdateSubscriptionOperation(
+                        appId,
+                        remoteOneSignalId,
+                        null,
+                        remoteSubscriptionId,
+                        SubscriptionType.PUSH,
+                        true,
+                        "pushTokenFinal",
+                        SubscriptionStatus.SUBSCRIBED,
+                    ),
+                )
+
+            // When
+            val response = subscriptionOperationExecutor.execute(operations)
+
+            // Then
+            response.result shouldBe ExecutionResult.SUCCESS
+            coVerify(exactly = 0) {
+                mockSubscriptionBackendService.createSubscription(any(), any(), any(), any())
+            }
+            coVerify(exactly = 1) {
+                mockSubscriptionBackendService.updateSubscription(
+                    appId,
+                    remoteSubscriptionId,
+                    withArg {
+                        it.type shouldBe SubscriptionObjectType.ANDROID_PUSH
+                        it.enabled shouldBe true
+                        it.token shouldBe "pushTokenFinal"
+                        it.notificationTypes shouldBe SubscriptionStatus.SUBSCRIBED.value
+                    },
+                )
+            }
+        }
     })

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/SubscriptionOperationExecutorTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/SubscriptionOperationExecutorTests.kt
@@ -109,11 +109,14 @@ class SubscriptionOperationExecutorTests :
             }
         }
 
-        test("create subscription includes the subscription ID if non-local") {
+        // SDK-4388: A CreateSubscriptionOperation can carry a non-local subscriptionId when
+        // a subscription that already exists on the backend is re-attached to a new local user
+        // (e.g. createAndSwitchToNewUser after login). POSTing to /subscriptions with that id is
+        // silently a no-op on the server, so we must PATCH the existing subscription instead.
+        test("create subscription PATCHes existing subscription when subscription ID is non-local") {
             // Given
             val mockSubscriptionBackendService = mockk<ISubscriptionBackendService>()
-            coEvery { mockSubscriptionBackendService.createSubscription(any(), any(), any(), any()) } returns
-                Pair(remoteSubscriptionId, rywData)
+            coEvery { mockSubscriptionBackendService.updateSubscription(any(), any(), any()) } returns rywData
 
             val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
             val subscriptionModel = SubscriptionModel()
@@ -150,16 +153,22 @@ class SubscriptionOperationExecutorTests :
                 )
 
             // When
-            subscriptionOperationExecutor.execute(operations)
+            val response = subscriptionOperationExecutor.execute(operations)
 
             // Then
+            response.result shouldBe ExecutionResult.SUCCESS
+            coVerify(exactly = 0) {
+                mockSubscriptionBackendService.createSubscription(any(), any(), any(), any())
+            }
             coVerify(exactly = 1) {
-                mockSubscriptionBackendService.createSubscription(
+                mockSubscriptionBackendService.updateSubscription(
                     appId,
-                    IdentityConstants.ONESIGNAL_ID,
-                    remoteOneSignalId,
+                    remoteSubscriptionId,
                     withArg {
-                        it.id shouldBe remoteSubscriptionId
+                        it.type shouldBe SubscriptionObjectType.ANDROID_PUSH
+                        it.enabled shouldBe true
+                        it.token shouldBe "pushToken"
+                        it.notificationTypes shouldBe SubscriptionStatus.SUBSCRIBED.value
                     },
                 )
             }
@@ -950,5 +959,79 @@ class SubscriptionOperationExecutorTests :
             // Then
             response.result shouldBe ExecutionResult.FAIL_UNAUTHORIZED
             response.retryAfterSeconds shouldBe 5
+        }
+
+        // Repro for SDK-4388: when a CreateSubscriptionOperation is grouped with a follow-up
+        // UpdateSubscriptionOperation for a subscription that already exists on the server
+        // (non-local subscriptionId), the executor must PATCH the merged final state instead
+        // of POSTing (which the backend treats as a no-op, silently dropping enabled/status).
+        test("create subscription with non-local id PATCHes instead of POSTing when grouped with update") {
+            // Given
+            val mockSubscriptionBackendService = mockk<ISubscriptionBackendService>()
+            coEvery { mockSubscriptionBackendService.updateSubscription(any(), any(), any()) } returns rywData
+
+            val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
+            val subscriptionModel = SubscriptionModel().apply { id = remoteSubscriptionId }
+            every { mockSubscriptionsModelStore.get(remoteSubscriptionId) } returns subscriptionModel
+
+            val mockBuildUserService = mockk<IRebuildUserService>()
+
+            val subscriptionOperationExecutor =
+                SubscriptionOperationExecutor(
+                    mockSubscriptionBackendService,
+                    MockHelper.deviceService(),
+                    AndroidMockHelper.applicationService(),
+                    mockSubscriptionsModelStore,
+                    MockHelper.configModelStore(),
+                    mockBuildUserService,
+                    getNewRecordState(),
+                    mockConsistencyManager,
+                    getJwtTokenStore(), getIdentityVerificationService(),
+                )
+
+            val operations =
+                listOf<Operation>(
+                    CreateSubscriptionOperation(
+                        appId,
+                        remoteOneSignalId,
+                        null,
+                        remoteSubscriptionId,
+                        SubscriptionType.PUSH,
+                        false,
+                        "pushToken",
+                        SubscriptionStatus.NO_PERMISSION,
+                    ),
+                    UpdateSubscriptionOperation(
+                        appId,
+                        remoteOneSignalId,
+                        null,
+                        remoteSubscriptionId,
+                        SubscriptionType.PUSH,
+                        true,
+                        "pushToken",
+                        SubscriptionStatus.SUBSCRIBED,
+                    ),
+                )
+
+            // When
+            val response = subscriptionOperationExecutor.execute(operations)
+
+            // Then
+            response.result shouldBe ExecutionResult.SUCCESS
+            coVerify(exactly = 0) {
+                mockSubscriptionBackendService.createSubscription(any(), any(), any(), any())
+            }
+            coVerify(exactly = 1) {
+                mockSubscriptionBackendService.updateSubscription(
+                    appId,
+                    remoteSubscriptionId,
+                    withArg {
+                        it.type shouldBe SubscriptionObjectType.ANDROID_PUSH
+                        it.enabled shouldBe true
+                        it.token shouldBe "pushToken"
+                        it.notificationTypes shouldBe SubscriptionStatus.SUBSCRIBED.value
+                    },
+                )
+            }
         }
     })

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/SubscriptionOperationExecutorTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/SubscriptionOperationExecutorTests.kt
@@ -111,9 +111,9 @@ class SubscriptionOperationExecutorTests :
             }
         }
 
-        // SDK-4388: A CreateSubscriptionOperation can carry a non-local subscriptionId when
-        // a subscription that already exists on the backend is re-attached to a new local user
-        // (e.g. createAndSwitchToNewUser after login). POSTing to /subscriptions with that id is
+        // A CreateSubscriptionOperation can carry a non-local subscriptionId when a subscription
+        // that already exists on the backend is re-attached to a new local user (e.g.
+        // createAndSwitchToNewUser after login). POSTing to /subscriptions with that id is
         // silently a no-op on the server, so we must PATCH the existing subscription instead.
         test("create subscription PATCHes existing subscription when subscription ID is non-local") {
             // Given
@@ -629,7 +629,7 @@ class SubscriptionOperationExecutorTests :
             }
         }
 
-        // Regression for SDK-4388: when an UpdateSubscriptionOperation PATCH returns 404 outside
+        // Regression: when an UpdateSubscriptionOperation PATCH returns 404 outside
         // the missing-retry window, the executor must enqueue a recovery CreateSubscriptionOperation
         // with a *local* subscriptionId. Re-using the original non-local id would bounce back
         // through execute() -> updateExistingSubscriptionFromCreate -> PATCH -> 404 indefinitely
@@ -1027,7 +1027,7 @@ class SubscriptionOperationExecutorTests :
             response.retryAfterSeconds shouldBe 5
         }
 
-        // Repro for SDK-4388: when a CreateSubscriptionOperation is grouped with a follow-up
+        // When a CreateSubscriptionOperation is grouped with a follow-up
         // UpdateSubscriptionOperation for a subscription that already exists on the server
         // (non-local subscriptionId), the executor must PATCH the merged final state instead
         // of POSTing (which the backend treats as a no-op, silently dropping enabled/status).
@@ -1101,7 +1101,7 @@ class SubscriptionOperationExecutorTests :
             }
         }
 
-        // SDK-4388: when a CreateSubscriptionOperation with a non-local id is grouped with a
+        // When a CreateSubscriptionOperation with a non-local id is grouped with a
         // DeleteSubscriptionOperation, the executor must short-circuit to SUCCESS without
         // making any backend calls. Creating-then-deleting an already-existing subscription is
         // a no-op, and a stray PATCH here would resurrect a subscription the caller intended
@@ -1160,7 +1160,7 @@ class SubscriptionOperationExecutorTests :
             }
         }
 
-        // SDK-4388: when the PATCH dispatched for a non-local-id Create fails with a retryable
+        // When the PATCH dispatched for a non-local-id Create fails with a retryable
         // network error, the executor must propagate FAIL_RETRY (and any retryAfterSeconds) so
         // OperationRepo can re-execute, rather than swallowing the error or routing back to a
         // POST that the backend would silently no-op.
@@ -1223,7 +1223,7 @@ class SubscriptionOperationExecutorTests :
             }
         }
 
-        // SDK-4388: when multiple UpdateSubscriptionOperations are batched with a non-local-id
+        // When multiple UpdateSubscriptionOperations are batched with a non-local-id
         // Create, the executor must collapse them into a single PATCH carrying the *last*
         // update's values (not the create's, not the first update's). Locks in last-wins
         // semantics so a future "merge updates" refactor can't silently change behavior on

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/SubscriptionOperationExecutorTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/SubscriptionOperationExecutorTests.kt
@@ -581,6 +581,7 @@ class SubscriptionOperationExecutorTests :
             coEvery { mockSubscriptionBackendService.updateSubscription(any(), any(), any()) } throws BackendException(404)
 
             val mockSubscriptionsModelStore = mockk<SubscriptionModelStore>()
+            every { mockSubscriptionsModelStore.get(any()) } returns null
             val mockBuildUserService = mockk<IRebuildUserService>()
 
             val subscriptionOperationExecutor =


### PR DESCRIPTION
# Description
## One Line Summary
On session start, detect when the server's record of the device's push subscription is disabled while the local model says enabled-and-opted-in, and re-assert local truth via `PATCH /subscriptions/{id}` so users already stuck by [SDK-4388](https://linear.app/onesignal/issue/SDK-4388/android-sdk-subscription-state-permanently-stuck-at-never-subscribed) self-heal on next launch.

## Details

### Motivation
The fix in #2627 (parent PR) prevents *new* installs from getting stuck by flipping `POST /subscriptions` to `PATCH /subscriptions/{id}` in `SubscriptionOperationExecutor` when the subscription id is server-assigned. That covers the forward path, but it does **not** rescue the cohort that already triggered the bug on an older SDK build:

- The buggy `POST /subscriptions` returned `200 {}` (server-side no-op for an existing id).
- The merged `create-subscription + update-subscription(SUBSCRIBED)` group was therefore acked and dropped from the local op queue.
- On in-place upgrade to the fixed SDK there is nothing left in the queue to retry, and the server view stays at `enabled:false, notification_types:0` permanently.

This is confirmed with the SDK-4388 demo-app reproduction:
- force-stop on the buggy build (server stuck)
- upgrade to the fixed build
- relaunch — no `PATCH /subscriptions/{id}` in the logs.

### Scope
- **Affected:** `RefreshUserOperationExecutor.getUser`. On every session start the SDK already issues `GET /users/by/onesignal_id/{osid}`, whose response carries `enabled` / `notification_types` per subscription. We now inspect the entry whose `id` matches the device's cached push subscription id, and if `local.enabled && !server.enabled`, we emit a follow-up `UpdateSubscriptionOperation` returned via `ExecutionResponse.operations`. That op runs through the standard executor path and produces one `PATCH /subscriptions/{id}` carrying the device's true state.
- **Unchanged:** \"Device is the source of truth for push\" policy. We still do **not** hydrate the server's push subscription into `SubscriptionModelStore` (the existing `if (subscriptionModel.type != SubscriptionType.PUSH)` filter is preserved). The new code only enforces that policy across the wire when divergence is detected.
- **No-op for healthy users.** Server-matches-local triggers no PATCH.
- **Respects user intent.** A locally-opted-out subscription (`optedIn=false`, status `UNSUBSCRIBE`) or one with `NO_PERMISSION` does not trigger a reconcile — those server-side disables are correct, not stuck.

### Cost
One extra `PATCH /subscriptions/{id}` per stuck device on its first foreground session under the new SDK build. Healthy devices pay nothing. Once the PATCH succeeds, server matches local and no further reconciles fire.

# Testing
## Unit testing
Added 4 cases to `RefreshUserOperationExecutorTests`:

1. **divergence** — server `enabled:false, notification_types:0` + local opted-in + SUBSCRIBED + non-empty token → returns exactly one `UpdateSubscriptionOperation` with `enabled=true, status=SUBSCRIBED`, correct ids.
2. **healthy** — server `enabled:true, notification_types:1` + local opted-in → no follow-up op.
3. **opted-out** — server `enabled:false, notification_types:-2` + local `optedIn=false` → no follow-up op (UNSUBSCRIBE is intentional).
4. **NO_PERMISSION** — server `enabled:false, notification_types:0` + local `status=NO_PERMISSION` → no follow-up op (OS denial is real).

The existing happy-path test `refresh user is successful and models are hydrated properly` was updated to set `notificationTypes = 1` on the cached push subscription so it stays on the new healthy path.

Test gate: `./gradlew :OneSignal:core:testReleaseUnitTest --tests \"...RefreshUserOperationExecutorTests\"` → 10/10 PASS. Two unrelated `SDKInitTests` failures exist on the parent branch and are not introduced by this PR.

Detekt + production assemble (`:OneSignal:core:detekt`, `:OneSignal:core:assembleRelease`) clean.

## Manual testing
End-to-end repro and validation are intended to run on the demo app shipped with the parent SDK-4388 branch (which has the \"Reproduce SDK-4388\" + \"Self-heal test\" sections):

1. Force-stop demo on the **broken** SDK build with cached stuck state (`enabled:false, notification_types:0` on dashboard).
2. Upgrade in place to this branch, relaunch.
3. Expect on first session: `GET /users/by/onesignal_id/{osid}` followed by a single `PATCH /subscriptions/{id}` with `enabled:true, notification_types:1`.
4. Dashboard subscription flips from \"Never Subscribed\" to \"Subscribed\".
5. On subsequent sessions: only `GET` (no further PATCH) — divergence check is a no-op once reconciled.

# Affected code checklist
- [ ] Notifications
   - [ ] Display
   - [ ] Open
   - [ ] Push Processing
   - [ ] Confirm Deliveries
- [ ] Outcomes
- [ ] Sessions
- [ ] In-App Messaging
- [x] REST API requests — adds at most one `PATCH /subscriptions/{id}` per stuck device on first session post-upgrade
- [ ] Public API changes

# Checklist
## Overview
- [x] I have filled out all **REQUIRED** sections above
- [x] PR does one thing — adds a single divergence detection branch in `RefreshUserOperationExecutor.getUser`
- [x] No public API changes

## Testing
- [x] Unit test coverage added for all four boundary cases
- [x] All automated tests pass (pre-existing `SDKInitTests` failures are unrelated to this change)
- [ ] Personally tested on device — pending end-to-end verification with the demo-app repro flow described above

## Final pass
- [x] Code is as readable as possible — divergence logic isolated in a single helper `buildPushSelfHealOperationOrNull` with explanatory comments referencing SDK-4388 / SDK-4474
- [x] Self-reviewed

---

**Branching:** This PR targets the SDK-4388 fix branch (#2627 parent) so the two changes can land together as a complete \"prevent new + heal old\" pair. If the team prefers to ship the SDK-4388 fix first and follow up with this independently, retarget to `main`.

Refs: [SDK-4474](https://linear.app/onesignal/issue/SDK-4474), [SDK-4388](https://linear.app/onesignal/issue/SDK-4388)