### PR TITLE
chore: [SDK-4213] make async init the default in OneSignalImp + startup (part 2/3)

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/startup/StartupService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/startup/StartupService.kt
@@ -2,8 +2,6 @@ package com.onesignal.core.internal.startup
 
 import com.onesignal.common.services.ServiceProvider
 import com.onesignal.common.threading.OneSignalDispatchers
-import com.onesignal.core.internal.features.FeatureFlag
-import com.onesignal.core.internal.features.IFeatureManager
 import com.onesignal.debug.internal.logging.Logging
 
 internal class StartupService(
@@ -16,35 +14,14 @@ internal class StartupService(
     // schedule to start all startable services using OneSignal dispatcher
     @Suppress("TooGenericExceptionCaught")
     fun scheduleStart() {
-        val useBackgroundThreading =
-            try {
-                val featureManager = services.getService<IFeatureManager>()
-                featureManager.isEnabled(FeatureFlag.SDK_BACKGROUND_THREADING)
-            } catch (t: Throwable) {
-                Logging.warn("OneSignal: Failed to resolve BACKGROUND_THREADING in StartupService. Falling back to legacy thread.", t)
-                false
-            }
-
-        if (useBackgroundThreading) {
-            OneSignalDispatchers.launchOnDefault {
-                services.getAllServices<IStartableService>().forEach { startableService ->
-                    try {
-                        startableService.start()
-                    } catch (t: Throwable) {
-                        Logging.error("OneSignal: Startable service failed: ${startableService::class.java.simpleName}", t)
-                    }
+        OneSignalDispatchers.launchOnDefault {
+            services.getAllServices<IStartableService>().forEach { startableService ->
+                try {
+                    startableService.start()
+                } catch (t: Throwable) {
+                    Logging.error("OneSignal: Startable service failed: ${startableService::class.java.simpleName}", t)
                 }
             }
-        } else {
-            Thread {
-                services.getAllServices<IStartableService>().forEach { startableService ->
-                    try {
-                        startableService.start()
-                    } catch (t: Throwable) {
-                        Logging.error("OneSignal: Startable service failed: ${startableService::class.java.simpleName}", t)
-                    }
-                }
-            }.start()
         }
     }
 }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
@@ -18,7 +18,6 @@ import com.onesignal.core.internal.application.impl.ApplicationService
 import com.onesignal.core.internal.config.ConfigModel
 import com.onesignal.core.internal.config.ConfigModelStore
 import com.onesignal.core.internal.config.impl.IdentityVerificationService
-import com.onesignal.core.internal.features.FeatureFlag
 import com.onesignal.core.internal.features.IFeatureManager
 import com.onesignal.core.internal.operations.IOperationRepo
 import com.onesignal.core.internal.preferences.IPreferencesService
@@ -45,13 +44,10 @@ import com.onesignal.user.internal.resolveAppId
 import com.onesignal.user.internal.subscriptions.SubscriptionModelStore
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 
-internal class OneSignalImp(
-    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
-) : IOneSignal,
+internal class OneSignalImp : IOneSignal,
     IServiceProvider {
     // Reset every time the synchronized(initLock) block flips state to IN_PROGRESS so that
     // a retry-after-FAILED gets a fresh latch instead of an already-completed one. Mutated only
@@ -123,23 +119,23 @@ internal class OneSignalImp(
 
     override val session: ISessionManager
         get() =
-            getServiceWithFeatureGate { services.getService() }
+            waitAndReturn { services.getService() }
 
     override val notifications: INotificationsManager
         get() =
-            getServiceWithFeatureGate { services.getService() }
+            waitAndReturn { services.getService() }
 
     override val location: ILocationManager
         get() =
-            getServiceWithFeatureGate { services.getService() }
+            waitAndReturn { services.getService() }
 
     override val inAppMessages: IInAppMessagesManager
         get() =
-            getServiceWithFeatureGate { services.getService() }
+            waitAndReturn { services.getService() }
 
     override val user: IUserManager
         get() =
-            getServiceWithFeatureGate { services.getService() }
+            waitAndReturn { services.getService() }
 
     // Services required by this class
     // WARNING: OperationRepo depends on OperationModelStore which in-turn depends
@@ -178,24 +174,15 @@ internal class OneSignalImp(
                 }
             }.build()
 
-    private val featureManager: IFeatureManager by lazy { services.getService<IFeatureManager>() }
-    private val runtimeIoDispatcher: CoroutineDispatcher
-        get() = if (isBackgroundThreadingEnabled) OneSignalDispatchers.IO else ioDispatcher
-
-    @Suppress("TooGenericExceptionCaught")
-    private val isBackgroundThreadingEnabled: Boolean
-        get() {
-            if (!applicationServiceStarted) {
-                return false
-            }
-
-            return try {
-                featureManager.isEnabled(FeatureFlag.SDK_BACKGROUND_THREADING)
-            } catch (t: Throwable) {
-                Logging.warn("OneSignal: Failed to resolve BACKGROUND_THREADING feature, defaulting to legacy mode.", t)
-                false
-            }
-        }
+    // Off-main work routes through OneSignal's centralized dispatcher pool rather than ad-hoc
+    // threads / Dispatchers.IO.
+    //
+    // Resolved per-access (get()) rather than captured once: an eager `val` would construct the
+    // lazy `pools.IO` dispatcher during OneSignalImp construction on the main thread (before
+    // prewarm() runs), and would pin this instance to one pool generation -- so after
+    // resetForTest() swaps `pools` and shutdownNow()'s the old executor, a reused instance would
+    // dispatch onto a dead pool. The getter always reads the current generation's warm dispatcher.
+    private val ioDispatcher: CoroutineDispatcher get() = OneSignalDispatchers.IO
 
     // get the current config model, if there is one
     private val configModel: ConfigModel by lazy { services.getService<ConfigModelStore>().model }
@@ -304,6 +291,16 @@ internal class OneSignalImp(
         return startupService
     }
 
+    /**
+     * Fire-and-forget init. The actual work runs asynchronously on the IO pool, so this method
+     * cannot know the real outcome before it returns.
+     *
+     * Return value: always `true` once init has been kicked off (or is already in progress/done).
+     * It does NOT reflect init success — a failure surfaces later, either via a subsequent
+     * accessor throwing or by querying [isInitialized]. Callers (including wrapper SDKs) must not
+     * branch on this boolean to detect init failure; use the suspending [initWithContextSuspend],
+     * which returns an accurate result, when the outcome matters.
+     */
     @Suppress("ReturnCount", "TooGenericExceptionCaught")
     override fun initWithContext(
         context: Context,
@@ -313,10 +310,8 @@ internal class OneSignalImp(
 
         // Warm OneSignalDispatchers on a dedicated daemon thread so the first production caller
         // of suspendifyOnIO / launchOnSerialIO doesn't pay the ThreadPoolExecutor + dispatcher +
-        // scope construction cost on the main thread. See SDK-4507; OTel showed that cost as
-        // 5–20s main-thread blocks at first foreground/background lifecycle event under
-        // sdk_background_threading. Calling prewarm() is idempotent, fire-and-forget, and safe
-        // even if a prior initWithContext attempt already started the prewarm.
+        // scope construction cost on the main thread (observed as 5-20s main-thread blocks at the
+        // first foreground/background lifecycle event). prewarm() is idempotent and fire-and-forget.
         OneSignalDispatchers.prewarm()
 
         synchronized(initLock) {
@@ -350,26 +345,12 @@ internal class OneSignalImp(
             throw e
         }
 
-        if (isBackgroundThreadingEnabled) {
-            // FF-on: dispatch init asynchronously so this method never blocks the caller.
-            // Callers that need to wait (accessors, login, logout) will block via suspendCompletion.
-            suspendifyOnIO {
-                internalInit(context, appId)
-            }
-            return true
-        }
-
-        // FF-off: legacy behavior. Block the caller thread until initialization completes.
-        // [internalInit] owns its own terminal-state cleanup on failure (catches, transitions
-        // to FAILED via [completeInit], returns `false` with the cause attached to
-        // `initFailureException.suppressed`) so the caller gets `false` returned through
-        // `runBlocking` and a subsequent accessor surfaces the failure cause via
-        // [waitUntilInitInternal]. The synchronous-bootstrap throw above (the only path that
-        // can throw out of `initWithContext`) is preserved by the `try { ensureApplicationServiceStarted }`
-        // catch — same shape pre-#2605 callers got from runBlocking propagation.
-        return runBlocking(runtimeIoDispatcher) {
+        // Dispatch init asynchronously so this method never blocks the caller. Callers that
+        // need to wait (accessors, login, logout) will block via suspendCompletion.
+        suspendifyOnIO {
             internalInit(context, appId)
         }
+        return true
     }
 
     /**
@@ -434,10 +415,9 @@ internal class OneSignalImp(
             // `await()`. Reach a terminal state via [completeInit] (atomic state+completion) and
             // return `false`. The throw is captured on `initFailureException.addSuppressed(...)`
             // so a subsequent accessor surfaces it to the caller. We deliberately don't rethrow
-            // here: the FF-on `suspendifyOnIO { ... }` arm would swallow it anyway, the FF-off
-            // `runBlocking { ... }` arm would propagate it, and the [initWithContextSuspend]
-            // path would propagate it — three different observable behaviors for the same kind
-            // of failure. `return false` gives one consistent shape; callers can query
+            // here: the synchronous [initWithContext] dispatches this via `suspendifyOnIO { ... }`
+            // (which has no caller to rethrow to), so returning `false` on every path — including
+            // [initWithContextSuspend] — gives one consistent shape. Callers can query
             // `initFailureException` (or just the returned `Boolean`) to react.
             Logging.error("OneSignal: internalInit threw unexpectedly; marking init FAILED", e)
             initFailureException?.addSuppressed(e)
@@ -452,45 +432,21 @@ internal class OneSignalImp(
     ) {
         Logging.log(LogLevel.DEBUG, "Calling deprecated login(externalId: $externalId, jwtBearerToken: ...${jwtBearerToken?.takeLast(8)})")
 
-        if (isBackgroundThreadingEnabled) {
-            waitForInit(operationName = "login")
-        } else {
-            requireInitForOperation("login")
-        }
+        waitForInit(operationName = "login")
 
         val context = loginHelper.switchUser(externalId, jwtBearerToken) ?: return
 
-        if (isBackgroundThreadingEnabled) {
-            suspendifyOnIO { loginHelper.enqueueLogin(context) }
-        } else {
-            Thread {
-                runBlocking(runtimeIoDispatcher) {
-                    loginHelper.enqueueLogin(context)
-                }
-            }.start()
-        }
+        suspendifyOnIO { loginHelper.enqueueLogin(context) }
     }
 
     override fun logout() {
         Logging.log(LogLevel.DEBUG, "Calling deprecated logout()")
 
-        if (isBackgroundThreadingEnabled) {
-            waitForInit(operationName = "logout")
-        } else {
-            requireInitForOperation("logout")
-        }
+        waitForInit(operationName = "logout")
 
         val context = logoutHelper.switchUser() ?: return
 
-        if (isBackgroundThreadingEnabled) {
-            suspendifyOnIO { logoutHelper.enqueueLogout(context) }
-        } else {
-            Thread {
-                runBlocking(runtimeIoDispatcher) {
-                    logoutHelper.enqueueLogout(context)
-                }
-            }.start()
-        }
+        suspendifyOnIO { logoutHelper.enqueueLogout(context) }
     }
 
     override fun updateUserJwt(
@@ -499,13 +455,7 @@ internal class OneSignalImp(
     ) {
         Logging.log(LogLevel.DEBUG, "updateUserJwt(externalId: $externalId, token: ...${token.takeLast(8)})")
 
-        if (isBackgroundThreadingEnabled) {
-            waitForInit(operationName = "updateUserJwt")
-        } else {
-            if (!isInitialized) {
-                throw IllegalStateException("Must call 'initWithContext' before 'updateUserJwt'")
-            }
-        }
+        waitForInit(operationName = "updateUserJwt")
 
         jwtTokenStore.putJwt(externalId, token)
         // Wake the queue so any deferred ops can dispatch with the fresh token.
@@ -513,24 +463,12 @@ internal class OneSignalImp(
     }
 
     override fun addUserJwtInvalidatedListener(listener: IUserJwtInvalidatedListener) {
-        if (isBackgroundThreadingEnabled) {
-            waitForInit(operationName = "addUserJwtInvalidatedListener")
-        } else {
-            if (!isInitialized) {
-                throw IllegalStateException("Must call 'initWithContext' before 'addUserJwtInvalidatedListener'")
-            }
-        }
+        waitForInit(operationName = "addUserJwtInvalidatedListener")
         jwtTokenStore.addUserJwtInvalidatedListener(listener)
     }
 
     override fun removeUserJwtInvalidatedListener(listener: IUserJwtInvalidatedListener) {
-        if (isBackgroundThreadingEnabled) {
-            waitForInit(operationName = "removeUserJwtInvalidatedListener")
-        } else {
-            if (!isInitialized) {
-                throw IllegalStateException("Must call 'initWithContext' before 'removeUserJwtInvalidatedListener'")
-            }
-        }
+        waitForInit(operationName = "removeUserJwtInvalidatedListener")
         jwtTokenStore.removeUserJwtInvalidatedListener(listener)
     }
 
@@ -541,65 +479,6 @@ internal class OneSignalImp(
     override fun <T> getServiceOrNull(c: Class<T>): T? = services.getServiceOrNull(c)
 
     override fun <T> getAllServices(c: Class<T>): List<T> = services.getAllServices(c)
-
-    /**
-     * Ensures initialization is complete before proceeding with an operation.
-     * Blocks if init is in progress; throws immediately if not started or failed.
-     */
-    @Suppress("UseCheckOrError")
-    private fun requireInitForOperation(operationName: String) {
-        when (initState) {
-            InitState.NOT_STARTED -> {
-                throw IllegalStateException("Must call 'initWithContext' before '$operationName'")
-            }
-
-            InitState.IN_PROGRESS -> {
-                warnIfBlockingOnMainThread(operationName)
-                waitForInit(operationName = operationName)
-            }
-
-            InitState.FAILED -> {
-                throw initFailureException
-                    ?: IllegalStateException("Initialization failed before '$operationName'")
-            }
-
-            InitState.SUCCESS -> {}
-        }
-    }
-
-    /**
-     * Surfaces the narrow race in legacy (FF-off) mode where [initWithContext] is running on a
-     * background thread (so it's still IN_PROGRESS) and a *concurrent* call on the main thread
-     * — an accessor via [getServiceWithFeatureGate], or [login]/[logout] via
-     * [requireInitForOperation] — falls into the IN_PROGRESS branch and blocks on
-     * [runBlocking] inside [waitForInit] / [waitAndReturn]. The common case (init called from
-     * the main thread) doesn't hit this path because [initWithContext] itself blocks the caller
-     * via `runBlocking`, so by the time any accessor runs init is already SUCCESS or FAILED.
-     *
-     * FF-on mode already accepts the ANR-vs-throw trade-off (see [waitUntilInitInternal]); the
-     * warning is short-circuited there.
-     */
-    @Suppress("TooGenericExceptionCaught", "ReturnCount")
-    private fun warnIfBlockingOnMainThread(operationName: String?) {
-        if (isBackgroundThreadingEnabled) return
-        val onMain =
-            try {
-                AndroidUtils.isRunningOnMainThread()
-            } catch (e: RuntimeException) {
-                // Looper.getMainLooper() may be unavailable in test environments — skip the warning.
-                Logging.debug("Could not determine main-thread status; skipping ANR-risk warning: ${e.message}")
-                return
-            }
-        if (!onMain) return
-        val target = operationName?.let { "'$it'" } ?: "this OneSignal API"
-        Logging.warn(
-            "Calling $target on the main thread while OneSignal initialization is still in progress. " +
-                "This will block the UI thread until init completes (ANR risk on slow devices). " +
-                "Prefer calling from a background thread, or use the suspend API " +
-                "(OneSignal.initWithContextSuspend, OneSignal.getUser(), OneSignal.loginSuspend(), etc.) " +
-                "from a coroutine.",
-        )
-    }
 
     /**
      * Blocking version that waits for initialization to complete.
@@ -698,12 +577,10 @@ internal class OneSignalImp(
 
         // Wait indefinitely until init actually completes - ensures consistent state
         // Function only returns when initState is SUCCESS or FAILED
-        // NOTE: This is a suspend function, so it's non-blocking when called from coroutines.
-        // However, if waitForInit() (which uses runBlocking) is called from the main thread,
-        // it will block the main thread indefinitely until init completes, which can cause ANRs.
-        // This is intentional per PR #2412: "ANR is the lesser of two evils and the app can recover,
-        // where an uncaught throw it can not." To avoid ANRs, call SDK methods from background threads
-        // or use the suspend API from coroutines.
+        // Non-blocking when called from coroutines. But if waitForInit() (which uses runBlocking)
+        // is called from the main thread, it blocks the main thread until init completes, which can
+        // ANR. This is intentional: an ANR is recoverable, an uncaught throw is not. To avoid it,
+        // call SDK methods from background threads or use the suspend API.
         completionToAwait.await()
 
         // Log how long initialization took
@@ -728,34 +605,11 @@ internal class OneSignalImp(
         return getter()
     }
 
+    // Blocks until init completes; [waitForInit] throws on NOT_STARTED / FAILED and
+    // returns once initState == SUCCESS.
     private fun <T> waitAndReturn(getter: () -> T): T {
         waitForInit()
         return getter()
-    }
-
-    private fun <T> getServiceWithFeatureGate(getter: () -> T): T {
-        if (isBackgroundThreadingEnabled) {
-            return waitAndReturn(getter)
-        }
-        return when (initState) {
-            InitState.SUCCESS -> {
-                getter()
-            }
-
-            InitState.IN_PROGRESS -> {
-                warnIfBlockingOnMainThread(operationName = null)
-                waitAndReturn(getter)
-            }
-
-            InitState.FAILED -> {
-                throw initFailureException
-                    ?: IllegalStateException("Initialization failed. Cannot proceed.")
-            }
-
-            InitState.NOT_STARTED -> {
-                throw IllegalStateException("Must call 'initWithContext' before use")
-            }
-        }
     }
 
     private fun <T> blockingGet(getter: () -> T): T {
@@ -783,48 +637,48 @@ internal class OneSignalImp(
     // ===============================
 
     override suspend fun getSession(): ISessionManager =
-        withContext(runtimeIoDispatcher) {
+        withContext(ioDispatcher) {
             suspendAndReturn { services.getService() }
         }
 
     override suspend fun getNotifications(): INotificationsManager =
-        withContext(runtimeIoDispatcher) {
+        withContext(ioDispatcher) {
             suspendAndReturn { services.getService() }
         }
 
     override suspend fun getLocation(): ILocationManager =
-        withContext(runtimeIoDispatcher) {
+        withContext(ioDispatcher) {
             suspendAndReturn { services.getService() }
         }
 
     override suspend fun getInAppMessages(): IInAppMessagesManager =
-        withContext(runtimeIoDispatcher) {
+        withContext(ioDispatcher) {
             suspendAndReturn { services.getService() }
         }
 
     override suspend fun getUser(): IUserManager =
-        withContext(runtimeIoDispatcher) {
+        withContext(ioDispatcher) {
             suspendAndReturn { services.getService() }
         }
 
     override suspend fun getConsentRequired(): Boolean =
-        withContext(runtimeIoDispatcher) {
+        withContext(ioDispatcher) {
             configModel.consentRequired ?: (_consentRequired == true)
         }
 
     override suspend fun setConsentRequired(required: Boolean) =
-        withContext(runtimeIoDispatcher) {
+        withContext(ioDispatcher) {
             _consentRequired = required
             configModel.consentRequired = required
         }
 
     override suspend fun getConsentGiven(): Boolean =
-        withContext(runtimeIoDispatcher) {
+        withContext(ioDispatcher) {
             configModel.consentGiven ?: (_consentGiven == true)
         }
 
     override suspend fun setConsentGiven(value: Boolean) =
-        withContext(runtimeIoDispatcher) {
+        withContext(ioDispatcher) {
             val oldValue = _consentGiven
             _consentGiven = value
             configModel.consentGiven = value
@@ -834,12 +688,12 @@ internal class OneSignalImp(
         }
 
     override suspend fun getDisableGMSMissingPrompt(): Boolean =
-        withContext(runtimeIoDispatcher) {
+        withContext(ioDispatcher) {
             configModel.disableGMSMissingPrompt
         }
 
     override suspend fun setDisableGMSMissingPrompt(value: Boolean) =
-        withContext(runtimeIoDispatcher) {
+        withContext(ioDispatcher) {
             _disableGMSMissingPrompt = value
             configModel.disableGMSMissingPrompt = value
         }
@@ -850,14 +704,14 @@ internal class OneSignalImp(
     ): Boolean {
         Logging.log(LogLevel.DEBUG, "initWithContext(context: $context, appId: $appId)")
 
-        // Same SDK-4507 warm-up as the synchronous variant. Reaching this entry point on the
-        // main thread (e.g. SyncJobService.onStartJob -> suspendifyOnIO -> initWithContext(context))
-        // pays the cold-init cost on the dispatcher used to enter [withContext] below, so warm
-        // OneSignalDispatchers on a background thread before we touch [runtimeIoDispatcher].
+        // Same warm-up as the synchronous variant. Reaching this entry point on the main thread
+        // (e.g. SyncJobService.onStartJob -> suspendifyOnIO -> initWithContext(context)) pays the
+        // cold-init cost on the dispatcher used to enter [withContext] below, so warm
+        // OneSignalDispatchers on a background thread before we touch [ioDispatcher].
         OneSignalDispatchers.prewarm()
 
         // Use IO dispatcher for initialization to prevent ANRs and optimize for I/O operations
-        return withContext(runtimeIoDispatcher) {
+        return withContext(ioDispatcher) {
             val shouldRunInit: Boolean
             // Local-capture under the lock so that even if a concurrent retry-after-FAILED
             // resets `suspendCompletion`, we await on the same generation we observed.
@@ -883,7 +737,7 @@ internal class OneSignalImp(
                 // Another caller has already started (or completed) init. Honor this method's
                 // contract by suspending until initialization is *fully* completed -- not just
                 // kicked off. This closes a race where re-entrant suspend callers (e.g. the
-                // SyncJobService entry point under SDK_BACKGROUND_THREADING) would otherwise
+                // SyncJobService entry point) would otherwise
                 // proceed to use IBackgroundService implementations like SessionService whose
                 // bootstrap() had not yet run, NPE'ing on still-null model fields.
                 Logging.log(LogLevel.DEBUG, "initWithContext: init already in progress or completed, awaiting completion")
@@ -899,7 +753,7 @@ internal class OneSignalImp(
     override suspend fun loginSuspend(
         externalId: String,
         jwtBearerToken: String?,
-    ) = withContext(runtimeIoDispatcher) {
+    ) = withContext(ioDispatcher) {
         Logging.log(LogLevel.DEBUG, "login(externalId: $externalId, jwtBearerToken: ...${jwtBearerToken?.takeLast(8)})")
 
         // suspendUntilInit throws on NOT_STARTED / FAILED (preserving initFailureException as the
@@ -913,7 +767,7 @@ internal class OneSignalImp(
     override suspend fun updateUserJwtSuspend(
         externalId: String,
         token: String,
-    ) = withContext(runtimeIoDispatcher) {
+    ) = withContext(ioDispatcher) {
         Logging.log(LogLevel.DEBUG, "updateUserJwtSuspend(externalId: $externalId, token: ...${token.takeLast(8)})")
 
         suspendUntilInit(operationName = "updateUserJwt")
@@ -927,7 +781,7 @@ internal class OneSignalImp(
     }
 
     override suspend fun logoutSuspend() =
-        withContext(runtimeIoDispatcher) {
+        withContext(ioDispatcher) {
             Logging.log(LogLevel.DEBUG, "logoutSuspend()")
 
             suspendUntilInit(operationName = "logout")

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/application/SDKInitTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/application/SDKInitTests.kt
@@ -7,13 +7,8 @@ import androidx.test.core.app.ApplicationProvider.getApplicationContext
 import br.com.colman.kotest.android.extensions.robolectric.RobolectricTest
 import com.onesignal.common.AndroidUtils
 import com.onesignal.common.threading.OneSignalDispatchers
-import com.onesignal.common.threading.ThreadingMode
-import com.onesignal.core.internal.config.ConfigModelStore
-import com.onesignal.core.internal.features.FeatureFlag
 import com.onesignal.core.internal.preferences.PreferenceOneSignalKeys.PREFS_LEGACY_APP_ID
-import com.onesignal.debug.ILogListener
 import com.onesignal.debug.LogLevel
-import com.onesignal.debug.OneSignalLogEvent
 import com.onesignal.debug.internal.logging.Logging
 import com.onesignal.internal.OneSignalImp
 import io.kotest.assertions.throwables.shouldThrow
@@ -50,11 +45,6 @@ class SDKInitTests : FunSpec({
         oneSignalImp.isInitialized shouldBe true
     }
 
-    fun enableBackgroundThreadingBeforeInit(oneSignalImp: OneSignalImp) {
-        oneSignalImp.getService(ConfigModelStore::class.java).model.sdkRemoteFeatureFlags =
-            listOf(FeatureFlag.SDK_BACKGROUND_THREADING.key)
-    }
-
     fun withSaturatedOneSignalIo(block: () -> Unit) {
         val running = CountDownLatch(2)
         val release = CountDownLatch(1)
@@ -83,6 +73,9 @@ class SDKInitTests : FunSpec({
                     error.set(t)
                 }
             }
+        // Daemon so a stuck waitForInit() (e.g. if a dispatch is rejected under pool pressure)
+        // can never keep the test JVM alive and trip the 6h CI timeout (SDK-4213).
+        thread.isDaemon = true
         thread.start()
         thread.join(2_000)
 
@@ -92,17 +85,9 @@ class SDKInitTests : FunSpec({
 
     beforeAny {
         Logging.logLevel = LogLevel.NONE
-        // FF-off (legacy mode) is the default; most tests in this file exercise that contract.
-        // FF-on tests opt in per-test via [enableBackgroundThreadingBeforeInit], which seeds the
-        // flag straight onto `configModelStore.model.sdkRemoteFeatureFlags` (no SharedPreferences
-        // planting), so `featureManager.isEnabled(SDK_BACKGROUND_THREADING)` resolves true.
-        ThreadingMode.useBackgroundThreading = false
     }
 
     afterAny {
-        // Reset FF state so a test setting it to true can't leak into the next test.
-        ThreadingMode.useBackgroundThreading = false
-
         val context = getApplicationContext<Context>()
         val prefs = context.getSharedPreferences("OneSignal", Context.MODE_PRIVATE)
         prefs.edit()
@@ -173,7 +158,11 @@ class SDKInitTests : FunSpec({
         os.initWithContext(context, "appId")
 
         // Then
-        // returns gracefully but isInitialized should be false
+        // Init runs asynchronously and fails the locked-storage check, transitioning to FAILED.
+        // Reading an accessor blocks until that terminal state and surfaces the failure.
+        shouldThrow<IllegalStateException> {
+            os.user.onesignalId
+        }
         os.isInitialized shouldBe false
 
         unmockkObject(AndroidUtils)
@@ -199,12 +188,8 @@ class SDKInitTests : FunSpec({
 
     test("initWithContext with no appId succeeds when configModel has appId") {
         // Given
-        // block SharedPreference before calling init
-        val trigger = CountDownLatch(1)
         val context = getApplicationContext<Context>()
-        val blockingPrefContext = BlockingPrefsContext(context, trigger)
         val os = OneSignalImp()
-        var initSuccess = true
 
         // Clear any existing appId from previous tests by clearing SharedPreferences
         val prefs = context.getSharedPreferences("OneSignal", Context.MODE_PRIVATE)
@@ -218,59 +203,29 @@ class SDKInitTests : FunSpec({
             .putString(PREFS_LEGACY_APP_ID, "testAppId") // Set legacy appId
             .commit()
 
-        // When
-        val accessorThread =
-            Thread {
-                // this will block until after SharedPreferences is released
-                runBlocking {
-                    initSuccess = os.initWithContext(blockingPrefContext)
-                }
-            }
+        // When - no appId passed; resolved from the legacy SharedPreferences value.
+        os.initWithContext(context)
 
-        accessorThread.start()
-        accessorThread.join(500)
-
-        accessorThread.isAlive shouldBe true
-
-        // release SharedPreferences
-        trigger.countDown()
-
-        accessorThread.join(500)
-        accessorThread.isAlive shouldBe false
-
-        // Should return true because configModel already has an appId from previous tests
-        initSuccess shouldBe true
+        // Then - init completes successfully because an appId was resolvable.
+        waitForInitialization(os)
         os.isInitialized shouldBe true
     }
 
-    test("initWithContext blocks caller until init completes when SDK_BACKGROUND_THREADING is off") {
-        // FF-off contract (matches main pre-#2605): initWithContext runs internalInit on the
-        // caller thread via runBlocking and only returns once init reaches a terminal state.
-        // Pinned so future restructures don't silently flip legacy callers to the async shape
-        // without an explicit FF flip.
-        ThreadingMode.useBackgroundThreading shouldBe false // belt-and-suspenders w/ beforeAny
-
+    test("initWithContext returns immediately and completes init asynchronously") {
+        // Background-threaded init is the default: initWithContext dispatches internalInit to a
+        // background dispatcher and returns immediately, even while internalInit is parked on a
+        // slow SharedPreferences read. isInitialized only flips to true once init completes.
         val trigger = CountDownLatch(1)
         val context = getApplicationContext<Context>()
         val blockingPrefContext = BlockingPrefsContext(context, trigger)
         val os = OneSignalImp()
 
-        val initThread =
-            Thread {
-                os.initWithContext(blockingPrefContext, "appId")
-            }
-        initThread.start()
-        initThread.join(500)
-
-        // initWithContext is parked inside runBlocking { internalInit } waiting on
-        // BlockingPrefsContext.unblockTrigger.await() — proves the legacy synchronous path is
-        // active.
-        initThread.isAlive shouldBe true
+        // Returns right away despite the blocked prefs read happening on the background worker.
+        os.initWithContext(blockingPrefContext, "appId") shouldBe true
         os.isInitialized shouldBe false
 
         trigger.countDown()
-        initThread.join(2_000)
-        initThread.isAlive shouldBe false
+        waitForInitialization(os)
         os.isInitialized shouldBe true
     }
 
@@ -288,6 +243,8 @@ class SDKInitTests : FunSpec({
                 os.user // This should block until either trigger is released or timed out
             }
 
+        // Daemon so a stuck waitForInit() can never keep the test JVM alive (SDK-4213 CI hang).
+        accessorThread.isDaemon = true
         accessorThread.start()
         accessorThread.join(500)
 
@@ -340,6 +297,8 @@ class SDKInitTests : FunSpec({
                 }
             }
 
+        // Daemon so a stuck waitForInit() can never keep the test JVM alive (SDK-4213 CI hang).
+        accessorThread.isDaemon = true
         accessorThread.start()
         accessorThread.join(500)
 
@@ -556,79 +515,12 @@ class SDKInitTests : FunSpec({
         waitForInitialization(os)
     }
 
-    test("legacy mode logs guidance when accessor on main thread blocks during in-progress init") {
-        // Given (FF-off): initWithContext on a background thread is parked inside
-        // runBlocking { internalInit } waiting on shared-prefs access. A *concurrent* call on
-        // the main thread (mocked) — accessor or login/logout — falls into the IN_PROGRESS
-        // branch of getServiceWithFeatureGate / requireInitForOperation and would block on
-        // runBlocking { suspendCompletion.await() }. Before that block, warnIfBlockingOnMainThread
-        // logs a warning so the ANR-risk shape is visible. The common case (init + accessor on
-        // the same thread) doesn't hit this — initWithContext blocks the caller, so by the time
-        // any accessor runs init is already SUCCESS or FAILED.
-        val trigger = CountDownLatch(1)
-        val context = getApplicationContext<Context>()
-        val blockingPrefContext = BlockingPrefsContext(context, trigger)
-        val os = OneSignalImp()
-        val warnings = mutableListOf<String>()
-        val listener =
-            ILogListener { event: OneSignalLogEvent ->
-                if (event.level == LogLevel.WARN) warnings.add(event.entry)
-            }
-
-        mockkObject(AndroidUtils)
-        every { AndroidUtils.isAndroidUserUnlocked(any()) } returns true
-        every { AndroidUtils.isRunningOnMainThread() } returns true
-
-        os.debug.addLogListener(listener)
-        try {
-            // initWithContext runs on a background thread under FF-off so it doesn't block this
-            // test thread; it parks inside runBlocking on BlockingPrefsContext.unblockTrigger.
-            val initThread =
-                Thread {
-                    os.initWithContext(blockingPrefContext, "appId")
-                }
-            initThread.start()
-            // Give the init thread time to enter runBlocking and stall on the prefs read.
-            Thread.sleep(100)
-            os.isInitialized shouldBe false
-
-            // Concurrent accessor on a "main" thread (isRunningOnMainThread mocked to true) hits
-            // the IN_PROGRESS branch and the warning fires.
-            val accessorThread =
-                Thread {
-                    runCatching { os.user.onesignalId }
-                }
-            accessorThread.start()
-            // Let warnIfBlockingOnMainThread log before we tear down.
-            Thread.sleep(100)
-
-            // Release prefs so init + accessor unwind cleanly.
-            trigger.countDown()
-            initThread.join(2_000)
-            accessorThread.join(2_000)
-            initThread.isAlive shouldBe false
-            accessorThread.isAlive shouldBe false
-
-            // Then: a warning must have been emitted with actionable guidance.
-            val match = warnings.firstOrNull { it.contains("OneSignal initialization is still in progress") }
-            match shouldNotBe null
-            (match!!.contains("main thread")) shouldBe true
-            (match.contains("suspend API")) shouldBe true
-        } finally {
-            os.debug.removeLogListener(listener)
-            // Ensure any waiter is released even if assertions failed early.
-            if (trigger.count > 0) trigger.countDown()
-            unmockkObject(AndroidUtils)
-        }
-    }
-
-    test("FF-on accessor returns once init is SUCCESS even when the IO dispatcher is saturated (OneSignal-Flutter-SDK#1163)") {
-        // Regression test for the Flutter main-thread ANR. Under SDK_BACKGROUND_THREADING,
-        // getServiceWithFeatureGate used to ALWAYS route through
-        // waitAndReturn -> waitForInit -> runBlocking(OneSignalDispatchers.IO), even after init
-        // had already reached SUCCESS. On Flutter's main-thread lifecycleInit that parks the UI
-        // thread on a cold-start-contended IO pool (OneSignal-Flutter-SDK#1163). The fix adds a
-        // lock-free SUCCESS fast-path, centralized in waitForInit().
+    test("accessor returns once init is SUCCESS even when the IO dispatcher is saturated (OneSignal-Flutter-SDK#1163)") {
+        // Regression test for the Flutter main-thread ANR. getServiceWithFeatureGate used to
+        // ALWAYS route through waitAndReturn -> waitForInit -> runBlocking(OneSignalDispatchers.IO),
+        // even after init had already reached SUCCESS. On Flutter's main-thread lifecycleInit that
+        // parks the UI thread on a cold-start-contended IO pool (OneSignal-Flutter-SDK#1163). The
+        // fix adds a lock-free SUCCESS fast-path, centralized in waitForInit().
         //
         // We reproduce the contention faithfully: saturate OneSignalDispatchers.IO so that the
         // pre-fix runBlocking(OneSignalDispatchers.IO) would park indefinitely behind the busy
@@ -637,12 +529,8 @@ class SDKInitTests : FunSpec({
         val context = getApplicationContext<Context>()
         val os = OneSignalImp()
 
-        // SDK_BACKGROUND_THREADING is APP_STARTUP-latched, so seed it before init first resolves
-        // FeatureManager. This exercises the real FF-on branch without spying on OneSignalImp.
-        enableBackgroundThreadingBeforeInit(os)
         os.initWithContext(context, "appId")
         waitForInitialization(os)
-        ThreadingMode.useBackgroundThreading shouldBe true
 
         withSaturatedOneSignalIo {
             // When: a SUCCESS-state accessor is read while the IO pool is fully saturated.
@@ -655,21 +543,17 @@ class SDKInitTests : FunSpec({
         }
     }
 
-    test("FF-on login returns once init is SUCCESS even when the IO dispatcher is saturated (OneSignal-Flutter-SDK#1163)") {
+    test("login returns once init is SUCCESS even when the IO dispatcher is saturated (OneSignal-Flutter-SDK#1163)") {
         // Companion regression test proving the SUCCESS fast-path is centralized in waitForInit(),
         // so it covers the operation paths (login / logout / updateUserJwt / JWT listeners), not
-        // just the service accessors. Under SDK_BACKGROUND_THREADING, login() used to route through
+        // just the service accessors. login() used to route through
         // waitForInit -> runBlocking(OneSignalDispatchers.IO) even after init reached SUCCESS, so a
         // saturated IO pool would park the caller indefinitely.
         val context = getApplicationContext<Context>()
         val os = OneSignalImp()
 
-        // SDK_BACKGROUND_THREADING is APP_STARTUP-latched, so seed it before init first resolves
-        // FeatureManager. This exercises the real FF-on branch without spying on OneSignalImp.
-        enableBackgroundThreadingBeforeInit(os)
         os.initWithContext(context, "appId")
         waitForInitialization(os)
-        ThreadingMode.useBackgroundThreading shouldBe true
 
         withSaturatedOneSignalIo {
             // When: login() is invoked while the IO pool is fully saturated. waitForInit must
@@ -682,14 +566,12 @@ class SDKInitTests : FunSpec({
         }
     }
 
-    test("FF-on consent getters return once init is SUCCESS even when the IO dispatcher is saturated") {
+    test("consent getters return once init is SUCCESS even when the IO dispatcher is saturated") {
         val context = getApplicationContext<Context>()
         val os = OneSignalImp()
 
-        enableBackgroundThreadingBeforeInit(os)
         os.initWithContext(context, "appId")
         waitForInitialization(os)
-        ThreadingMode.useBackgroundThreading shouldBe true
 
         withSaturatedOneSignalIo {
             val results = arrayOfNulls<Boolean>(3)
@@ -731,7 +613,7 @@ class SDKInitTests : FunSpec({
         exception.message shouldBe "Must call 'initWithContext' before 'logout'"
     }
 
-    // Regression test for the SessionService NPE under SDK_BACKGROUND_THREADING.
+    // Regression test for the SessionService NPE during in-flight background init.
     //
     // Background: when init is in flight, internalInit() has not yet called bootstrapServices(),
     // which means IBootstrapService implementations like SessionService have null model fields.

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/startup/StartupServiceTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/startup/StartupServiceTests.kt
@@ -2,8 +2,6 @@ package com.onesignal.core.internal.startup
 
 import com.onesignal.common.services.ServiceBuilder
 import com.onesignal.common.services.ServiceProvider
-import com.onesignal.core.internal.features.FeatureFlag
-import com.onesignal.core.internal.features.IFeatureManager
 import com.onesignal.debug.LogLevel
 import com.onesignal.debug.internal.logging.Logging
 import com.onesignal.mocks.IOMockHelper
@@ -16,21 +14,13 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.verify
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
 
 class StartupServiceTests : FunSpec({
     fun setupServiceProvider(
         bootstrapServices: List<IBootstrapService>,
         startableServices: List<IStartableService>,
-        backgroundThreadingEnabled: Boolean = true,
     ): ServiceProvider {
-        val featureManager = mockk<IFeatureManager>()
-        every { featureManager.isEnabled(FeatureFlag.SDK_BACKGROUND_THREADING) } returns backgroundThreadingEnabled
-        every { featureManager.remoteFeatureFlagMetadata() } returns null
-
         val serviceBuilder = ServiceBuilder()
-        serviceBuilder.register(featureManager).provides<IFeatureManager>()
         for (reg in bootstrapServices)
             serviceBuilder.register(reg).provides<IBootstrapService>()
         for (reg in startableServices)
@@ -103,32 +93,6 @@ class StartupServiceTests : FunSpec({
 
         // Then - wait deterministically for both services to start using IOMockHelper
         awaitIO()
-        verify(exactly = 1) { mockStartupService1.start() }
-        verify(exactly = 1) { mockStartupService2.start() }
-    }
-
-    test("startup will call all IStartableService dependencies when BACKGROUND_THREADING is off") {
-        // Given
-        val latch = CountDownLatch(2)
-        val mockStartupService1 = mockk<IStartableService>(relaxed = true)
-        val mockStartupService2 = mockk<IStartableService>(relaxed = true)
-        every { mockStartupService1.start() } answers { latch.countDown() }
-        every { mockStartupService2.start() } answers { latch.countDown() }
-
-        val startupService =
-            StartupService(
-                setupServiceProvider(
-                    listOf(),
-                    listOf(mockStartupService1, mockStartupService2),
-                    backgroundThreadingEnabled = false
-                )
-            )
-
-        // When
-        startupService.scheduleStart()
-
-        // Then
-        latch.await(1, TimeUnit.SECONDS) shouldBe true
         verify(exactly = 1) { mockStartupService1.start() }
         verify(exactly = 1) { mockStartupService2.start() }
     }

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/internal/OneSignalImpTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/internal/OneSignalImpTests.kt
@@ -6,26 +6,14 @@ import io.kotest.assertions.throwables.shouldThrowUnit
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.CoroutineDispatcher
 import java.lang.reflect.InvocationTargetException
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
-import kotlin.coroutines.CoroutineContext
 
 class OneSignalImpTests : FunSpec({
     beforeAny {
         Logging.logLevel = LogLevel.NONE
     }
-
-    val throwingDispatcher =
-        object : CoroutineDispatcher() {
-            override fun dispatch(
-                context: CoroutineContext,
-                block: Runnable,
-            ) {
-                error("SUCCESS fast-path should not dispatch")
-            }
-        }
 
     fun markInitialized(os: OneSignalImp) {
         val initStateField = OneSignalImp::class.java.getDeclaredField("initState")
@@ -72,7 +60,7 @@ class OneSignalImpTests : FunSpec({
     }
 
     test("waitForInit returns synchronously without dispatching when initState is SUCCESS") {
-        val os = OneSignalImp(ioDispatcher = throwingDispatcher)
+        val os = OneSignalImp()
         markInitialized(os)
 
         val waitForInit = OneSignalImp::class.java.getDeclaredMethod("waitForInit", String::class.java)
@@ -83,7 +71,7 @@ class OneSignalImpTests : FunSpec({
     }
 
     test("blockingGet returns synchronously without dispatching when initState is SUCCESS") {
-        val os = OneSignalImp(ioDispatcher = throwingDispatcher)
+        val os = OneSignalImp()
         markInitialized(os)
 
         val blockingGet = OneSignalImp::class.java.getDeclaredMethod("blockingGet", Function0::class.java)
@@ -93,12 +81,11 @@ class OneSignalImpTests : FunSpec({
         blockingGet.invoke(os, getter) shouldBe "value"
     }
 
-    test("waitForInit at IN_PROGRESS awaits the completion signal without dispatching to the IO dispatcher") {
-        // Under FF-off, runtimeIoDispatcher == ioDispatcher (the throwing dispatcher). Pre-fix the
-        // IN_PROGRESS wait ran runBlocking(runtimeIoDispatcher) { ... }, coupling it to a dispatcher
-        // that can never run the body (models a saturated IO pool). Post-fix the wait runs on the
-        // caller's own event loop and resumes off the completion signal alone (#1163).
-        val os = OneSignalImp(ioDispatcher = throwingDispatcher)
+    test("waitForInit at IN_PROGRESS awaits the completion signal on the caller's event loop") {
+        // The IN_PROGRESS wait uses a dispatcher-less runBlocking so it resumes on the caller's
+        // own event loop off the completion signal alone, rather than depending on a free worker
+        // in a (possibly saturated) IO pool (#1163).
+        val os = OneSignalImp()
         setPrivateField(os, "initState", InitState.IN_PROGRESS)
         val deferred = CompletableDeferred<Unit>()
         setPrivateField(os, "suspendCompletion", deferred)


### PR DESCRIPTION
## Summary
Part 2 of 3 of the SDK-4213 stack. **Stacked on https://github.com/OneSignal/OneSignal-Android-SDK/pull/2672 — review/merge after part 1.**

Drops feature-flag branching from initialization:
- `OneSignalImp` always runs init asynchronously on the dispatcher pool; suspend/blocking wait paths kept consistent.
- Removes the dead `getServiceWithFeatureGate` pass-through.
- `StartupService` no longer gates on the flag.
- Updates `SDKInitTests`, `OneSignalImpTests`, `StartupServiceTests`.

## Test plan
- [ ] CI green on the full stack (part 3)
- [ ] init/startup unit tests pass

Made with [Cursor](https://cursor.com)