### PR TITLE
fix(notifications): guard against null PendingResult from goAsync() [SDK-4803]

### DIFF
--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/receivers/BootUpReceiver.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/receivers/BootUpReceiver.kt
@@ -44,18 +44,18 @@ class BootUpReceiver : BroadcastReceiver() {
         // goAsync() so the daemon has lead time before the first suspendifyOnIO dispatch.
         OneSignalDispatchers.prewarm()
 
-        val pendingResult = goAsync()
+        val pendingResult: BroadcastReceiver.PendingResult? = goAsync()
         // in background, init onesignal and begin enqueueing restore work
         suspendifyOnIO {
             if (!OneSignal.initWithContext(context.applicationContext)) {
                 Logging.warn("NotificationRestoreReceiver skipped due to failed OneSignal init")
-                pendingResult.finish()
+                pendingResult?.finish()
                 return@suspendifyOnIO
             }
 
             val restoreWorkManager = OneSignal.getService<INotificationRestoreWorkManager>()
             restoreWorkManager.beginEnqueueingWork(context, true)
-            pendingResult.finish()
+            pendingResult?.finish()
         }
     }
 }

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/receivers/FCMBroadcastReceiver.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/receivers/FCMBroadcastReceiver.kt
@@ -31,12 +31,12 @@ class FCMBroadcastReceiver : BroadcastReceiver() {
         // likely to be warm by the time the suspendifyOnIO below submits its work.
         OneSignalDispatchers.prewarm()
 
-        val pendingResult = goAsync()
+        val pendingResult: BroadcastReceiver.PendingResult? = goAsync()
         // process in background
         suspendifyOnIO {
             if (!OneSignal.initWithContext(context.applicationContext)) {
                 Logging.warn("FCMBroadcastReceiver skipped due to failed OneSignal init")
-                pendingResult.finish()
+                pendingResult?.finish()
                 return@suspendifyOnIO
             }
 
@@ -44,7 +44,7 @@ class FCMBroadcastReceiver : BroadcastReceiver() {
 
             if (!isFCMMessage(intent)) {
                 setSuccessfulResultCode()
-                pendingResult.finish()
+                pendingResult?.finish()
                 return@suspendifyOnIO
             }
 
@@ -53,12 +53,12 @@ class FCMBroadcastReceiver : BroadcastReceiver() {
             // Prevent other FCM receivers from firing if work manager is processing the notification
             if (processedResult?.isWorkManagerProcessing == true) {
                 setAbort()
-                pendingResult.finish()
+                pendingResult?.finish()
                 return@suspendifyOnIO
             }
 
             setSuccessfulResultCode()
-            pendingResult.finish()
+            pendingResult?.finish()
         }
     }
 

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/receivers/NotificationDismissReceiver.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/receivers/NotificationDismissReceiver.kt
@@ -44,12 +44,12 @@ class NotificationDismissReceiver : BroadcastReceiver() {
         // goAsync() so the daemon has lead time before the first suspendifyOnIO dispatch.
         OneSignalDispatchers.prewarm()
 
-        val pendingResult = goAsync()
+        val pendingResult: BroadcastReceiver.PendingResult? = goAsync()
 
         suspendifyOnIO {
             if (!OneSignal.initWithContext(context.applicationContext)) {
                 Logging.warn("NotificationOpenedReceiver skipped due to failed OneSignal init")
-                pendingResult.finish()
+                pendingResult?.finish()
                 return@suspendifyOnIO
             }
 
@@ -59,7 +59,7 @@ class NotificationDismissReceiver : BroadcastReceiver() {
             withContext(Dispatchers.Main) {
                 notificationOpenedProcessor.processFromContext(context, intent)
             }
-            pendingResult.finish()
+            pendingResult?.finish()
         }
     }
 }

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/receivers/UpgradeReceiver.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/receivers/UpgradeReceiver.kt
@@ -53,19 +53,19 @@ class UpgradeReceiver : BroadcastReceiver() {
         // goAsync() so the daemon has lead time before the first suspendifyOnIO dispatch.
         OneSignalDispatchers.prewarm()
 
-        val pendingResult = goAsync()
+        val pendingResult: BroadcastReceiver.PendingResult? = goAsync()
 
         // init OneSignal and enqueue restore work in background
         suspendifyOnIO {
             if (!OneSignal.initWithContext(context.applicationContext)) {
                 Logging.warn("UpgradeReceiver skipped due to failed OneSignal init")
-                pendingResult.finish()
+                pendingResult?.finish()
                 return@suspendifyOnIO
             }
 
             val restoreWorkManager = OneSignal.getService<INotificationRestoreWorkManager>()
             restoreWorkManager.beginEnqueueingWork(context, true)
-            pendingResult.finish()
+            pendingResult?.finish()
         }
     }
 }


### PR DESCRIPTION
## Summary

`BroadcastReceiver.goAsync()` returns the Kotlin platform type `PendingResult!`, and the platform contract permits it to return `null` (for example, during background/OEM dispatch such as on vivo devices running Android 14). The receiver code dereferenced the result directly via `pendingResult.finish()`, which could throw a `NullPointerException`.

This NPE was caught and logged by `suspendifyWithCompletion` rather than crashing the host process, but the in-flight work was silently abandoned with no retry.

## Fix

- Declared the result as a nullable type: `val pendingResult: BroadcastReceiver.PendingResult? = goAsync()`.
- Changed every `pendingResult.finish()` call to the null-safe `pendingResult?.finish()` across all four receivers:
  - `FCMBroadcastReceiver`
  - `UpgradeReceiver`
  - `NotificationDismissReceiver`
  - `BootUpReceiver`

No other behavior changed.

## Ticket

Linear: SDK-4803

## Test plan

- [x] `:onesignal:notifications:compileReleaseKotlin` passes
- [x] `:onesignal:notifications:testReleaseUnitTest` passes

Made with [Cursor](https://cursor.com)