### PR TITLE
fix: [SDK-4732] track activity lifecycle from process start to fix late-init focus

### DIFF
--- a/OneSignalSDK/build.gradle
+++ b/OneSignalSDK/build.gradle
@@ -23,6 +23,7 @@ buildscript {
         // AndroidX Lifecycle and Activity versions
         lifecycleVersion = '2.6.2'
         activityVersion = '1.7.2'
+        startupVersion = '1.1.1'
         ktlintVersion = '0.50.0' // Used by Spotless for Kotlin formatting (compatible with Kotlin 1.7.10)
         spotlessVersion = '6.25.0'
         tdunningJsonForTest = '1.0' // DO NOT upgrade for tests, using an old version so it matches AOSP

--- a/OneSignalSDK/onesignal/core/build.gradle
+++ b/OneSignalSDK/onesignal/core/build.gradle
@@ -81,6 +81,9 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:$lifecycleVersion"
     implementation "androidx.activity:activity-ktx:$activityVersion"
 
+    // Registers activity lifecycle observation at process start (see ActivityLifecycleInitializer)
+    implementation "androidx.startup:startup-runtime:$startupVersion"
+
     compileOnly('com.amazon.device:amazon-appstore-sdk:[3.0.1, 3.0.99]')
 
     api('androidx.appcompat:appcompat') {

--- a/OneSignalSDK/onesignal/core/src/main/AndroidManifest.xml
+++ b/OneSignalSDK/onesignal/core/src/main/AndroidManifest.xml
@@ -25,6 +25,19 @@
         <activity android:name="com.onesignal.core.activities.PermissionsActivity"
                   android:theme="@android:style/Theme.Translucent.NoTitleBar"
                   android:exported="false" />
+
+        <!-- Observe the activity lifecycle from process start so late SDK init (wrapper SDKs)
+             still sees the first activity's full lifecycle. Merges into the app's androidx.startup
+             provider; hosts that disable it fall back to lifecycle registration at init time. -->
+        <provider
+            android:name="androidx.startup.InitializationProvider"
+            android:authorities="${applicationId}.androidx-startup"
+            android:exported="false"
+            tools:node="merge">
+            <meta-data
+                android:name="com.onesignal.core.internal.application.impl.ActivityLifecycleInitializer"
+                android:value="androidx.startup" />
+        </provider>
     </application>
 
     <!-- NOTE: See release version for tags with placeholders -->

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/CoreModule.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/CoreModule.kt
@@ -56,7 +56,11 @@ internal class CoreModule : IModule {
             .provides<IStartableService>()
         builder.register<HttpConnectionFactory>().provides<IHttpConnectionFactory>()
         builder.register<HttpClient>().provides<IHttpClient>()
-        builder.register<ApplicationService>().provides<IApplicationService>()
+        // Reuse the process-wide instance shared with ActivityLifecycleInitializer (so the activity
+        // lifecycle observed before SDK init is visible) when the startup initializer ran; otherwise
+        // create a fresh instance for this init.
+        builder.register { ApplicationService.getInstanceOrNull() ?: ApplicationService() }
+            .provides<IApplicationService>()
         builder.register<DeviceService>().provides<IDeviceService>()
         builder.register<Time>().provides<ITime>()
         builder.register<DatabaseProvider>().provides<IDatabaseProvider>()

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/application/OneSignalInternalActivity.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/application/OneSignalInternalActivity.kt
@@ -1,0 +1,12 @@
+package com.onesignal.core.internal.application
+
+/**
+ * Marker for SDK-internal, transient activities (such as the notification-open trampolines) that
+ * must be excluded from app focus / foreground tracking.
+ *
+ * These activities are launched by the SDK itself, often before the host app's real activity
+ * resumes, and they finish immediately after handling their intent. Counting them toward focus
+ * would prematurely toggle [IApplicationService.isInForeground] / entry state and corrupt the
+ * activity reference count once the SDK observes the full activity lifecycle from process start.
+ */
+interface OneSignalInternalActivity

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/application/impl/ActivityLifecycleInitializer.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/application/impl/ActivityLifecycleInitializer.kt
@@ -1,0 +1,30 @@
+package com.onesignal.core.internal.application.impl
+
+import android.app.Application
+import android.content.Context
+import androidx.startup.Initializer
+import com.onesignal.core.internal.application.IApplicationService
+
+/**
+ * Registers activity lifecycle observation at process start via androidx.startup, before the host
+ * app initializes the SDK.
+ *
+ * Wrapper SDKs (Flutter/React Native/Capacitor/etc.) call `initWithContext` late — after the first
+ * activity has already been created/started/resumed — so observing the lifecycle only from `start`
+ * misses those early callbacks. Registering here lets [ApplicationService] see the first activity's
+ * full lifecycle regardless of when init later happens.
+ *
+ * This intentionally does NOT initialize the SDK or require an App ID; it only attaches lifecycle
+ * observation. App ID / consent gating remains in the runtime `initWithContext` path.
+ */
+class ActivityLifecycleInitializer : Initializer<IApplicationService> {
+    override fun create(context: Context): IApplicationService {
+        val applicationService = ApplicationService.getInstance()
+        (context.applicationContext as? Application)?.let { application ->
+            applicationService.attachToApplication(application)
+        }
+        return applicationService
+    }
+
+    override fun dependencies(): List<Class<out Initializer<*>>> = emptyList()
+}

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/application/impl/ApplicationService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/application/impl/ApplicationService.kt
@@ -326,6 +326,11 @@ class ApplicationService() : IApplicationService, ActivityLifecycleCallbacks, On
         // underflow the reference count and falsely drop app focus.
         val wasCounted = startedActivities.remove(activity)
         if (!wasCounted || --activityReferences > 0) {
+            // An internal trampoline can reach onStop without its onStart ever being counted — e.g. a
+            // wrapper SDK that disabled the process-start initializer, so the trampoline started
+            // before the lifecycle observer attached. If it finishes with nothing in the foreground,
+            // the NOTIFICATION_CLICK reset below would otherwise be skipped, leaving entry state stale.
+            resetStaleNotificationEntryIfBackgrounded(isInternal)
             return
         }
 
@@ -342,10 +347,18 @@ class ApplicationService() : IApplicationService, ActivityLifecycleCallbacks, On
             return
         }
 
-        // The trampoline ran without any real activity ever taking focus (e.g. a URL notification
-        // tapped from the background). Reset a stale NOTIFICATION_CLICK so a later organic open is
-        // not mis-attributed, but do not fire onUnfocused — no focus was ever held.
-        if (entryState == AppEntryAction.NOTIFICATION_CLICK) {
+        resetStaleNotificationEntryIfBackgrounded(isInternal)
+    }
+
+    /**
+     * Reset a stale [AppEntryAction.NOTIFICATION_CLICK] left by an internal trampoline that finished
+     * without a real activity ever taking focus (e.g. a URL notification that opened a browser).
+     * Guarded on [current] being null so a foregrounded real activity is never affected. Does not
+     * fire onUnfocused — no focus was ever held — so a later organic open is not mis-attributed as a
+     * direct notification session.
+     */
+    private fun resetStaleNotificationEntryIfBackgrounded(isInternal: Boolean) {
+        if (isInternal && current == null && entryState == AppEntryAction.NOTIFICATION_CLICK) {
             entryState = AppEntryAction.APP_CLOSE
         }
     }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/application/impl/ApplicationService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/application/impl/ApplicationService.kt
@@ -166,12 +166,6 @@ class ApplicationService() : IApplicationService, ActivityLifecycleCallbacks, On
             // provider was disabled, or in unit tests). Seed focus state from the init context so
             // late initialization still establishes the current activity and entry state.
             seedFocusFromInitContext(context)
-        } else if (current == null) {
-            // The observer was installed at process start but no non-internal activity has been
-            // observed yet (e.g. cold start from a notification, where only the internal trampoline
-            // has run). Treat the next activity start as the first foreground entry so onFocus fires
-            // even when the notification module has already set entryState to NOTIFICATION_CLICK.
-            nextResumeIsFirstActivity = true
         }
 
         Logging.debug("ApplicationService.init: entryState=$entryState")
@@ -242,6 +236,15 @@ class ApplicationService() : IApplicationService, ActivityLifecycleCallbacks, On
         // (e.g. rotation). That stop skipped the decrement, so this replacement start must not
         // increment — otherwise the reference count climbs on every rotation and focus is never lost.
         val recreatedAfterConfigChange = isActivityChangingConfigurations
+
+        if (current == null && !recreatedAfterConfigChange) {
+            // No foreground activity was present: a cold start, or a warm start after the app was
+            // backgrounded. This first non-internal activity start is a foreground entry, so arm the
+            // first-activity flag. This forces wasInBackground true even when the notification module
+            // has already set entryState to NOTIFICATION_CLICK (which otherwise reads as foreground),
+            // ensuring onFocus fires. handleFocus preserves the NOTIFICATION_CLICK entry state.
+            nextResumeIsFirstActivity = true
+        }
 
         current = activity
 

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/application/impl/ApplicationService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/application/impl/ApplicationService.kt
@@ -104,6 +104,17 @@ class ApplicationService() : IApplicationService, ActivityLifecycleCallbacks, On
     private val startedActivities: MutableSet<Activity> =
         Collections.synchronizedSet(Collections.newSetFromMap(WeakHashMap()))
 
+    /**
+     * Started SDK-internal activities ([OneSignalInternalActivity], e.g. notification-open
+     * trampolines). These are tracked separately from [startedActivities]: they never become
+     * [current], take focus, or change entry state, but while one is on top a real activity's stop
+     * is treated as transient (the trampoline often lives in its own task, briefly stopping the
+     * host that resumes once the trampoline finishes). Weak references so a forgotten activity is
+     * not retained.
+     */
+    private val startedInternalActivities: MutableSet<Activity> =
+        Collections.synchronizedSet(Collections.newSetFromMap(WeakHashMap()))
+
     /** True once the activity lifecycle observer has been registered with the [Application]. */
     private var lifecycleObserverInstalled = false
 
@@ -225,6 +236,11 @@ class ApplicationService() : IApplicationService, ActivityLifecycleCallbacks, On
         Logging.debug("ApplicationService.onActivityStarted($activityReferences,$entryState): $activity")
 
         if (activity is OneSignalInternalActivity) {
+            // A transient SDK activity (notification-open trampoline), frequently launched into its
+            // own task. Track it so a real activity's stop while it is on top can be treated as
+            // transient, but never let it become current, take focus, or change entry state — those
+            // are owned by real activities and the notification module.
+            startedInternalActivities.add(activity)
             return
         }
 
@@ -294,9 +310,21 @@ class ApplicationService() : IApplicationService, ActivityLifecycleCallbacks, On
     override fun onActivityStopped(activity: Activity) {
         Logging.debug("ApplicationService.onActivityStopped($activityReferences,$entryState): $activity")
 
-        if (activity !is OneSignalInternalActivity) {
+        if (activity is OneSignalInternalActivity) {
+            startedInternalActivities.remove(activity)
+            // If the trampoline finished without a real activity ever becoming current (e.g. a URL
+            // notification that opens a browser and never launches the host), the notification
+            // module's NOTIFICATION_CLICK entry state would otherwise remain set and mis-attribute a
+            // later organic open. Clear it now that nothing is in the foreground.
+            if (startedInternalActivities.isEmpty() &&
+                current == null &&
+                entryState == AppEntryAction.NOTIFICATION_CLICK
+            ) {
+                entryState = AppEntryAction.APP_CLOSE
+            }
+        } else {
             isActivityChangingConfigurations = activity.isChangingConfigurations
-            if (!isActivityChangingConfigurations) {
+            if (!isActivityChangingConfigurations && startedInternalActivities.isEmpty()) {
                 // Only decrement for an activity whose start we previously counted. A late-init SDK
                 // can observe a transient activity's stop without ever seeing its start; counting
                 // that would underflow the reference count and falsely drop app focus.
@@ -307,6 +335,8 @@ class ApplicationService() : IApplicationService, ActivityLifecycleCallbacks, On
                     handleLostFocus()
                 }
             }
+            // When a trampoline is on top the host's stop is transient — it resumes once the
+            // trampoline finishes — so the reference count and focus are intentionally left intact.
         }
 
         activityLifecycleNotifier.fire { it.onActivityStopped(activity) }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/application/impl/ApplicationService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/application/impl/ApplicationService.kt
@@ -232,6 +232,11 @@ class ApplicationService() : IApplicationService, ActivityLifecycleCallbacks, On
             return
         }
 
+        // Set by the preceding onActivityStopped when an activity is recreated for a config change
+        // (e.g. rotation). That stop skipped the decrement, so this replacement start must not
+        // increment — otherwise the reference count climbs on every rotation and focus is never lost.
+        val recreatedAfterConfigChange = isActivityChangingConfigurations
+
         current = activity
 
         val isNewlyStarted = startedActivities.add(activity)
@@ -242,6 +247,8 @@ class ApplicationService() : IApplicationService, ActivityLifecycleCallbacks, On
             startedActivities.add(activity)
             activityReferences = 1
             handleFocus()
+        } else if (recreatedAfterConfigChange) {
+            isActivityChangingConfigurations = false
         } else if (isNewlyStarted) {
             activityReferences++
         }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/application/impl/ApplicationService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/application/impl/ApplicationService.kt
@@ -254,7 +254,7 @@ class ApplicationService() : IApplicationService, ActivityLifecycleCallbacks, On
             nextResumeIsFirstActivity = true
         }
 
