### PR TITLE
fix: [SDK-4793] add SUCCESS fast-path to FF-on service accessors to prevent main-thread ANR

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
@@ -726,6 +726,16 @@ internal class OneSignalImp(
 
     private fun <T> getServiceWithFeatureGate(getter: () -> T): T {
         if (isBackgroundThreadingEnabled) {
+            // Once init reaches SUCCESS the state is terminal and never flips back, so the
+            // requested service is already constructable. Answer synchronously instead of
+            // hopping onto the (cold-start-contended) IO dispatcher via runBlocking, which
+            // parks the calling thread -- e.g. Flutter's main-thread lifecycleInit -- and is
+            // the ANR in OneSignal-Flutter-SDK#1163. Only the genuinely-not-yet-ready states
+            // (IN_PROGRESS / FAILED / NOT_STARTED) need waitAndReturn, which preserves the
+            // existing block-or-throw semantics.
+            if (initState == InitState.SUCCESS) {
+                return getter()
+            }
             return waitAndReturn(getter)
         }
         return when (initState) {

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/application/SDKInitTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/application/SDKInitTests.kt
@@ -6,6 +6,7 @@ import android.content.SharedPreferences
 import androidx.test.core.app.ApplicationProvider.getApplicationContext
 import br.com.colman.kotest.android.extensions.robolectric.RobolectricTest
 import com.onesignal.common.AndroidUtils
+import com.onesignal.common.threading.OneSignalDispatchers
 import com.onesignal.common.threading.ThreadingMode
 import com.onesignal.core.internal.preferences.PreferenceOneSignalKeys.PREFS_LEGACY_APP_ID
 import com.onesignal.debug.ILogListener
@@ -20,6 +21,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.mockk.every
 import io.mockk.mockkObject
+import io.mockk.spyk
 import io.mockk.unmockkObject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
@@ -582,6 +584,61 @@ class SDKInitTests : FunSpec({
             // Ensure any waiter is released even if assertions failed early.
             if (trigger.count > 0) trigger.countDown()
             unmockkObject(AndroidUtils)
+        }
+    }
+
+    test("FF-on accessor returns once init is SUCCESS even when the IO dispatcher is saturated (OneSignal-Flutter-SDK#1163)") {
+        // Regression test for the Flutter main-thread ANR. Under SDK_BACKGROUND_THREADING,
+        // getServiceWithFeatureGate used to ALWAYS route through
+        // waitAndReturn -> waitForInit -> runBlocking(OneSignalDispatchers.IO), even after init
+        // had already reached SUCCESS. On Flutter's main-thread lifecycleInit that parks the UI
+        // thread on a cold-start-contended IO pool (OneSignal-Flutter-SDK#1163). The fix adds a
+        // lock-free SUCCESS fast-path.
+        //
+        // We reproduce the contention faithfully: saturate OneSignalDispatchers.IO so that the
+        // pre-fix runBlocking(OneSignalDispatchers.IO) would park indefinitely behind the busy
+        // workers, then assert the accessor still returns. With the fix it answers synchronously;
+        // without it the accessor thread would still be parked when we check.
+        val context = getApplicationContext<Context>()
+        // recordPrivateCalls so the private FF gate can be stubbed and intercepted on internal
+        // self-calls inside getServiceWithFeatureGate.
+        val os = spyk(OneSignalImp(), recordPrivateCalls = true)
+
+        // Initialize on the legacy (FF-off) path so init completes deterministically (and uses
+        // the injected Dispatchers.IO, leaving OneSignalDispatchers.IO idle for us to saturate),
+        // then flip the SDK onto the FF-on accessor branch.
+        os.initWithContext(context, "appId")
+        waitForInitialization(os)
+        every { os getProperty "isBackgroundThreadingEnabled" } returns true
+
+        // Saturate OneSignalDispatchers.IO. The backing ThreadPoolExecutor has a core pool of 2
+        // and a large queue, so two long-running tasks occupy every concurrently-running worker;
+        // anything dispatched afterwards (e.g. a runBlocking continuation) just queues and never
+        // runs until we release.
+        val running = CountDownLatch(2)
+        val release = CountDownLatch(1)
+        repeat(4) {
+            OneSignalDispatchers.launchOnIO {
+                running.countDown()
+                // Bounded await so a missed release can't wedge the shared pool for the suite.
+                release.await(30, TimeUnit.SECONDS)
+            }
+        }
+        running.await(5, TimeUnit.SECONDS) shouldBe true
+
+        try {
+            // When: a SUCCESS-state accessor is read while the IO pool is fully saturated.
+            val result = arrayOfNulls<Any>(1)
+            val accessorThread = Thread { result[0] = os.user }
+            accessorThread.start()
+            accessorThread.join(2_000)
+
+            // Then: the fast-path answered synchronously and the thread finished. The pre-fix
+            // runBlocking(OneSignalDispatchers.IO) path would still be parked here.
+            accessorThread.isAlive shouldBe false
+            result[0] shouldNotBe null
+        } finally {
+            release.countDown()
         }
     }
 


### PR DESCRIPTION
## Summary

Under the `sdk_background_threading` feature flag, the public service accessors (`OneSignal.getUser()`, `getInAppMessages()`, `getNotifications()`, `getSession()`, `getLocation()`) blocked the calling thread on `runBlocking(OneSignalDispatchers.IO)` on **every** call — even after init had already reached `SUCCESS`. On Flutter, the plugin resolves these managers synchronously on the platform/main thread in `lifecycleInit`, so during a cold-start-contended IO pool the main thread parks waiting for a free IO worker, producing ANRs.

- Linear: SDK-4793
- Reported in Flutter SDK: OneSignal/OneSignal-Flutter-SDK#1163 (5.6.0, 20k+ users, Play Console vitals anomaly)

### Reported stack trace (both reported traces share this shape)

```
main (Timed Waiting)
  LockSupport.parkNanos
  kotlinx.coroutines.BlockingCoroutine.joinBlocking
  kotlinx.coroutines.BuildersKt.runBlocking
  OneSignalImp.waitForInit
  OneSignalImp.waitAndReturn
  OneSignalImp.getServiceWithFeatureGate
  OneSignalImp.getInAppMessages / getUser
  OneSignalInAppMessages.lifecycleInit / OneSignalUser.lifecycleInit  (Flutter plugin, main thread)
  MethodChannel ... Looper.loop ... ActivityThread.main
```

## Root cause

`getServiceWithFeatureGate` had no `SUCCESS` fast-path in the FF-on branch. The legacy (FF-off) branch returns the service directly when `initState == SUCCESS`, but the FF-on branch unconditionally routed through `waitAndReturn -> waitForInit -> runBlocking(runtimeIoDispatcher)` (where `runtimeIoDispatcher == OneSignalDispatchers.IO`). Every accessor therefore paid a dispatcher round-trip and parked the caller, even when init had long since finished.

## Fix

Add a lock-free `SUCCESS` fast-path to the FF-on branch. `SUCCESS` is terminal and never flips back (a re-`initWithContext` short-circuits on `initState.isSDKAccessible()`; only `FAILED -> IN_PROGRESS` retries exist), so the service is constructable and can be returned synchronously without `runBlocking`. `IN_PROGRESS` / `FAILED` / `NOT_STARTED` still go through `waitAndReturn`, preserving the existing block-or-throw semantics. `initState` is `@Volatile`, so the read is safe and lock-free — identical to what the FF-off branch already relies on.

## Impact classification

**Not a crash.** The main thread is parked inside `runBlocking`, bottoming out at `Looper.loop` / `ActivityThread.main`, so the OS surfaces this as an **ANR** (Android vitals anomaly), not a fatal force-close. Self-recovering once init completes and an IO worker frees. **Severity: High** — main-thread block on the hottest startup path with broad user-visible impact.

## Test plan

- [x] New regression test in `SDKInitTests` saturates `OneSignalDispatchers.IO` and asserts a `SUCCESS`-state FF-on accessor still returns synchronously.
- [x] Verified the new test **fails** without the fix (accessor thread stays parked) and **passes** with it.
- [x] Full `:onesignal:core` `SDKInitTests` suite passes (21 tests).

## Follow-ups (separate, not in this PR)

- Consent getters (`consentRequired`/`consentGiven`/`disableGMSMissingPrompt`) have the same pattern via `blockingGet` (always `runBlocking` even when initialized). Not in the reported traces.
- Durable Flutter-side fix: resolve managers off the platform thread in `lifecycleInit` (OneSignal-Flutter-SDK).