### PR TITLE
ci: [SDK-4492] use GH_PUSH_TOKEN for project workflow

### DIFF
--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -13,4 +13,4 @@ jobs:
         with:
           # SDK Mobile Project
           project-url: https://github.com/orgs/OneSignal/projects/18
-          github-token: ${{ secrets.GH_PROJECTS_TOKEN }}
+          github-token: ${{ secrets.GH_PUSH_TOKEN }}


### PR DESCRIPTION
# Description
## One Line Summary
Switch the project automation workflow to authenticate with `GH_PUSH_TOKEN` instead of `GH_PROJECTS_TOKEN`.

## Details

### Motivation
The `GH_PROJECTS_TOKEN` secret is being retired in favor of the `GH_PUSH_TOKEN` org secret used across the SDK repos for adding issues/PRs to the SDK Mobile Project board (project 18). This keeps the Android SDK aligned with the other SDK repos.

### Scope
Only affects `.github/workflows/project.yml`. No SDK source code, public API, or runtime behavior is changed.

# Testing
## Manual testing
Will be verified post-merge by opening an issue and confirming the workflow run successfully adds it to the SDK Mobile Project board.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed (CI-only change)
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible (workflow change, validated post-merge)

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

Made with [Cursor](https://cursor.com)