-        if (!isInternal) {
+        if (!isInternal && current != activity) {
             current = activity
         }
 

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/application/impl/ApplicationService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/application/impl/ApplicationService.kt
@@ -22,11 +22,38 @@ import com.onesignal.core.internal.application.AppEntryAction
 import com.onesignal.core.internal.application.IActivityLifecycleHandler
 import com.onesignal.core.internal.application.IApplicationLifecycleHandler
 import com.onesignal.core.internal.application.IApplicationService
+import com.onesignal.core.internal.application.OneSignalInternalActivity
 import com.onesignal.debug.internal.logging.Logging
 import kotlinx.coroutines.delay
 import java.lang.ref.WeakReference
+import java.util.Collections
+import java.util.WeakHashMap
 
 class ApplicationService() : IApplicationService, ActivityLifecycleCallbacks, OnGlobalLayoutListener {
+    companion object {
+        @Volatile
+        private var sharedInstance: ApplicationService? = null
+
+        /**
+         * Process-wide instance shared between [ActivityLifecycleInitializer] (which registers
+         * lifecycle observation at process start) and dependency injection (which resolves the
+         * service later, during SDK init). Both must reference the same object so the activity
+         * lifecycle observed before init is visible to the running SDK.
+         */
+        fun getInstance(): ApplicationService =
+            sharedInstance ?: synchronized(this) {
+                sharedInstance ?: ApplicationService().also { sharedInstance = it }
+            }
+
+        /**
+         * The process-wide instance only if [ActivityLifecycleInitializer] already created one;
+         * never creates it. Dependency injection uses this so that when the startup initializer did
+         * not run (its provider was disabled, or unit tests), each SDK init gets its own instance
+         * rather than a leaked process-wide one.
+         */
+        fun getInstanceOrNull(): ApplicationService? = sharedInstance
+    }
+
     private val activityLifecycleNotifier = EventProducer<IActivityLifecycleHandler>()
     private val applicationLifecycleNotifier = EventProducer<IApplicationLifecycleHandler>()
     private val systemConditionNotifier = EventProducer<ISystemConditionHandler>()
@@ -67,8 +94,58 @@ class ApplicationService() : IApplicationService, ActivityLifecycleCallbacks, On
     private var activityReferences = 0
     private var isActivityChangingConfigurations = false
 
+    /**
+     * Activities whose [onActivityStarted] we have counted toward [activityReferences] and have not
+     * yet stopped. Stored as weak references so a forgotten activity cannot be retained by the SDK.
+     * Guards [onActivityStopped] from decrementing for an activity whose start was never observed,
+     * which happens when the SDK initializes late (after the first activity is already running) or
+     * when a transient trampoline stops without its start having been counted.
+     */
+    private val startedActivities: MutableSet<Activity> =
+        Collections.synchronizedSet(Collections.newSetFromMap(WeakHashMap()))
+
+    /** True once the activity lifecycle observer has been registered with the [Application]. */
+    private var lifecycleObserverInstalled = false
+
+    private val componentCallbacks =
+        object : ComponentCallbacks {
+            override fun onConfigurationChanged(newConfig: Configuration) {
+                // If Activity contains the configChanges orientation flag, re-create the view this way
+                if (current != null &&
+                    AndroidUtils.hasConfigChangeFlag(
+                        current!!,
+                        ActivityInfo.CONFIG_ORIENTATION,
+                    )
+                ) {
+                    onOrientationChanged(newConfig.orientation, current!!)
+                }
+            }
+
+            override fun onLowMemory() {}
+        }
+
     private val wasInBackground: Boolean
         get() = !isInForeground || nextResumeIsFirstActivity
+
+    /**
+     * Register activity lifecycle observation with the [Application]. Safe to call multiple times;
+     * only the first call registers. Invoked at process start by [ActivityLifecycleInitializer] so
+     * the SDK observes the first activity's full lifecycle regardless of when [start] is later
+     * called.
+     */
+    fun attachToApplication(application: Application) {
+        if (lifecycleObserverInstalled) {
+            return
+        }
+        lifecycleObserverInstalled = true
+
+        if (_appContext == null) {
+            _appContext = application
+        }
+
+        application.registerActivityLifecycleCallbacks(this)
+        application.registerComponentCallbacks(componentCallbacks)
+    }
 
     /**
      * Call to "start" this service, expected to be called during initialization of the SDK.
@@ -76,37 +153,34 @@ class ApplicationService() : IApplicationService, ActivityLifecycleCallbacks, On
      * @param context The context the SDK has been initialized under.
      */
     fun start(context: Context) {
+        val needsFallbackSeeding = !lifecycleObserverInstalled
+
+        // The runtime init context wins for appContext (callers, including tests, may pass a
+        // wrapping context). The pre-init observer only needs the Application for registration.
         _appContext = context
 
-        val application = context.applicationContext as Application
-        application.registerActivityLifecycleCallbacks(this)
+        attachToApplication(context.applicationContext as Application)
 
-        val configuration =
-            object : ComponentCallbacks {
-                override fun onConfigurationChanged(newConfig: Configuration) {
-                    // If Activity contains the configChanges orientation flag, re-create the view this way
-                    if (current != null &&
-                        AndroidUtils.hasConfigChangeFlag(
-                            current!!,
-                            ActivityInfo.CONFIG_ORIENTATION,
-                        )
-                    ) {
-                        onOrientationChanged(newConfig.orientation, current!!)
-                    }
-                }
+        if (needsFallbackSeeding) {
+            // The lifecycle observer was not installed at process start (e.g. the androidx.startup
+            // provider was disabled, or in unit tests). Seed focus state from the init context so
+            // late initialization still establishes the current activity and entry state.
+            seedFocusFromInitContext(context)
+        }
 
-                override fun onLowMemory() {}
-            }
+        Logging.debug("ApplicationService.init: entryState=$entryState")
+    }
 
-        application.registerComponentCallbacks(configuration)
-
+    private fun seedFocusFromInitContext(context: Context) {
         val isContextActivity = context is Activity
         val isCurrentActivityNull = current == null
 
         if (!isCurrentActivityNull || isContextActivity) {
             entryState = AppEntryAction.APP_OPEN
             if (isCurrentActivityNull && isContextActivity) {
-                current = context as Activity?
+                val activity = context as Activity
+                current = activity
+                startedActivities.add(activity)
                 activityReferences = 1
                 nextResumeIsFirstActivity = false
             }
@@ -114,8 +188,6 @@ class ApplicationService() : IApplicationService, ActivityLifecycleCallbacks, On
             nextResumeIsFirstActivity = true
             entryState = AppEntryAction.APP_CLOSE
         }
-
-        Logging.debug("ApplicationService.init: entryState=$entryState")
     }
 
     override fun addApplicationLifecycleHandler(handler: IApplicationLifecycleHandler) {
@@ -152,22 +224,35 @@ class ApplicationService() : IApplicationService, ActivityLifecycleCallbacks, On
     override fun onActivityStarted(activity: Activity) {
         Logging.debug("ApplicationService.onActivityStarted($activityReferences,$entryState): $activity")
 
+        if (activity is OneSignalInternalActivity) {
+            return
+        }
+
         if (current == activity) {
             return
         }
 
         current = activity
 
+        val isNewlyStarted = startedActivities.add(activity)
+
         if (wasInBackground && !isActivityChangingConfigurations) {
+            // Real entry into the foreground; re-baseline the counter against this activity.
+            startedActivities.clear()
+            startedActivities.add(activity)
             activityReferences = 1
             handleFocus()
-        } else {
+        } else if (isNewlyStarted) {
             activityReferences++
         }
     }
 
     override fun onActivityResumed(activity: Activity) {
         Logging.debug("ApplicationService.onActivityResumed($activityReferences,$entryState): $activity")
+
+        if (activity is OneSignalInternalActivity) {
+            return
+        }
 
         // When an activity has something shown above it, it will be paused allowing
         // the new activity to be started (where current is set).  However when that
@@ -179,6 +264,8 @@ class ApplicationService() : IApplicationService, ActivityLifecycleCallbacks, On
         }
 
         if (wasInBackground && !isActivityChangingConfigurations) {
+            startedActivities.clear()
+            startedActivities.add(activity)
             activityReferences = 1
             handleFocus()
         }
@@ -191,11 +278,19 @@ class ApplicationService() : IApplicationService, ActivityLifecycleCallbacks, On
     override fun onActivityStopped(activity: Activity) {
         Logging.debug("ApplicationService.onActivityStopped($activityReferences,$entryState): $activity")
 
-        isActivityChangingConfigurations = activity.isChangingConfigurations
-        if (!isActivityChangingConfigurations && --activityReferences <= 0) {
-            current = null
-            activityReferences = 0
-            handleLostFocus()
+        if (activity !is OneSignalInternalActivity) {
+            isActivityChangingConfigurations = activity.isChangingConfigurations
+            if (!isActivityChangingConfigurations) {
+                // Only decrement for an activity whose start we previously counted. A late-init SDK
+                // can observe a transient activity's stop without ever seeing its start; counting
+                // that would underflow the reference count and falsely drop app focus.
+                val wasCounted = startedActivities.remove(activity)
+                if (wasCounted && --activityReferences <= 0) {
+                    current = null
+                    activityReferences = 0
+                    handleLostFocus()
+                }
+            }
         }
 
         activityLifecycleNotifier.fire { it.onActivityStopped(activity) }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/application/impl/ApplicationService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/application/impl/ApplicationService.kt
@@ -166,6 +166,12 @@ class ApplicationService() : IApplicationService, ActivityLifecycleCallbacks, On
             // provider was disabled, or in unit tests). Seed focus state from the init context so
             // late initialization still establishes the current activity and entry state.
             seedFocusFromInitContext(context)
+        } else if (current == null) {
+            // The observer was installed at process start but no non-internal activity has been
+            // observed yet (e.g. cold start from a notification, where only the internal trampoline
+            // has run). Treat the next activity start as the first foreground entry so onFocus fires
+            // even when the notification module has already set entryState to NOTIFICATION_CLICK.
+            nextResumeIsFirstActivity = true
         }
 
         Logging.debug("ApplicationService.init: entryState=$entryState")

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/application/impl/ApplicationService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/application/impl/ApplicationService.kt
@@ -325,16 +325,20 @@ class ApplicationService() : IApplicationService, ActivityLifecycleCallbacks, On
 
         activityReferences = 0
 
-        if (!isInternal) {
+        if (!isInternal || current != null) {
+            // Either a real activity was the last counted one to stop, or a trampoline finished while
+            // a real host was still current. The latter happens on a foreground tap of a URL/
+            // suppressed notification: the open launches a browser (or nothing) instead of the host,
+            // so the host stops while the trampoline is on top (its decrement deferred) and current
+            // is never cleared. The app is genuinely backgrounded now, so drop focus.
             current = null
             handleLostFocus()
             return
         }
 
-        // The trampoline finished without a real activity ever taking focus (e.g. a URL
-        // notification that opens a browser and never launches the host). Reset a stale
-        // NOTIFICATION_CLICK so a later organic open is not mis-attributed, but do not fire
-        // onUnfocused — no focus was ever held.
+        // The trampoline ran without any real activity ever taking focus (e.g. a URL notification
+        // tapped from the background). Reset a stale NOTIFICATION_CLICK so a later organic open is
+        // not mis-attributed, but do not fire onUnfocused — no focus was ever held.
         if (entryState == AppEntryAction.NOTIFICATION_CLICK) {
             entryState = AppEntryAction.APP_CLOSE
         }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/application/impl/ApplicationService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/application/impl/ApplicationService.kt
@@ -224,7 +224,13 @@ class ApplicationService() : IApplicationService, ActivityLifecycleCallbacks, On
     override fun onActivityStarted(activity: Activity) {
         Logging.debug("ApplicationService.onActivityStarted($activityReferences,$entryState): $activity")
 
-        if (current == activity) {
+        // Re-entrant start for the activity that is already current and still counted: nothing to do.
+        // The membership check is essential: a notification-open trampoline can briefly stop the host
+        // and then resume the *same* host instance. That stop removed the host from startedActivities
+        // (decrementing the count) without clearing current, so this start must fall through to
+        // re-count it. Returning here would leave the count permanently short — every later host stop
+        // would see !wasCounted and onUnfocused would never fire again.
+        if (current == activity && startedActivities.contains(activity)) {
             return
         }
 

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/application/impl/ApplicationService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/application/impl/ApplicationService.kt
@@ -104,17 +104,6 @@ class ApplicationService() : IApplicationService, ActivityLifecycleCallbacks, On
     private val startedActivities: MutableSet<Activity> =
         Collections.synchronizedSet(Collections.newSetFromMap(WeakHashMap()))
 
-    /**
-     * Started SDK-internal activities ([OneSignalInternalActivity], e.g. notification-open
-     * trampolines). These are tracked separately from [startedActivities]: they never become
-     * [current], take focus, or change entry state, but while one is on top a real activity's stop
-     * is treated as transient (the trampoline often lives in its own task, briefly stopping the
-     * host that resumes once the trampoline finishes). Weak references so a forgotten activity is
-     * not retained.
-     */
-    private val startedInternalActivities: MutableSet<Activity> =
-        Collections.synchronizedSet(Collections.newSetFromMap(WeakHashMap()))
-
     /** True once the activity lifecycle observer has been registered with the [Application]. */
     private var lifecycleObserverInstalled = false
 
@@ -235,44 +224,43 @@ class ApplicationService() : IApplicationService, ActivityLifecycleCallbacks, On
     override fun onActivityStarted(activity: Activity) {
         Logging.debug("ApplicationService.onActivityStarted($activityReferences,$entryState): $activity")
 
-        if (activity is OneSignalInternalActivity) {
-            // A transient SDK activity (notification-open trampoline), frequently launched into its
-            // own task. Track it so a real activity's stop while it is on top can be treated as
-            // transient, but never let it become current, take focus, or change entry state — those
-            // are owned by real activities and the notification module.
-            startedInternalActivities.add(activity)
-            return
-        }
-
         if (current == activity) {
             return
         }
+
+        // SDK-internal activities (notification-open trampolines) are counted toward
+        // activityReferences so the count stays balanced (a trampoline often lives in its own task,
+        // briefly stopping the host), but they must never become current, take focus, or change
+        // entry state — those are owned by real activities and the notification module.
+        val isInternal = activity is OneSignalInternalActivity
 
         // Set by the preceding onActivityStopped when an activity is recreated for a config change
         // (e.g. rotation). That stop skipped the decrement, so this replacement start must not
         // increment — otherwise the reference count climbs on every rotation and focus is never lost.
         val recreatedAfterConfigChange = isActivityChangingConfigurations
 
-        if (current == null && !recreatedAfterConfigChange) {
+        if (!isInternal && current == null && !recreatedAfterConfigChange) {
             // No foreground activity was present: a cold start, or a warm start after the app was
-            // backgrounded. This first non-internal activity start is a foreground entry, so arm the
+            // backgrounded. This first real activity start is a foreground entry, so arm the
             // first-activity flag. This forces wasInBackground true even when the notification module
             // has already set entryState to NOTIFICATION_CLICK (which otherwise reads as foreground),
             // ensuring onFocus fires. handleFocus preserves the NOTIFICATION_CLICK entry state.
             nextResumeIsFirstActivity = true
         }
 
-        current = activity
+        if (!isInternal) {
+            current = activity
+        }
 
         val isNewlyStarted = startedActivities.add(activity)
 
-        if (wasInBackground && !isActivityChangingConfigurations) {
+        if (!isInternal && wasInBackground && !isActivityChangingConfigurations) {
             // Real entry into the foreground; re-baseline the counter against this activity.
             startedActivities.clear()
             startedActivities.add(activity)
             activityReferences = 1
             handleFocus()
-        } else if (recreatedAfterConfigChange) {
+        } else if (!isInternal && recreatedAfterConfigChange) {
             isActivityChangingConfigurations = false
         } else if (isNewlyStarted) {
             activityReferences++
@@ -310,36 +298,46 @@ class ApplicationService() : IApplicationService, ActivityLifecycleCallbacks, On
     override fun onActivityStopped(activity: Activity) {
         Logging.debug("ApplicationService.onActivityStopped($activityReferences,$entryState): $activity")
 
-        if (activity is OneSignalInternalActivity) {
-            startedInternalActivities.remove(activity)
-            // If the trampoline finished without a real activity ever becoming current (e.g. a URL
-            // notification that opens a browser and never launches the host), the notification
-            // module's NOTIFICATION_CLICK entry state would otherwise remain set and mis-attribute a
-            // later organic open. Clear it now that nothing is in the foreground.
-            if (startedInternalActivities.isEmpty() &&
-                current == null &&
-                entryState == AppEntryAction.NOTIFICATION_CLICK
-            ) {
-                entryState = AppEntryAction.APP_CLOSE
-            }
-        } else {
+        val isInternal = activity is OneSignalInternalActivity
+
+        if (!isInternal) {
             isActivityChangingConfigurations = activity.isChangingConfigurations
-            if (!isActivityChangingConfigurations && startedInternalActivities.isEmpty()) {
-                // Only decrement for an activity whose start we previously counted. A late-init SDK
-                // can observe a transient activity's stop without ever seeing its start; counting
-                // that would underflow the reference count and falsely drop app focus.
-                val wasCounted = startedActivities.remove(activity)
-                if (wasCounted && --activityReferences <= 0) {
-                    current = null
-                    activityReferences = 0
-                    handleLostFocus()
-                }
-            }
-            // When a trampoline is on top the host's stop is transient — it resumes once the
-            // trampoline finishes — so the reference count and focus are intentionally left intact.
+        }
+
+        if (isInternal || !isActivityChangingConfigurations) {
+            decrementStartedActivity(activity, isInternal)
         }
 
         activityLifecycleNotifier.fire { it.onActivityStopped(activity) }
+    }
+
+    private fun decrementStartedActivity(
+        activity: Activity,
+        isInternal: Boolean,
+    ) {
+        // Only decrement for an activity whose start we previously counted. A late-init SDK can
+        // observe a transient activity's stop without ever seeing its start; counting that would
+        // underflow the reference count and falsely drop app focus.
+        val wasCounted = startedActivities.remove(activity)
+        if (!wasCounted || --activityReferences > 0) {
+            return
+        }
+
+        activityReferences = 0
+
+        if (!isInternal) {
+            current = null
+            handleLostFocus()
+            return
+        }
+
+        // The trampoline finished without a real activity ever taking focus (e.g. a URL
+        // notification that opens a browser and never launches the host). Reset a stale
+        // NOTIFICATION_CLICK so a later organic open is not mis-attributed, but do not fire
+        // onUnfocused — no focus was ever held.
+        if (entryState == AppEntryAction.NOTIFICATION_CLICK) {
+            entryState = AppEntryAction.APP_CLOSE
+        }
     }
 
     override fun onActivitySaveInstanceState(

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/application/ApplicationServiceTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/application/ApplicationServiceTests.kt
@@ -247,6 +247,69 @@ class ApplicationServiceTests : FunSpec({
         // Then
         response shouldBe true
     }
+
+    test("internal trampoline activity does not affect focus, current, or entry state") {
+        // Given
+        val mainController = Robolectric.buildActivity(Activity::class.java)
+        mainController.setup()
+        val mainActivity = mainController.get()
+
+        val trampolineController = Robolectric.buildActivity(InternalTrampolineActivity::class.java)
+        trampolineController.setup()
+        val trampoline = trampolineController.get()
+
+        val handler = spyk<IApplicationLifecycleHandler>()
+        val applicationService = ApplicationService()
+        applicationService.addApplicationLifecycleHandler(handler)
+
+        // Simulate late cold-start init from a non-activity context, with the notification
+        // module having classified entry as NOTIFICATION_CLICK.
+        val appContext = ApplicationProvider.getApplicationContext<Context>()
+        applicationService.start(appContext)
+        applicationService.entryState = AppEntryAction.NOTIFICATION_CLICK
+
+        // When: the trampoline runs its full lifecycle.
+        applicationService.onActivityStarted(trampoline)
+        applicationService.onActivityResumed(trampoline)
+        applicationService.onActivityStopped(trampoline)
+
+        // Then: it is fully ignored — entry state is preserved and no focus is taken.
+        applicationService.entryState shouldBe AppEntryAction.NOTIFICATION_CLICK
+        applicationService.current shouldBe null
+
+        // When: the real activity starts after the trampoline finishes.
+        applicationService.onActivityStarted(mainActivity)
+
+        // Then: focus is established but the NOTIFICATION_CLICK entry state is retained.
+        applicationService.current shouldBe mainActivity
+        applicationService.entryState shouldBe AppEntryAction.NOTIFICATION_CLICK
+        verify(exactly = 0) { handler.onUnfocused() }
+    }
+
+    test("stopping an activity whose start was never counted does not drop focus") {
+        // Given
+        val mainController = Robolectric.buildActivity(Activity::class.java)
+        mainController.setup()
+        val mainActivity = mainController.get()
+
+        val unseenController = Robolectric.buildActivity(Activity::class.java)
+        unseenController.setup()
+        val unseen = unseenController.get()
+
+        val handler = spyk<IApplicationLifecycleHandler>()
+        val applicationService = ApplicationService()
+        applicationService.addApplicationLifecycleHandler(handler)
+
+        // current is established for mainActivity, reference count is 1.
+        applicationService.start(mainActivity)
+
+        // When: an activity the SDK never observed starting now stops (late-init trampoline).
+        applicationService.onActivityStopped(unseen)
+
+        // Then: the reference count does not underflow and focus is retained.
+        applicationService.current shouldBe mainActivity
+        verify(exactly = 0) { handler.onUnfocused() }
+    }
 }) {
     companion object {
         fun pushActivity(
@@ -279,3 +342,8 @@ class ApplicationServiceTests : FunSpec({
         }
     }
 }
+
+/** Stands in for an SDK-internal trampoline (e.g. NotificationOpenedActivity) in tests. */
+class InternalTrampolineActivity :
+    Activity(),
+    OneSignalInternalActivity

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/application/ApplicationServiceTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/application/ApplicationServiceTests.kt
@@ -316,6 +316,33 @@ class ApplicationServiceTests : FunSpec({
         applicationService.entryState shouldBe AppEntryAction.APP_CLOSE
     }
 
+    test("trampoline stop without a counted start still clears stale notification entry state") {
+        // Given: a wrapper SDK disabled the process-start initializer, so a URL notification's
+        // trampoline started before the lifecycle observer attached — its onStart was never counted.
+        // The app is backgrounded (no current activity) and the open processor classified entry as
+        // NOTIFICATION_CLICK.
+        val trampolineController = Robolectric.buildActivity(InternalTrampolineActivity::class.java)
+        trampolineController.setup()
+        val trampoline = trampolineController.get()
+
+        val handler = spyk<IApplicationLifecycleHandler>()
+        val applicationService = ApplicationService()
+        applicationService.addApplicationLifecycleHandler(handler)
+
+        val appContext = ApplicationProvider.getApplicationContext<Context>()
+        applicationService.start(appContext)
+        applicationService.entryState = AppEntryAction.NOTIFICATION_CLICK
+
+        // When: only the trampoline's stop is observed (its start was missed, so it was never counted).
+        applicationService.onActivityStopped(trampoline)
+
+        // Then: the stale entry state is cleared despite the uncounted start, without firing
+        // onUnfocused (no focus was ever held).
+        applicationService.current shouldBe null
+        applicationService.entryState shouldBe AppEntryAction.APP_CLOSE
+        verify(exactly = 0) { handler.onUnfocused() }
+    }
+
     test("notification tap while the host is foregrounded does not drop focus, and a later background still unfocuses") {
         // Given: the host is foregrounded.
         val hostController = Robolectric.buildActivity(Activity::class.java)

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/application/ApplicationServiceTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/application/ApplicationServiceTests.kt
@@ -250,7 +250,7 @@ class ApplicationServiceTests : FunSpec({
         response shouldBe true
     }
 
-    test("internal trampoline activity does not affect focus, current, or entry state") {
+    test("internal trampoline activity does not become current or take focus") {
         // Given
         val mainController = Robolectric.buildActivity(Activity::class.java)
         mainController.setup()
@@ -270,21 +270,82 @@ class ApplicationServiceTests : FunSpec({
         applicationService.start(appContext)
         applicationService.entryState = AppEntryAction.NOTIFICATION_CLICK
 
-        // When: the trampoline runs its full lifecycle.
+        // When: the trampoline starts and resumes, it must not become current or take focus.
+        applicationService.onActivityStarted(trampoline)
+        applicationService.onActivityResumed(trampoline)
+
+        applicationService.current shouldBe null
+        applicationService.entryState shouldBe AppEntryAction.NOTIFICATION_CLICK
+
+        // When: the host launches before the trampoline finishes (the real Android ordering: a new
+        // activity starts before the previous one stops).
+        applicationService.onActivityStarted(mainActivity)
+        applicationService.onActivityResumed(mainActivity)
+        applicationService.onActivityStopped(trampoline)
+
+        // Then: focus is established on the host and the NOTIFICATION_CLICK entry state is retained.
+        applicationService.current shouldBe mainActivity
+        applicationService.entryState shouldBe AppEntryAction.NOTIFICATION_CLICK
+        verify(exactly = 0) { handler.onUnfocused() }
+        verify(exactly = 1) { handler.onFocus(false) }
+    }
+
+    test("trampoline that finishes without launching an activity resets the notification entry state") {
+        // Given: the app is backgrounded (no current activity).
+        val trampolineController = Robolectric.buildActivity(InternalTrampolineActivity::class.java)
+        trampolineController.setup()
+        val trampoline = trampolineController.get()
+
+        val handler = spyk<IApplicationLifecycleHandler>()
+        val applicationService = ApplicationService()
+        applicationService.addApplicationLifecycleHandler(handler)
+
+        val appContext = ApplicationProvider.getApplicationContext<Context>()
+        applicationService.start(appContext)
+
+        // When: a URL notification is tapped — the module sets NOTIFICATION_CLICK, the trampoline
+        // opens a browser and finishes without ever launching the host.
+        applicationService.entryState = AppEntryAction.NOTIFICATION_CLICK
         applicationService.onActivityStarted(trampoline)
         applicationService.onActivityResumed(trampoline)
         applicationService.onActivityStopped(trampoline)
 
-        // Then: it is fully ignored — entry state is preserved and no focus is taken.
-        applicationService.entryState shouldBe AppEntryAction.NOTIFICATION_CLICK
+        // Then: the stale notification entry state is cleared so a later organic open is not
+        // mis-attributed as a direct notification session.
         applicationService.current shouldBe null
+        applicationService.entryState shouldBe AppEntryAction.APP_CLOSE
+    }
 
-        // When: the real activity starts after the trampoline finishes.
-        applicationService.onActivityStarted(mainActivity)
+    test("notification tap while the host is foregrounded does not drop focus or change entry state") {
+        // Given: the host is foregrounded.
+        val hostController = Robolectric.buildActivity(Activity::class.java)
+        hostController.setup()
+        val host = hostController.get()
 
-        // Then: focus is established but the NOTIFICATION_CLICK entry state is retained.
-        applicationService.current shouldBe mainActivity
-        applicationService.entryState shouldBe AppEntryAction.NOTIFICATION_CLICK
+        val trampolineController = Robolectric.buildActivity(InternalTrampolineActivity::class.java)
+        trampolineController.setup()
+        val trampoline = trampolineController.get()
+
+        val handler = spyk<IApplicationLifecycleHandler>()
+        val applicationService = ApplicationService()
+
+        applicationService.start(host)
+        applicationService.addApplicationLifecycleHandler(handler)
+
+        // When: a notification is tapped while the host is foreground. The trampoline launches in
+        // its own task, so the host stops while it is on top and resumes when it finishes.
+        applicationService.onActivityPaused(host)
+        applicationService.onActivityStarted(trampoline)
+        applicationService.onActivityResumed(trampoline)
+        applicationService.onActivityStopped(host)
+        applicationService.onActivityStopped(trampoline)
+        applicationService.onActivityStarted(host)
+        applicationService.onActivityResumed(host)
+
+        // Then: no spurious unfocus/focus cycle, entry state stays APP_OPEN (the foreground tap is
+        // not a direct notification session), and the host remains current.
+        applicationService.current shouldBe host
+        applicationService.entryState shouldBe AppEntryAction.APP_OPEN
         verify(exactly = 0) { handler.onUnfocused() }
     }
 

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/application/ApplicationServiceTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/application/ApplicationServiceTests.kt
@@ -363,6 +363,48 @@ class ApplicationServiceTests : FunSpec({
         verify(exactly = 1) { handler.onUnfocused() }
     }
 
+    test("foreground tap on a URL notification that opens a browser drops and restores focus") {
+        // Given: the host is foregrounded.
+        val hostController = Robolectric.buildActivity(Activity::class.java)
+        hostController.setup()
+        val host = hostController.get()
+
+        val trampolineController = Robolectric.buildActivity(InternalTrampolineActivity::class.java)
+        trampolineController.setup()
+        val trampoline = trampolineController.get()
+
+        val handler = spyk<IApplicationLifecycleHandler>()
+        val applicationService = ApplicationService()
+
+        applicationService.start(host)
+        applicationService.addApplicationLifecycleHandler(handler)
+
+        // When: a URL (or otherwise suppressed) notification is tapped while the host is foreground.
+        // The open launches a browser instead of the host, so no real activity is started: the host
+        // stops while the trampoline is on top, then the trampoline stops. The foreground guard kept
+        // the entry state at APP_OPEN (no NOTIFICATION_CLICK promotion).
+        applicationService.onActivityPaused(host)
+        applicationService.onActivityStarted(trampoline)
+        applicationService.onActivityResumed(trampoline)
+        applicationService.onActivityStopped(host)
+        applicationService.onActivityStopped(trampoline)
+
+        // Then: the app is recognized as backgrounded (browser is foreground) — focus is lost exactly
+        // once and current is cleared, rather than being left stale.
+        applicationService.current shouldBe null
+        verify(exactly = 1) { handler.onUnfocused() }
+
+        // When: the user returns from the browser to the host.
+        applicationService.onActivityStarted(host)
+        applicationService.onActivityResumed(host)
+
+        // Then: focus is restored — the host start is not swallowed by a stale current reference.
+        // (The initial foreground was delivered via addApplicationLifecycleHandler's onFocus(true)
+        // before the handler subscribed, so this return is the first onFocus(false) it observes.)
+        applicationService.current shouldBe host
+        verify(exactly = 1) { handler.onFocus(false) }
+    }
+
     test("stopping an activity whose start was never counted does not drop focus") {
         // Given
         val mainController = Robolectric.buildActivity(Activity::class.java)

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/application/ApplicationServiceTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/application/ApplicationServiceTests.kt
@@ -11,6 +11,7 @@ import com.onesignal.debug.LogLevel
 import com.onesignal.debug.internal.logging.Logging
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import io.mockk.every
 import io.mockk.spyk
 import io.mockk.verify
 import kotlinx.coroutines.delay
@@ -309,6 +310,45 @@ class ApplicationServiceTests : FunSpec({
         // Then: the reference count does not underflow and focus is retained.
         applicationService.current shouldBe mainActivity
         verify(exactly = 0) { handler.onUnfocused() }
+    }
+
+    test("configuration change recreation does not inflate the reference count") {
+        // Given
+        val firstController = Robolectric.buildActivity(Activity::class.java)
+        firstController.setup()
+        val firstInstance = firstController.get()
+
+        val recreatedController = Robolectric.buildActivity(Activity::class.java)
+        recreatedController.setup()
+        val recreatedInstance = recreatedController.get()
+
+        val handler = spyk<IApplicationLifecycleHandler>()
+        val applicationService = ApplicationService()
+        applicationService.addApplicationLifecycleHandler(handler)
+
+        // current is established for the first instance, reference count is 1.
+        applicationService.start(firstInstance)
+
+        // When: a config change (e.g. rotation) destroys the old instance and starts a new one.
+        // The old instance's stop reports isChangingConfigurations = true.
+        val rotatingOldInstance = spyk(firstInstance)
+        every { rotatingOldInstance.isChangingConfigurations } returns true
+        applicationService.onActivityPaused(rotatingOldInstance)
+        applicationService.onActivityStopped(rotatingOldInstance)
+        applicationService.onActivityStarted(recreatedInstance)
+        applicationService.onActivityResumed(recreatedInstance)
+
+        // Then: focus is retained throughout, current points at the recreated instance.
+        applicationService.current shouldBe recreatedInstance
+        verify(exactly = 0) { handler.onUnfocused() }
+
+        // When: the app is now genuinely backgrounded (single, non-config stop).
+        applicationService.onActivityPaused(recreatedInstance)
+        applicationService.onActivityStopped(recreatedInstance)
+
+        // Then: focus is lost exactly once — the count never climbed during rotation.
+        applicationService.current shouldBe null
+        verify(exactly = 1) { handler.onUnfocused() }
     }
 }) {
     companion object {

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/application/ApplicationServiceTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/application/ApplicationServiceTests.kt
@@ -1,6 +1,7 @@
 package com.onesignal.core.internal.application
 
 import android.app.Activity
+import android.app.Application
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import br.com.colman.kotest.android.extensions.robolectric.RobolectricTest
@@ -310,6 +311,38 @@ class ApplicationServiceTests : FunSpec({
         // Then: the reference count does not underflow and focus is retained.
         applicationService.current shouldBe mainActivity
         verify(exactly = 0) { handler.onUnfocused() }
+    }
+
+    test("cold start from notification fires focus when lifecycle observer is installed at process start") {
+        // Given: the production path where androidx.startup registered the observer at process start.
+        val application = ApplicationProvider.getApplicationContext<Application>()
+
+        val mainController = Robolectric.buildActivity(Activity::class.java)
+        mainController.setup()
+        val mainActivity = mainController.get()
+
+        val handler = spyk<IApplicationLifecycleHandler>()
+        val applicationService = ApplicationService()
+
+        // The observer is attached before init runs (no activity observed yet — only the internal
+        // trampoline, which is ignored).
+        applicationService.attachToApplication(application)
+
+        // Late init from a non-activity (trampoline) context.
+        applicationService.start(application)
+        applicationService.addApplicationLifecycleHandler(handler)
+
+        // The notification module classifies the entry before the host activity launches.
+        applicationService.entryState = AppEntryAction.NOTIFICATION_CLICK
+
+        // When: the host activity launches.
+        applicationService.onActivityStarted(mainActivity)
+        applicationService.onActivityResumed(mainActivity)
+
+        // Then: focus is delivered exactly once and the notification entry state is preserved.
+        verify(exactly = 1) { handler.onFocus(false) }
+        applicationService.current shouldBe mainActivity
+        applicationService.entryState shouldBe AppEntryAction.NOTIFICATION_CLICK
     }
 
     test("configuration change recreation does not inflate the reference count") {

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/application/ApplicationServiceTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/application/ApplicationServiceTests.kt
@@ -345,6 +345,41 @@ class ApplicationServiceTests : FunSpec({
         applicationService.entryState shouldBe AppEntryAction.NOTIFICATION_CLICK
     }
 
+    test("warm start from notification fires focus after the app was backgrounded") {
+        // Given: an initialized, foregrounded app (SDK already started, so start() will not run again).
+        val firstController = Robolectric.buildActivity(Activity::class.java)
+        firstController.setup()
+        val firstActivity = firstController.get()
+
+        val notifController = Robolectric.buildActivity(Activity::class.java)
+        notifController.setup()
+        val notifActivity = notifController.get()
+
+        val handler = spyk<IApplicationLifecycleHandler>()
+        val applicationService = ApplicationService()
+
+        applicationService.start(firstActivity)
+        applicationService.addApplicationLifecycleHandler(handler)
+
+        // The app is backgrounded: focus is lost and current is cleared.
+        applicationService.onActivityPaused(firstActivity)
+        applicationService.onActivityStopped(firstActivity)
+
+        applicationService.current shouldBe null
+        verify(exactly = 1) { handler.onUnfocused() }
+
+        // When: the user taps a notification. The module classifies the entry before the host
+        // activity launches; no start() runs because the SDK is already initialized.
+        applicationService.entryState = AppEntryAction.NOTIFICATION_CLICK
+        applicationService.onActivityStarted(notifActivity)
+        applicationService.onActivityResumed(notifActivity)
+
+        // Then: focus fires again for the warm start and the notification entry state is preserved.
+        applicationService.current shouldBe notifActivity
+        applicationService.entryState shouldBe AppEntryAction.NOTIFICATION_CLICK
+        verify(exactly = 1) { handler.onFocus(false) }
+    }
+
     test("configuration change recreation does not inflate the reference count") {
         // Given
         val firstController = Robolectric.buildActivity(Activity::class.java)

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/application/ApplicationServiceTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/application/ApplicationServiceTests.kt
@@ -316,11 +316,17 @@ class ApplicationServiceTests : FunSpec({
         applicationService.entryState shouldBe AppEntryAction.APP_CLOSE
     }
 
-    test("notification tap while the host is foregrounded does not drop focus or change entry state") {
+    test("notification tap while the host is foregrounded does not drop focus, and a later background still unfocuses") {
         // Given: the host is foregrounded.
         val hostController = Robolectric.buildActivity(Activity::class.java)
         hostController.setup()
         val host = hostController.get()
+
+        // The notification open launches a fresh host instance (the real Android behavior observed
+        // on device: the previous instance is stopped/destroyed and a new one is created).
+        val relaunchedHostController = Robolectric.buildActivity(Activity::class.java)
+        relaunchedHostController.setup()
+        val relaunchedHost = relaunchedHostController.get()
 
         val trampolineController = Robolectric.buildActivity(InternalTrampolineActivity::class.java)
         trampolineController.setup()
@@ -333,20 +339,28 @@ class ApplicationServiceTests : FunSpec({
         applicationService.addApplicationLifecycleHandler(handler)
 
         // When: a notification is tapped while the host is foreground. The trampoline launches in
-        // its own task, so the host stops while it is on top and resumes when it finishes.
+        // its own task, a new host instance starts, then the old host and the trampoline stop.
         applicationService.onActivityPaused(host)
         applicationService.onActivityStarted(trampoline)
         applicationService.onActivityResumed(trampoline)
+        applicationService.onActivityStarted(relaunchedHost)
+        applicationService.onActivityResumed(relaunchedHost)
         applicationService.onActivityStopped(host)
         applicationService.onActivityStopped(trampoline)
-        applicationService.onActivityStarted(host)
-        applicationService.onActivityResumed(host)
 
         // Then: no spurious unfocus/focus cycle, entry state stays APP_OPEN (the foreground tap is
-        // not a direct notification session), and the host remains current.
-        applicationService.current shouldBe host
+        // not a direct notification session), and the new host instance is current.
+        applicationService.current shouldBe relaunchedHost
         applicationService.entryState shouldBe AppEntryAction.APP_OPEN
         verify(exactly = 0) { handler.onUnfocused() }
+
+        // When: the app is genuinely backgrounded later, focus is lost exactly once — the trampoline
+        // counting did not leave a phantom reference that would suppress the real background.
+        applicationService.onActivityPaused(relaunchedHost)
+        applicationService.onActivityStopped(relaunchedHost)
+
+        applicationService.current shouldBe null
+        verify(exactly = 1) { handler.onUnfocused() }
     }
 
     test("stopping an activity whose start was never counted does not drop focus") {

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/application/ApplicationServiceTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/application/ApplicationServiceTests.kt
@@ -401,10 +401,12 @@ class ApplicationServiceTests : FunSpec({
         val trampoline = trampolineController.get()
 
         val handler = spyk<IApplicationLifecycleHandler>()
+        val activityHandler = spyk<IActivityLifecycleHandler>()
         val applicationService = ApplicationService()
 
         applicationService.start(host)
         applicationService.addApplicationLifecycleHandler(handler)
+        applicationService.addActivityLifecycleHandler(activityHandler)
 
         // When: a notification tap resumes the SAME host instance (launcher-style open intent:
         // NEW_TASK | RESET_TASK_IF_NEEDED). The real Android ordering: the host stops while the
@@ -422,6 +424,7 @@ class ApplicationServiceTests : FunSpec({
         applicationService.current shouldBe host
         applicationService.entryState shouldBe AppEntryAction.APP_OPEN
         verify(exactly = 0) { handler.onUnfocused() }
+        verify(exactly = 1) { activityHandler.onActivityAvailable(host) }
 
         // When: the app is genuinely backgrounded later, focus is lost exactly once — the host stop is
         // counted rather than skipped as !wasCounted.

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/application/ApplicationServiceTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/application/ApplicationServiceTests.kt
@@ -363,6 +363,48 @@ class ApplicationServiceTests : FunSpec({
         verify(exactly = 1) { handler.onUnfocused() }
     }
 
+    test("foreground tap that resumes the same host instance keeps focus tracking intact") {
+        // Given: the host is foregrounded.
+        val hostController = Robolectric.buildActivity(Activity::class.java)
+        hostController.setup()
+        val host = hostController.get()
+
+        val trampolineController = Robolectric.buildActivity(InternalTrampolineActivity::class.java)
+        trampolineController.setup()
+        val trampoline = trampolineController.get()
+
+        val handler = spyk<IApplicationLifecycleHandler>()
+        val applicationService = ApplicationService()
+
+        applicationService.start(host)
+        applicationService.addApplicationLifecycleHandler(handler)
+
+        // When: a notification tap resumes the SAME host instance (launcher-style open intent:
+        // NEW_TASK | RESET_TASK_IF_NEEDED). The real Android ordering: the host stops while the
+        // trampoline is on top, the same host instance is re-started, then the trampoline stops.
+        applicationService.onActivityPaused(host)
+        applicationService.onActivityStarted(trampoline)
+        applicationService.onActivityResumed(trampoline)
+        applicationService.onActivityStopped(host)
+        applicationService.onActivityStarted(host)
+        applicationService.onActivityResumed(host)
+        applicationService.onActivityStopped(trampoline)
+
+        // Then: no spurious unfocus, the host stays current, and it was re-counted (the start was not
+        // swallowed by the current == activity early return now that the stop had removed it).
+        applicationService.current shouldBe host
+        applicationService.entryState shouldBe AppEntryAction.APP_OPEN
+        verify(exactly = 0) { handler.onUnfocused() }
+
+        // When: the app is genuinely backgrounded later, focus is lost exactly once — the host stop is
+        // counted rather than skipped as !wasCounted.
+        applicationService.onActivityPaused(host)
+        applicationService.onActivityStopped(host)
+
+        applicationService.current shouldBe null
+        verify(exactly = 1) { handler.onUnfocused() }
+    }
+
     test("foreground tap on a URL notification that opens a browser drops and restores focus") {
         // Given: the host is foregrounded.
         val hostController = Robolectric.buildActivity(Activity::class.java)

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/NotificationOpenedActivityHMS.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/NotificationOpenedActivityHMS.kt
@@ -31,6 +31,7 @@ import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
 import com.onesignal.common.threading.suspendifyOnDefault
+import com.onesignal.core.internal.application.OneSignalInternalActivity
 import com.onesignal.notifications.internal.open.INotificationOpenedProcessorHMS
 
 // HMS Core creates a notification with an Intent when opened to start this Activity.
@@ -55,7 +56,13 @@ import com.onesignal.notifications.internal.open.INotificationOpenedProcessorHMS
 //   Some developer want to process the click in the background without bring the app to the foreground.
 //   The launcher Activity is started in OneSignal.java:startOrResumeApp if the developer does want the app
 //     to be opened.
-class NotificationOpenedActivityHMS : Activity() {
+/**
+ * Transient activity HMS launches when a notification is opened. Implements
+ * [OneSignalInternalActivity] so it is excluded from app focus / foreground tracking.
+ */
+class NotificationOpenedActivityHMS :
+    Activity(),
+    OneSignalInternalActivity {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         processIntent()

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/activities/NotificationOpenedActivityBase.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/activities/NotificationOpenedActivityBase.kt
@@ -32,9 +32,16 @@ import android.os.Bundle
 import com.onesignal.OneSignal
 import com.onesignal.common.AndroidUtils
 import com.onesignal.common.threading.suspendifyOnDefault
+import com.onesignal.core.internal.application.OneSignalInternalActivity
 import com.onesignal.notifications.internal.open.INotificationOpenedProcessor
 
-abstract class NotificationOpenedActivityBase : Activity() {
+/**
+ * Base for the transient activities the SDK launches to handle a notification open. Implements
+ * [OneSignalInternalActivity] so it is excluded from app focus / foreground tracking.
+ */
+abstract class NotificationOpenedActivityBase :
+    Activity(),
+    OneSignalInternalActivity {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         processIntent()


### PR DESCRIPTION
# Description
## One Line Summary
Register the activity lifecycle observer at process start (via `androidx.startup`) and make the activity reference counter membership- and config-change-aware, so focus/entry-state tracking is correct regardless of when the SDK initializes.

## Details

### Motivation
Wrapper SDKs (Flutter, React Native, Capacitor) have to add their own workarounds because `ApplicationService` only begins observing the activity lifecycle once `OneSignal.initWithContext` runs. When init happens after the first activity is already started, the SDK misses lifecycle callbacks, which produces:
- a wrong `entryState` (e.g. `NOTIFICATION_CLICK` reported for an organic cold start),
- an unbalanced `activityReferences` count that can underflow and falsely drop focus, and
- a reference count that climbs on every configuration change (rotation), permanently suppressing background detection.

This consolidates the fix in the native SDK so wrappers can drop their nudges.

### Scope
- A process-start `androidx.startup` `Initializer` attaches the `ActivityLifecycleCallbacks` to the `Application` before init runs. The same process-wide `ApplicationService` instance is then resolved by DI, so lifecycle observed before init is visible to the running SDK. If the startup provider is disabled (or in unit tests), DI falls back to a fresh instance and `start()` seeds focus state from the init context as before.
- Activity counting is now membership-based (`WeakHashMap`-backed set): a stop only decrements for an activity whose start was actually counted, preventing underflow when a late-init SDK observes a transient activity's stop without its start.
- Configuration-change recreation (e.g. rotation) no longer inflates the count: the recreated instance replaces its predecessor without incrementing, since the predecessor's stop already skipped the decrement.
- SDK-internal trampoline activities (notification open activities) implement a new internal `OneSignalInternalActivity` marker and are excluded from focus/entry-state tracking.
- No public API changes.

# Testing
## Unit testing
Added `ApplicationServiceTests` cases covering: internal trampoline activities are ignored for focus/current/entry-state; stopping an activity whose start was never counted does not drop focus (no underflow); and configuration-change recreation does not inflate the reference count.

## Manual testing
Built the SDK to `mavenLocal` and ran the OneSignal example app (gms variant) on an Android 16 emulator, driving scenarios via a helper script:
- Cold start: `entryState=APP_OPEN` (not `NOTIFICATION_CLICK`), one `onFocus`, count settles at 1.
- Background -> foreground: exactly one `onUnfocused` then one `onFocus`, count returns to 1 with no underflow.
- Rotation x4: count stayed pinned at 1 throughout (only values 0/1 ever observed), with no false `onUnfocused`/`onFocus` and `entryState` preserved.

# Affected code checklist
   - [x] Notifications
      - [x] Open
   - [x] Outcomes
   - [x] Sessions

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

Made with [Cursor](https://cursor.com)