### PR TITLE
chore: [SDK-4783] deprecate blocking OneSignal APIs in favor of suspend variants

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/IOneSignal.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/IOneSignal.kt
@@ -25,8 +25,8 @@ interface IOneSignal {
      */
     @Deprecated(
         message =
-            "Accessing this property may block the calling thread until the SDK is initialized and " +
-                "cause ANRs when called on the main thread. Use the suspend function getUser() instead.",
+        "Accessing this property may block the calling thread until the SDK is initialized and " +
+            "cause ANRs when called on the main thread. Use the suspend function getUser() instead.",
         replaceWith = ReplaceWith("getUser()"),
     )
     val user: IUserManager
@@ -36,8 +36,8 @@ interface IOneSignal {
      */
     @Deprecated(
         message =
-            "Accessing this property may block the calling thread until the SDK is initialized and " +
-                "cause ANRs when called on the main thread. Use the suspend function getSession() instead.",
+        "Accessing this property may block the calling thread until the SDK is initialized and " +
+            "cause ANRs when called on the main thread. Use the suspend function getSession() instead.",
         replaceWith = ReplaceWith("getSession()"),
     )
     val session: ISessionManager
@@ -48,8 +48,8 @@ interface IOneSignal {
      */
     @Deprecated(
         message =
-            "Accessing this property may block the calling thread until the SDK is initialized and " +
-                "cause ANRs when called on the main thread. Use the suspend function getNotifications() instead.",
+        "Accessing this property may block the calling thread until the SDK is initialized and " +
+            "cause ANRs when called on the main thread. Use the suspend function getNotifications() instead.",
         replaceWith = ReplaceWith("getNotifications()"),
     )
     val notifications: INotificationsManager
@@ -60,8 +60,8 @@ interface IOneSignal {
      */
     @Deprecated(
         message =
-            "Accessing this property may block the calling thread until the SDK is initialized and " +
-                "cause ANRs when called on the main thread. Use the suspend function getLocation() instead.",
+        "Accessing this property may block the calling thread until the SDK is initialized and " +
+            "cause ANRs when called on the main thread. Use the suspend function getLocation() instead.",
         replaceWith = ReplaceWith("getLocation()"),
     )
     val location: ILocationManager
@@ -72,8 +72,8 @@ interface IOneSignal {
      */
     @Deprecated(
         message =
-            "Accessing this property may block the calling thread until the SDK is initialized and " +
-                "cause ANRs when called on the main thread. Use the suspend function getInAppMessages() instead.",
+        "Accessing this property may block the calling thread until the SDK is initialized and " +
+            "cause ANRs when called on the main thread. Use the suspend function getInAppMessages() instead.",
         replaceWith = ReplaceWith("getInAppMessages()"),
     )
     val inAppMessages: IInAppMessagesManager
@@ -94,9 +94,9 @@ interface IOneSignal {
      */
     @Deprecated(
         message =
-            "Accessing this property may block the calling thread until the SDK is initialized and " +
-                "cause ANRs when called on the main thread. Use the suspend functions getConsentRequired() " +
-                "and setConsentRequired(required) instead.",
+        "Accessing this property may block the calling thread until the SDK is initialized and " +
+            "cause ANRs when called on the main thread. Use the suspend functions getConsentRequired() " +
+            "and setConsentRequired(required) instead.",
         replaceWith = ReplaceWith("getConsentRequired()"),
     )
     var consentRequired: Boolean
@@ -107,9 +107,9 @@ interface IOneSignal {
      */
     @Deprecated(
         message =
-            "Accessing this property may block the calling thread until the SDK is initialized and " +
-                "cause ANRs when called on the main thread. Use the suspend functions getConsentGiven() " +
-                "and setConsentGiven(value) instead.",
+        "Accessing this property may block the calling thread until the SDK is initialized and " +
+            "cause ANRs when called on the main thread. Use the suspend functions getConsentGiven() " +
+            "and setConsentGiven(value) instead.",
         replaceWith = ReplaceWith("getConsentGiven()"),
     )
     var consentGiven: Boolean
@@ -119,9 +119,9 @@ interface IOneSignal {
      */
     @Deprecated(
         message =
-            "Accessing this property may block the calling thread until the SDK is initialized and " +
-                "cause ANRs when called on the main thread. Use the suspend functions getDisableGMSMissingPrompt() " +
-                "and setDisableGMSMissingPrompt(value) instead.",
+        "Accessing this property may block the calling thread until the SDK is initialized and " +
+            "cause ANRs when called on the main thread. Use the suspend functions getDisableGMSMissingPrompt() " +
+            "and setDisableGMSMissingPrompt(value) instead.",
         replaceWith = ReplaceWith("getDisableGMSMissingPrompt()"),
     )
     var disableGMSMissingPrompt: Boolean
@@ -136,8 +136,8 @@ interface IOneSignal {
      */
     @Deprecated(
         message =
-            "This blocking method may block the calling thread and cause ANRs when called on the " +
-                "main thread. Use the suspend function initWithContextSuspend(context, appId) instead.",
+        "This blocking method may block the calling thread and cause ANRs when called on the " +
+            "main thread. Use the suspend function initWithContextSuspend(context, appId) instead.",
         replaceWith = ReplaceWith("initWithContextSuspend(context, appId)"),
     )
     fun initWithContext(
@@ -175,8 +175,8 @@ interface IOneSignal {
      */
     @Deprecated(
         message =
-            "This blocking method may block the calling thread and cause ANRs when called on the " +
-                "main thread. Use the suspend function loginSuspend(externalId, jwtBearerToken) instead.",
+        "This blocking method may block the calling thread and cause ANRs when called on the " +
+            "main thread. Use the suspend function loginSuspend(externalId, jwtBearerToken) instead.",
         replaceWith = ReplaceWith("loginSuspend(externalId, jwtBearerToken)"),
     )
     fun login(
@@ -186,8 +186,8 @@ interface IOneSignal {
 
     @Deprecated(
         message =
-            "This blocking method may block the calling thread and cause ANRs when called on the " +
-                "main thread. Use the suspend function loginSuspend(externalId) instead.",
+        "This blocking method may block the calling thread and cause ANRs when called on the " +
+            "main thread. Use the suspend function loginSuspend(externalId) instead.",
         replaceWith = ReplaceWith("loginSuspend(externalId)"),
     )
     @Suppress("DEPRECATION")
@@ -201,8 +201,8 @@ interface IOneSignal {
      */
     @Deprecated(
         message =
-            "This blocking method may block the calling thread and cause ANRs when called on the " +
-                "main thread. Use the suspend function logoutSuspend() instead.",
+        "This blocking method may block the calling thread and cause ANRs when called on the " +
+            "main thread. Use the suspend function logoutSuspend() instead.",
         replaceWith = ReplaceWith("logoutSuspend()"),
     )
     fun logout()
@@ -218,8 +218,8 @@ interface IOneSignal {
      */
     @Deprecated(
         message =
-            "This blocking method may block the calling thread and cause ANRs when called on the " +
-                "main thread. Use the suspend function updateUserJwtSuspend(externalId, token) instead.",
+        "This blocking method may block the calling thread and cause ANRs when called on the " +
+            "main thread. Use the suspend function updateUserJwtSuspend(externalId, token) instead.",
         replaceWith = ReplaceWith("updateUserJwtSuspend(externalId, token)"),
     )
     fun updateUserJwt(

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/IOneSignal.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/IOneSignal.kt
@@ -94,8 +94,8 @@ interface IOneSignal {
      */
     @get:Deprecated(
         message =
-            "Reading this property may block the calling thread until the SDK is initialized and " +
-                "cause ANRs when called on the main thread. Use the suspend function getConsentRequired() instead.",
+        "Reading this property may block the calling thread until the SDK is initialized and " +
+            "cause ANRs when called on the main thread. Use the suspend function getConsentRequired() instead.",
         replaceWith = ReplaceWith("getConsentRequired()"),
     )
     @set:Deprecated(
@@ -110,8 +110,8 @@ interface IOneSignal {
      */
     @get:Deprecated(
         message =
-            "Reading this property may block the calling thread until the SDK is initialized and " +
-                "cause ANRs when called on the main thread. Use the suspend function getConsentGiven() instead.",
+        "Reading this property may block the calling thread until the SDK is initialized and " +
+            "cause ANRs when called on the main thread. Use the suspend function getConsentGiven() instead.",
         replaceWith = ReplaceWith("getConsentGiven()"),
     )
     @set:Deprecated(
@@ -125,8 +125,8 @@ interface IOneSignal {
      */
     @get:Deprecated(
         message =
-            "Reading this property may block the calling thread until the SDK is initialized and " +
-                "cause ANRs when called on the main thread. Use the suspend function getDisableGMSMissingPrompt() instead.",
+        "Reading this property may block the calling thread until the SDK is initialized and " +
+            "cause ANRs when called on the main thread. Use the suspend function getDisableGMSMissingPrompt() instead.",
         replaceWith = ReplaceWith("getDisableGMSMissingPrompt()"),
     )
     @set:Deprecated(

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/IOneSignal.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/IOneSignal.kt
@@ -99,8 +99,8 @@ interface IOneSignal {
         replaceWith = ReplaceWith("getConsentRequired()"),
     )
     @set:Deprecated(
-        message = "Use the suspend function setConsentRequired(required) instead.",
-        replaceWith = ReplaceWith("setConsentRequired(required)"),
+        message = "Use the suspend function setConsentRequired(value) instead.",
+        replaceWith = ReplaceWith("setConsentRequired(value)"),
     )
     var consentRequired: Boolean
 

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/IOneSignal.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/IOneSignal.kt
@@ -23,29 +23,59 @@ interface IOneSignal {
      * The user manager for accessing user-scoped
      * management.
      */
+    @Deprecated(
+        message =
+            "Accessing this property may block the calling thread until the SDK is initialized and " +
+                "cause ANRs when called on the main thread. Use the suspend function getUser() instead.",
+        replaceWith = ReplaceWith("getUser()"),
+    )
     val user: IUserManager
 
     /**
      * The session manager for accessing session-scoped management.
      */
+    @Deprecated(
+        message =
+            "Accessing this property may block the calling thread until the SDK is initialized and " +
+                "cause ANRs when called on the main thread. Use the suspend function getSession() instead.",
+        replaceWith = ReplaceWith("getSession()"),
+    )
     val session: ISessionManager
 
     /**
      * The notification manager for accessing device-scoped
      * notification management.
      */
+    @Deprecated(
+        message =
+            "Accessing this property may block the calling thread until the SDK is initialized and " +
+                "cause ANRs when called on the main thread. Use the suspend function getNotifications() instead.",
+        replaceWith = ReplaceWith("getNotifications()"),
+    )
     val notifications: INotificationsManager
 
     /**
      * The location manager for accessing device-scoped
      * location management.
      */
+    @Deprecated(
+        message =
+            "Accessing this property may block the calling thread until the SDK is initialized and " +
+                "cause ANRs when called on the main thread. Use the suspend function getLocation() instead.",
+        replaceWith = ReplaceWith("getLocation()"),
+    )
     val location: ILocationManager
 
     /**
      * The In App Messaging manager for accessing device-scoped
      * IAP management.
      */
+    @Deprecated(
+        message =
+            "Accessing this property may block the calling thread until the SDK is initialized and " +
+                "cause ANRs when called on the main thread. Use the suspend function getInAppMessages() instead.",
+        replaceWith = ReplaceWith("getInAppMessages()"),
+    )
     val inAppMessages: IInAppMessagesManager
 
     /**
@@ -62,17 +92,38 @@ interface IOneSignal {
      * should be set to `true` prior to the invocation of
      * [initWithContext] to ensure compliance.
      */
+    @Deprecated(
+        message =
+            "Accessing this property may block the calling thread until the SDK is initialized and " +
+                "cause ANRs when called on the main thread. Use the suspend functions getConsentRequired() " +
+                "and setConsentRequired(required) instead.",
+        replaceWith = ReplaceWith("getConsentRequired()"),
+    )
     var consentRequired: Boolean
 
     /**
      * Indicates whether privacy consent has been granted. This field is only relevant when
      * the application has opted into data privacy protections. See [consentRequired].
      */
+    @Deprecated(
+        message =
+            "Accessing this property may block the calling thread until the SDK is initialized and " +
+                "cause ANRs when called on the main thread. Use the suspend functions getConsentGiven() " +
+                "and setConsentGiven(value) instead.",
+        replaceWith = ReplaceWith("getConsentGiven()"),
+    )
     var consentGiven: Boolean
 
     /**
      * Whether to disable the "GMS is missing" prompt to the user.
      */
+    @Deprecated(
+        message =
+            "Accessing this property may block the calling thread until the SDK is initialized and " +
+                "cause ANRs when called on the main thread. Use the suspend functions getDisableGMSMissingPrompt() " +
+                "and setDisableGMSMissingPrompt(value) instead.",
+        replaceWith = ReplaceWith("getDisableGMSMissingPrompt()"),
+    )
     var disableGMSMissingPrompt: Boolean
 
     /**
@@ -83,6 +134,12 @@ interface IOneSignal {
      *
      * @return true if the SDK could be successfully initialized, false otherwise.
      */
+    @Deprecated(
+        message =
+            "This blocking method may block the calling thread and cause ANRs when called on the " +
+                "main thread. Use the suspend function initWithContextSuspend(context, appId) instead.",
+        replaceWith = ReplaceWith("initWithContextSuspend(context, appId)"),
+    )
     fun initWithContext(
         context: Context,
         appId: String,
@@ -116,11 +173,24 @@ interface IOneSignal {
      * trust for the login operation.  Required when identity verification has been enabled. See
      * [Identity Verification | OneSignal](https://documentation.onesignal.com/docs/identity-verification)
      */
+    @Deprecated(
+        message =
+            "This blocking method may block the calling thread and cause ANRs when called on the " +
+                "main thread. Use the suspend function loginSuspend(externalId, jwtBearerToken) instead.",
+        replaceWith = ReplaceWith("loginSuspend(externalId, jwtBearerToken)"),
+    )
     fun login(
         externalId: String,
         jwtBearerToken: String? = null,
     )
 
+    @Deprecated(
+        message =
+            "This blocking method may block the calling thread and cause ANRs when called on the " +
+                "main thread. Use the suspend function loginSuspend(externalId) instead.",
+        replaceWith = ReplaceWith("loginSuspend(externalId)"),
+    )
+    @Suppress("DEPRECATION")
     fun login(externalId: String) = login(externalId, null)
 
     /**
@@ -129,6 +199,12 @@ interface IOneSignal {
      * be retrieved, except through this device as long as the app remains installed and the app
      * data is not cleared.
      */
+    @Deprecated(
+        message =
+            "This blocking method may block the calling thread and cause ANRs when called on the " +
+                "main thread. Use the suspend function logoutSuspend() instead.",
+        replaceWith = ReplaceWith("logoutSuspend()"),
+    )
     fun logout()
 
     /**
@@ -140,6 +216,12 @@ interface IOneSignal {
      * @param externalId The external ID the JWT belongs to.
      * @param token The new JWT bearer token issued by your backend.
      */
+    @Deprecated(
+        message =
+            "This blocking method may block the calling thread and cause ANRs when called on the " +
+                "main thread. Use the suspend function updateUserJwtSuspend(externalId, token) instead.",
+        replaceWith = ReplaceWith("updateUserJwtSuspend(externalId, token)"),
+    )
     fun updateUserJwt(
         externalId: String,
         token: String,

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/IOneSignal.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/IOneSignal.kt
@@ -184,6 +184,12 @@ interface IOneSignal {
         jwtBearerToken: String? = null,
     )
 
+    /**
+     * Login to OneSignal under the user identified by the [externalId] provided, without a JWT
+     * bearer token. Convenience overload of [login] equivalent to calling it with a `null` token.
+     *
+     * @param externalId The external ID of the user that is to be logged in.
+     */
     @Deprecated(
         message =
         "This blocking method may block the calling thread and cause ANRs when called on the " +

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/IOneSignal.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/IOneSignal.kt
@@ -92,12 +92,15 @@ interface IOneSignal {
      * should be set to `true` prior to the invocation of
      * [initWithContext] to ensure compliance.
      */
-    @Deprecated(
+    @get:Deprecated(
         message =
-        "Accessing this property may block the calling thread until the SDK is initialized and " +
-            "cause ANRs when called on the main thread. Use the suspend functions getConsentRequired() " +
-            "and setConsentRequired(required) instead.",
+            "Reading this property may block the calling thread until the SDK is initialized and " +
+                "cause ANRs when called on the main thread. Use the suspend function getConsentRequired() instead.",
         replaceWith = ReplaceWith("getConsentRequired()"),
+    )
+    @set:Deprecated(
+        message = "Use the suspend function setConsentRequired(required) instead.",
+        replaceWith = ReplaceWith("setConsentRequired(required)"),
     )
     var consentRequired: Boolean
 
@@ -105,24 +108,30 @@ interface IOneSignal {
      * Indicates whether privacy consent has been granted. This field is only relevant when
      * the application has opted into data privacy protections. See [consentRequired].
      */
-    @Deprecated(
+    @get:Deprecated(
         message =
-        "Accessing this property may block the calling thread until the SDK is initialized and " +
-            "cause ANRs when called on the main thread. Use the suspend functions getConsentGiven() " +
-            "and setConsentGiven(value) instead.",
+            "Reading this property may block the calling thread until the SDK is initialized and " +
+                "cause ANRs when called on the main thread. Use the suspend function getConsentGiven() instead.",
         replaceWith = ReplaceWith("getConsentGiven()"),
+    )
+    @set:Deprecated(
+        message = "Use the suspend function setConsentGiven(value) instead.",
+        replaceWith = ReplaceWith("setConsentGiven(value)"),
     )
     var consentGiven: Boolean
 
     /**
      * Whether to disable the "GMS is missing" prompt to the user.
      */
-    @Deprecated(
+    @get:Deprecated(
         message =
-        "Accessing this property may block the calling thread until the SDK is initialized and " +
-            "cause ANRs when called on the main thread. Use the suspend functions getDisableGMSMissingPrompt() " +
-            "and setDisableGMSMissingPrompt(value) instead.",
+            "Reading this property may block the calling thread until the SDK is initialized and " +
+                "cause ANRs when called on the main thread. Use the suspend function getDisableGMSMissingPrompt() instead.",
         replaceWith = ReplaceWith("getDisableGMSMissingPrompt()"),
+    )
+    @set:Deprecated(
+        message = "Use the suspend function setDisableGMSMissingPrompt(value) instead.",
+        replaceWith = ReplaceWith("setDisableGMSMissingPrompt(value)"),
     )
     var disableGMSMissingPrompt: Boolean
 

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/OneSignal.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/OneSignal.kt
@@ -131,8 +131,8 @@ object OneSignal {
     @JvmStatic
     @get:Deprecated(
         message =
-            "Reading this property may block the calling thread until the SDK is initialized and " +
-                "cause ANRs when called on the main thread. Use the suspend function getConsentRequiredSuspend() instead.",
+        "Reading this property may block the calling thread until the SDK is initialized and " +
+            "cause ANRs when called on the main thread. Use the suspend function getConsentRequiredSuspend() instead.",
         replaceWith = ReplaceWith("getConsentRequiredSuspend()"),
     )
     @set:Deprecated(
@@ -153,8 +153,8 @@ object OneSignal {
     @JvmStatic
     @get:Deprecated(
         message =
-            "Reading this property may block the calling thread until the SDK is initialized and " +
-                "cause ANRs when called on the main thread. Use the suspend function getConsentGivenSuspend() instead.",
+        "Reading this property may block the calling thread until the SDK is initialized and " +
+            "cause ANRs when called on the main thread. Use the suspend function getConsentGivenSuspend() instead.",
         replaceWith = ReplaceWith("getConsentGivenSuspend()"),
     )
     @set:Deprecated(
@@ -174,8 +174,8 @@ object OneSignal {
     @JvmStatic
     @get:Deprecated(
         message =
-            "Reading this property may block the calling thread until the SDK is initialized and " +
-                "cause ANRs when called on the main thread. Use the suspend function getDisableGMSMissingPromptSuspend() instead.",
+        "Reading this property may block the calling thread until the SDK is initialized and " +
+            "cause ANRs when called on the main thread. Use the suspend function getDisableGMSMissingPromptSuspend() instead.",
         replaceWith = ReplaceWith("getDisableGMSMissingPromptSuspend()"),
     )
     @set:Deprecated(

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/OneSignal.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/OneSignal.kt
@@ -129,12 +129,15 @@ object OneSignal {
      * [initWithContext] to ensure compliance.
      */
     @JvmStatic
-    @Deprecated(
+    @get:Deprecated(
         message =
-        "Accessing this property may block the calling thread until the SDK is initialized and " +
-            "cause ANRs when called on the main thread. Use the suspend functions getConsentRequiredSuspend() " +
-            "and setConsentRequiredSuspend(required) instead.",
+            "Reading this property may block the calling thread until the SDK is initialized and " +
+                "cause ANRs when called on the main thread. Use the suspend function getConsentRequiredSuspend() instead.",
         replaceWith = ReplaceWith("getConsentRequiredSuspend()"),
+    )
+    @set:Deprecated(
+        message = "Use the suspend function setConsentRequiredSuspend(required) instead.",
+        replaceWith = ReplaceWith("setConsentRequiredSuspend(required)"),
     )
     @Suppress("DEPRECATION")
     var consentRequired: Boolean
@@ -148,12 +151,15 @@ object OneSignal {
      * the application has opted into data privacy protections. See [requiresPrivacyConsent].
      */
     @JvmStatic
-    @Deprecated(
+    @get:Deprecated(
         message =
-        "Accessing this property may block the calling thread until the SDK is initialized and " +
-            "cause ANRs when called on the main thread. Use the suspend functions getConsentGivenSuspend() " +
-            "and setConsentGivenSuspend(value) instead.",
+            "Reading this property may block the calling thread until the SDK is initialized and " +
+                "cause ANRs when called on the main thread. Use the suspend function getConsentGivenSuspend() instead.",
         replaceWith = ReplaceWith("getConsentGivenSuspend()"),
+    )
+    @set:Deprecated(
+        message = "Use the suspend function setConsentGivenSuspend(value) instead.",
+        replaceWith = ReplaceWith("setConsentGivenSuspend(value)"),
     )
     @Suppress("DEPRECATION")
     var consentGiven: Boolean
@@ -166,12 +172,15 @@ object OneSignal {
      * Whether to disable the "GMS is missing" prompt to the user.
      */
     @JvmStatic
-    @Deprecated(
+    @get:Deprecated(
         message =
-        "Accessing this property may block the calling thread until the SDK is initialized and " +
-            "cause ANRs when called on the main thread. Use the suspend functions getDisableGMSMissingPromptSuspend() " +
-            "and setDisableGMSMissingPromptSuspend(value) instead.",
+            "Reading this property may block the calling thread until the SDK is initialized and " +
+                "cause ANRs when called on the main thread. Use the suspend function getDisableGMSMissingPromptSuspend() instead.",
         replaceWith = ReplaceWith("getDisableGMSMissingPromptSuspend()"),
+    )
+    @set:Deprecated(
+        message = "Use the suspend function setDisableGMSMissingPromptSuspend(value) instead.",
+        replaceWith = ReplaceWith("setDisableGMSMissingPromptSuspend(value)"),
     )
     @Suppress("DEPRECATION")
     var disableGMSMissingPrompt: Boolean

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/OneSignal.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/OneSignal.kt
@@ -44,8 +44,8 @@ object OneSignal {
     @JvmStatic
     @Deprecated(
         message =
-            "Accessing this property may block the calling thread until the SDK is initialized and " +
-                "cause ANRs when called on the main thread. Use the suspend function getUserSuspend() instead.",
+        "Accessing this property may block the calling thread until the SDK is initialized and " +
+            "cause ANRs when called on the main thread. Use the suspend function getUserSuspend() instead.",
         replaceWith = ReplaceWith("getUserSuspend()"),
     )
     @Suppress("DEPRECATION")
@@ -59,8 +59,8 @@ object OneSignal {
     @JvmStatic
     @Deprecated(
         message =
-            "Accessing this property may block the calling thread until the SDK is initialized and " +
-                "cause ANRs when called on the main thread. Use the suspend function getSessionSuspend() instead.",
+        "Accessing this property may block the calling thread until the SDK is initialized and " +
+            "cause ANRs when called on the main thread. Use the suspend function getSessionSuspend() instead.",
         replaceWith = ReplaceWith("getSessionSuspend()"),
     )
     @Suppress("DEPRECATION")
@@ -74,8 +74,8 @@ object OneSignal {
     @JvmStatic
     @Deprecated(
         message =
-            "Accessing this property may block the calling thread until the SDK is initialized and " +
-                "cause ANRs when called on the main thread. Use the suspend function getNotificationsSuspend() instead.",
+        "Accessing this property may block the calling thread until the SDK is initialized and " +
+            "cause ANRs when called on the main thread. Use the suspend function getNotificationsSuspend() instead.",
         replaceWith = ReplaceWith("getNotificationsSuspend()"),
     )
     @Suppress("DEPRECATION")
@@ -89,8 +89,8 @@ object OneSignal {
     @JvmStatic
     @Deprecated(
         message =
-            "Accessing this property may block the calling thread until the SDK is initialized and " +
-                "cause ANRs when called on the main thread. Use the suspend function getLocationSuspend() instead.",
+        "Accessing this property may block the calling thread until the SDK is initialized and " +
+            "cause ANRs when called on the main thread. Use the suspend function getLocationSuspend() instead.",
         replaceWith = ReplaceWith("getLocationSuspend()"),
     )
     @Suppress("DEPRECATION")
@@ -104,8 +104,8 @@ object OneSignal {
     @JvmStatic
     @Deprecated(
         message =
-            "Accessing this property may block the calling thread until the SDK is initialized and " +
-                "cause ANRs when called on the main thread. Use the suspend function getInAppMessagesSuspend() instead.",
+        "Accessing this property may block the calling thread until the SDK is initialized and " +
+            "cause ANRs when called on the main thread. Use the suspend function getInAppMessagesSuspend() instead.",
         replaceWith = ReplaceWith("getInAppMessagesSuspend()"),
     )
     @Suppress("DEPRECATION")
@@ -131,9 +131,9 @@ object OneSignal {
     @JvmStatic
     @Deprecated(
         message =
-            "Accessing this property may block the calling thread until the SDK is initialized and " +
-                "cause ANRs when called on the main thread. Use the suspend functions getConsentRequiredSuspend() " +
-                "and setConsentRequiredSuspend(required) instead.",
+        "Accessing this property may block the calling thread until the SDK is initialized and " +
+            "cause ANRs when called on the main thread. Use the suspend functions getConsentRequiredSuspend() " +
+            "and setConsentRequiredSuspend(required) instead.",
         replaceWith = ReplaceWith("getConsentRequiredSuspend()"),
     )
     @Suppress("DEPRECATION")
@@ -150,9 +150,9 @@ object OneSignal {
     @JvmStatic
     @Deprecated(
         message =
-            "Accessing this property may block the calling thread until the SDK is initialized and " +
-                "cause ANRs when called on the main thread. Use the suspend functions getConsentGivenSuspend() " +
-                "and setConsentGivenSuspend(value) instead.",
+        "Accessing this property may block the calling thread until the SDK is initialized and " +
+            "cause ANRs when called on the main thread. Use the suspend functions getConsentGivenSuspend() " +
+            "and setConsentGivenSuspend(value) instead.",
         replaceWith = ReplaceWith("getConsentGivenSuspend()"),
     )
     @Suppress("DEPRECATION")
@@ -168,9 +168,9 @@ object OneSignal {
     @JvmStatic
     @Deprecated(
         message =
-            "Accessing this property may block the calling thread until the SDK is initialized and " +
-                "cause ANRs when called on the main thread. Use the suspend functions getDisableGMSMissingPromptSuspend() " +
-                "and setDisableGMSMissingPromptSuspend(value) instead.",
+        "Accessing this property may block the calling thread until the SDK is initialized and " +
+            "cause ANRs when called on the main thread. Use the suspend functions getDisableGMSMissingPromptSuspend() " +
+            "and setDisableGMSMissingPromptSuspend(value) instead.",
         replaceWith = ReplaceWith("getDisableGMSMissingPromptSuspend()"),
     )
     @Suppress("DEPRECATION")
@@ -189,8 +189,8 @@ object OneSignal {
     @JvmStatic
     @Deprecated(
         message =
-            "This blocking method may block the calling thread and cause ANRs when called on the " +
-                "main thread. Use the suspend function initWithContextSuspend(context, appId) instead.",
+        "This blocking method may block the calling thread and cause ANRs when called on the " +
+            "main thread. Use the suspend function initWithContextSuspend(context, appId) instead.",
         replaceWith = ReplaceWith("initWithContextSuspend(context, appId)"),
     )
     @Suppress("DEPRECATION")
@@ -373,8 +373,8 @@ object OneSignal {
     @JvmStatic
     @Deprecated(
         message =
-            "This blocking method may block the calling thread and cause ANRs when called on the " +
-                "main thread. Use the suspend function loginSuspend(externalId) instead.",
+        "This blocking method may block the calling thread and cause ANRs when called on the " +
+            "main thread. Use the suspend function loginSuspend(externalId) instead.",
         replaceWith = ReplaceWith("loginSuspend(externalId)"),
     )
     @Suppress("DEPRECATION")
@@ -404,8 +404,8 @@ object OneSignal {
     @JvmStatic
     @Deprecated(
         message =
-            "This blocking method may block the calling thread and cause ANRs when called on the " +
-                "main thread. Use the suspend function loginSuspend(externalId, jwtBearerToken) instead.",
+        "This blocking method may block the calling thread and cause ANRs when called on the " +
+            "main thread. Use the suspend function loginSuspend(externalId, jwtBearerToken) instead.",
         replaceWith = ReplaceWith("loginSuspend(externalId, jwtBearerToken)"),
     )
     @Suppress("DEPRECATION")
@@ -423,8 +423,8 @@ object OneSignal {
     @JvmStatic
     @Deprecated(
         message =
-            "This blocking method may block the calling thread and cause ANRs when called on the " +
-                "main thread. Use the suspend function logoutSuspend() instead.",
+        "This blocking method may block the calling thread and cause ANRs when called on the " +
+            "main thread. Use the suspend function logoutSuspend() instead.",
         replaceWith = ReplaceWith("logoutSuspend()"),
     )
     @Suppress("DEPRECATION")
@@ -442,8 +442,8 @@ object OneSignal {
     @JvmStatic
     @Deprecated(
         message =
-            "This blocking method may block the calling thread and cause ANRs when called on the " +
-                "main thread. Use the suspend function updateUserJwtSuspend(externalId, token) instead.",
+        "This blocking method may block the calling thread and cause ANRs when called on the " +
+            "main thread. Use the suspend function updateUserJwtSuspend(externalId, token) instead.",
         replaceWith = ReplaceWith("updateUserJwtSuspend(externalId, token)"),
     )
     @Suppress("DEPRECATION")

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/OneSignal.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/OneSignal.kt
@@ -136,8 +136,8 @@ object OneSignal {
         replaceWith = ReplaceWith("getConsentRequiredSuspend()"),
     )
     @set:Deprecated(
-        message = "Use the suspend function setConsentRequiredSuspend(required) instead.",
-        replaceWith = ReplaceWith("setConsentRequiredSuspend(required)"),
+        message = "Use the suspend function setConsentRequiredSuspend(value) instead.",
+        replaceWith = ReplaceWith("setConsentRequiredSuspend(value)"),
     )
     @Suppress("DEPRECATION")
     var consentRequired: Boolean

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/OneSignal.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/OneSignal.kt
@@ -42,6 +42,13 @@ object OneSignal {
      * called.
      */
     @JvmStatic
+    @Deprecated(
+        message =
+            "Accessing this property may block the calling thread until the SDK is initialized and " +
+                "cause ANRs when called on the main thread. Use the suspend function getUserSuspend() instead.",
+        replaceWith = ReplaceWith("getUserSuspend()"),
+    )
+    @Suppress("DEPRECATION")
     val User: IUserManager
         get() = oneSignal.user
 
@@ -50,6 +57,13 @@ object OneSignal {
      * has been called.
      */
     @JvmStatic
+    @Deprecated(
+        message =
+            "Accessing this property may block the calling thread until the SDK is initialized and " +
+                "cause ANRs when called on the main thread. Use the suspend function getSessionSuspend() instead.",
+        replaceWith = ReplaceWith("getSessionSuspend()"),
+    )
+    @Suppress("DEPRECATION")
     val Session: ISessionManager
         get() = oneSignal.session
 
@@ -58,6 +72,13 @@ object OneSignal {
      * only after [initWithContext] has been called.
      */
     @JvmStatic
+    @Deprecated(
+        message =
+            "Accessing this property may block the calling thread until the SDK is initialized and " +
+                "cause ANRs when called on the main thread. Use the suspend function getNotificationsSuspend() instead.",
+        replaceWith = ReplaceWith("getNotificationsSuspend()"),
+    )
+    @Suppress("DEPRECATION")
     val Notifications: INotificationsManager
         get() = oneSignal.notifications
 
@@ -66,6 +87,13 @@ object OneSignal {
      * only after [initWithContext] has been called.
      */
     @JvmStatic
+    @Deprecated(
+        message =
+            "Accessing this property may block the calling thread until the SDK is initialized and " +
+                "cause ANRs when called on the main thread. Use the suspend function getLocationSuspend() instead.",
+        replaceWith = ReplaceWith("getLocationSuspend()"),
+    )
+    @Suppress("DEPRECATION")
     val Location: ILocationManager
         get() = oneSignal.location
 
@@ -74,6 +102,13 @@ object OneSignal {
      * only after [initWithContext] has been called.
      */
     @JvmStatic
+    @Deprecated(
+        message =
+            "Accessing this property may block the calling thread until the SDK is initialized and " +
+                "cause ANRs when called on the main thread. Use the suspend function getInAppMessagesSuspend() instead.",
+        replaceWith = ReplaceWith("getInAppMessagesSuspend()"),
+    )
+    @Suppress("DEPRECATION")
     val InAppMessages: IInAppMessagesManager
         get() = oneSignal.inAppMessages
 
@@ -94,6 +129,14 @@ object OneSignal {
      * [initWithContext] to ensure compliance.
      */
     @JvmStatic
+    @Deprecated(
+        message =
+            "Accessing this property may block the calling thread until the SDK is initialized and " +
+                "cause ANRs when called on the main thread. Use the suspend functions getConsentRequiredSuspend() " +
+                "and setConsentRequiredSuspend(required) instead.",
+        replaceWith = ReplaceWith("getConsentRequiredSuspend()"),
+    )
+    @Suppress("DEPRECATION")
     var consentRequired: Boolean
         get() = oneSignal.consentRequired
         set(value) {
@@ -105,6 +148,14 @@ object OneSignal {
      * the application has opted into data privacy protections. See [requiresPrivacyConsent].
      */
     @JvmStatic
+    @Deprecated(
+        message =
+            "Accessing this property may block the calling thread until the SDK is initialized and " +
+                "cause ANRs when called on the main thread. Use the suspend functions getConsentGivenSuspend() " +
+                "and setConsentGivenSuspend(value) instead.",
+        replaceWith = ReplaceWith("getConsentGivenSuspend()"),
+    )
+    @Suppress("DEPRECATION")
     var consentGiven: Boolean
         get() = oneSignal.consentGiven
         set(value) {
@@ -115,6 +166,14 @@ object OneSignal {
      * Whether to disable the "GMS is missing" prompt to the user.
      */
     @JvmStatic
+    @Deprecated(
+        message =
+            "Accessing this property may block the calling thread until the SDK is initialized and " +
+                "cause ANRs when called on the main thread. Use the suspend functions getDisableGMSMissingPromptSuspend() " +
+                "and setDisableGMSMissingPromptSuspend(value) instead.",
+        replaceWith = ReplaceWith("getDisableGMSMissingPromptSuspend()"),
+    )
+    @Suppress("DEPRECATION")
     var disableGMSMissingPrompt: Boolean
         get() = oneSignal.disableGMSMissingPrompt
         set(value) {
@@ -128,6 +187,13 @@ object OneSignal {
      * @param appId The application ID the OneSignal SDK is bound to.
      */
     @JvmStatic
+    @Deprecated(
+        message =
+            "This blocking method may block the calling thread and cause ANRs when called on the " +
+                "main thread. Use the suspend function initWithContextSuspend(context, appId) instead.",
+        replaceWith = ReplaceWith("initWithContextSuspend(context, appId)"),
+    )
+    @Suppress("DEPRECATION")
     fun initWithContext(
         context: Context,
         appId: String,
@@ -305,6 +371,13 @@ object OneSignal {
      * @param externalId The external ID of the user that is to be logged in.
      */
     @JvmStatic
+    @Deprecated(
+        message =
+            "This blocking method may block the calling thread and cause ANRs when called on the " +
+                "main thread. Use the suspend function loginSuspend(externalId) instead.",
+        replaceWith = ReplaceWith("loginSuspend(externalId)"),
+    )
+    @Suppress("DEPRECATION")
     fun login(externalId: String) = oneSignal.login(externalId)
 
     /**
@@ -329,6 +402,13 @@ object OneSignal {
      * [Identity Verification | OneSignal](https://documentation.onesignal.com/docs/identity-verification)
      */
     @JvmStatic
+    @Deprecated(
+        message =
+            "This blocking method may block the calling thread and cause ANRs when called on the " +
+                "main thread. Use the suspend function loginSuspend(externalId, jwtBearerToken) instead.",
+        replaceWith = ReplaceWith("loginSuspend(externalId, jwtBearerToken)"),
+    )
+    @Suppress("DEPRECATION")
     fun login(
         externalId: String,
         jwtBearerToken: String? = null,
@@ -341,6 +421,13 @@ object OneSignal {
      * data is not cleared.
      */
     @JvmStatic
+    @Deprecated(
+        message =
+            "This blocking method may block the calling thread and cause ANRs when called on the " +
+                "main thread. Use the suspend function logoutSuspend() instead.",
+        replaceWith = ReplaceWith("logoutSuspend()"),
+    )
+    @Suppress("DEPRECATION")
     fun logout() = oneSignal.logout()
 
     /**
@@ -353,6 +440,13 @@ object OneSignal {
      * @param token The new JWT bearer token issued by your backend.
      */
     @JvmStatic
+    @Deprecated(
+        message =
+            "This blocking method may block the calling thread and cause ANRs when called on the " +
+                "main thread. Use the suspend function updateUserJwtSuspend(externalId, token) instead.",
+        replaceWith = ReplaceWith("updateUserJwtSuspend(externalId, token)"),
+    )
+    @Suppress("DEPRECATION")
     fun updateUserJwt(
         externalId: String,
         token: String,

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
@@ -72,12 +72,15 @@ internal class OneSignalImp(
     override val isInitialized: Boolean
         get() = initState == InitState.SUCCESS
 
-    @Deprecated(
+    @get:Deprecated(
         message =
-        "Accessing this property may block the calling thread until the SDK is initialized and " +
-            "cause ANRs when called on the main thread. Use the suspend functions getConsentRequired() " +
-            "and setConsentRequired(required) instead.",
+            "Reading this property may block the calling thread until the SDK is initialized and " +
+                "cause ANRs when called on the main thread. Use the suspend function getConsentRequired() instead.",
         replaceWith = ReplaceWith("getConsentRequired()"),
+    )
+    @set:Deprecated(
+        message = "Use the suspend function setConsentRequired(required) instead.",
+        replaceWith = ReplaceWith("setConsentRequired(required)"),
     )
     override var consentRequired: Boolean
         get() =
@@ -93,12 +96,15 @@ internal class OneSignalImp(
             }
         }
 
-    @Deprecated(
+    @get:Deprecated(
         message =
-        "Accessing this property may block the calling thread until the SDK is initialized and " +
-            "cause ANRs when called on the main thread. Use the suspend functions getConsentGiven() " +
-            "and setConsentGiven(value) instead.",
+            "Reading this property may block the calling thread until the SDK is initialized and " +
+                "cause ANRs when called on the main thread. Use the suspend function getConsentGiven() instead.",
         replaceWith = ReplaceWith("getConsentGiven()"),
+    )
+    @set:Deprecated(
+        message = "Use the suspend function setConsentGiven(value) instead.",
+        replaceWith = ReplaceWith("setConsentGiven(value)"),
     )
     override var consentGiven: Boolean
         get() =
@@ -118,12 +124,15 @@ internal class OneSignalImp(
             }
         }
 
-    @Deprecated(
+    @get:Deprecated(
         message =
-        "Accessing this property may block the calling thread until the SDK is initialized and " +
-            "cause ANRs when called on the main thread. Use the suspend functions getDisableGMSMissingPrompt() " +
-            "and setDisableGMSMissingPrompt(value) instead.",
+            "Reading this property may block the calling thread until the SDK is initialized and " +
+                "cause ANRs when called on the main thread. Use the suspend function getDisableGMSMissingPrompt() instead.",
         replaceWith = ReplaceWith("getDisableGMSMissingPrompt()"),
+    )
+    @set:Deprecated(
+        message = "Use the suspend function setDisableGMSMissingPrompt(value) instead.",
+        replaceWith = ReplaceWith("setDisableGMSMissingPrompt(value)"),
     )
     override var disableGMSMissingPrompt: Boolean
         get() =
@@ -509,6 +518,20 @@ internal class OneSignalImp(
     @Deprecated(
         message =
         "This blocking method may block the calling thread and cause ANRs when called on the " +
+            "main thread. Use the suspend function loginSuspend(externalId) instead.",
+        replaceWith = ReplaceWith("loginSuspend(externalId)"),
+    )
+    override fun login(externalId: String) {
+        Logging.warn(
+            "login(externalId) is deprecated and should no longer be used. " +
+                "Use the suspend function loginSuspend(externalId) instead.",
+        )
+        loginInternal(externalId, null)
+    }
+
+    @Deprecated(
+        message =
+        "This blocking method may block the calling thread and cause ANRs when called on the " +
             "main thread. Use the suspend function loginSuspend(externalId, jwtBearerToken) instead.",
         replaceWith = ReplaceWith("loginSuspend(externalId, jwtBearerToken)"),
     )
@@ -520,7 +543,13 @@ internal class OneSignalImp(
             "login(externalId, jwtBearerToken) is deprecated and should no longer be used. " +
                 "Use the suspend function loginSuspend(externalId, jwtBearerToken) instead.",
         )
+        loginInternal(externalId, jwtBearerToken)
+    }
 
+    private fun loginInternal(
+        externalId: String,
+        jwtBearerToken: String?,
+    ) {
         if (isBackgroundThreadingEnabled) {
             waitForInit(operationName = "login")
         } else {

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
@@ -526,8 +526,8 @@ internal class OneSignalImp(
             externalId = externalId,
             jwtBearerToken = null,
             deprecationMessage =
-                "login(externalId) is deprecated and should no longer be used. " +
-                    "Use the suspend function loginSuspend(externalId) instead.",
+            "login(externalId) is deprecated and should no longer be used. " +
+                "Use the suspend function loginSuspend(externalId) instead.",
         )
     }
 
@@ -545,8 +545,8 @@ internal class OneSignalImp(
             externalId = externalId,
             jwtBearerToken = jwtBearerToken,
             deprecationMessage =
-                "login(externalId, jwtBearerToken) is deprecated and should no longer be used. " +
-                    "Use the suspend function loginSuspend(externalId, jwtBearerToken) instead.",
+            "login(externalId, jwtBearerToken) is deprecated and should no longer be used. " +
+                "Use the suspend function loginSuspend(externalId, jwtBearerToken) instead.",
         )
     }
 

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
@@ -74,9 +74,9 @@ internal class OneSignalImp(
 
     @Deprecated(
         message =
-            "Accessing this property may block the calling thread until the SDK is initialized and " +
-                "cause ANRs when called on the main thread. Use the suspend functions getConsentRequired() " +
-                "and setConsentRequired(required) instead.",
+        "Accessing this property may block the calling thread until the SDK is initialized and " +
+            "cause ANRs when called on the main thread. Use the suspend functions getConsentRequired() " +
+            "and setConsentRequired(required) instead.",
         replaceWith = ReplaceWith("getConsentRequired()"),
     )
     override var consentRequired: Boolean
@@ -95,9 +95,9 @@ internal class OneSignalImp(
 
     @Deprecated(
         message =
-            "Accessing this property may block the calling thread until the SDK is initialized and " +
-                "cause ANRs when called on the main thread. Use the suspend functions getConsentGiven() " +
-                "and setConsentGiven(value) instead.",
+        "Accessing this property may block the calling thread until the SDK is initialized and " +
+            "cause ANRs when called on the main thread. Use the suspend functions getConsentGiven() " +
+            "and setConsentGiven(value) instead.",
         replaceWith = ReplaceWith("getConsentGiven()"),
     )
     override var consentGiven: Boolean
@@ -120,9 +120,9 @@ internal class OneSignalImp(
 
     @Deprecated(
         message =
-            "Accessing this property may block the calling thread until the SDK is initialized and " +
-                "cause ANRs when called on the main thread. Use the suspend functions getDisableGMSMissingPrompt() " +
-                "and setDisableGMSMissingPrompt(value) instead.",
+        "Accessing this property may block the calling thread until the SDK is initialized and " +
+            "cause ANRs when called on the main thread. Use the suspend functions getDisableGMSMissingPrompt() " +
+            "and setDisableGMSMissingPrompt(value) instead.",
         replaceWith = ReplaceWith("getDisableGMSMissingPrompt()"),
     )
     override var disableGMSMissingPrompt: Boolean
@@ -144,8 +144,8 @@ internal class OneSignalImp(
 
     @Deprecated(
         message =
-            "Accessing this property may block the calling thread until the SDK is initialized and " +
-                "cause ANRs when called on the main thread. Use the suspend function getSession() instead.",
+        "Accessing this property may block the calling thread until the SDK is initialized and " +
+            "cause ANRs when called on the main thread. Use the suspend function getSession() instead.",
         replaceWith = ReplaceWith("getSession()"),
     )
     override val session: ISessionManager
@@ -154,8 +154,8 @@ internal class OneSignalImp(
 
     @Deprecated(
         message =
-            "Accessing this property may block the calling thread until the SDK is initialized and " +
-                "cause ANRs when called on the main thread. Use the suspend function getNotifications() instead.",
+        "Accessing this property may block the calling thread until the SDK is initialized and " +
+            "cause ANRs when called on the main thread. Use the suspend function getNotifications() instead.",
         replaceWith = ReplaceWith("getNotifications()"),
     )
     override val notifications: INotificationsManager
@@ -164,8 +164,8 @@ internal class OneSignalImp(
 
     @Deprecated(
         message =
-            "Accessing this property may block the calling thread until the SDK is initialized and " +
-                "cause ANRs when called on the main thread. Use the suspend function getLocation() instead.",
+        "Accessing this property may block the calling thread until the SDK is initialized and " +
+            "cause ANRs when called on the main thread. Use the suspend function getLocation() instead.",
         replaceWith = ReplaceWith("getLocation()"),
     )
     override val location: ILocationManager
@@ -174,8 +174,8 @@ internal class OneSignalImp(
 
     @Deprecated(
         message =
-            "Accessing this property may block the calling thread until the SDK is initialized and " +
-                "cause ANRs when called on the main thread. Use the suspend function getInAppMessages() instead.",
+        "Accessing this property may block the calling thread until the SDK is initialized and " +
+            "cause ANRs when called on the main thread. Use the suspend function getInAppMessages() instead.",
         replaceWith = ReplaceWith("getInAppMessages()"),
     )
     override val inAppMessages: IInAppMessagesManager
@@ -184,8 +184,8 @@ internal class OneSignalImp(
 
     @Deprecated(
         message =
-            "Accessing this property may block the calling thread until the SDK is initialized and " +
-                "cause ANRs when called on the main thread. Use the suspend function getUser() instead.",
+        "Accessing this property may block the calling thread until the SDK is initialized and " +
+            "cause ANRs when called on the main thread. Use the suspend function getUser() instead.",
         replaceWith = ReplaceWith("getUser()"),
     )
     override val user: IUserManager
@@ -357,8 +357,8 @@ internal class OneSignalImp(
 
     @Deprecated(
         message =
-            "This blocking method may block the calling thread and cause ANRs when called on the " +
-                "main thread. Use the suspend function initWithContextSuspend(context, appId) instead.",
+        "This blocking method may block the calling thread and cause ANRs when called on the " +
+            "main thread. Use the suspend function initWithContextSuspend(context, appId) instead.",
         replaceWith = ReplaceWith("initWithContextSuspend(context, appId)"),
     )
     @Suppress("ReturnCount", "TooGenericExceptionCaught")
@@ -508,8 +508,8 @@ internal class OneSignalImp(
 
     @Deprecated(
         message =
-            "This blocking method may block the calling thread and cause ANRs when called on the " +
-                "main thread. Use the suspend function loginSuspend(externalId, jwtBearerToken) instead.",
+        "This blocking method may block the calling thread and cause ANRs when called on the " +
+            "main thread. Use the suspend function loginSuspend(externalId, jwtBearerToken) instead.",
         replaceWith = ReplaceWith("loginSuspend(externalId, jwtBearerToken)"),
     )
     override fun login(
@@ -542,8 +542,8 @@ internal class OneSignalImp(
 
     @Deprecated(
         message =
-            "This blocking method may block the calling thread and cause ANRs when called on the " +
-                "main thread. Use the suspend function logoutSuspend() instead.",
+        "This blocking method may block the calling thread and cause ANRs when called on the " +
+            "main thread. Use the suspend function logoutSuspend() instead.",
         replaceWith = ReplaceWith("logoutSuspend()"),
     )
     override fun logout() {
@@ -573,8 +573,8 @@ internal class OneSignalImp(
 
     @Deprecated(
         message =
-            "This blocking method may block the calling thread and cause ANRs when called on the " +
-                "main thread. Use the suspend function updateUserJwtSuspend(externalId, token) instead.",
+        "This blocking method may block the calling thread and cause ANRs when called on the " +
+            "main thread. Use the suspend function updateUserJwtSuspend(externalId, token) instead.",
         replaceWith = ReplaceWith("updateUserJwtSuspend(externalId, token)"),
     )
     override fun updateUserJwt(

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
@@ -72,6 +72,13 @@ internal class OneSignalImp(
     override val isInitialized: Boolean
         get() = initState == InitState.SUCCESS
 
+    @Deprecated(
+        message =
+            "Accessing this property may block the calling thread until the SDK is initialized and " +
+                "cause ANRs when called on the main thread. Use the suspend functions getConsentRequired() " +
+                "and setConsentRequired(required) instead.",
+        replaceWith = ReplaceWith("getConsentRequired()"),
+    )
     override var consentRequired: Boolean
         get() =
             if (isInitialized) {
@@ -86,6 +93,13 @@ internal class OneSignalImp(
             }
         }
 
+    @Deprecated(
+        message =
+            "Accessing this property may block the calling thread until the SDK is initialized and " +
+                "cause ANRs when called on the main thread. Use the suspend functions getConsentGiven() " +
+                "and setConsentGiven(value) instead.",
+        replaceWith = ReplaceWith("getConsentGiven()"),
+    )
     override var consentGiven: Boolean
         get() =
             if (isInitialized) {
@@ -104,6 +118,13 @@ internal class OneSignalImp(
             }
         }
 
+    @Deprecated(
+        message =
+            "Accessing this property may block the calling thread until the SDK is initialized and " +
+                "cause ANRs when called on the main thread. Use the suspend functions getDisableGMSMissingPrompt() " +
+                "and setDisableGMSMissingPrompt(value) instead.",
+        replaceWith = ReplaceWith("getDisableGMSMissingPrompt()"),
+    )
     override var disableGMSMissingPrompt: Boolean
         get() =
             if (isInitialized) {
@@ -121,22 +142,52 @@ internal class OneSignalImp(
     // we hardcode the DebugManager implementation so it can be used prior to calling `initWithContext`
     override val debug: IDebugManager = DebugManager()
 
+    @Deprecated(
+        message =
+            "Accessing this property may block the calling thread until the SDK is initialized and " +
+                "cause ANRs when called on the main thread. Use the suspend function getSession() instead.",
+        replaceWith = ReplaceWith("getSession()"),
+    )
     override val session: ISessionManager
         get() =
             getServiceWithFeatureGate { services.getService() }
 
+    @Deprecated(
+        message =
+            "Accessing this property may block the calling thread until the SDK is initialized and " +
+                "cause ANRs when called on the main thread. Use the suspend function getNotifications() instead.",
+        replaceWith = ReplaceWith("getNotifications()"),
+    )
     override val notifications: INotificationsManager
         get() =
             getServiceWithFeatureGate { services.getService() }
 
+    @Deprecated(
+        message =
+            "Accessing this property may block the calling thread until the SDK is initialized and " +
+                "cause ANRs when called on the main thread. Use the suspend function getLocation() instead.",
+        replaceWith = ReplaceWith("getLocation()"),
+    )
     override val location: ILocationManager
         get() =
             getServiceWithFeatureGate { services.getService() }
 
+    @Deprecated(
+        message =
+            "Accessing this property may block the calling thread until the SDK is initialized and " +
+                "cause ANRs when called on the main thread. Use the suspend function getInAppMessages() instead.",
+        replaceWith = ReplaceWith("getInAppMessages()"),
+    )
     override val inAppMessages: IInAppMessagesManager
         get() =
             getServiceWithFeatureGate { services.getService() }
 
+    @Deprecated(
+        message =
+            "Accessing this property may block the calling thread until the SDK is initialized and " +
+                "cause ANRs when called on the main thread. Use the suspend function getUser() instead.",
+        replaceWith = ReplaceWith("getUser()"),
+    )
     override val user: IUserManager
         get() =
             getServiceWithFeatureGate { services.getService() }
@@ -304,12 +355,21 @@ internal class OneSignalImp(
         return startupService
     }
 
+    @Deprecated(
+        message =
+            "This blocking method may block the calling thread and cause ANRs when called on the " +
+                "main thread. Use the suspend function initWithContextSuspend(context, appId) instead.",
+        replaceWith = ReplaceWith("initWithContextSuspend(context, appId)"),
+    )
     @Suppress("ReturnCount", "TooGenericExceptionCaught")
     override fun initWithContext(
         context: Context,
         appId: String,
     ): Boolean {
-        Logging.log(LogLevel.DEBUG, "Calling deprecated initWithContext(context: $context, appId: $appId)")
+        Logging.warn(
+            "initWithContext(context, appId) is deprecated and should no longer be used. " +
+                "Use the suspend function initWithContextSuspend(context, appId) instead.",
+        )
 
         // Warm OneSignalDispatchers on a dedicated daemon thread so the first production caller
         // of suspendifyOnIO / launchOnSerialIO doesn't pay the ThreadPoolExecutor + dispatcher +
@@ -446,11 +506,20 @@ internal class OneSignalImp(
         }
     }
 
+    @Deprecated(
+        message =
+            "This blocking method may block the calling thread and cause ANRs when called on the " +
+                "main thread. Use the suspend function loginSuspend(externalId, jwtBearerToken) instead.",
+        replaceWith = ReplaceWith("loginSuspend(externalId, jwtBearerToken)"),
+    )
     override fun login(
         externalId: String,
         jwtBearerToken: String?,
     ) {
-        Logging.log(LogLevel.DEBUG, "Calling deprecated login(externalId: $externalId, jwtBearerToken: ...${jwtBearerToken?.takeLast(8)})")
+        Logging.warn(
+            "login(externalId, jwtBearerToken) is deprecated and should no longer be used. " +
+                "Use the suspend function loginSuspend(externalId, jwtBearerToken) instead.",
+        )
 
         if (isBackgroundThreadingEnabled) {
             waitForInit(operationName = "login")
@@ -471,8 +540,17 @@ internal class OneSignalImp(
         }
     }
 
+    @Deprecated(
+        message =
+            "This blocking method may block the calling thread and cause ANRs when called on the " +
+                "main thread. Use the suspend function logoutSuspend() instead.",
+        replaceWith = ReplaceWith("logoutSuspend()"),
+    )
     override fun logout() {
-        Logging.log(LogLevel.DEBUG, "Calling deprecated logout()")
+        Logging.warn(
+            "logout() is deprecated and should no longer be used. " +
+                "Use the suspend function logoutSuspend() instead.",
+        )
 
         if (isBackgroundThreadingEnabled) {
             waitForInit(operationName = "logout")
@@ -493,11 +571,20 @@ internal class OneSignalImp(
         }
     }
 
+    @Deprecated(
+        message =
+            "This blocking method may block the calling thread and cause ANRs when called on the " +
+                "main thread. Use the suspend function updateUserJwtSuspend(externalId, token) instead.",
+        replaceWith = ReplaceWith("updateUserJwtSuspend(externalId, token)"),
+    )
     override fun updateUserJwt(
         externalId: String,
         token: String,
     ) {
-        Logging.log(LogLevel.DEBUG, "updateUserJwt(externalId: $externalId, token: ...${token.takeLast(8)})")
+        Logging.warn(
+            "updateUserJwt(externalId, token) is deprecated and should no longer be used. " +
+                "Use the suspend function updateUserJwtSuspend(externalId, token) instead.",
+        )
 
         if (isBackgroundThreadingEnabled) {
             waitForInit(operationName = "updateUserJwt")

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
@@ -522,11 +522,13 @@ internal class OneSignalImp(
         replaceWith = ReplaceWith("loginSuspend(externalId)"),
     )
     override fun login(externalId: String) {
-        Logging.warn(
-            "login(externalId) is deprecated and should no longer be used. " +
-                "Use the suspend function loginSuspend(externalId) instead.",
+        loginInternal(
+            externalId = externalId,
+            jwtBearerToken = null,
+            deprecationMessage =
+                "login(externalId) is deprecated and should no longer be used. " +
+                    "Use the suspend function loginSuspend(externalId) instead.",
         )
-        loginInternal(externalId, null)
     }
 
     @Deprecated(
@@ -539,22 +541,27 @@ internal class OneSignalImp(
         externalId: String,
         jwtBearerToken: String?,
     ) {
-        Logging.warn(
-            "login(externalId, jwtBearerToken) is deprecated and should no longer be used. " +
-                "Use the suspend function loginSuspend(externalId, jwtBearerToken) instead.",
+        loginInternal(
+            externalId = externalId,
+            jwtBearerToken = jwtBearerToken,
+            deprecationMessage =
+                "login(externalId, jwtBearerToken) is deprecated and should no longer be used. " +
+                    "Use the suspend function loginSuspend(externalId, jwtBearerToken) instead.",
         )
-        loginInternal(externalId, jwtBearerToken)
     }
 
     private fun loginInternal(
         externalId: String,
         jwtBearerToken: String?,
+        deprecationMessage: String,
     ) {
         if (isBackgroundThreadingEnabled) {
             waitForInit(operationName = "login")
         } else {
             requireInitForOperation("login")
         }
+
+        Logging.warn(deprecationMessage)
 
         val context = loginHelper.switchUser(externalId, jwtBearerToken) ?: return
 
@@ -576,16 +583,16 @@ internal class OneSignalImp(
         replaceWith = ReplaceWith("logoutSuspend()"),
     )
     override fun logout() {
-        Logging.warn(
-            "logout() is deprecated and should no longer be used. " +
-                "Use the suspend function logoutSuspend() instead.",
-        )
-
         if (isBackgroundThreadingEnabled) {
             waitForInit(operationName = "logout")
         } else {
             requireInitForOperation("logout")
         }
+
+        Logging.warn(
+            "logout() is deprecated and should no longer be used. " +
+                "Use the suspend function logoutSuspend() instead.",
+        )
 
         val context = logoutHelper.switchUser() ?: return
 
@@ -610,11 +617,6 @@ internal class OneSignalImp(
         externalId: String,
         token: String,
     ) {
-        Logging.warn(
-            "updateUserJwt(externalId, token) is deprecated and should no longer be used. " +
-                "Use the suspend function updateUserJwtSuspend(externalId, token) instead.",
-        )
-
         if (isBackgroundThreadingEnabled) {
             waitForInit(operationName = "updateUserJwt")
         } else {
@@ -622,6 +624,11 @@ internal class OneSignalImp(
                 throw IllegalStateException("Must call 'initWithContext' before 'updateUserJwt'")
             }
         }
+
+        Logging.warn(
+            "updateUserJwt(externalId, token) is deprecated and should no longer be used. " +
+                "Use the suspend function updateUserJwtSuspend(externalId, token) instead.",
+        )
 
         jwtTokenStore.putJwt(externalId, token)
         // Wake the queue so any deferred ops can dispatch with the fresh token.

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
@@ -74,8 +74,8 @@ internal class OneSignalImp(
 
     @get:Deprecated(
         message =
-            "Reading this property may block the calling thread until the SDK is initialized and " +
-                "cause ANRs when called on the main thread. Use the suspend function getConsentRequired() instead.",
+        "Reading this property may block the calling thread until the SDK is initialized and " +
+            "cause ANRs when called on the main thread. Use the suspend function getConsentRequired() instead.",
         replaceWith = ReplaceWith("getConsentRequired()"),
     )
     @set:Deprecated(
@@ -98,8 +98,8 @@ internal class OneSignalImp(
 
     @get:Deprecated(
         message =
-            "Reading this property may block the calling thread until the SDK is initialized and " +
-                "cause ANRs when called on the main thread. Use the suspend function getConsentGiven() instead.",
+        "Reading this property may block the calling thread until the SDK is initialized and " +
+            "cause ANRs when called on the main thread. Use the suspend function getConsentGiven() instead.",
         replaceWith = ReplaceWith("getConsentGiven()"),
     )
     @set:Deprecated(
@@ -126,8 +126,8 @@ internal class OneSignalImp(
 
     @get:Deprecated(
         message =
-            "Reading this property may block the calling thread until the SDK is initialized and " +
-                "cause ANRs when called on the main thread. Use the suspend function getDisableGMSMissingPrompt() instead.",
+        "Reading this property may block the calling thread until the SDK is initialized and " +
+            "cause ANRs when called on the main thread. Use the suspend function getDisableGMSMissingPrompt() instead.",
         replaceWith = ReplaceWith("getDisableGMSMissingPrompt()"),
     )
     @set:Deprecated(

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
@@ -79,8 +79,8 @@ internal class OneSignalImp(
         replaceWith = ReplaceWith("getConsentRequired()"),
     )
     @set:Deprecated(
-        message = "Use the suspend function setConsentRequired(required) instead.",
-        replaceWith = ReplaceWith("setConsentRequired(required)"),
+        message = "Use the suspend function setConsentRequired(value) instead.",
+        replaceWith = ReplaceWith("setConsentRequired(value)"),
     )
     override var consentRequired: Boolean
         get() =


### PR DESCRIPTION
# Description
## One Line Summary
Mark the blocking (non-suspend) OneSignal public APIs as `@Deprecated`, pointing each to its suspend equivalent.

## Details

### Motivation
Closes [SDK-4783](https://linear.app/onesignal/issue/SDK-4783/mark-initwithcontext-as-deprecated).

The blocking APIs (`initWithContext`, `login`, `logout`, `updateUserJwt`, the manager accessors, and the config properties) can block the calling thread until the SDK is initialized, which risks ANRs when invoked on the main thread. The SDK already exposes suspend equivalents for all of them. This PR formally deprecates the blocking variants so developers get a compile-time signal (with an IDE quick-fix via `ReplaceWith`) and a runtime log nudging them toward the suspend APIs.

### Scope
Deprecations are applied consistently across all three layers:
- `IOneSignal` (interface contract)
- `OneSignalImp` (implementation overrides — also where the runtime `Logging.warn` deprecation notices live for the blocking methods)
- `OneSignal` (public static object app developers call)

Deprecated members and their replacements:

| Deprecated (blocking) | Replacement (suspend) |
| --- | --- |
| `initWithContext(context, appId)` | `initWithContextSuspend(context, appId)` |
| `login(externalId)` / `login(externalId, jwtBearerToken)` | `loginSuspend(...)` |
| `logout()` | `logoutSuspend()` |
| `updateUserJwt(externalId, token)` | `updateUserJwtSuspend(externalId, token)` |
| `User` / `Session` / `Notifications` / `Location` / `InAppMessages` | `getUserSuspend()` / `getSessionSuspend()` / `getNotificationsSuspend()` / `getLocationSuspend()` / `getInAppMessagesSuspend()` |
| `consentRequired` / `consentGiven` / `disableGMSMissingPrompt` | `getX Suspend()` / `setX Suspend(...)` |

**Not changed:**
- The internal-only suspend `initWithContext(context)` path used by the SDK itself.
- `debug` (no suspend equivalent; usable before init).
- Property accessors deliberately do **not** emit runtime logs (they can be read frequently and would flood logs); the `@Deprecated` annotation is the signal there.

### Notes
- Deprecation level is `WARNING` (not `ERROR`) so the SDK's own unit tests that exercise the blocking APIs still compile.
- All internal SDK callers already use the suspend variants, so main source compiles with zero new deprecation warnings.

# Testing
## Unit testing
No new tests; this is an annotation/logging change. Existing tests that call the blocking APIs continue to compile and pass (they now surface expected deprecation warnings).

## Manual testing
Verified `:OneSignal:core`, `:OneSignal:notifications`, `:OneSignal:location`, and `:OneSignal:in-app-messages` compile successfully (`compileDebugKotlin`) with no new deprecation warnings in SDK source.

# Affected code checklist
   - [x] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

Made with [Cursor](https://cursor.com)