### PR TITLE
fix: prevent location permission crashes from FusedLocation API calls

### DIFF
--- a/OneSignalSDK/onesignal/location/src/main/java/com/onesignal/location/internal/controller/impl/FusedLocationApiWrapperImpl.kt
+++ b/OneSignalSDK/onesignal/location/src/main/java/com/onesignal/location/internal/controller/impl/FusedLocationApiWrapperImpl.kt
@@ -42,8 +42,12 @@ internal class FusedLocationApiWrapperImpl : IFusedLocationApiWrapper {
     }
 
     override fun getLastLocation(googleApiClient: GoogleApiClient): Location? {
-        if (googleApiClient.isConnected) {
-            return LocationServices.FusedLocationApi.getLastLocation(googleApiClient)
+        try {
+            if (googleApiClient.isConnected) {
+                return LocationServices.FusedLocationApi.getLastLocation(googleApiClient)
+            }
+        } catch (t: Throwable) {
+            Logging.warn("FusedLocationApi.getLastLocation failed!", t)
         }
         return null
     }

--- a/OneSignalSDK/onesignal/location/src/main/java/com/onesignal/location/internal/controller/impl/FusedLocationApiWrapperImpl.kt
+++ b/OneSignalSDK/onesignal/location/src/main/java/com/onesignal/location/internal/controller/impl/FusedLocationApiWrapperImpl.kt
@@ -13,10 +13,14 @@ internal class FusedLocationApiWrapperImpl : IFusedLocationApiWrapper {
         googleApiClient: GoogleApiClient,
         locationListener: LocationListener,
     ) {
-        if (googleApiClient.isConnected) {
-            LocationServices.FusedLocationApi.removeLocationUpdates(googleApiClient, locationListener)
-        } else {
-            Logging.warn("GoogleApiClient is not connected. Unable to cancel location updates.")
+        try {
+            if (googleApiClient.isConnected) {
+                LocationServices.FusedLocationApi.removeLocationUpdates(googleApiClient, locationListener)
+            } else {
+                Logging.warn("GoogleApiClient is not connected. Unable to cancel location updates.")
+            }
+        } catch (t: Throwable) {
+            Logging.warn("FusedLocationApi.cancelLocationUpdates failed!", t)
         }
     }
 


### PR DESCRIPTION
# Description
## One Line Summary
Add try/catch to cancelLocationUpdates

## Details

### Motivation
App crashes on reopen due to `java.lang.SecurityException: no location permission`

```
type: crash
osVersion: google/bluejay/bluejay:16/BP4A.251205.006/2026050901:user/release-keys
package: com.fig:14968, targetSdk 36
process: com.fig
processUptime: 20962 + 909 ms
installer: com.android.vending

java.lang.SecurityException: no location permission
	at app.grapheneos.gmscompat.location.Client.<init>(Client.kt:23)
	at app.grapheneos.gmscompat.location.Client.<init>(Client.kt:9)
	at app.grapheneos.gmscompat.location.GLocationService.unregisterLocationReceiver(GLocationService.kt:81)
	at com.google.android.gms.location.internal.IGoogleLocationManagerService$Stub.onTransact(IGoogleLocationManagerService.java:232)
	at android.os.Binder.transact(Binder.java:1351)
...
	at com.google.android.gms.internal.location.zzau.removeLocationUpdates(com.google.android.gms:play-services-location@@21.0.1:3)
	at com.onesignal.location.internal.controller.impl.FusedLocationApiWrapperImpl.cancelLocationUpdates(FusedLocationApiWrapperImpl.kt:17)
	at com.onesignal.location.internal.controller.impl.GmsLocationController$LocationUpdateListener.refreshRequest(GmsLocationController.kt:203)
	at com.onesignal.location.internal.controller.impl.GmsLocationController$LocationUpdateListener.onFocus(GmsLocationController.kt:180)
	at com.onesignal.core.internal.application.impl.ApplicationService$handleFocus$1.invoke(ApplicationService.kt:395)
	at com.onesignal.core.internal.application.impl.ApplicationService$handleFocus$1.invoke(ApplicationService.kt:395)
	at com.onesignal.common.events.EventProducer.fire(EventProducer.kt:50)
	at com.onesignal.core.internal.application.impl.ApplicationService.handleFocus(ApplicationService.kt:395)
	at com.onesignal.core.internal.application.impl.ApplicationService.onActivityStarted(ApplicationService.kt:163)
	at android.app.Application.dispatchActivityStarted(Application.java:422)
...
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:566)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:837)

```

## Manual testing
Now gracefully handles exception
```
[DefaultDispatcher-worker-10] FusedLocationApi.requestLocationUpdates failed!
java.lang.SecurityException: no location permission
	at app.grapheneos.gmscompat.location.Client.<init>(Client.kt:23)
	at app.grapheneos.gmscompat.location.Client.<init>(Client.kt:9)
	at app.grapheneos.gmscompat.location.GLocationService.registerLocationReceiver(GLocationService.kt:49)
	at com.google.android.gms.location.internal.IGoogleLocationManagerService$Stub.onTransact(IGoogleLocationManagerService.java:221)
...
	at com.onesignal.location.internal.controller.impl.GmsLocationController$start$2.invokeSuspend(GmsLocationController.kt:62)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:101)
	at kotlinx.coroutines.internal.LimitedDispatcher$Worker.run(LimitedDispatcher.kt:113)
	at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:89)
	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:589)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:823)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:720)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:707)

```

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
