### PR TITLE
fix: [SDK-4792] keep devices subscribed when a push token fetch temporarily fails

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/subscriptions/SubscriptionModel.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/subscriptions/SubscriptionModel.kt
@@ -64,7 +64,7 @@ enum class SubscriptionStatus(val value: Int) {
     /** The subscription is not enabled due to a missing HMS library */
     MISSING_HMS_PUSHKIT_LIBRARY(-28),
 
-    /** The subscription is not enabled due to an FCM authentication failed IOException */
+    /** The subscription is not enabled due to an FCM authentication failed IOException, this can be retried */
     FIREBASE_FCM_ERROR_IOEXCEPTION_AUTHENTICATION_FAILED(-29),
 
     /** The subscription is not enabled because the app has disabled the subscription via API */

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/subscriptions/SubscriptionModel.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/subscriptions/SubscriptionModel.kt
@@ -74,7 +74,33 @@ enum class SubscriptionStatus(val value: Int) {
     ERROR(9999),
     ;
 
+    /**
+     * `true` when this status represents a *transient, retryable* failure to fetch a push token
+     * from FCM/HMS (e.g. a temporary IOException, service-unavailable, or init error)
+     *
+     * A retryable token error means "we momentarily couldn't reach FCM/HMS", not "this device can
+     * no longer receive push". It must therefore never downgrade a subscription that is already
+     * [SUBSCRIBED] with a valid token — the next successful registration recovers the token.
+     */
+    val isRetryableTokenError: Boolean
+        get() = this in RETRYABLE_TOKEN_ERRORS
+
     companion object {
+        /**
+         * Transient, retryable token-fetch failures. These are the statuses that should not
+         * overwrite a healthy push subscription.
+         */
+        private val RETRYABLE_TOKEN_ERRORS =
+            setOf(
+                FIREBASE_FCM_INIT_ERROR, // -8
+                FIREBASE_FCM_ERROR_IOEXCEPTION_SERVICE_NOT_AVAILABLE, // -9
+                FIREBASE_FCM_ERROR_IOEXCEPTION_OTHER, // -11
+                FIREBASE_FCM_ERROR_MISC_EXCEPTION, // -12
+                HMS_TOKEN_TIMEOUT, // -25
+                HMS_API_EXCEPTION_OTHER, // -27
+                FIREBASE_FCM_ERROR_IOEXCEPTION_AUTHENTICATION_FAILED, // -29
+            )
+
         fun fromInt(value: Int): SubscriptionStatus? {
             return SubscriptionStatus.values().firstOrNull { it.value == value }
         }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/subscriptions/impl/SubscriptionManager.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/subscriptions/impl/SubscriptionManager.kt
@@ -89,6 +89,19 @@ internal class SubscriptionManager(
                 pushSubModel.address = pushToken
             }
 
+            // A temporary token-fetch failure (no token) shouldn't unsubscribe a device that is
+            // already subscribed with a valid token. Keep the current status.
+            val isTransientTokenlessError = pushToken == null && pushTokenStatus.isRetryableTokenError
+            val isAlreadyHealthy =
+                pushSubModel.status == SubscriptionStatus.SUBSCRIBED && pushSubModel.address.isNotEmpty()
+            if (isTransientTokenlessError && isAlreadyHealthy) {
+                Logging.warn(
+                    "SubscriptionManager: ignoring transient push token status $pushTokenStatus " +
+                        "(${pushTokenStatus.value}).",
+                )
+                return
+            }
+
             pushSubModel.status = pushTokenStatus
         }
     }

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/subscriptions/SubscriptionManagerTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/subscriptions/SubscriptionManagerTests.kt
@@ -2,6 +2,7 @@ package com.onesignal.user.internal.subscriptions
 
 import com.onesignal.common.IDManager.LOCAL_PREFIX
 import com.onesignal.common.PIIHasher
+import com.onesignal.common.modeling.IModelChangedHandler
 import com.onesignal.common.modeling.ModelChangeTags
 import com.onesignal.common.modeling.ModelChangedArgs
 import com.onesignal.core.internal.application.IApplicationService
@@ -659,12 +660,17 @@ class SubscriptionManagerTests : FunSpec({
             val subscriptionManager =
                 SubscriptionManager(mockApplicationService, mockSessionService, mockSubscriptionModelStore)
 
+            val changeHandler = mockk<IModelChangedHandler>(relaxed = true)
+            pushSubscription.subscribe(changeHandler)
+
             // When a failed registration reports a null token alongside the transient error
             subscriptionManager.addOrUpdatePushSubscriptionToken(null, status)
 
             // Then the healthy SUBSCRIBED state and cached token are preserved
             pushSubscription.status shouldBe SubscriptionStatus.SUBSCRIBED
             pushSubscription.address shouldBe "validToken"
+            // And no model change is emitted, so no backend subscription-update operation is generated
+            verify(exactly = 0) { changeHandler.onChanged(any(), any()) }
         }
     }
 
@@ -696,11 +702,16 @@ class SubscriptionManagerTests : FunSpec({
             val subscriptionManager =
                 SubscriptionManager(mockApplicationService, mockSessionService, mockSubscriptionModelStore)
 
+            val changeHandler = mockk<IModelChangedHandler>(relaxed = true)
+            pushSubscription.subscribe(changeHandler)
+
             // When
             subscriptionManager.addOrUpdatePushSubscriptionToken(null, status)
 
             // Then the downgrade is applied
             pushSubscription.status shouldBe status
+            // And the change is emitted so the backend subscription is updated
+            verify(exactly = 1) { changeHandler.onChanged(any(), any()) }
         }
     }
 

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/subscriptions/SubscriptionManagerTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/subscriptions/SubscriptionManagerTests.kt
@@ -5,6 +5,8 @@ import com.onesignal.common.PIIHasher
 import com.onesignal.common.modeling.ModelChangeTags
 import com.onesignal.common.modeling.ModelChangedArgs
 import com.onesignal.core.internal.application.IApplicationService
+import com.onesignal.debug.LogLevel
+import com.onesignal.debug.internal.logging.Logging
 import com.onesignal.session.internal.session.ISessionService
 import com.onesignal.user.internal.Subscription
 import com.onesignal.user.internal.subscriptions.impl.SubscriptionManager
@@ -23,6 +25,10 @@ import io.mockk.spyk
 import io.mockk.verify
 
 class SubscriptionManagerTests : FunSpec({
+
+    beforeAny {
+        Logging.logLevel = LogLevel.NONE
+    }
 
     test("initializes subscriptions from model store") {
         // Given
@@ -182,12 +188,13 @@ class SubscriptionManagerTests : FunSpec({
 
         val subscriptionManager = SubscriptionManager(mockApplicationService, mockSessionService, mockSubscriptionModelStore)
 
-        // When
-        subscriptionManager.addOrUpdatePushSubscriptionToken("pushToken2", SubscriptionStatus.FIREBASE_FCM_ERROR_IOEXCEPTION_OTHER)
+        // When a new token arrives (a successful registration always reports SUBSCRIBED with a
+        // token; an error always reports a null token, never a token paired with an error status)
+        subscriptionManager.addOrUpdatePushSubscriptionToken("pushToken2", SubscriptionStatus.SUBSCRIBED)
 
         // Then
         pushSubscription.address shouldBe "pushToken2"
-        pushSubscription.status shouldBe SubscriptionStatus.FIREBASE_FCM_ERROR_IOEXCEPTION_OTHER
+        pushSubscription.status shouldBe SubscriptionStatus.SUBSCRIBED
     }
 
     test("remove email subscription removes from model store") {
@@ -616,5 +623,173 @@ class SubscriptionManagerTests : FunSpec({
         // Then
         result shouldNotBe null
         result!!.id shouldBe "subscription1"
+    }
+
+    // A transient, tokenless FCM/HMS token-fetch failure (e.g. -9 SERVICE_NOT_AVAILABLE) must not
+    // downgrade a push subscription that is already SUBSCRIBED with a valid cached token. A failed
+    // registration reports a null token alongside the error status, so the cached address is left
+    // intact and persisting the error would spuriously unsubscribe the device on the backend.
+    test("transient tokenless token-fetch error does not downgrade a healthy SUBSCRIBED push subscription") {
+        val retryableErrors =
+            listOf(
+                SubscriptionStatus.FIREBASE_FCM_INIT_ERROR,
+                SubscriptionStatus.FIREBASE_FCM_ERROR_IOEXCEPTION_SERVICE_NOT_AVAILABLE,
+                SubscriptionStatus.FIREBASE_FCM_ERROR_IOEXCEPTION_OTHER,
+                SubscriptionStatus.FIREBASE_FCM_ERROR_MISC_EXCEPTION,
+                SubscriptionStatus.HMS_TOKEN_TIMEOUT,
+                SubscriptionStatus.HMS_API_EXCEPTION_OTHER,
+                SubscriptionStatus.FIREBASE_FCM_ERROR_IOEXCEPTION_AUTHENTICATION_FAILED,
+            )
+
+        for (status in retryableErrors) {
+            // Given a healthy push subscription
+            val pushSubscription = SubscriptionModel()
+            pushSubscription.id = "subscription1"
+            pushSubscription.type = SubscriptionType.PUSH
+            pushSubscription.status = SubscriptionStatus.SUBSCRIBED
+            pushSubscription.optedIn = true
+            pushSubscription.address = "validToken"
+
+            val mockSubscriptionModelStore = mockk<SubscriptionModelStore>()
+            val mockApplicationService = mockk<IApplicationService>()
+            val mockSessionService = mockk<ISessionService>(relaxed = true)
+            every { mockSubscriptionModelStore.subscribe(any()) } just runs
+            every { mockSubscriptionModelStore.list() } returns listOf(pushSubscription)
+
+            val subscriptionManager =
+                SubscriptionManager(mockApplicationService, mockSessionService, mockSubscriptionModelStore)
+
+            // When a failed registration reports a null token alongside the transient error
+            subscriptionManager.addOrUpdatePushSubscriptionToken(null, status)
+
+            // Then the healthy SUBSCRIBED state and cached token are preserved
+            pushSubscription.status shouldBe SubscriptionStatus.SUBSCRIBED
+            pushSubscription.address shouldBe "validToken"
+        }
+    }
+
+    // The guard must be narrow: real opt-outs / permission changes are also tokenless, but they are
+    // not retryable token errors and must continue to downgrade the subscription as before.
+    test("non-retryable tokenless statuses still downgrade a SUBSCRIBED push subscription") {
+        val nonRetryableStatuses =
+            listOf(
+                SubscriptionStatus.NO_PERMISSION,
+                SubscriptionStatus.UNSUBSCRIBE,
+                SubscriptionStatus.DISABLED_FROM_REST_API_DEFAULT_REASON,
+            )
+
+        for (status in nonRetryableStatuses) {
+            // Given a healthy push subscription
+            val pushSubscription = SubscriptionModel()
+            pushSubscription.id = "subscription1"
+            pushSubscription.type = SubscriptionType.PUSH
+            pushSubscription.status = SubscriptionStatus.SUBSCRIBED
+            pushSubscription.optedIn = true
+            pushSubscription.address = "validToken"
+
+            val mockSubscriptionModelStore = mockk<SubscriptionModelStore>()
+            val mockApplicationService = mockk<IApplicationService>()
+            val mockSessionService = mockk<ISessionService>(relaxed = true)
+            every { mockSubscriptionModelStore.subscribe(any()) } just runs
+            every { mockSubscriptionModelStore.list() } returns listOf(pushSubscription)
+
+            val subscriptionManager =
+                SubscriptionManager(mockApplicationService, mockSessionService, mockSubscriptionModelStore)
+
+            // When
+            subscriptionManager.addOrUpdatePushSubscriptionToken(null, status)
+
+            // Then the downgrade is applied
+            pushSubscription.status shouldBe status
+        }
+    }
+
+    test("transient tokenless token-fetch error is persisted when there is no cached token to protect") {
+        // Given a SUBSCRIBED push subscription with no cached token (nothing to protect)
+        val pushSubscription = SubscriptionModel()
+        pushSubscription.id = "subscription1"
+        pushSubscription.type = SubscriptionType.PUSH
+        pushSubscription.status = SubscriptionStatus.SUBSCRIBED
+        pushSubscription.optedIn = true
+        pushSubscription.address = ""
+
+        val mockSubscriptionModelStore = mockk<SubscriptionModelStore>()
+        val mockApplicationService = mockk<IApplicationService>()
+        val mockSessionService = mockk<ISessionService>(relaxed = true)
+        every { mockSubscriptionModelStore.subscribe(any()) } just runs
+        every { mockSubscriptionModelStore.list() } returns listOf(pushSubscription)
+
+        val subscriptionManager =
+            SubscriptionManager(mockApplicationService, mockSessionService, mockSubscriptionModelStore)
+
+        // When
+        subscriptionManager.addOrUpdatePushSubscriptionToken(
+            null,
+            SubscriptionStatus.FIREBASE_FCM_ERROR_IOEXCEPTION_SERVICE_NOT_AVAILABLE,
+        )
+
+        // Then the error is persisted (the guard only protects an already-healthy, tokened subscription)
+        pushSubscription.status shouldBe SubscriptionStatus.FIREBASE_FCM_ERROR_IOEXCEPTION_SERVICE_NOT_AVAILABLE
+    }
+
+    test("transient tokenless token-fetch error is persisted when the subscription is not already SUBSCRIBED") {
+        // Given a push subscription that is already in a non-subscribed state
+        val pushSubscription = SubscriptionModel()
+        pushSubscription.id = "subscription1"
+        pushSubscription.type = SubscriptionType.PUSH
+        pushSubscription.status = SubscriptionStatus.NO_PERMISSION
+        pushSubscription.optedIn = true
+        pushSubscription.address = "validToken"
+
+        val mockSubscriptionModelStore = mockk<SubscriptionModelStore>()
+        val mockApplicationService = mockk<IApplicationService>()
+        val mockSessionService = mockk<ISessionService>(relaxed = true)
+        every { mockSubscriptionModelStore.subscribe(any()) } just runs
+        every { mockSubscriptionModelStore.list() } returns listOf(pushSubscription)
+
+        val subscriptionManager =
+            SubscriptionManager(mockApplicationService, mockSessionService, mockSubscriptionModelStore)
+
+        // When
+        subscriptionManager.addOrUpdatePushSubscriptionToken(
+            null,
+            SubscriptionStatus.FIREBASE_FCM_ERROR_IOEXCEPTION_SERVICE_NOT_AVAILABLE,
+        )
+
+        // Then the status is updated (there is no healthy SUBSCRIBED state to protect)
+        pushSubscription.status shouldBe SubscriptionStatus.FIREBASE_FCM_ERROR_IOEXCEPTION_SERVICE_NOT_AVAILABLE
+    }
+
+    test("SubscriptionStatus.isRetryableTokenError flags exactly the transient token-fetch errors") {
+        // Given the full enum
+        // When filtering by the new flag
+        val retryable = SubscriptionStatus.values().filter { it.isRetryableTokenError }.toSet()
+
+        // Then it is exactly the transient FCM/HMS token-fetch errors and nothing else
+        retryable shouldBe
+            setOf(
+                SubscriptionStatus.FIREBASE_FCM_INIT_ERROR,
+                SubscriptionStatus.FIREBASE_FCM_ERROR_IOEXCEPTION_SERVICE_NOT_AVAILABLE,
+                SubscriptionStatus.FIREBASE_FCM_ERROR_IOEXCEPTION_OTHER,
+                SubscriptionStatus.FIREBASE_FCM_ERROR_MISC_EXCEPTION,
+                SubscriptionStatus.HMS_TOKEN_TIMEOUT,
+                SubscriptionStatus.HMS_API_EXCEPTION_OTHER,
+                SubscriptionStatus.FIREBASE_FCM_ERROR_IOEXCEPTION_AUTHENTICATION_FAILED,
+            )
+    }
+
+    test("SubscriptionStatus.isRetryableTokenError is false for healthy and user-driven statuses") {
+        // SUBSCRIBED, permission/opt-out, and permanent configuration errors must never be treated
+        // as transient, otherwise the guard would mask real subscription state changes.
+        listOf(
+            SubscriptionStatus.SUBSCRIBED,
+            SubscriptionStatus.NO_PERMISSION,
+            SubscriptionStatus.UNSUBSCRIBE,
+            SubscriptionStatus.INVALID_FCM_SENDER_ID,
+            SubscriptionStatus.OUTDATED_GOOGLE_PLAY_SERVICES_APP,
+            SubscriptionStatus.HMS_ARGUMENTS_INVALID,
+            SubscriptionStatus.DISABLED_FROM_REST_API_DEFAULT_REASON,
+            SubscriptionStatus.ERROR,
+        ).forEach { it.isRetryableTokenError shouldBe false }
     }
 })


### PR DESCRIPTION
# Description
## One Line Summary
A temporary push token retrieval error no longer marks an already-subscribed device as unsubscribed.

## Details

### Motivation
Some devices showed as Unsubscribed in OneSignal even though they could still receive push.

When the SDK briefly can't get a push token from FCM/HMS (for example a short network or Google/Huawei service hiccup), it produces an error code such as -9 or -11 with no token in the response. The SDK saved that error onto a subscription that was already subscribed, which told the OneSignal backend the device was unsubscribed.

There was already a check meant to prevent this, but it relied on a value kept **only in memory**. That value is lost when the app process restarts, so opening the app fresh during an outage could still trigger the bug.

### Scope
- The fix is in `SubscriptionManager`, the single place push subscription status is saved. It ignores a temporary, no-token error when the subscription is already subscribed and still has a token. Because it reads the saved subscription, it also holds after an app restart.
- Real unsubscribes are unaffected: turning off notification permission, opting out, or disabling via the REST API are not temporary errors and still update the status.
- Email and SMS subscriptions are untouched, and the normal case of receiving a fresh token still updates as before.

### Other
The error codes treated as temporary (ignored only when a valid token already exists): -8, -9, -11, -12 (FCM), -25, -27 (HMS), and -29 (FCM auth). They're grouped behind a new internal `SubscriptionStatus.isRetryableTokenError` flag.

# Testing
## Unit testing
Added to `SubscriptionManagerTests`:
- For each of the 7 temporary codes: an already-subscribed device with a token stays subscribed and keeps its token.
- Real downgrades (no permission, opt-out, REST API disable) still apply.
- The error is still saved when there is no token to protect, or when the device is not already subscribed.
- The new flag matches exactly those 7 codes and nothing else.
- Fixed an existing test that paired a real token with an error code, a combination that never happens in production (a success always returns a token; an error always returns no token).

## Manual testing
On a device already subscribed with a valid token, forced push registration to return -9 (SERVICE_NOT_AVAILABLE) with no token, then cold-started the app:
- Before this change: the status was overwritten to -9 and the device was marked unsubscribed.
- After this change: the -9 is ignored, the device stays subscribed, and no subscription update is sent.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

Made with [Cursor](https://cursor.com)