### PR TITLE
fix: [SDK-3475] restrict notification component exports

### DIFF
--- a/OneSignalSDK/onesignal/notifications/src/main/AndroidManifest.xml
+++ b/OneSignalSDK/onesignal/notifications/src/main/AndroidManifest.xml
@@ -85,7 +85,6 @@
             android:exported="false">
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
-                <action android:name="android.intent.action.QUICKBOOT_POWERON" />
             </intent-filter>
         </receiver>
         <receiver

--- a/OneSignalSDK/onesignal/notifications/src/main/AndroidManifest.xml
+++ b/OneSignalSDK/onesignal/notifications/src/main/AndroidManifest.xml
@@ -70,7 +70,7 @@
             android:name="com.onesignal.NotificationOpenedActivityHMS"
             android:noHistory="true"
             android:theme="@android:style/Theme.Translucent.NoTitleBar"
-            android:exported="false">
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
             </intent-filter>

--- a/OneSignalSDK/onesignal/notifications/src/main/AndroidManifest.xml
+++ b/OneSignalSDK/onesignal/notifications/src/main/AndroidManifest.xml
@@ -70,7 +70,7 @@
             android:name="com.onesignal.NotificationOpenedActivityHMS"
             android:noHistory="true"
             android:theme="@android:style/Theme.Translucent.NoTitleBar"
-            android:exported="true">
+            android:exported="false">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
             </intent-filter>
@@ -78,11 +78,11 @@
 
         <receiver
             android:name="com.onesignal.notifications.receivers.NotificationDismissReceiver"
-            android:exported="true"/>
+            android:exported="false"/>
 
         <receiver
             android:name="com.onesignal.notifications.receivers.BootUpReceiver"
-            android:exported="true">
+            android:exported="false">
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
                 <action android:name="android.intent.action.QUICKBOOT_POWERON" />
@@ -90,7 +90,7 @@
         </receiver>
         <receiver
             android:name="com.onesignal.notifications.receivers.UpgradeReceiver"
-            android:exported="true">
+            android:exported="false">
             <intent-filter>
                 <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
             </intent-filter>
@@ -102,13 +102,13 @@
             android:excludeFromRecents="true"
             android:taskAffinity=""
             android:theme="@android:style/Theme.Translucent.NoTitleBar"
-            android:exported="true" />
+            android:exported="false" />
 
         <activity
             android:name="com.onesignal.notifications.activities.NotificationOpenedActivityAndroid22AndOlder"
             android:noHistory="true"
             android:excludeFromRecents="true"
             android:theme="@android:style/Theme.Translucent.NoTitleBar"
-            android:exported="true" />
+            android:exported="false" />
     </application>
 </manifest>


### PR DESCRIPTION
# Description
## One Line Summary
Restrict OneSignal notification components that do not need external app access to non-exported Android components.

## Details

### Motivation
Android security scanners flag several OneSignal notification components as exported without a guarding permission. The affected SDK-owned notification open, dismiss, boot restore, and upgrade restore components are invoked by app-created `PendingIntent`s or protected system broadcasts, so they should not be externally launchable by arbitrary apps.

### Scope
This updates the notifications module manifest only. `FCMBroadcastReceiver` remains exported because it is the FCM entry point and remains protected by `com.google.android.c2dm.permission.SEND`. `NotificationOpenedActivityHMS` also remains exported because HMS Core launches it cross-UID for Huawei notification opens. The legacy OEM `QUICKBOOT_POWERON` action was removed from `BootUpReceiver` because it is not delivered to a non-exported receiver.

# Testing
## Unit testing
No new unit tests were added because this is a manifest-only component exposure change.

## Manual testing
Automated verification run locally:

- `./gradlew :OneSignal:notifications:spotlessXmlCheck :OneSignal:notifications:processDebugManifest :OneSignal:notifications:processReleaseManifest :OneSignal:notifications:assembleRelease`
- Inspected `onesignal/notifications/build/outputs/aar/notifications-release.aar` and confirmed the affected components are packaged with the intended `android:exported` values, `NotificationOpenedActivityHMS` remains exported, `FCMBroadcastReceiver` remains exported with `com.google.android.c2dm.permission.SEND`, and `QUICKBOOT_POWERON` is no longer present.
- `./gradlew :OneSignal:notifications:testDebugUnitTest`

Device smoke testing has not been run yet. Recommended follow-up coverage: notification open, action button open, dismiss handling, boot restore, package upgrade restore, and HMS notification open.

# Affected code checklist
   - [x] Notifications
      - [x] Display
      - [x] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

Made with [Cursor](https://cursor.com)