### PR TITLE
fix: demote spurious ANR log from warn to info

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/debug/internal/crash/OtelAnrDetector.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/debug/internal/crash/OtelAnrDetector.kt
@@ -104,7 +104,7 @@ internal class OtelAnrDetector(
 
         // Only report if enough time has passed since last report (avoid duplicates)
         if (timeSinceLastReport > MIN_TIME_BETWEEN_ANR_REPORTS_MS) {
-            logger.warn("$TAG: ⚠️ ANR detected! Main thread unresponsive for ${timeSinceLastResponse}ms")
+            logger.info("$TAG: ⚠️ ANR detected! Main thread unresponsive for ${timeSinceLastResponse}ms")
             lastAnrReportTime.set(now)
             reportAnr(timeSinceLastResponse)
         } else {


### PR DESCRIPTION
# Description
## One Line Summary
Demote a log from warn to info, and we send the exception log anyway down the line.

## Details
If we set apps to WARN level, we get a lot of spurious "⚠️ ANR detected" warning logs that overwhelm the real warning-level logs. This also logs when the ANR is not due to OneSignal, so it is extraneous.

If the ANR is due to the SDK, we do send the exception to our logging service anyway:

```
val anrException = ApplicationNotRespondingException(
    "Application Not Responding: Main thread blocked for ${unresponsiveDurationMs}ms",
    stackTrace
)
```
### Motivation
Logs are overwhelmed by this spurious warning.

### Scope
logging only

# Testing
## Unit testing
None

## Manual testing
Seeing a lot of these logs in logcat 

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [ ] I have filled out all **REQUIRED** sections above
   - [ ] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [ ] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [ ] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.
