### PR TITLE
fix: [SDK-4793] prevent main-thread ANR in blocking SDK APIs during/after init

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
@@ -609,6 +609,19 @@ internal class OneSignalImp(
      * @param operationName Optional operation name to include in error messages (e.g., "login", "logout")
      */
     private fun waitForInit(operationName: String? = null) {
+        // Fast-path: once init reaches SUCCESS the state is terminal and never flips back (a
+        // re-initWithContext short-circuits on initState.isSDKAccessible(); only FAILED ->
+        // IN_PROGRESS retries exist), so there is nothing to await. Return synchronously instead
+        // of hopping onto the (cold-start-contended) IO dispatcher via runBlocking, which parks
+        // the calling thread -- e.g. Flutter's main-thread lifecycleInit -- and is the ANR in
+        // OneSignal-Flutter-SDK#1163. Centralizing the fast-path here covers every blocking entry
+        // point (service accessors via waitAndReturn, plus login / logout / updateUserJwt /
+        // add|removeUserJwtInvalidatedListener). The non-terminal states (IN_PROGRESS / FAILED /
+        // NOT_STARTED) still go through waitUntilInitInternal, preserving block-until-ready / throw
+        // semantics. initState is @Volatile, so the read is safe and lock-free.
+        if (initState == InitState.SUCCESS) {
+            return
+        }
         runBlocking(runtimeIoDispatcher) {
             waitUntilInitInternal(operationName)
         }
@@ -726,14 +739,9 @@ internal class OneSignalImp(
 
     private fun <T> getServiceWithFeatureGate(getter: () -> T): T {
         if (isBackgroundThreadingEnabled) {
-            // Once init reaches SUCCESS the state is terminal and never flips back, so the
-            // requested service is already constructable. Answer synchronously instead of
-            // hopping onto the (cold-start-contended) IO dispatcher via runBlocking, which
-            // parks the calling thread -- e.g. Flutter's main-thread lifecycleInit -- and is
-            // the ANR in OneSignal-Flutter-SDK#1163. Only the genuinely-not-yet-ready states
-            // (IN_PROGRESS / FAILED / NOT_STARTED) need waitAndReturn, which preserves the
-            // existing block-or-throw semantics.
-            return if (initState == InitState.SUCCESS) getter() else waitAndReturn(getter)
+            // waitAndReturn -> waitForInit short-circuits synchronously once init is SUCCESS
+            // (see waitForInit), so this no longer parks the caller on the IO dispatcher.
+            return waitAndReturn(getter)
         }
         return when (initState) {
             InitState.SUCCESS -> {

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
@@ -613,7 +613,10 @@ internal class OneSignalImp(
         if (initState == InitState.SUCCESS) {
             return
         }
-        runBlocking(runtimeIoDispatcher) {
+        // Wait on the caller's own runBlocking event loop, not OneSignalDispatchers.IO: the body
+        // only awaits the init-completion signal, so coupling it to a saturated IO pool can park
+        // the caller even after init finishes (OneSignal-Flutter-SDK#1163).
+        runBlocking {
             waitUntilInitInternal(operationName)
         }
     }
@@ -767,8 +770,8 @@ internal class OneSignalImp(
             return getter()
         }
 
-        // Call suspendAndReturn directly to avoid nested runBlocking (waitAndReturn -> waitForInit -> runBlocking)
-        return runBlocking(runtimeIoDispatcher) {
+        // Wait on the caller's own runBlocking event loop, not OneSignalDispatchers.IO (see waitForInit).
+        return runBlocking {
             suspendAndReturn(getter)
         }
     }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
@@ -726,7 +726,14 @@ internal class OneSignalImp(
 
     private fun <T> getServiceWithFeatureGate(getter: () -> T): T {
         if (isBackgroundThreadingEnabled) {
-            return waitAndReturn(getter)
+            // Once init reaches SUCCESS the state is terminal and never flips back, so the
+            // requested service is already constructable. Answer synchronously instead of
+            // hopping onto the (cold-start-contended) IO dispatcher via runBlocking, which
+            // parks the calling thread -- e.g. Flutter's main-thread lifecycleInit -- and is
+            // the ANR in OneSignal-Flutter-SDK#1163. Only the genuinely-not-yet-ready states
+            // (IN_PROGRESS / FAILED / NOT_STARTED) need waitAndReturn, which preserves the
+            // existing block-or-throw semantics.
+            return if (initState == InitState.SUCCESS) getter() else waitAndReturn(getter)
         }
         return when (initState) {
             InitState.SUCCESS -> {

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
@@ -609,13 +609,11 @@ internal class OneSignalImp(
      * @param operationName Optional operation name to include in error messages (e.g., "login", "logout")
      */
     private fun waitForInit(operationName: String? = null) {
-        // SUCCESS is terminal, so initialized callers can return without parking behind the IO dispatcher.
         if (initState == InitState.SUCCESS) {
             return
         }
-        // Wait on the caller's own runBlocking event loop, not OneSignalDispatchers.IO: the body
-        // only awaits the init-completion signal, so coupling it to a saturated IO pool can park
-        // the caller even after init finishes (OneSignal-Flutter-SDK#1163).
+        // Intentionally dispatcher-less: wait on the calling thread's own event loop so resuming
+        // when init completes never depends on a free worker in a busy pool.
         runBlocking {
             waitUntilInitInternal(operationName)
         }
@@ -770,7 +768,7 @@ internal class OneSignalImp(
             return getter()
         }
 
-        // Wait on the caller's own runBlocking event loop, not OneSignalDispatchers.IO (see waitForInit).
+        // Intentionally dispatcher-less (see waitForInit).
         return runBlocking {
             suspendAndReturn(getter)
         }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
@@ -609,16 +609,7 @@ internal class OneSignalImp(
      * @param operationName Optional operation name to include in error messages (e.g., "login", "logout")
      */
     private fun waitForInit(operationName: String? = null) {
-        // Fast-path: once init reaches SUCCESS the state is terminal and never flips back (a
-        // re-initWithContext short-circuits on initState.isSDKAccessible(); only FAILED ->
-        // IN_PROGRESS retries exist), so there is nothing to await. Return synchronously instead
-        // of hopping onto the (cold-start-contended) IO dispatcher via runBlocking, which parks
-        // the calling thread -- e.g. Flutter's main-thread lifecycleInit -- and is the ANR in
-        // OneSignal-Flutter-SDK#1163. Centralizing the fast-path here covers every blocking entry
-        // point (service accessors via waitAndReturn, plus login / logout / updateUserJwt /
-        // add|removeUserJwtInvalidatedListener). The non-terminal states (IN_PROGRESS / FAILED /
-        // NOT_STARTED) still go through waitUntilInitInternal, preserving block-until-ready / throw
-        // semantics. initState is @Volatile, so the read is safe and lock-free.
+        // SUCCESS is terminal, so initialized callers can return without parking behind the IO dispatcher.
         if (initState == InitState.SUCCESS) {
             return
         }
@@ -739,8 +730,6 @@ internal class OneSignalImp(
 
     private fun <T> getServiceWithFeatureGate(getter: () -> T): T {
         if (isBackgroundThreadingEnabled) {
-            // waitAndReturn -> waitForInit short-circuits synchronously once init is SUCCESS
-            // (see waitForInit), so this no longer parks the caller on the IO dispatcher.
             return waitAndReturn(getter)
         }
         return when (initState) {
@@ -774,6 +763,10 @@ internal class OneSignalImp(
             // because Looper.getMainLooper() is not mocked. This is safe to ignore.
             Logging.debug("Could not check main thread status (likely in test environment): ${e.message}")
         }
+        if (initState == InitState.SUCCESS) {
+            return getter()
+        }
+
         // Call suspendAndReturn directly to avoid nested runBlocking (waitAndReturn -> waitForInit -> runBlocking)
         return runBlocking(runtimeIoDispatcher) {
             suspendAndReturn(getter)

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/application/SDKInitTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/application/SDKInitTests.kt
@@ -92,17 +92,10 @@ class SDKInitTests : FunSpec({
 
     beforeAny {
         Logging.logLevel = LogLevel.NONE
-        // FF-off (legacy mode) is the default; tests in this file exercise that contract.
-        // FF-on coverage of [initWithContext] (async dispatch via [suspendifyOnIO]) lives
-        // upstream of this PR and isn't repeated here — exercising it cleanly requires more
-        // setup than is in scope: OneSignalImp reads the FF via `featureManager.isEnabled(...)`,
-        // backed by `featureStates`, which is itself populated from
-        // `configModelStore.model.sdkRemoteFeatureFlags`. To flip the FF on we'd have to plant
-        // the cached ConfigModel JSON in SharedPreferences before [OneSignalImp] is constructed,
-        // and that conflicts with [BlockingPrefsContext] (used for the does-not-block /
-        // recovery shapes) because the FF check itself reads prefs synchronously through the
-        // lazy chain. The FF-on path is exercised in production usage; the regression we
-        // protect against here is the FF-off blocking contract pinned below.
+        // FF-off (legacy mode) is the default; most tests in this file exercise that contract.
+        // FF-on tests opt in per-test via [enableBackgroundThreadingBeforeInit], which seeds the
+        // flag straight onto `configModelStore.model.sdkRemoteFeatureFlags` (no SharedPreferences
+        // planting), so `featureManager.isEnabled(SDK_BACKGROUND_THREADING)` resolves true.
         ThreadingMode.useBackgroundThreading = false
     }
 

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/application/SDKInitTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/application/SDKInitTests.kt
@@ -8,6 +8,8 @@ import br.com.colman.kotest.android.extensions.robolectric.RobolectricTest
 import com.onesignal.common.AndroidUtils
 import com.onesignal.common.threading.OneSignalDispatchers
 import com.onesignal.common.threading.ThreadingMode
+import com.onesignal.core.internal.config.ConfigModelStore
+import com.onesignal.core.internal.features.FeatureFlag
 import com.onesignal.core.internal.preferences.PreferenceOneSignalKeys.PREFS_LEGACY_APP_ID
 import com.onesignal.debug.ILogListener
 import com.onesignal.debug.LogLevel
@@ -21,7 +23,6 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.mockk.every
 import io.mockk.mockkObject
-import io.mockk.spyk
 import io.mockk.unmockkObject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
@@ -46,6 +47,11 @@ class SDKInitTests : FunSpec({
             attempts++
         }
         oneSignalImp.isInitialized shouldBe true
+    }
+
+    fun enableBackgroundThreadingBeforeInit(oneSignalImp: OneSignalImp) {
+        oneSignalImp.getService(ConfigModelStore::class.java).model.sdkRemoteFeatureFlags =
+            listOf(FeatureFlag.SDK_BACKGROUND_THREADING.key)
     }
 
     beforeAny {
@@ -600,16 +606,14 @@ class SDKInitTests : FunSpec({
         // workers, then assert the accessor still returns. With the fix it answers synchronously;
         // without it the accessor thread would still be parked when we check.
         val context = getApplicationContext<Context>()
-        // recordPrivateCalls so the private FF gate can be stubbed and intercepted on internal
-        // self-calls inside getServiceWithFeatureGate.
-        val os = spyk(OneSignalImp(), recordPrivateCalls = true)
+        val os = OneSignalImp()
 
-        // Initialize on the legacy (FF-off) path so init completes deterministically (and uses
-        // the injected Dispatchers.IO, leaving OneSignalDispatchers.IO idle for us to saturate),
-        // then flip the SDK onto the FF-on accessor branch.
+        // SDK_BACKGROUND_THREADING is APP_STARTUP-latched, so seed it before init first resolves
+        // FeatureManager. This exercises the real FF-on branch without spying on OneSignalImp.
+        enableBackgroundThreadingBeforeInit(os)
         os.initWithContext(context, "appId")
         waitForInitialization(os)
-        every { os getProperty "isBackgroundThreadingEnabled" } returns true
+        ThreadingMode.useBackgroundThreading shouldBe true
 
         // Saturate OneSignalDispatchers.IO. The backing ThreadPoolExecutor has a core pool of 2
         // and a large queue, so two long-running tasks occupy every concurrently-running worker;
@@ -649,13 +653,14 @@ class SDKInitTests : FunSpec({
         // waitForInit -> runBlocking(OneSignalDispatchers.IO) even after init reached SUCCESS, so a
         // saturated IO pool would park the caller indefinitely.
         val context = getApplicationContext<Context>()
-        val os = spyk(OneSignalImp(), recordPrivateCalls = true)
+        val os = OneSignalImp()
 
-        // Initialize on the legacy (FF-off) path so init completes deterministically and leaves
-        // OneSignalDispatchers.IO idle for us to saturate, then flip onto the FF-on path.
+        // SDK_BACKGROUND_THREADING is APP_STARTUP-latched, so seed it before init first resolves
+        // FeatureManager. This exercises the real FF-on branch without spying on OneSignalImp.
+        enableBackgroundThreadingBeforeInit(os)
         os.initWithContext(context, "appId")
         waitForInitialization(os)
-        every { os getProperty "isBackgroundThreadingEnabled" } returns true
+        ThreadingMode.useBackgroundThreading shouldBe true
 
         // Saturate OneSignalDispatchers.IO so any post-fix runBlocking continuation would queue
         // forever behind the busy workers.

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/application/SDKInitTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/application/SDKInitTests.kt
@@ -6,6 +6,7 @@ import android.content.SharedPreferences
 import androidx.test.core.app.ApplicationProvider.getApplicationContext
 import br.com.colman.kotest.android.extensions.robolectric.RobolectricTest
 import com.onesignal.common.AndroidUtils
+import com.onesignal.common.threading.OneSignalDispatchers
 import com.onesignal.common.threading.ThreadingMode
 import com.onesignal.core.internal.preferences.PreferenceOneSignalKeys.PREFS_LEGACY_APP_ID
 import com.onesignal.debug.ILogListener
@@ -20,6 +21,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.mockk.every
 import io.mockk.mockkObject
+import io.mockk.spyk
 import io.mockk.unmockkObject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
@@ -582,6 +584,61 @@ class SDKInitTests : FunSpec({
             // Ensure any waiter is released even if assertions failed early.
             if (trigger.count > 0) trigger.countDown()
             unmockkObject(AndroidUtils)
+        }
+    }
+
+    test("FF-on accessor returns once init is SUCCESS even when the IO dispatcher is saturated (OneSignal-Flutter-SDK#1163)") {
+        // Regression test for the Flutter main-thread ANR. Under SDK_BACKGROUND_THREADING,
+        // getServiceWithFeatureGate used to ALWAYS route through
+        // waitAndReturn -> waitForInit -> runBlocking(OneSignalDispatchers.IO), even after init
+        // had already reached SUCCESS. On Flutter's main-thread lifecycleInit that parks the UI
+        // thread on a cold-start-contended IO pool (OneSignal-Flutter-SDK#1163). The fix adds a
+        // lock-free SUCCESS fast-path.
+        //
+        // We reproduce the contention faithfully: saturate OneSignalDispatchers.IO so that the
+        // pre-fix runBlocking(OneSignalDispatchers.IO) would park indefinitely behind the busy
+        // workers, then assert the accessor still returns. With the fix it answers synchronously;
+        // without it the accessor thread would still be parked when we check.
+        val context = getApplicationContext<Context>()
+        // recordPrivateCalls so the private FF gate can be stubbed and intercepted on internal
+        // self-calls inside getServiceWithFeatureGate.
+        val os = spyk(OneSignalImp(), recordPrivateCalls = true)
+
+        // Initialize on the legacy (FF-off) path so init completes deterministically (and uses
+        // the injected Dispatchers.IO, leaving OneSignalDispatchers.IO idle for us to saturate),
+        // then flip the SDK onto the FF-on accessor branch.
+        os.initWithContext(context, "appId")
+        waitForInitialization(os)
+        every { os getProperty "isBackgroundThreadingEnabled" } returns true
+
+        // Saturate OneSignalDispatchers.IO. The backing ThreadPoolExecutor has a core pool of 2
+        // and a large queue, so two long-running tasks occupy every concurrently-running worker;
+        // anything dispatched afterwards (e.g. a runBlocking continuation) just queues and never
+        // runs until we release.
+        val running = CountDownLatch(2)
+        val release = CountDownLatch(1)
+        repeat(4) {
+            OneSignalDispatchers.launchOnIO {
+                running.countDown()
+                // Bounded await so a missed release can't wedge the shared pool for the suite.
+                release.await(30, TimeUnit.SECONDS)
+            }
+        }
+        running.await(5, TimeUnit.SECONDS) shouldBe true
+
+        try {
+            // When: a SUCCESS-state accessor is read while the IO pool is fully saturated.
+            val result = arrayOfNulls<Any>(1)
+            val accessorThread = Thread { result[0] = os.user }
+            accessorThread.start()
+            accessorThread.join(2_000)
+
+            // Then: the fast-path answered synchronously and the thread finished. The pre-fix
+            // runBlocking(OneSignalDispatchers.IO) path would still be parked here.
+            accessorThread.isAlive shouldBe false
+            result[0] shouldNotBe null
+        } finally {
+            release.countDown()
         }
     }
 

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/application/SDKInitTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/application/SDKInitTests.kt
@@ -593,7 +593,7 @@ class SDKInitTests : FunSpec({
         // waitAndReturn -> waitForInit -> runBlocking(OneSignalDispatchers.IO), even after init
         // had already reached SUCCESS. On Flutter's main-thread lifecycleInit that parks the UI
         // thread on a cold-start-contended IO pool (OneSignal-Flutter-SDK#1163). The fix adds a
-        // lock-free SUCCESS fast-path.
+        // lock-free SUCCESS fast-path, centralized in waitForInit().
         //
         // We reproduce the contention faithfully: saturate OneSignalDispatchers.IO so that the
         // pre-fix runBlocking(OneSignalDispatchers.IO) would park indefinitely behind the busy
@@ -637,6 +637,49 @@ class SDKInitTests : FunSpec({
             // runBlocking(OneSignalDispatchers.IO) path would still be parked here.
             accessorThread.isAlive shouldBe false
             result[0] shouldNotBe null
+        } finally {
+            release.countDown()
+        }
+    }
+
+    test("FF-on login returns once init is SUCCESS even when the IO dispatcher is saturated (OneSignal-Flutter-SDK#1163)") {
+        // Companion regression test proving the SUCCESS fast-path is centralized in waitForInit(),
+        // so it covers the operation paths (login / logout / updateUserJwt / JWT listeners), not
+        // just the service accessors. Under SDK_BACKGROUND_THREADING, login() used to route through
+        // waitForInit -> runBlocking(OneSignalDispatchers.IO) even after init reached SUCCESS, so a
+        // saturated IO pool would park the caller indefinitely.
+        val context = getApplicationContext<Context>()
+        val os = spyk(OneSignalImp(), recordPrivateCalls = true)
+
+        // Initialize on the legacy (FF-off) path so init completes deterministically and leaves
+        // OneSignalDispatchers.IO idle for us to saturate, then flip onto the FF-on path.
+        os.initWithContext(context, "appId")
+        waitForInitialization(os)
+        every { os getProperty "isBackgroundThreadingEnabled" } returns true
+
+        // Saturate OneSignalDispatchers.IO so any post-fix runBlocking continuation would queue
+        // forever behind the busy workers.
+        val running = CountDownLatch(2)
+        val release = CountDownLatch(1)
+        repeat(4) {
+            OneSignalDispatchers.launchOnIO {
+                running.countDown()
+                release.await(30, TimeUnit.SECONDS)
+            }
+        }
+        running.await(5, TimeUnit.SECONDS) shouldBe true
+
+        try {
+            // When: login() is invoked while the IO pool is fully saturated. waitForInit must
+            // short-circuit (the subsequent enqueue is fire-and-forget via suspendifyOnIO and does
+            // not block the caller).
+            val loginThread = Thread { os.login("externalId") }
+            loginThread.start()
+            loginThread.join(2_000)
+
+            // Then: the fast-path answered synchronously and the call returned. The pre-fix
+            // runBlocking(OneSignalDispatchers.IO) path would still be parked here.
+            loginThread.isAlive shouldBe false
         } finally {
             release.countDown()
         }

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/application/SDKInitTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/application/SDKInitTests.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeoutOrNull
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
 
 @RobolectricTest
 class SDKInitTests : FunSpec({
@@ -52,6 +53,41 @@ class SDKInitTests : FunSpec({
     fun enableBackgroundThreadingBeforeInit(oneSignalImp: OneSignalImp) {
         oneSignalImp.getService(ConfigModelStore::class.java).model.sdkRemoteFeatureFlags =
             listOf(FeatureFlag.SDK_BACKGROUND_THREADING.key)
+    }
+
+    fun withSaturatedOneSignalIo(block: () -> Unit) {
+        val running = CountDownLatch(2)
+        val release = CountDownLatch(1)
+        repeat(4) {
+            OneSignalDispatchers.launchOnIO {
+                running.countDown()
+                release.await(30, TimeUnit.SECONDS)
+            }
+        }
+
+        try {
+            running.await(5, TimeUnit.SECONDS) shouldBe true
+            block()
+        } finally {
+            release.countDown()
+        }
+    }
+
+    fun runOnThreadAndWait(block: () -> Unit) {
+        val error = AtomicReference<Throwable?>(null)
+        val thread =
+            Thread {
+                try {
+                    block()
+                } catch (t: Throwable) {
+                    error.set(t)
+                }
+            }
+        thread.start()
+        thread.join(2_000)
+
+        thread.isAlive shouldBe false
+        error.get() shouldBe null
     }
 
     beforeAny {
@@ -615,34 +651,14 @@ class SDKInitTests : FunSpec({
         waitForInitialization(os)
         ThreadingMode.useBackgroundThreading shouldBe true
 
-        // Saturate OneSignalDispatchers.IO. The backing ThreadPoolExecutor has a core pool of 2
-        // and a large queue, so two long-running tasks occupy every concurrently-running worker;
-        // anything dispatched afterwards (e.g. a runBlocking continuation) just queues and never
-        // runs until we release.
-        val running = CountDownLatch(2)
-        val release = CountDownLatch(1)
-        repeat(4) {
-            OneSignalDispatchers.launchOnIO {
-                running.countDown()
-                // Bounded await so a missed release can't wedge the shared pool for the suite.
-                release.await(30, TimeUnit.SECONDS)
-            }
-        }
-        running.await(5, TimeUnit.SECONDS) shouldBe true
-
-        try {
+        withSaturatedOneSignalIo {
             // When: a SUCCESS-state accessor is read while the IO pool is fully saturated.
             val result = arrayOfNulls<Any>(1)
-            val accessorThread = Thread { result[0] = os.user }
-            accessorThread.start()
-            accessorThread.join(2_000)
+            runOnThreadAndWait { result[0] = os.user }
 
             // Then: the fast-path answered synchronously and the thread finished. The pre-fix
             // runBlocking(OneSignalDispatchers.IO) path would still be parked here.
-            accessorThread.isAlive shouldBe false
             result[0] shouldNotBe null
-        } finally {
-            release.countDown()
         }
     }
 
@@ -662,31 +678,35 @@ class SDKInitTests : FunSpec({
         waitForInitialization(os)
         ThreadingMode.useBackgroundThreading shouldBe true
 
-        // Saturate OneSignalDispatchers.IO so any post-fix runBlocking continuation would queue
-        // forever behind the busy workers.
-        val running = CountDownLatch(2)
-        val release = CountDownLatch(1)
-        repeat(4) {
-            OneSignalDispatchers.launchOnIO {
-                running.countDown()
-                release.await(30, TimeUnit.SECONDS)
-            }
-        }
-        running.await(5, TimeUnit.SECONDS) shouldBe true
-
-        try {
+        withSaturatedOneSignalIo {
             // When: login() is invoked while the IO pool is fully saturated. waitForInit must
             // short-circuit (the subsequent enqueue is fire-and-forget via suspendifyOnIO and does
             // not block the caller).
-            val loginThread = Thread { os.login("externalId") }
-            loginThread.start()
-            loginThread.join(2_000)
+            runOnThreadAndWait { os.login("externalId") }
 
             // Then: the fast-path answered synchronously and the call returned. The pre-fix
             // runBlocking(OneSignalDispatchers.IO) path would still be parked here.
-            loginThread.isAlive shouldBe false
-        } finally {
-            release.countDown()
+        }
+    }
+
+    test("FF-on consent getters return once init is SUCCESS even when the IO dispatcher is saturated") {
+        val context = getApplicationContext<Context>()
+        val os = OneSignalImp()
+
+        enableBackgroundThreadingBeforeInit(os)
+        os.initWithContext(context, "appId")
+        waitForInitialization(os)
+        ThreadingMode.useBackgroundThreading shouldBe true
+
+        withSaturatedOneSignalIo {
+            val results = arrayOfNulls<Boolean>(3)
+            runOnThreadAndWait {
+                results[0] = os.consentRequired
+                results[1] = os.consentGiven
+                results[2] = os.disableGMSMissingPrompt
+            }
+
+            results.toList() shouldBe listOf(false, false, false)
         }
     }
 

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/internal/OneSignalImpTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/internal/OneSignalImpTests.kt
@@ -39,6 +39,19 @@ class OneSignalImpTests : FunSpec({
         exception.message shouldBe "Must call 'initWithContext' before 'logout'"
     }
 
+    test("waitForInit returns synchronously when initState is SUCCESS") {
+        val os = OneSignalImp()
+        val initStateField = OneSignalImp::class.java.getDeclaredField("initState")
+        initStateField.isAccessible = true
+        initStateField.set(os, InitState.SUCCESS)
+
+        val waitForInit = OneSignalImp::class.java.getDeclaredMethod("waitForInit", String::class.java)
+        waitForInit.isAccessible = true
+        waitForInit.invoke(os, null as String?)
+
+        os.isInitialized shouldBe true
+    }
+
     // Comprehensive tests for deprecated properties that should work before and after initialization
     context("consentRequired property") {
         context("before initWithContext") {

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/internal/OneSignalImpTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/internal/OneSignalImpTests.kt
@@ -52,6 +52,19 @@ class OneSignalImpTests : FunSpec({
         os.isInitialized shouldBe true
     }
 
+    test("blockingGet returns synchronously when initState is SUCCESS") {
+        val os = OneSignalImp()
+        val initStateField = OneSignalImp::class.java.getDeclaredField("initState")
+        initStateField.isAccessible = true
+        initStateField.set(os, InitState.SUCCESS)
+
+        val blockingGet = OneSignalImp::class.java.getDeclaredMethod("blockingGet", Function0::class.java)
+        blockingGet.isAccessible = true
+
+        val getter = { "value" }
+        blockingGet.invoke(os, getter) shouldBe "value"
+    }
+
     // Comprehensive tests for deprecated properties that should work before and after initialization
     context("consentRequired property") {
         context("before initWithContext") {

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/internal/OneSignalImpTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/internal/OneSignalImpTests.kt
@@ -5,7 +5,11 @@ import com.onesignal.debug.internal.logging.Logging
 import io.kotest.assertions.throwables.shouldThrowUnit
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
+import java.lang.reflect.InvocationTargetException
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import kotlin.coroutines.CoroutineContext
 
 class OneSignalImpTests : FunSpec({
@@ -27,6 +31,16 @@ class OneSignalImpTests : FunSpec({
         val initStateField = OneSignalImp::class.java.getDeclaredField("initState")
         initStateField.isAccessible = true
         initStateField.set(os, InitState.SUCCESS)
+    }
+
+    fun setPrivateField(
+        os: OneSignalImp,
+        name: String,
+        value: Any,
+    ) {
+        val field = OneSignalImp::class.java.getDeclaredField(name)
+        field.isAccessible = true
+        field.set(os, value)
     }
 
     test("attempting login before initWithContext throws exception") {
@@ -77,6 +91,41 @@ class OneSignalImpTests : FunSpec({
 
         val getter = { "value" }
         blockingGet.invoke(os, getter) shouldBe "value"
+    }
+
+    test("waitForInit at IN_PROGRESS awaits the completion signal without dispatching to the IO dispatcher") {
+        // Under FF-off, runtimeIoDispatcher == ioDispatcher (the throwing dispatcher). Pre-fix the
+        // IN_PROGRESS wait ran runBlocking(runtimeIoDispatcher) { ... }, coupling it to a dispatcher
+        // that can never run the body (models a saturated IO pool). Post-fix the wait runs on the
+        // caller's own event loop and resumes off the completion signal alone (#1163).
+        val os = OneSignalImp(ioDispatcher = throwingDispatcher)
+        setPrivateField(os, "initState", InitState.IN_PROGRESS)
+        val deferred = CompletableDeferred<Unit>()
+        setPrivateField(os, "suspendCompletion", deferred)
+
+        val waitForInit = OneSignalImp::class.java.getDeclaredMethod("waitForInit", String::class.java)
+        waitForInit.isAccessible = true
+
+        val failure = arrayOfNulls<Throwable>(1)
+        val finished = CountDownLatch(1)
+        Thread {
+            try {
+                waitForInit.invoke(os, null as String?)
+            } catch (t: InvocationTargetException) {
+                failure[0] = t.targetException
+            } finally {
+                finished.countDown()
+            }
+        }.start()
+
+        // Still parked on the not-yet-completed signal (pre-fix it would throw/finish immediately).
+        finished.await(300, TimeUnit.MILLISECONDS) shouldBe false
+
+        setPrivateField(os, "initState", InitState.SUCCESS)
+        deferred.complete(Unit)
+
+        finished.await(2, TimeUnit.SECONDS) shouldBe true
+        failure[0] shouldBe null
     }
 
     // Comprehensive tests for deprecated properties that should work before and after initialization

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/internal/OneSignalImpTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/internal/OneSignalImpTests.kt
@@ -5,10 +5,28 @@ import com.onesignal.debug.internal.logging.Logging
 import io.kotest.assertions.throwables.shouldThrowUnit
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlin.coroutines.CoroutineContext
 
 class OneSignalImpTests : FunSpec({
     beforeAny {
         Logging.logLevel = LogLevel.NONE
+    }
+
+    val throwingDispatcher =
+        object : CoroutineDispatcher() {
+            override fun dispatch(
+                context: CoroutineContext,
+                block: Runnable,
+            ) {
+                error("SUCCESS fast-path should not dispatch")
+            }
+        }
+
+    fun markInitialized(os: OneSignalImp) {
+        val initStateField = OneSignalImp::class.java.getDeclaredField("initState")
+        initStateField.isAccessible = true
+        initStateField.set(os, InitState.SUCCESS)
     }
 
     test("attempting login before initWithContext throws exception") {
@@ -39,11 +57,9 @@ class OneSignalImpTests : FunSpec({
         exception.message shouldBe "Must call 'initWithContext' before 'logout'"
     }
 
-    test("waitForInit returns synchronously when initState is SUCCESS") {
-        val os = OneSignalImp()
-        val initStateField = OneSignalImp::class.java.getDeclaredField("initState")
-        initStateField.isAccessible = true
-        initStateField.set(os, InitState.SUCCESS)
+    test("waitForInit returns synchronously without dispatching when initState is SUCCESS") {
+        val os = OneSignalImp(ioDispatcher = throwingDispatcher)
+        markInitialized(os)
 
         val waitForInit = OneSignalImp::class.java.getDeclaredMethod("waitForInit", String::class.java)
         waitForInit.isAccessible = true
@@ -52,11 +68,9 @@ class OneSignalImpTests : FunSpec({
         os.isInitialized shouldBe true
     }
 
-    test("blockingGet returns synchronously when initState is SUCCESS") {
-        val os = OneSignalImp()
-        val initStateField = OneSignalImp::class.java.getDeclaredField("initState")
-        initStateField.isAccessible = true
-        initStateField.set(os, InitState.SUCCESS)
+    test("blockingGet returns synchronously without dispatching when initState is SUCCESS") {
+        val os = OneSignalImp(ioDispatcher = throwingDispatcher)
+        markInitialized(os)
 
         val blockingGet = OneSignalImp::class.java.getDeclaredMethod("blockingGet", Function0::class.java)
         blockingGet.isAccessible = true


### PR DESCRIPTION
## Summary

Under the `sdk_background_threading` feature flag, OneSignal's synchronous public APIs blocked the calling thread on `runBlocking(OneSignalDispatchers.IO)` to wait for initialization — even after init had already reached `SUCCESS`, and even though the wait itself needs no IO work. On Flutter, the plugin resolves managers synchronously on the platform/main thread in `lifecycleInit`, so during a cold-start-contended IO pool the main thread parks waiting for a free IO worker, producing ANRs.

Affected entry points (all reached only under `sdk_background_threading`):
- Service accessors `getUser()` / `getInAppMessages()` / `getNotifications()` / `getSession()` / `getLocation()`, and `login` / `logout` / `updateUserJwt` / JWT-invalidated listeners — via `waitForInit`.
- Consent getters `consentRequired` / `consentGiven` / `disableGMSMissingPrompt` — via `blockingGet`.

- Linear: SDK-4793
- Reported in Flutter SDK: OneSignal/OneSignal-Flutter-SDK#1163 (5.6.0, 20k+ users, Play Console vitals anomaly)

### Reported stack trace (both reported traces share this shape)

```
main (Timed Waiting)
  LockSupport.parkNanos
  kotlinx.coroutines.BlockingCoroutine.joinBlocking
  kotlinx.coroutines.BuildersKt.runBlocking
  OneSignalImp.waitForInit
  OneSignalImp.waitAndReturn
  OneSignalImp.getServiceWithFeatureGate
  OneSignalImp.getInAppMessages / getUser
  OneSignalInAppMessages.lifecycleInit / OneSignalUser.lifecycleInit  (Flutter plugin, main thread)
  MethodChannel ... Looper.loop ... ActivityThread.main
```

## Root cause

Two compounding issues in the blocking wait primitives (`waitForInit`, `blockingGet`):

1. **No `SUCCESS` short-circuit.** The FF-on path routed every call through `runBlocking(runtimeIoDispatcher)` even when init had long since finished. (The legacy FF-off accessor branch already returned directly at `SUCCESS`.)
2. **The wait was dispatched onto `OneSignalDispatchers.IO`.** The wait body only awaits the init-completion signal — it needs no IO worker — yet it was scheduled on the IO pool. On a saturated pool the caller parks until a worker frees, both to *start* the wait and to *deliver the result after init completes*.

## Fix

Centralized in the two blocking primitives, so every entry point above is covered:

1. **`SUCCESS` fast-path.** `SUCCESS` is terminal and never flips back (a re-`initWithContext` short-circuits on `initState.isSDKAccessible()`; only `FAILED -> IN_PROGRESS` retries exist), so return synchronously without `runBlocking`. `initState` is `@Volatile`, so the read is safe and lock-free — identical to what the FF-off branch already relies on.
2. **Decouple the wait from the IO pool.** For the non-`SUCCESS` path, use plain `runBlocking { ... }` so the wait runs on the caller's own event loop and resumes off the init-completion signal alone, never blocked on IO-worker availability.

`NOT_STARTED` / `FAILED` still throw and `IN_PROGRESS` still blocks until init completes, preserving the existing block-or-throw semantics.

## Impact classification

**Not a crash.** The main thread is parked inside `runBlocking`, bottoming out at `Looper.loop` / `ActivityThread.main`, so the OS surfaces this as an **ANR** (Android vitals anomaly), not a fatal force-close. Self-recovering once init completes and an IO worker frees. **Severity: High** — main-thread block on the hottest startup path with broad user-visible impact.

## Test plan

- [x] `SDKInitTests` saturates the real `OneSignalDispatchers.IO` and asserts SUCCESS-state accessors / `login` / consent getters return synchronously.
- [x] `OneSignalImpTests` injects a throwing `CoroutineDispatcher` to prove the SUCCESS fast-path never dispatches, plus a new IN_PROGRESS regression test proving the wait resumes off the completion signal without touching the IO dispatcher.
- [x] Each new test verified to **fail** without its corresponding fix and **pass** with it.
- [x] Full `:onesignal:core` unit test suite passes.

## Known limitation / follow-ups

- Under FF-on, init itself runs on `OneSignalDispatchers.IO` (`suspendifyOnIO`). If that pool is *fully* saturated, init cannot complete and an `IN_PROGRESS` caller must still wait — no waiter-side change can avoid that. This PR removes the SUCCESS-state park and the post-completion IO dependency; the durable fix is Flutter-side: resolve managers off the platform thread in `lifecycleInit` (OneSignal-Flutter-SDK).
- Optional hardening (not in this PR): bound the wait with a timeout so a wedged init degrades to a logged error instead of an indefinite block.

Made with [Cursor](https://cursor.com)
