### PR TITLE
fix: defensive JSON parsing for params + IAM (SDK-4478, SDK-4494)

### DIFF
--- a/OneSignalSDK/detekt/detekt-baseline-core.xml
+++ b/OneSignalSDK/detekt/detekt-baseline-core.xml
@@ -174,6 +174,7 @@
     <ID>InstanceOfCheckForException:HttpClient.kt$HttpClient$t is UnknownHostException</ID>
     <ID>LongMethod:ApplicationService.kt$ApplicationService$override suspend fun waitUntilSystemConditionsAvailable(): Boolean</ID>
     <ID>LongMethod:ConfigModelStoreListener.kt$ConfigModelStoreListener$private fun fetchParams()</ID>
+    <ID>LongMethod:FeatureFlagsBackendService.kt$FeatureFlagsBackendService$override suspend fun fetchRemoteFeatureFlags(appId: String): RemoteFeatureFlagsFetchOutcome</ID>
     <ID>LongMethod:HttpClient.kt$HttpClient$private suspend fun makeRequestIODispatcher( url: String, method: String?, jsonBody: JSONObject?, timeout: Int, headers: OptionalHeaders?, ): HttpResponse</ID>
     <ID>LongMethod:IdentityOperationExecutor.kt$IdentityOperationExecutor$override suspend fun execute(operations: List&lt;Operation>): ExecutionResponse</ID>
     <ID>LongMethod:LoginUserOperationExecutor.kt$LoginUserOperationExecutor$private suspend fun createUser( createUserOperation: LoginUserOperation, operations: List&lt;Operation>, ): ExecutionResponse</ID>
@@ -196,7 +197,6 @@
     <ID>LongParameterList:ICustomEventBackendService.kt$ICustomEventBackendService$( appId: String, onesignalId: String, externalId: String?, timestamp: Long, eventName: String, eventProperties: String?, metadata: CustomEventMetadata, )</ID>
     <ID>LongParameterList:IDatabase.kt$IDatabase$( table: String, columns: Array&lt;String>? = null, whereClause: String? = null, whereArgs: Array&lt;String>? = null, groupBy: String? = null, having: String? = null, orderBy: String? = null, limit: String? = null, action: (ICursor) -> Unit, )</ID>
     <ID>LongParameterList:IOutcomeEventsBackendService.kt$IOutcomeEventsBackendService$( appId: String, userId: String, subscriptionId: String, deviceType: String, direct: Boolean?, event: OutcomeEvent, )</ID>
-    <ID>LongParameterList:IParamsBackendService.kt$ParamsObject$( var googleProjectNumber: String? = null, var enterprise: Boolean? = null, var useIdentityVerification: Boolean? = null, var notificationChannels: JSONArray? = null, var firebaseAnalytics: Boolean? = null, var restoreTTLFilter: Boolean? = null, var clearGroupOnSummaryClick: Boolean? = null, var receiveReceiptEnabled: Boolean? = null, var disableGMSMissingPrompt: Boolean? = null, var unsubscribeWhenNotificationsDisabled: Boolean? = null, var locationShared: Boolean? = null, var requiresUserPrivacyConsent: Boolean? = null, var opRepoExecutionInterval: Long? = null, var influenceParams: InfluenceParamsObject, var fcmParams: FCMParamsObject, )</ID>
     <ID>LongParameterList:IUserBackendService.kt$IUserBackendService$( appId: String, aliasLabel: String, aliasValue: String, properties: PropertiesObject, refreshDeviceMetadata: Boolean, propertyiesDelta: PropertiesDeltasObject, )</ID>
     <ID>LongParameterList:LoginUserOperationExecutor.kt$LoginUserOperationExecutor$( private val _identityOperationExecutor: IdentityOperationExecutor, private val _application: IApplicationService, private val _deviceService: IDeviceService, private val _userBackend: IUserBackendService, private val _identityModelStore: IdentityModelStore, private val _propertiesModelStore: PropertiesModelStore, private val _subscriptionsModelStore: SubscriptionModelStore, private val _configModelStore: ConfigModelStore, private val _languageContext: ILanguageContext, )</ID>
     <ID>LongParameterList:OutcomeEventsController.kt$OutcomeEventsController$( private val _session: ISessionService, private val _influenceManager: IInfluenceManager, private val _outcomeEventsCache: IOutcomeEventsRepository, private val _outcomeEventsPreferences: IOutcomeEventsPreferences, private val _outcomeEventsBackend: IOutcomeEventsBackendService, private val _configModelStore: ConfigModelStore, private val _identityModelStore: IdentityModelStore, private val _subscriptionManager: ISubscriptionManager, private val _deviceService: IDeviceService, private val _time: ITime, )</ID>
