### PR TITLE
fix: SDK-4504 ConcurrentModificationException in Model.initializeFromModel

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/modeling/Model.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/modeling/Model.kt
@@ -129,15 +129,23 @@ open class Model(
         id: String?,
         model: Model,
     ) {
-        val newData = Collections.synchronizedMap(mutableMapOf<String, Any?>())
+        // Snapshot the source map under its own monitor. `model.data` is a
+        // Collections.synchronizedMap, which only makes individual operations
+        // thread-safe; iterating its entry set requires holding the map's
+        // monitor or a ConcurrentModificationException can be thrown if
+        // another thread mutates it (e.g. via setOptAnyProperty).
+        val sourceSnapshot =
+            synchronized(model.data) {
+                model.data.toMap()
+            }
 
-        for (item in model.data) {
-            if (item.value is Model) {
-                val childModel = item.value as Model
-                childModel._parentModel = this
-                newData[item.key] = childModel
+        val newData = mutableMapOf<String, Any?>()
+        for ((key, value) in sourceSnapshot) {
+            if (value is Model) {
+                value._parentModel = this
+                newData[key] = value
             } else {
-                newData[item.key] = item.value
+                newData[key] = value
             }
         }
 
@@ -145,6 +153,9 @@ open class Model(
             newData[::id.name] = id
         }
 
+        // Acquire `this.data` only after releasing `model.data` so the two
+        // monitors are never held simultaneously, avoiding any lock-ordering
+        // deadlocks between concurrent initializeFromModel calls.
         synchronized(data) {
             data.clear()
             data.putAll(newData)

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/common/ModelingTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/common/ModelingTests.kt
@@ -20,6 +20,50 @@ import java.util.UUID
 
 class ModelingTests : FunSpec({
 
+    test("initializeFromModel does not throw ConcurrentModificationException when source model is mutated concurrently") {
+        // Given a source model that is being mutated continuously on one thread...
+        val sourceModel = MockHelper.configModelStore().model
+        val destinationModel = MockHelper.configModelStore().model
+
+        val stop = java.util.concurrent.atomic.AtomicBoolean(false)
+        val failure = java.util.concurrent.atomic.AtomicReference<Throwable?>(null)
+
+        val mutator =
+            Thread {
+                var i = 0
+                while (!stop.get()) {
+                    sourceModel.setOptAnyProperty("k${i % 32}", "v$i")
+                    i++
+                }
+            }
+
+        val initializer =
+            Thread {
+                try {
+                    repeat(500) {
+                        destinationModel.initializeFromModel(null, sourceModel)
+                    }
+                } catch (t: Throwable) {
+                    failure.set(t)
+                } finally {
+                    stop.set(true)
+                }
+            }
+
+        // When both threads run concurrently
+        mutator.start()
+        initializer.start()
+
+        initializer.join(10_000)
+        stop.set(true)
+        mutator.join(10_000)
+
+        // Then initializeFromModel must not throw a ConcurrentModificationException
+        failure.get() shouldBe null
+        initializer.state shouldBe Thread.State.TERMINATED
+        mutator.state shouldBe Thread.State.TERMINATED
+    }
+
     test("Deadlock related to Model.setOptAnyProperty") {
         // Given
         val modelStore = MockHelper.configModelStore()


### PR DESCRIPTION
## Summary

Fixes a `java.util.ConcurrentModificationException` thrown from `Model.initializeFromModel` when the source model is mutated by another thread while being copied. Reproduced in production on a coroutine worker (`DefaultDispatcher-worker-8`) inside `suspendifyWithCompletion` on SDK `5.9.0` with the `sdk_background_threading` flag enabled.

Linear: [SDK-4504](https://linear.app/onesignal/issue/SDK-4504/fix-concurrentmodificationexception-in-modelinitializefrommodel)

## Root cause

```kotlin
fun initializeFromModel(id: String?, model: Model) {
    val newData = Collections.synchronizedMap(mutableMapOf<String, Any?>())

    for (item in model.data) {            // iterates source map without holding its monitor
        ...
    }

    synchronized(data) {
        data.clear()
        data.putAll(newData)
    }
}
```

`model.data` is a `Collections.synchronizedMap(LinkedHashMap)`. The wrapper only synchronizes individual method calls — iteration over the entry view requires the caller to hold the wrapper's monitor (per the `Collections.synchronizedMap` Javadoc). When another thread mutates the source via `setOptAnyProperty`, the underlying `LinkedHashMap.modCount` advances mid-iteration and the iterator's fail-fast check throws `ConcurrentModificationException`.

This regressed in 536fc7e (`Update initializeFromModel to build a local map to replace data`), which intentionally moved the iteration out of the synchronized block to fix a deadlock but did not re-protect the iteration on the source map.

## Affected callers

- `SingletonModelStore.replace()` — replaces the singleton ConfigModel / IdentityModel / PropertiesModel.
- `ConfigModelStoreListener.fetchParams` — applies server config over the local config.
- `RebuildUserService.getRebuildOperationsIfCurrentUser()` — copies identity / properties / subscription models to build rebuild operations.

Any of these flows can race with concurrent property mutations once background threading is enabled.

## Production stack trace

```
java.util.ConcurrentModificationException
    at java.util.LinkedHashMap$LinkedHashIterator.nextNode(LinkedHashMap.java:1061)
    at java.util.LinkedHashMap$LinkedEntryIterator.next(LinkedHashMap.java:1096)
    at java.util.LinkedHashMap$LinkedEntryIterator.next(LinkedHashMap.java:1093)
    at fu4.initializeFromModel(SourceFile:26)              // Model.initializeFromModel
    at dn0$b.invokeSuspend(SourceFile:131)
    ...
```

- App package: `com.dvex.movp`
- Device: TECNO CM6 / Android 15
- SDK: `5.9.0` (`ossdk.sdk_base_version=050900`)
- Feature flag: `sdk_background_threading`
- App state: foreground

## Fix

1. Snapshot the source map (`model.data.toMap()`) under `synchronized(model.data)`.
2. Build the new local map from the snapshot — no shared state, no lock needed.
3. Atomically swap `this.data` under `synchronized(data)`.

The two monitors are acquired sequentially, never simultaneously, so the deadlock that 536fc7e originally fixed cannot return.

## Test plan

- [x] New regression test `ModelingTests > initializeFromModel does not throw ConcurrentModificationException when source model is mutated concurrently`
  - Mutates a source model in a tight loop on one thread while another thread calls `initializeFromModel` 500 times.
  - Verified to **fail** with the exact production CME against the buggy code (`Expected null but actual was java.util.ConcurrentModificationException`).
  - Verified to **pass** against the fix.
- [x] Existing deadlock tests still pass:
  - `ModelingTests > Deadlock related to Model.setOptAnyProperty`
  - `ModelingTests > Deadlock related to ModelStore add() or remove()`
  - `ModelingTests > Unsubscribing handler in change event may cause the concurrent modification exception`
  - `ModelingTests > ensure Model Store load pulls cached operations and doesn't duplicate models`
- [x] Local run: `./gradlew :onesignal:core:testReleaseUnitTest --tests "com.onesignal.common.ModelingTests"` — all 5 tests pass.

Made with [Cursor](https://cursor.com)