### PR TITLE
chore: [SDK-4213] route consumer call-sites through serial IO (part 3/3)

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/background/impl/BackgroundManager.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/background/impl/BackgroundManager.kt
@@ -32,7 +32,7 @@ import android.content.ComponentName
 import android.content.Context
 import android.content.pm.PackageManager
 import androidx.core.content.ContextCompat
-import com.onesignal.common.threading.runOnSerialIOIfBackgroundThreading
+import com.onesignal.common.threading.runOnSerialIO
 import com.onesignal.core.internal.application.IApplicationLifecycleHandler
 import com.onesignal.core.internal.application.IApplicationService
 import com.onesignal.core.internal.background.IBackgroundManager
@@ -73,13 +73,13 @@ internal class BackgroundManager(
 
     // JobScheduler.cancel/schedule are synchronous Binder calls; on some devices they block the
     // main thread for seconds (SDK-4505). Offload to SerialIO so a rapid unfocus -> focus burst
-    // still runs cancel-then-schedule in submission order. FF gates the rollout.
+    // still runs cancel-then-schedule in submission order.
     override fun onFocus(firedOnSubscribe: Boolean) {
-        runOnSerialIOIfBackgroundThreading { cancelSyncTask() }
+        runOnSerialIO { cancelSyncTask() }
     }
 
     override fun onUnfocused() {
-        runOnSerialIOIfBackgroundThreading { scheduleBackground() }
+        runOnSerialIO { scheduleBackground() }
     }
 
     private fun scheduleBackground() {

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/debug/internal/crash/OneSignalCrashUploaderWrapper.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/debug/internal/crash/OneSignalCrashUploaderWrapper.kt
@@ -2,14 +2,12 @@ package com.onesignal.debug.internal.crash
 
 import com.onesignal.common.threading.OneSignalDispatchers
 import com.onesignal.core.internal.application.IApplicationService
-import com.onesignal.core.internal.features.FeatureFlag
 import com.onesignal.core.internal.features.IFeatureManager
 import com.onesignal.core.internal.startup.IStartableService
 import com.onesignal.debug.internal.logging.otel.android.AndroidOtelLogger
 import com.onesignal.debug.internal.logging.otel.android.createAndroidOtelPlatformProvider
 import com.onesignal.otel.OtelFactory
 import com.onesignal.otel.crash.OtelCrashUploader
-import kotlinx.coroutines.runBlocking
 
 /**
  * Android-specific wrapper for OtelCrashUploader that implements IStartableService.
@@ -51,29 +49,15 @@ internal class OneSignalCrashUploaderWrapper(
     @Suppress("TooGenericExceptionCaught")
     override fun start() {
         if (!OtelSdkSupport.isSupported) return
-        if (featureManager.isEnabled(FeatureFlag.SDK_BACKGROUND_THREADING)) {
-            OneSignalDispatchers.launchOnIO {
-                try {
-                    uploader.start()
-                } catch (t: Throwable) {
-                    com.onesignal.debug.internal.logging.Logging.warn(
-                        "OneSignal: Crash uploader failed to start: ${t.message}",
-                        t,
-                    )
-                }
-            }
-            return
-        }
-
-        Thread {
+        OneSignalDispatchers.launchOnIO {
             try {
-                runBlocking { uploader.start() }
+                uploader.start()
             } catch (t: Throwable) {
                 com.onesignal.debug.internal.logging.Logging.warn(
                     "OneSignal: Crash uploader failed to start: ${t.message}",
                     t,
                 )
             }
-        }.start()
+        }
     }
 }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/session/internal/session/impl/SessionService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/session/internal/session/impl/SessionService.kt
@@ -1,7 +1,7 @@
 package com.onesignal.session.internal.session.impl
 
 import com.onesignal.common.events.EventProducer
-import com.onesignal.common.threading.runOnSerialIOIfBackgroundThreading
+import com.onesignal.common.threading.runOnSerialIO
 import com.onesignal.core.internal.application.IApplicationLifecycleHandler
 import com.onesignal.core.internal.application.IApplicationService
 import com.onesignal.core.internal.background.IBackgroundService
@@ -45,7 +45,7 @@ internal class SessionService(
      * Run in the background when the session would time out, only if a session is currently active.
      *
      * Returns null if [bootstrap] has not yet run -- callers that invoke us before bootstrap
-     * (possible under SDK_BACKGROUND_THREADING when init is still in flight) should treat this
+     * (possible when init is still in flight) should treat this
      * as "no schedule needed" rather than crashing on a null-deref.
      */
     override val scheduleBackgroundRunIn: Long?
@@ -82,7 +82,7 @@ internal class SessionService(
 
     private fun endSession() {
         // Defensive: if bootstrap() has not run yet, there is no session state to end.
-        // This can happen under SDK_BACKGROUND_THREADING when SyncJobService races with
+        // This can happen when SyncJobService races with
         // an in-flight initWithContext that has not yet reached bootstrapServices().
         val session = this.session ?: return
         if (!session.isValid) return
@@ -107,7 +107,7 @@ internal class SessionService(
         // Capture focus time on the caller's thread so session timestamps reflect lifecycle
         // arrival, not dispatcher latency (SDK-4506).
         val focusTimeMs = _time.currentTimeMillis
-        runOnSerialIOIfBackgroundThreading {
+        runOnSerialIO {
             handleOnFocus(firedOnSubscribe, focusTimeMs)
         }
     }
@@ -150,7 +150,7 @@ internal class SessionService(
     override fun onUnfocused() {
         // Capture on the caller's thread so activeDuration is unaffected by dispatcher latency.
         val unfocusTimeMs = _time.currentTimeMillis
-        runOnSerialIOIfBackgroundThreading {
+        runOnSerialIO {
             handleOnUnfocused(unfocusTimeMs)
         }
     }

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/background/impl/BackgroundManagerTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/background/impl/BackgroundManagerTests.kt
@@ -1,10 +1,6 @@
 package com.onesignal.core.internal.background.impl
 
-import android.app.job.JobScheduler
-import android.content.Context
 import com.onesignal.common.threading.OneSignalDispatchers
-import com.onesignal.common.threading.ThreadingMode
-import com.onesignal.core.internal.application.IApplicationService
 import com.onesignal.debug.LogLevel
 import com.onesignal.debug.internal.logging.Logging
 import com.onesignal.mocks.MockHelper
@@ -18,44 +14,21 @@ import io.mockk.verifyOrder
 import kotlinx.coroutines.Job
 
 /**
- * Regression coverage for SDK-4505. Asserts the two-pronged behavior of
- * BackgroundManager.onFocus / onUnfocused:
- *
- *   FF on  (sdk_background_threading enabled)
- *     -> route through OneSignalDispatchers.launchOnSerialIO so the
- *        JobScheduler Binder call doesn't run inline on the main thread
- *        (the ANR fix), and rapid bursts stay in submission order (the
- *        serial-dispatcher refinement).
- *
- *   FF off
- *     -> legacy inline path. cancelSyncTask / scheduleBackground execute
- *        on the calling thread; no dispatcher is involved. This is the
- *        control cohort for the gated rollout.
+ * Asserts that BackgroundManager.onFocus / onUnfocused route through
+ * OneSignalDispatchers.launchOnSerialIO so the JobScheduler Binder call doesn't run inline on the
+ * main thread (avoiding an ANR), and that rapid bursts stay in submission order.
  */
 class BackgroundManagerTests : FunSpec({
 
-    fun applicationServiceWithStubbedJobScheduler(): IApplicationService {
-        val appService = MockHelper.applicationService()
-        val context = mockk<Context>(relaxed = true)
-        val jobScheduler = mockk<JobScheduler>(relaxed = true)
-        every { appService.appContext } returns context
-        every { context.getSystemService(Context.JOB_SCHEDULER_SERVICE) } returns jobScheduler
-        every { jobScheduler.allPendingJobs } returns emptyList()
-        return appService
-    }
-
     beforeEach {
         Logging.logLevel = LogLevel.NONE
-        ThreadingMode.useBackgroundThreading = false
     }
 
     afterEach {
         unmockkObject(OneSignalDispatchers)
-        ThreadingMode.useBackgroundThreading = false
     }
 
-    test("FF on: onFocus routes through OneSignalDispatchers.launchOnSerialIO") {
-        ThreadingMode.useBackgroundThreading = true
+    test("onFocus routes through OneSignalDispatchers.launchOnSerialIO") {
         mockkObject(OneSignalDispatchers)
         every { OneSignalDispatchers.launchOnSerialIO(any<suspend () -> Unit>()) } returns mockk<Job>(relaxed = true)
 
@@ -71,8 +44,7 @@ class BackgroundManagerTests : FunSpec({
         verify(exactly = 1) { OneSignalDispatchers.launchOnSerialIO(any<suspend () -> Unit>()) }
     }
 
-    test("FF on: onUnfocused routes through OneSignalDispatchers.launchOnSerialIO") {
-        ThreadingMode.useBackgroundThreading = true
+    test("onUnfocused routes through OneSignalDispatchers.launchOnSerialIO") {
         mockkObject(OneSignalDispatchers)
         every { OneSignalDispatchers.launchOnSerialIO(any<suspend () -> Unit>()) } returns mockk<Job>(relaxed = true)
 
@@ -88,8 +60,7 @@ class BackgroundManagerTests : FunSpec({
         verify(exactly = 1) { OneSignalDispatchers.launchOnSerialIO(any<suspend () -> Unit>()) }
     }
 
-    test("FF on: rapid unfocus -> focus burst submits both events to the serial dispatcher in order") {
-        ThreadingMode.useBackgroundThreading = true
+    test("rapid unfocus -> focus burst submits both events to the serial dispatcher in order") {
         mockkObject(OneSignalDispatchers)
         every { OneSignalDispatchers.launchOnSerialIO(any<suspend () -> Unit>()) } returns mockk<Job>(relaxed = true)
 
@@ -100,9 +71,9 @@ class BackgroundManagerTests : FunSpec({
                 emptyList(),
             )
 
-        // Simulate the user backgrounding then immediately foregrounding the app on the
-        // main thread (the SDK-4505 reproducer). Both calls must route through the same
-        // serial dispatcher so the IO worker observes them in this submission order.
+        // Simulate the user backgrounding then immediately foregrounding the app on the main
+        // thread. Both calls must route through the same serial dispatcher so the IO worker
+        // observes them in this submission order.
         backgroundManager.onUnfocused()
         backgroundManager.onFocus(firedOnSubscribe = false)
 
@@ -111,39 +82,5 @@ class BackgroundManagerTests : FunSpec({
             OneSignalDispatchers.launchOnSerialIO(any<suspend () -> Unit>())
             OneSignalDispatchers.launchOnSerialIO(any<suspend () -> Unit>())
         }
-    }
-
-    test("FF off: onFocus runs inline and does NOT dispatch to the serial dispatcher") {
-        ThreadingMode.useBackgroundThreading = false
-        mockkObject(OneSignalDispatchers)
-        every { OneSignalDispatchers.launchOnSerialIO(any<suspend () -> Unit>()) } returns mockk<Job>(relaxed = true)
-
-        val backgroundManager =
-            BackgroundManager(
-                applicationServiceWithStubbedJobScheduler(),
-                MockHelper.time(0L),
-                emptyList(),
-            )
-
-        backgroundManager.onFocus(firedOnSubscribe = false)
-
-        verify(exactly = 0) { OneSignalDispatchers.launchOnSerialIO(any<suspend () -> Unit>()) }
-    }
-
-    test("FF off: onUnfocused runs inline and does NOT dispatch to the serial dispatcher") {
-        ThreadingMode.useBackgroundThreading = false
-        mockkObject(OneSignalDispatchers)
-        every { OneSignalDispatchers.launchOnSerialIO(any<suspend () -> Unit>()) } returns mockk<Job>(relaxed = true)
-
-        val backgroundManager =
-            BackgroundManager(
-                applicationServiceWithStubbedJobScheduler(),
-                MockHelper.time(0L),
-                emptyList(),
-            )
-
-        backgroundManager.onUnfocused()
-
-        verify(exactly = 0) { OneSignalDispatchers.launchOnSerialIO(any<suspend () -> Unit>()) }
     }
 })

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/debug/internal/crash/OneSignalCrashUploaderWrapperTest.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/debug/internal/crash/OneSignalCrashUploaderWrapperTest.kt
@@ -7,7 +7,6 @@ import androidx.test.core.app.ApplicationProvider
 import br.com.colman.kotest.android.extensions.robolectric.RobolectricTest
 import com.onesignal.core.internal.application.IApplicationService
 import com.onesignal.core.internal.config.ConfigModel
-import com.onesignal.core.internal.features.FeatureFlag
 import com.onesignal.core.internal.features.IFeatureManager
 import com.onesignal.core.internal.preferences.PreferenceOneSignalKeys
 import com.onesignal.core.internal.preferences.PreferenceStores
@@ -39,11 +38,9 @@ class OneSignalCrashUploaderWrapperTest : FunSpec({
         sharedPreferences.edit().clear().commit()
     }
 
-    fun mockFeatureManager(backgroundThreadingEnabled: Boolean = true): IFeatureManager {
+    fun mockFeatureManager(): IFeatureManager {
         val featureManager = mockk<IFeatureManager>()
-        every { featureManager.isEnabled(FeatureFlag.SDK_BACKGROUND_THREADING) } returns backgroundThreadingEnabled
-        every { featureManager.enabledFeatureKeys() } returns
-            if (backgroundThreadingEnabled) listOf(FeatureFlag.SDK_BACKGROUND_THREADING.key) else emptyList()
+        every { featureManager.enabledFeatureKeys() } returns emptyList()
         every { featureManager.remoteFeatureFlagMetadata() } returns null
         return featureManager
     }
@@ -95,7 +92,7 @@ class OneSignalCrashUploaderWrapperTest : FunSpec({
         val mockApplicationService = mockk<IApplicationService>(relaxed = true)
         every { mockApplicationService.appContext } returns appContext
 
-        val wrapper = OneSignalCrashUploaderWrapper(mockApplicationService, mockFeatureManager(backgroundThreadingEnabled = false))
+        val wrapper = OneSignalCrashUploaderWrapper(mockApplicationService, mockFeatureManager())
 
         // Multiple calls should not throw
         runBlocking {

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/session/internal/session/SessionServiceTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/session/internal/session/SessionServiceTests.kt
@@ -1,7 +1,8 @@
 package com.onesignal.session.internal.session
 
 import com.onesignal.common.threading.OneSignalDispatchers
-import com.onesignal.common.threading.runOnSerialIOIfBackgroundThreading
+import com.onesignal.common.threading.runOnSerialIO
+import com.onesignal.mocks.IOMockHelper
 import com.onesignal.mocks.MockHelper
 import com.onesignal.session.internal.session.impl.SessionService
 import io.kotest.core.spec.style.FunSpec
@@ -37,6 +38,13 @@ private class Mocks {
 }
 
 class SessionServiceTests : FunSpec({
+    // SessionService.onFocus/onUnfocused dispatch their state mutation through the now-always-async
+    // runOnSerialIO. IOMockHelper.beforeSpec stubs runOnSerialIO to run inline so the tests below
+    // can assert session state synchronously after the call. The SDK-4508 tests further down
+    // re-mock/unmock runOnSerialIO themselves to assert the dispatch contract; they run last, so
+    // their finally-unmock does not affect the earlier inline-dispatch tests.
+    listener(IOMockHelper)
+
     test("session created on focus when current session invalid") {
         // Given
         val mocks = Mocks()
@@ -175,12 +183,12 @@ class SessionServiceTests : FunSpec({
         verify(exactly = 0) { mocks.spyCallback.onSessionEnded(any()) }
     }
 
-    test("onFocus dispatches the session-mutation body through runOnSerialIOIfBackgroundThreading (SDK-4508)") {
+    test("onFocus dispatches the session-mutation body through runOnSerialIO (SDK-4508)") {
         // SDK-4508: SessionService.onFocus runs on the main thread via
         // ApplicationService.handleFocus -> applicationLifecycleNotifier.fire. Its body fires
         // session lifecycle handlers (operation repo, IAM trigger eval, etc.) which can in turn
         // touch OneSignalDispatchers' cold-init chain. The fix wraps the body in
-        // runOnSerialIOIfBackgroundThreading; this test pins down the dispatch contract.
+        // runOnSerialIO; this test pins down the dispatch contract.
         //
         // Stub the helper as a pass-through so the underlying state mutations still happen
         // (`startTime`, `focusTime`, lifecycle-handler fires) and the existing assertions
@@ -188,7 +196,7 @@ class SessionServiceTests : FunSpec({
         val threadUtilsPath = "com.onesignal.common.threading.ThreadUtilsKt"
         mockkStatic(threadUtilsPath)
         mockkObject(OneSignalDispatchers)
-        every { runOnSerialIOIfBackgroundThreading(any<() -> Unit>()) } answers {
+        every { runOnSerialIO(any<() -> Unit>()) } answers {
             firstArg<() -> Unit>().invoke()
         }
         every { OneSignalDispatchers.launchOnSerialIO(any<suspend () -> Unit>()) } returns mockk<Job>(relaxed = true)
@@ -202,18 +210,18 @@ class SessionServiceTests : FunSpec({
 
             sessionService.onFocus(firedOnSubscribe = false)
 
-            verify(exactly = 1) { runOnSerialIOIfBackgroundThreading(any<() -> Unit>()) }
+            verify(exactly = 1) { runOnSerialIO(any<() -> Unit>()) }
         } finally {
             unmockkObject(OneSignalDispatchers)
             unmockkStatic(threadUtilsPath)
         }
     }
 
-    test("onUnfocused dispatches the activeDuration update through runOnSerialIOIfBackgroundThreading (SDK-4508)") {
+    test("onUnfocused dispatches the activeDuration update through runOnSerialIO (SDK-4508)") {
         val threadUtilsPath = "com.onesignal.common.threading.ThreadUtilsKt"
         mockkStatic(threadUtilsPath)
         mockkObject(OneSignalDispatchers)
-        every { runOnSerialIOIfBackgroundThreading(any<() -> Unit>()) } answers {
+        every { runOnSerialIO(any<() -> Unit>()) } answers {
             firstArg<() -> Unit>().invoke()
         }
         every { OneSignalDispatchers.launchOnSerialIO(any<suspend () -> Unit>()) } returns mockk<Job>(relaxed = true)
@@ -230,23 +238,23 @@ class SessionServiceTests : FunSpec({
 
             sessionService.onUnfocused()
 
-            verify(exactly = 1) { runOnSerialIOIfBackgroundThreading(any<() -> Unit>()) }
+            verify(exactly = 1) { runOnSerialIO(any<() -> Unit>()) }
         } finally {
             unmockkObject(OneSignalDispatchers)
             unmockkStatic(threadUtilsPath)
         }
     }
 
-    test("rapid onUnfocused -> onFocus burst dispatches each event through the gated helper in submission order (SDK-4508)") {
+    test("rapid onUnfocused -> onFocus burst dispatches each event through the serial IO helper in submission order (SDK-4508)") {
         // Mirrors the SDK-4505 BackgroundManager burst test. Real-world scenario: the user
         // backgrounds then immediately re-foregrounds the app on the main thread. Both lifecycle
-        // events must route through the same gated helper in submission order so the serial IO
+        // events must route through the same serial IO helper in submission order so the serial IO
         // worker sees focusTime / activeDuration mutations in main-thread arrival order. If they
         // ever raced across the IO pool, activeDuration accounting could drift.
         val threadUtilsPath = "com.onesignal.common.threading.ThreadUtilsKt"
         mockkStatic(threadUtilsPath)
         mockkObject(OneSignalDispatchers)
-        every { runOnSerialIOIfBackgroundThreading(any<() -> Unit>()) } just runs
+        every { runOnSerialIO(any<() -> Unit>()) } just runs
         every { OneSignalDispatchers.launchOnSerialIO(any<suspend () -> Unit>()) } returns mockk<Job>(relaxed = true)
 
         try {
@@ -259,10 +267,10 @@ class SessionServiceTests : FunSpec({
             sessionService.onUnfocused()
             sessionService.onFocus(firedOnSubscribe = false)
 
-            verify(exactly = 2) { runOnSerialIOIfBackgroundThreading(any<() -> Unit>()) }
+            verify(exactly = 2) { runOnSerialIO(any<() -> Unit>()) }
             verifyOrder {
-                runOnSerialIOIfBackgroundThreading(any<() -> Unit>())
-                runOnSerialIOIfBackgroundThreading(any<() -> Unit>())
+                runOnSerialIO(any<() -> Unit>())
+                runOnSerialIO(any<() -> Unit>())
             }
         } finally {
             unmockkObject(OneSignalDispatchers)

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/NotificationsManager.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/NotificationsManager.kt
@@ -2,7 +2,7 @@ package com.onesignal.notifications.internal
 
 import android.app.Activity
 import com.onesignal.common.events.EventProducer
-import com.onesignal.common.threading.runOnSerialIOIfBackgroundThreading
+import com.onesignal.common.threading.runOnSerialIO
 import com.onesignal.common.threading.suspendifyOnIO
 import com.onesignal.core.internal.application.IApplicationLifecycleHandler
 import com.onesignal.core.internal.application.IApplicationService
@@ -63,7 +63,7 @@ internal class NotificationsManager(
     // (opens/migrates its SQLite store) and can block the main thread for seconds on slow storage
     // (SDK-4506).
     override fun onFocus(firedOnSubscribe: Boolean) {
-        runOnSerialIOIfBackgroundThreading { refreshNotificationState() }
+        runOnSerialIO { refreshNotificationState() }
     }
 
     override fun onUnfocused() {

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/permissions/impl/NotificationPermissionController.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/permissions/impl/NotificationPermissionController.kt
@@ -35,7 +35,7 @@ import com.onesignal.common.events.EventProducer
 import com.onesignal.common.threading.Waiter
 import com.onesignal.common.threading.WaiterWithValue
 import com.onesignal.common.threading.launchOnIO
-import com.onesignal.common.threading.runOnSerialIOIfBackgroundThreading
+import com.onesignal.common.threading.runOnSerialIO
 import com.onesignal.core.activities.PermissionsActivity
 import com.onesignal.core.internal.application.ApplicationLifecycleHandlerBase
 import com.onesignal.core.internal.application.IActivityLifecycleHandler
@@ -93,7 +93,7 @@ internal class NotificationPermissionController(
                 // main thread (SDK-4506).
                 override fun onFocus(firedOnSubscribe: Boolean) {
                     super.onFocus(firedOnSubscribe)
-                    runOnSerialIOIfBackgroundThreading {
+                    runOnSerialIO {
                         pollingWaitInterval = _configModelStore.model.foregroundFetchNotificationPermissionInterval
                         pollingWaiter.wake()
                     }
@@ -101,7 +101,7 @@ internal class NotificationPermissionController(
 
                 override fun onUnfocused() {
                     super.onUnfocused()
-                    runOnSerialIOIfBackgroundThreading {
+                    runOnSerialIO {
                         // Changing the polling interval to 1 day to effectively pause polling
                         pollingWaitInterval = _configModelStore.model.backgroundFetchNotificationPermissionInterval
                     }

--- a/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/NotificationsManagerTests.kt
+++ b/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/NotificationsManagerTests.kt
@@ -2,7 +2,7 @@ package com.onesignal.notifications.internal
 
 import androidx.test.core.app.ApplicationProvider
 import br.com.colman.kotest.android.extensions.robolectric.RobolectricTest
-import com.onesignal.common.threading.runOnSerialIOIfBackgroundThreading
+import com.onesignal.common.threading.runOnSerialIO
 import com.onesignal.common.threading.suspendifyOnIO
 import com.onesignal.core.internal.application.IApplicationService
 import com.onesignal.debug.LogLevel
@@ -37,12 +37,10 @@ import org.robolectric.annotation.Config
  * SQLite store on first call) inline, and the SQLite write stalled the main thread on
  * devices with slow / contended storage.
  *
- * The fix routes through `runOnSerialIOIfBackgroundThreading` — gated on the
- * `SDK_BACKGROUND_THREADING` remote feature flag so we can A/B compare the offloaded
- * behavior (FF on → serial IO dispatch) against the previous inline behavior (FF off →
- * main thread) in production. These tests assert the dispatch contract on `onFocus`; the
- * helper's two branches are tested in `:core` against `ThreadUtilsTests`, which has direct
- * access to the internal `ThreadingMode` flag.
+ * The fix routes through `runOnSerialIO`, which offloads the work to the serial IO
+ * dispatcher instead of running it inline on the main thread. These tests assert the
+ * dispatch contract on `onFocus`; the helper itself is tested in `:core` against
+ * `ThreadUtilsDispatchTests`.
  *
  * `suspendifyOnIO` is also stubbed because `NotificationsManager`'s init block fires it for
  * `deleteExpiredNotifications`; without the stub a real coroutine would leak past test
@@ -62,7 +60,7 @@ class NotificationsManagerTests : FunSpec({
         Logging.logLevel = LogLevel.NONE
         ShadowRoboNotificationManager.reset()
         mockkStatic(threadUtilsPath)
-        every { runOnSerialIOIfBackgroundThreading(any<() -> Unit>()) } just runs
+        every { runOnSerialIO(any<() -> Unit>()) } just runs
         every { suspendifyOnIO(any<suspend () -> Unit>()) } just runs
     }
 
@@ -95,29 +93,29 @@ class NotificationsManagerTests : FunSpec({
         )
     }
 
-    test("onFocus dispatches refreshNotificationState through runOnSerialIOIfBackgroundThreading") {
+    test("onFocus dispatches refreshNotificationState through runOnSerialIO") {
         val manager = newManager()
 
         manager.onFocus(firedOnSubscribe = false)
 
-        verify(exactly = 1) { runOnSerialIOIfBackgroundThreading(any<() -> Unit>()) }
+        verify(exactly = 1) { runOnSerialIO(any<() -> Unit>()) }
     }
 
-    test("rapid onFocus burst dispatches each event through the gated helper in submission order") {
+    test("rapid onFocus burst dispatches each event through the serial IO helper in submission order") {
         val manager = newManager()
 
         // Two focus events in quick succession on the main thread (e.g. activity restart
-        // bouncing between activities). Both must route through the same gated helper in
+        // bouncing between activities). Both must route through the same serial IO helper in
         // submission order — same defense the BackgroundManager burst test enforces for
         // its `schedule`/`cancel` pair, ensuring future per-event work added here observes
-        // events in main-thread arrival order under the FF-on branch.
+        // events in main-thread arrival order.
         manager.onFocus(firedOnSubscribe = false)
         manager.onFocus(firedOnSubscribe = false)
 
-        verify(exactly = 2) { runOnSerialIOIfBackgroundThreading(any<() -> Unit>()) }
+        verify(exactly = 2) { runOnSerialIO(any<() -> Unit>()) }
         verifyOrder {
-            runOnSerialIOIfBackgroundThreading(any<() -> Unit>())
-            runOnSerialIOIfBackgroundThreading(any<() -> Unit>())
+            runOnSerialIO(any<() -> Unit>())
+            runOnSerialIO(any<() -> Unit>())
         }
     }
 })

--- a/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/generation/NotificationGenerationProcessorTests.kt
+++ b/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/generation/NotificationGenerationProcessorTests.kt
@@ -1,6 +1,7 @@
 package com.onesignal.notifications.internal.generation
 
 import android.content.Context
+import com.onesignal.common.threading.OneSignalDispatchers
 import com.onesignal.common.threading.suspendifyOnIO
 import com.onesignal.debug.LogLevel
 import com.onesignal.debug.internal.logging.Logging
@@ -23,7 +24,12 @@ import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.runs
 import io.mockk.spyk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
 import org.json.JSONObject
 
@@ -99,8 +105,23 @@ private class Mocks {
 class NotificationGenerationProcessorTests : FunSpec({
     listener(IOMockHelper)
 
+    // processNotificationData bounds the external callbacks with `withTimeout { launchOnIO { … }.join() }`.
+    // IOMockHelper stubs launchOnIO to run inline via runBlocking, which blocks the calling thread inside
+    // waitForWake() and defeats withTimeout (the suite hangs forever on the preventDefault-without-display
+    // cases). Restore the production async semantics for launchOnIO in this spec by dispatching on a large
+    // Dispatchers.IO-backed scope (mirroring the prior GlobalScope.launch(Dispatchers.IO) path) so .join()
+    // suspends and withTimeout can cancel it. The scope is cancelled in afterSpec to drop any callback
+    // coroutine still parked in waitForWake().
+    val callbackScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    afterSpec { callbackScope.cancel() }
+
     beforeAny {
         Logging.logLevel = LogLevel.NONE
+
+        every { OneSignalDispatchers.launchOnIO(any<suspend () -> Unit>()) } answers {
+            val block = firstArg<suspend () -> Unit>()
+            callbackScope.launch { block() }
+        }
 
         mockkStatic(android.text.TextUtils::class)
         every { android.text.TextUtils.isEmpty(any()) } answers { firstArg<CharSequence?>()?.isEmpty() ?: true }
@@ -282,10 +303,10 @@ class NotificationGenerationProcessorTests : FunSpec({
     test("processNotificationData allows the will display callback to prevent default behavior twice") {
         // Given
         val mocks = Mocks()
-        // Bump the callback timeout from the suite default (10ms). Top-level launchOnIO falls
-        // through to GlobalScope.launch(Dispatchers.IO) (it's not stubbed by IOMockHelper),
-        // and on slow CI runners the IO scheduler can take longer than 10ms to dispatch the
-        // callback, causing withTimeout to cancel before discard is ever set.
+        // Bump the callback timeout from the suite default (10ms). launchOnIO is dispatched on a
+        // real Dispatchers.IO-backed scope in this spec (see the beforeAny override), and on slow
+        // CI runners the IO scheduler can take longer than 10ms to dispatch the callback, causing
+        // withTimeout to cancel before discard is ever set.
         every { mocks.notificationGenerationProcessor getProperty "EXTERNAL_CALLBACKS_TIMEOUT" } answers { 1_000L }
         coEvery { mocks.notificationDisplayer.displayNotification(any()) } returns true
         coEvery { mocks.notificationLifecycleService.externalRemoteNotificationReceived(any()) } just runs

--- a/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/permission/NotificationPermissionControllerTests.kt
+++ b/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/permission/NotificationPermissionControllerTests.kt
@@ -4,7 +4,7 @@ import android.app.Activity
 import androidx.test.core.app.ApplicationProvider
 import br.com.colman.kotest.android.extensions.robolectric.RobolectricTest
 import com.onesignal.common.threading.OneSignalDispatchers
-import com.onesignal.common.threading.runOnSerialIOIfBackgroundThreading
+import com.onesignal.common.threading.runOnSerialIO
 import com.onesignal.core.activities.PermissionsActivity
 import com.onesignal.core.internal.application.IActivityLifecycleHandler
 import com.onesignal.core.internal.application.IApplicationLifecycleHandler
@@ -330,22 +330,20 @@ class NotificationPermissionControllerTests : FunSpec({
         }
     }
 
-    test("onFocus dispatches polling-interval update + waker through runOnSerialIOIfBackgroundThreading (SDK-4507)") {
-        // SDK-4507: the lifecycle-registered onFocus handler reads ConfigModel and calls
-        // Waiter.wake(), the latter of which dispatches a coroutine resume into the IO pool.
-        // On cold start this is the SDK's first OneSignalDispatchers consumer in the process,
-        // and the executor + dispatcher + scope lazy chain pinned the main thread for many
-        // seconds under sdk_background_threading. The fix routes through
-        // runOnSerialIOIfBackgroundThreading; verify that contract here.
+    test("onFocus dispatches polling-interval update + waker through runOnSerialIO") {
+        // The lifecycle-registered onFocus handler reads ConfigModel and calls Waiter.wake(),
+        // the latter of which dispatches a coroutine resume into the IO pool. On cold start this
+        // is the SDK's first OneSignalDispatchers consumer in the process, and the executor +
+        // dispatcher + scope lazy chain pinned the main thread for many seconds. The fix routes
+        // through runOnSerialIO; verify that contract here.
         //
         // We stub the helper so the wrapped block does not run (we don't want a real
-        // pollingWaiter.wake() to spawn a real coroutine from this test). The FF branches of
-        // the helper itself are covered in :core's ThreadUtilsFeatureFlagTests, which has
-        // direct access to the internal ThreadingMode flag.
+        // pollingWaiter.wake() to spawn a real coroutine from this test). The helper itself
+        // is covered in :core's ThreadUtilsDispatchTests.
         val threadUtilsPath = "com.onesignal.common.threading.ThreadUtilsKt"
         mockkStatic(threadUtilsPath)
         mockkObject(OneSignalDispatchers)
-        every { runOnSerialIOIfBackgroundThreading(any<() -> Unit>()) } just runs
+        every { runOnSerialIO(any<() -> Unit>()) } just runs
         every { OneSignalDispatchers.launchOnIO(any<suspend () -> Unit>()) } returns mockk<Job>(relaxed = true)
 
         try {
@@ -373,18 +371,18 @@ class NotificationPermissionControllerTests : FunSpec({
 
             // Only the polling lifecycle listener (registered inside the controller's init)
             // routes through the gated helper, so we assert exactly 1 invocation here.
-            verify(exactly = 1) { runOnSerialIOIfBackgroundThreading(any<() -> Unit>()) }
+            verify(exactly = 1) { runOnSerialIO(any<() -> Unit>()) }
         } finally {
             unmockkObject(OneSignalDispatchers)
             unmockkStatic(threadUtilsPath)
         }
     }
 
-    test("onUnfocused dispatches polling-interval reset through runOnSerialIOIfBackgroundThreading (SDK-4507)") {
+    test("onUnfocused dispatches polling-interval reset through runOnSerialIO") {
         val threadUtilsPath = "com.onesignal.common.threading.ThreadUtilsKt"
         mockkStatic(threadUtilsPath)
         mockkObject(OneSignalDispatchers)
-        every { runOnSerialIOIfBackgroundThreading(any<() -> Unit>()) } just runs
+        every { runOnSerialIO(any<() -> Unit>()) } just runs
         every { OneSignalDispatchers.launchOnIO(any<suspend () -> Unit>()) } returns mockk<Job>(relaxed = true)
 
         try {
@@ -410,7 +408,7 @@ class NotificationPermissionControllerTests : FunSpec({
                 focusHandler.onUnfocused()
             }
 
-            verify(exactly = 1) { runOnSerialIOIfBackgroundThreading(any<() -> Unit>()) }
+            verify(exactly = 1) { runOnSerialIO(any<() -> Unit>()) }
         } finally {
             unmockkObject(OneSignalDispatchers)
             unmockkStatic(threadUtilsPath)


### PR DESCRIPTION
## Summary
Part 3 of 3 (final) of the SDK-4213 stack. **Stacked on https://github.com/OneSignal/OneSignal-Android-SDK/pull/2673 — review/merge last.**

Updates the feature-flag consumers to the unconditional async API:
- `BackgroundManager` focus/unfocus, `SessionService`, `NotificationsManager`, `NotificationPermissionController` polling, and `OneSignalCrashUploaderWrapper` dispatch through the serial IO helper so lifecycle/Binder work never runs inline on the main thread.
- Updates corresponding tests; strips stale ticket references from comments.

The tip of this PR reproduces the original `ar/sdk-4213` net diff exactly.

## Test plan
- [ ] CI green
- [ ] consumer + notifications unit tests pass

Made with [Cursor](https://cursor.com)