@@ -282,8 +282,8 @@
     <ID>RethrowCaughtException:OSDatabase.kt$OSDatabase$throw e</ID>
     <ID>ReturnCount:AppIdResolution.kt$fun resolveAppId( inputAppId: String?, configModel: ConfigModel, preferencesService: IPreferencesService, ): AppIdResolution</ID>
     <ID>ReturnCount:BackgroundManager.kt$BackgroundManager$override fun cancelRunBackgroundServices(): Boolean</ID>
-    <ID>ReturnCount:OneSignalImp.kt$OneSignalImp$private fun internalInit( context: Context, appId: String?, ): Boolean</ID>
     <ID>ReturnCount:ConfigModel.kt$ConfigModel$override fun createModelForProperty( property: String, jsonObject: JSONObject, ): Model?</ID>
+    <ID>ReturnCount:FeatureFlagsBackendService.kt$FeatureFlagsBackendService$override suspend fun fetchRemoteFeatureFlags(appId: String): RemoteFeatureFlagsFetchOutcome</ID>
     <ID>ReturnCount:HttpClient.kt$HttpClient$private suspend fun makeRequest( url: String, method: String?, jsonBody: JSONObject?, timeout: Int, headers: OptionalHeaders?, ): HttpResponse</ID>
     <ID>ReturnCount:IdentityOperationExecutor.kt$IdentityOperationExecutor$override suspend fun execute(operations: List&lt;Operation>): ExecutionResponse</ID>
     <ID>ReturnCount:JSONUtils.kt$JSONUtils$fun compareJSONArrays( jsonArray1: JSONArray?, jsonArray2: JSONArray?, ): Boolean</ID>
@@ -295,6 +295,8 @@
     <ID>ReturnCount:Model.kt$Model$protected fun getOptIntProperty( name: String, create: (() -> Int?)? = null, ): Int?</ID>
     <ID>ReturnCount:Model.kt$Model$protected fun getOptLongProperty( name: String, create: (() -> Long?)? = null, ): Long?</ID>
     <ID>ReturnCount:Model.kt$Model$protected inline fun &lt;reified T : Enum&lt;T>> getOptEnumProperty(name: String): T?</ID>
+    <ID>ReturnCount:OneSignalImp.kt$OneSignalImp$@Suppress("TooGenericExceptionCaught") private fun internalInit( context: Context, appId: String?, ): Boolean</ID>
+    <ID>ReturnCount:OneSignalImp.kt$OneSignalImp$@Suppress("TooGenericExceptionCaught") private fun warnIfBlockingOnMainThread(operationName: String?)</ID>
     <ID>ReturnCount:OperationModelStore.kt$OperationModelStore$override fun create(jsonObject: JSONObject?): Operation?</ID>
     <ID>ReturnCount:OperationModelStore.kt$OperationModelStore$private fun isValidOperation(jsonObject: JSONObject): Boolean</ID>
     <ID>ReturnCount:OutcomeEventsController.kt$OutcomeEventsController$private suspend fun sendAndCreateOutcomeEvent( name: String, weight: Float, // Note: this is optional sessionTime: Long, influences: List&lt;Influence>, ): OutcomeEvent?</ID>
@@ -319,22 +321,27 @@
     <ID>SwallowedException:DeviceService.kt$DeviceService$e: ClassNotFoundException</ID>
     <ID>SwallowedException:DeviceService.kt$DeviceService$e: PackageManager.NameNotFoundException</ID>
     <ID>SwallowedException:JSONUtils.kt$JSONUtils$t: Throwable</ID>
+    <ID>SwallowedException:OneSignalImp.kt$OneSignalImp$e: RuntimeException</ID>
     <ID>SwallowedException:PermissionsActivity.kt$PermissionsActivity$e: ClassNotFoundException</ID>
     <ID>SwallowedException:PreferencesService.kt$PreferencesService$ex: Exception</ID>
+    <ID>SwallowedException:PreferencesService.kt$PreferencesService$t: Throwable</ID>
     <ID>SwallowedException:SyncJobService.kt$SyncJobService$e: Exception</ID>
     <ID>SwallowedException:TrackGooglePurchase.kt$TrackGooglePurchase.Companion$t: Throwable</ID>
     <ID>ThrowsCount:OneSignalImp.kt$OneSignalImp$private suspend fun waitUntilInitInternal(operationName: String? = null)</ID>
     <ID>TooGenericExceptionCaught:AndroidUtils.kt$AndroidUtils$e: Throwable</ID>
     <ID>TooGenericExceptionCaught:DeviceUtils.kt$DeviceUtils$t: Throwable</ID>
+    <ID>TooGenericExceptionCaught:FeatureFlagsRefreshService.kt$FeatureFlagsRefreshService$e: Exception</ID>
     <ID>TooGenericExceptionCaught:HttpClient.kt$HttpClient$e: Throwable</ID>
     <ID>TooGenericExceptionCaught:HttpClient.kt$HttpClient$t: Throwable</ID>
     <ID>TooGenericExceptionCaught:JSONUtils.kt$JSONUtils$t: Throwable</ID>
     <ID>TooGenericExceptionCaught:Logging.kt$Logging$t: Throwable</ID>
     <ID>TooGenericExceptionCaught:OneSignalDispatchers.kt$OneSignalDispatchers$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:OneSignalImp.kt$OneSignalImp$e: Exception</ID>
     <ID>TooGenericExceptionCaught:OperationRepo.kt$OperationRepo$e: Throwable</ID>
     <ID>TooGenericExceptionCaught:PreferenceStoreFix.kt$PreferenceStoreFix$e: Throwable</ID>
     <ID>TooGenericExceptionCaught:PreferencesService.kt$PreferencesService$e: Throwable</ID>
     <ID>TooGenericExceptionCaught:PreferencesService.kt$PreferencesService$ex: Exception</ID>
+    <ID>TooGenericExceptionCaught:PreferencesService.kt$PreferencesService$t: Throwable</ID>
     <ID>TooGenericExceptionCaught:SyncJobService.kt$SyncJobService$e: Exception</ID>
     <ID>TooGenericExceptionCaught:ThreadUtils.kt$e: Exception</ID>
     <ID>TooGenericExceptionCaught:TrackGooglePurchase.kt$TrackGooglePurchase$e: Throwable</ID>
@@ -413,10 +420,6 @@
     <ID>UndocumentedPublicClass:IOperationExecutor.kt$ExecutionResponse</ID>
     <ID>UndocumentedPublicClass:IOperationExecutor.kt$ExecutionResult</ID>
     <ID>UndocumentedPublicClass:IOutcomeEvent.kt$IOutcomeEvent</ID>
-    <ID>UndocumentedPublicClass:IParamsBackendService.kt$FCMParamsObject</ID>
-    <ID>UndocumentedPublicClass:IParamsBackendService.kt$IParamsBackendService</ID>
-    <ID>UndocumentedPublicClass:IParamsBackendService.kt$InfluenceParamsObject</ID>
-    <ID>UndocumentedPublicClass:IParamsBackendService.kt$ParamsObject</ID>
     <ID>UndocumentedPublicClass:IPreferencesService.kt$PreferenceOneSignalKeys</ID>
     <ID>UndocumentedPublicClass:IPreferencesService.kt$PreferencePlayerPurchasesKeys</ID>
     <ID>UndocumentedPublicClass:IPreferencesService.kt$PreferenceStores</ID>
@@ -549,8 +552,6 @@
     <ID>UndocumentedPublicFunction:Logging.kt$Logging$@JvmStatic fun warn( message: String, throwable: Throwable? = null, )</ID>
     <ID>UndocumentedPublicFunction:Logging.kt$Logging$fun addListener(listener: ILogListener)</ID>
     <ID>UndocumentedPublicFunction:Logging.kt$Logging$fun removeListener(listener: ILogListener)</ID>
-    <ID>UndocumentedPublicFunction:LoginHelper.kt$LoginHelper$suspend fun login( externalId: String, jwtBearerToken: String? = null, )</ID>
-    <ID>UndocumentedPublicFunction:LogoutHelper.kt$LogoutHelper$fun logout()</ID>
     <ID>UndocumentedPublicFunction:Model.kt$Model$fun &lt;T> setListProperty( name: String, value: List&lt;T>, tag: String = ModelChangeTags.NORMAL, forceChange: Boolean = false, )</ID>
     <ID>UndocumentedPublicFunction:Model.kt$Model$fun &lt;T> setMapModelProperty( name: String, value: MapModel&lt;T>, tag: String = ModelChangeTags.NORMAL, forceChange: Boolean = false, )</ID>
     <ID>UndocumentedPublicFunction:Model.kt$Model$fun &lt;T> setOptListProperty( name: String, value: List&lt;T>?, tag: String = ModelChangeTags.NORMAL, forceChange: Boolean = false, )</ID>
@@ -610,9 +611,9 @@
     <ID>UnusedPrivateMember:OperationRepo.kt$OperationRepo$private val _time: ITime</ID>
     <ID>UseCheckOrError:OneSignalImp.kt$OneSignalImp$throw IllegalStateException("'initWithContext failed' before 'login'")</ID>
     <ID>UseCheckOrError:OneSignalImp.kt$OneSignalImp$throw IllegalStateException("'initWithContext failed' before 'logout'")</ID>
-    <ID>UseCheckOrError:OneSignalImp.kt$OneSignalImp$throw IllegalStateException("Must call 'initWithContext' before 'login'")</ID>
-    <ID>UseCheckOrError:OneSignalImp.kt$OneSignalImp$throw IllegalStateException("Must call 'initWithContext' before 'logout'")</ID>
+    <ID>UseCheckOrError:OneSignalImp.kt$OneSignalImp$throw IllegalStateException("Must call 'initWithContext' before '$operationName'")</ID>
     <ID>UseCheckOrError:OneSignalImp.kt$OneSignalImp$throw IllegalStateException("Must call 'initWithContext' before use")</ID>
+    <ID>UseCheckOrError:OneSignalImp.kt$OneSignalImp$throw initFailureException ?: IllegalStateException("Initialization failed before '$operationName'")</ID>
     <ID>UseCheckOrError:OneSignalImp.kt$OneSignalImp$throw initFailureException ?: IllegalStateException("Initialization failed. Cannot proceed.")</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/backend/impl/ParamsBackendService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/backend/impl/ParamsBackendService.kt
@@ -17,6 +17,7 @@ import com.onesignal.core.internal.http.IHttpClient
 import com.onesignal.core.internal.http.impl.OptionalHeaders
 import com.onesignal.debug.LogLevel
 import com.onesignal.debug.internal.logging.Logging
+import org.json.JSONException
 import org.json.JSONObject
 
 internal class ParamsBackendService(
@@ -39,7 +40,23 @@ internal class ParamsBackendService(
             throw BackendException(response.statusCode, response.payload, response.retryAfterSeconds)
         }
 
-        val responseJson = JSONObject(response.payload!!)
+        // A 2xx response with a non-JSON body (e.g. an intercepting proxy / captive portal /
+        // CDN error page returning HTML) used to surface as an uncaught JSONException on the
+        // IO dispatcher and silently kill the params refresh loop. Convert it into a
+        // BackendException so the caller's existing retry/backoff path handles it like any
+        // other transient backend failure.
+        val payload = response.payload
+        val responseJson =
+            try {
+                JSONObject(payload ?: "")
+            } catch (ex: JSONException) {
+                Logging.warn(
+                    "ParamsBackendService.fetchParams: malformed (non-JSON) response payload, will retry. " +
+                        "status=${response.statusCode}",
+                    ex,
+                )
+                throw BackendException(response.statusCode, payload, response.retryAfterSeconds)
+            }
 
         // Process outcomes params
         var influenceParams: InfluenceParamsObject? = null

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/backend/impl/FeatureFlagsBackendServiceTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/backend/impl/FeatureFlagsBackendServiceTests.kt
@@ -105,6 +105,27 @@ class FeatureFlagsBackendServiceTests : FunSpec({
         warns[0].entry.contains("""{"errors":["Forbidden"]}""") shouldBe true
     }
 
+    // Companion regression to SDK-4478 on the params endpoint: a 2xx response with a
+    // completely non-JSON body (intercepting proxy like Burp, captive portal, CDN error
+    // HTML, etc.) must NOT throw and must NOT kill the refresh loop. It should fall
+    // through to Unavailable and log a WARN with a body snippet, exactly like the
+    // existing "wrong-shape JSON" path. FeatureFlagsJsonParser.parseSuccessful already
+    // catches Throwable internally; this test pins that contract so nobody regresses it.
+    test("200 with totally non-JSON body (HTML) returns Unavailable and does not throw") {
+        val htmlBody = "<html><head><title>Burp</title></head><body>intercepted</body></html>"
+        val http = mockk<IHttpClient>()
+        coEvery { http.get(any(), any()) } returns HttpResponse(200, htmlBody)
+
+        FeatureFlagsBackendService(http).fetchRemoteFeatureFlags("appId") shouldBe
+            RemoteFeatureFlagsFetchOutcome.Unavailable
+        val warns =
+            logsForService().filter {
+                it.level == LogLevel.WARN && it.entry.contains("not valid Turbine feature-flags JSON")
+            }
+        warns shouldHaveSize 1
+        warns[0].entry.contains("<html>") shouldBe true
+    }
+
     test("body snippet caps long payloads at 200 chars") {
         val longBody = "x".repeat(1_000)
         val http = mockk<IHttpClient>()

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/backend/impl/ParamsBackendServiceTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/backend/impl/ParamsBackendServiceTests.kt
@@ -1,0 +1,92 @@
+package com.onesignal.core.internal.backend.impl
+
+import com.onesignal.common.exceptions.BackendException
+import com.onesignal.core.internal.http.HttpResponse
+import com.onesignal.core.internal.http.IHttpClient
+import com.onesignal.debug.LogLevel
+import com.onesignal.debug.internal.logging.Logging
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.coEvery
+import io.mockk.mockk
+
+/**
+ * Regression coverage for SDK-4478: a 2xx response with a non-JSON body (e.g. an
+ * intercepting proxy or captive portal returning HTML) used to surface as an uncaught
+ * [org.json.JSONException] on the IO dispatcher and silently kill the params refresh
+ * loop. [ParamsBackendService.fetchParams] now converts those into [BackendException] so
+ * the caller's existing retry/backoff path handles them like any other transient failure.
+ */
+class ParamsBackendServiceTests : FunSpec({
+    var originalLogLevel: LogLevel = LogLevel.WARN
+
+    beforeEach {
+        // Logging.warn() ultimately routes through android.util.Log, which is not mocked
+        // in plain JVM unit tests. Silence it for the duration of these tests.
+        originalLogLevel = Logging.logLevel
+        Logging.logLevel = LogLevel.NONE
+    }
+
+    afterEach {
+        Logging.logLevel = originalLogLevel
+    }
+
+    test("malformed (HTML) 200 payload throws BackendException instead of JSONException") {
+        val http = mockk<IHttpClient>()
+        val htmlBody = "<html><head><title>Burp</title></head><body>intercepted</body></html>"
+        coEvery { http.get(any(), any()) } returns HttpResponse(200, htmlBody)
+
+        val ex =
+            shouldThrow<BackendException> {
+                ParamsBackendService(http).fetchParams("appId", null)
+            }
+
+        ex.statusCode shouldBe 200
+        ex.response shouldBe htmlBody
+    }
+
+    test("empty 200 payload throws BackendException instead of NullPointerException") {
+        val http = mockk<IHttpClient>()
+        coEvery { http.get(any(), any()) } returns HttpResponse(200, null)
+
+        val ex =
+            shouldThrow<BackendException> {
+                ParamsBackendService(http).fetchParams("appId", null)
+            }
+
+        ex.statusCode shouldBe 200
+    }
+
+    test("non-2xx response still throws BackendException with the original status code") {
+        val http = mockk<IHttpClient>()
+        coEvery { http.get(any(), any()) } returns HttpResponse(403, """{"errors":["Forbidden"]}""")
+
+        val ex =
+            shouldThrow<BackendException> {
+                ParamsBackendService(http).fetchParams("appId", null)
+            }
+
+        ex.statusCode shouldBe 403
+        ex.response shouldBe """{"errors":["Forbidden"]}"""
+    }
+
+    test("valid JSON payload is parsed and returns a populated ParamsObject") {
+        val http = mockk<IHttpClient>()
+        coEvery { http.get(any(), any()) } returns
+            HttpResponse(
+                200,
+                """{"android_sender_id":"sender-123","enterp":true,"fcm":{"api_key":"k","app_id":"a","project_id":"p"}}""",
+            )
+
+        val params = ParamsBackendService(http).fetchParams("appId", null)
+
+        params shouldNotBe null
+        params.googleProjectNumber shouldBe "sender-123"
+        params.enterprise shouldBe true
+        params.fcmParams.apiKey shouldBe "k"
+        params.fcmParams.appId shouldBe "a"
+        params.fcmParams.projectId shouldBe "p"
+    }
+})

--- a/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/display/impl/WebViewManager.kt
+++ b/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/display/impl/WebViewManager.kt
@@ -175,19 +175,45 @@ internal class WebViewManager(
         activity: Activity,
         jsonObject: JSONObject,
     ): Int {
-        return try {
-            val pageHeight = jsonObject.getJSONObject("rect").getInt("height")
-            var pxHeight = ViewUtils.dpToPx(pageHeight)
-            Logging.debug("getPageHeightData:pxHeight: $pxHeight")
-            val maxPxHeight = getWebViewMaxSizeY(activity)
-            if (pxHeight > maxPxHeight) {
-                pxHeight = maxPxHeight
-                Logging.debug("getPageHeightData:pxHeight is over screen max: $maxPxHeight")
-            }
-            pxHeight
-        } catch (e: JSONException) {
-            Logging.error("pageRectToViewHeight could not get page height", e)
-            -1
+        // SDK-4494: avoid throw-then-catch on `rect` being absent. The IAM HTML's
+        // `getPageMetaData()` can legitimately return a payload without `rect` for
+        // benign/recoverable reasons (e.g. JS not yet defined when the activity
+        // rotates, custom IAM template, partial metadata). The previous
+        // `getJSONObject("rect")` raised `JSONException` which we caught and logged
+        // at ERROR with a full stack trace, flooding OTel/Datadog with non-actionable
+        // alerts. Use `optJSONObject` and `optInt` so missing fields are a structured
+        // null/sentinel instead, and downgrade the log to a single WARN line.
+        val rect = jsonObject.optJSONObject("rect")
+        val pageHeight = rect?.optInt("height", -1) ?: -1
+        if (pageHeight < 0) {
+            Logging.warn(
+                "pageRectToViewHeight could not get page height (missing/invalid 'rect.height'); " +
+                    "snippet=${bodySnippet(jsonObject.toString())}",
+            )
+            return -1
+        }
+        var pxHeight = ViewUtils.dpToPx(pageHeight)
+        Logging.debug("getPageHeightData:pxHeight: $pxHeight")
+        val maxPxHeight = getWebViewMaxSizeY(activity)
+        if (pxHeight > maxPxHeight) {
+            pxHeight = maxPxHeight
+            Logging.debug("getPageHeightData:pxHeight is over screen max: $maxPxHeight")
+        }
+        return pxHeight
+    }
+
+    /**
+     * Trim [body] to a short, single-line snippet safe for logcat / OTel. See
+     * SDK-4494 - we only want enough context to debug shape mismatches without
+     * dumping the full WebView payload into log pipelines.
+     */
+    private fun bodySnippet(body: String?): String {
+        if (body.isNullOrEmpty()) return "<empty>"
+        val flattened = body.replace('\n', ' ').replace('\r', ' ')
+        return if (flattened.length <= LOG_BODY_SNIPPET_MAX_CHARS) {
+            flattened
+        } else {
+            flattened.take(LOG_BODY_SNIPPET_MAX_CHARS) + "…"
         }
     }
 
@@ -233,6 +259,19 @@ internal class WebViewManager(
         }
 
         webView!!.evaluateJavascript(GET_PAGE_META_DATA_JS_FUNCTION) { value ->
+            // SDK-4494: `evaluateJavascript` returns the JSON-encoded result of the
+            // expression. When the JS function is undefined or returns `undefined`
+            // (e.g. WebView not fully loaded yet) the callback receives the literal
+            // string "null", which `JSONObject(...)` rejects. Bail out early instead
+            // of throwing+catching, and route any remaining surprise through Logging
+            // (was previously `e.printStackTrace()`, which bypassed our log pipeline).
+            if (value.isNullOrBlank() || value == "null") {
+                Logging.warn(
+                    "calculateHeightAndShowWebViewAfterNewActivity: empty/null page metadata " +
+                        "from WebView; skipping height update",
+                )
+                return@evaluateJavascript
+            }
             try {
                 val pagePxHeight = pageRectToViewHeight(activity, JSONObject(value))
 
@@ -240,7 +279,11 @@ internal class WebViewManager(
                     showMessageView(pagePxHeight)
                 }
             } catch (e: JSONException) {
-                e.printStackTrace()
+                Logging.warn(
+                    "calculateHeightAndShowWebViewAfterNewActivity: could not parse page metadata; " +
+                        "snippet=${bodySnippet(value)}",
+                    e,
+                )
             }
         }
     }
@@ -463,6 +506,12 @@ internal class WebViewManager(
 
     companion object {
         private val MARGIN_PX_SIZE = ViewUtils.dpToPx(24)
+
+        // SDK-4494: cap the body snippet included in WARN logs so a malformed/large
+        // WebView payload can't blow up the OTel log entry. Same pattern as
+        // FeatureFlagsBackendService.
+        private const val LOG_BODY_SNIPPET_MAX_CHARS = 200
+
         const val JS_OBJ_NAME = "OSAndroid"
         const val GET_PAGE_META_DATA_JS_FUNCTION = "getPageMetaData()"
         const val SET_SAFE_AREA_INSETS_JS_FUNCTION = "setSafeAreaInsets(%s)"


### PR DESCRIPTION
Two related fixes that stop the SDK from generating noisy / dangerous `JSONException`s when an upstream payload is the wrong shape.

Fixes:
- [SDK-4478](https://linear.app/onesignal/issue/SDK-4478/paramsbackendservicefetchparams-silently-kills-params-refresh-loop-on) — `ParamsBackendService.fetchParams` silently kills the params refresh loop on a non-JSON 2xx response.
- [SDK-4494](https://linear.app/onesignal/issue/SDK-4494/webviewmanagerpagerecttoviewheight-emits-noisy-error-level) — `WebViewManager.pageRectToViewHeight` emits an ERROR-level `JSONException` (with full stack trace) on missing `rect`, flooding OTel/Datadog with non-actionable alerts.

Common theme: stop the SDK from throwing `JSONException` for benign/recoverable conditions, and route any remaining surprise through `Logging.warn` with a bounded body snippet so issues are still observable without being alert-worthy.

## SDK-4478 — Params refresh loop

`ParamsBackendService.fetchParams` calls `JSONObject(response.payload!!)` unconditionally on any 2xx response. When the body isn't valid JSON (intercepting proxy like Burp, captive portal, CDN error HTML, charset/gzip corruption, etc.) the resulting `JSONException` escapes the caller's retry loop because `ConfigModelStoreListener.fetchParams` only catches `BackendException`.

This is **not** an app-level crash today: `suspendifyOnIO` wraps the block in a top-level `try { ... } catch (Exception) { Logging.error(...) }`, so the exception is caught at the dispatcher boundary and printed via `Log.e`. The actual symptom is a **silent functional regression** — the `do { ... } while (!success)` retry/backoff loop is unwound entirely, so for the rest of that session `android_params.js` is never re-fetched and the SDK keeps running on cached/default params (FCM params, notification channels, outcomes config, log level, etc.).

> Note: in older revisions of `ThreadUtils.suspendifyOnIO` that didn't have a top-level `catch (Exception)`, this same `JSONException` could have escaped to `Thread.UncaughtExceptionHandler` and actually crashed the process. On current `main` it's silent. The fix is correct either way.

Reported logcat trace:

```
org.json.JSONException: Value <html><head><title>Burp of type java.lang.String cannot be converted to JSONObject
    at org.json.JSON.typeMismatch(JSON.java:112)
    at org.json.JSONObject.<init>(JSONObject.java:163)
    at org.json.JSONObject.<init>(JSONObject.java:176)
    at com.onesignal.core.internal.backend.impl.ParamsBackendService.fetchParams(ParamsBackendService.kt:42)
    ...
```

**Fix:** wrap the `JSONObject(...)` parse in a try/catch and rethrow as `BackendException(statusCode, payload, retryAfterSeconds)`. This routes a malformed body into the existing retry/backoff path in `ConfigModelStoreListener` exactly like any other transient backend failure. Original status code is preserved so the existing 403 short-circuit still works. A `null` payload (which would have NPE'd on `payload!!`) is also handled the same way.

**Additional companion test in `FeatureFlagsBackendServiceTests`** asserts that the Turbine SDK feature-flags endpoint already handles a fully non-JSON 200 body safely (its `FeatureFlagsJsonParser.parseSuccessful` already catches `Throwable`). No production change there — just locking the contract so a future refactor can't drop the catch silently.

## SDK-4494 — IAM page-rect noisy ERROR log

Production OTel logs (sample insertId `4133ooyq0ths9s5j`) show this at ERROR level with a full stack trace:

```
org.json.JSONException: No value for rect
    at org.json.JSONObject.get(JSONObject.java:398)
    at org.json.JSONObject.getJSONObject(JSONObject.java:618)
    at com.onesignal.inAppMessages.internal.display.impl.W.pageRectToViewHeight(SourceFile:7)
    at com.onesignal.inAppMessages.internal.display.impl.W.calculateHeightAndShowWebViewAfterNewActivity$lambda$0(SourceFile:13)
    ...
log.message: "[main] pageRectToViewHeight could not get page height"
severity: ERROR
```

Like SDK-4478 this is **not** a crash — `pageRectToViewHeight` already catches `JSONException`, logs `Logging.error(...)` and returns `-1`. The IAM keeps working. But the `WebView.evaluateJavascript("getPageMetaData()")` callback can deliver a payload without `rect` for benign, recoverable reasons:

- The IAM HTML's JS hasn't finished defining `getPageMetaData()` yet (race with activity rotation / new activity).
- The page returned partial metadata (custom IAM template).
- The function returned `undefined` (callback delivers the literal string `"null"`, which `JSONObject("null")` rejects).

Logging this at ERROR floods OTel/Datadog and triggers operator alerts for a non-actionable race.

**Fix:**

- Switch `pageRectToViewHeight` to `optJSONObject("rect")` / `optInt("height", -1)` so missing fields stop generating thrown exceptions; demote the log to a single WARN with a 200-char body snippet (same pattern as `FeatureFlagsBackendService.bodySnippet`).
- In `calculateHeightAndShowWebViewAfterNewActivity`, bail out early when `evaluateJavascript` returns `null` or the literal `"null"`, instead of letting `JSONObject(...)` throw.
- Replace the bare `e.printStackTrace()` (which bypassed the SDK logging pipeline) with `Logging.warn(..., e)` + body snippet so any remaining surprise is still observable.

IAM display behavior on the happy path is unchanged.

## Test plan

- [x] `ParamsBackendServiceTests` (4 new tests): HTML 200, null 200, non-2xx passthrough, happy path. All pass.
- [x] `FeatureFlagsBackendServiceTests` (15 tests including new HTML-on-200 contract test). All pass.
- [x] `:OneSignal:core:detekt` clean for touched files.
- [x] `:OneSignal:in-app-messages:assembleRelease` clean (warnings only on pre-existing unrelated lines).
- [x] `:OneSignal:in-app-messages:detekt` clean.
- [x] `:OneSignal:in-app-messages:testReleaseUnitTest` — full module suite passes.
- [x] Full `:OneSignal:core:testReleaseUnitTest` — only 2 pre-existing `SDKInitTests` failures, unrelated and reproducible on bare `main` (verified by stashing this fix).

## Commits

1. `fix: SDK-4478: handle non-JSON params response without killing refresh loop` (`ParamsBackendService` + tests)
2. `test: pin FeatureFlags non-JSON 200 contract (companion to SDK-4478)` (no production change, regression test only)
3. `fix: SDK-4494: stop logging IAM page-rect JSONException at ERROR level` (`WebViewManager`)