### PR TITLE
fix: [SDK-4822] make ANR watchdog app-state aware to stop false background ANRs

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/debug/internal/crash/AnrCheckEvaluator.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/debug/internal/crash/AnrCheckEvaluator.kt
@@ -1,0 +1,182 @@
+package com.onesignal.debug.internal.crash
+
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Pure, Android-free decision core for the ANR watchdog.
+ *
+ * All timing/classification/deduplication state lives here so it can be exercised deterministically
+ * on the JVM (with an injected clock) without a `Handler`, `Looper`, or real background thread. The
+ * Android shell ([OtelAnrDetector]) owns the thread, the real sleep, and the reporting side effects,
+ * and delegates every per-iteration decision to [evaluate].
+ *
+ * Foreground and background blocks keep independent dedup timestamps: a stream of backgrounded
+ * warnings must never suppress a genuine foreground ANR (and vice versa).
+ */
+internal class AnrCheckEvaluator(
+    private val anrThresholdMs: Long,
+    private val checkIntervalMs: Long,
+    private val backgroundThresholdMs: Long,
+    private val frozenSlackMs: Long,
+    private val dedupWindowMs: Long,
+    private val now: () -> Long,
+) {
+    // Monotonic timestamps (from `now`); see OtelAnrDetector for why the clock must be monotonic.
+    private val lastResponseTime = AtomicLong(now())
+    private val lastForegroundReportTime = AtomicLong(NEVER_REPORTED)
+    private val lastBackgroundReportTime = AtomicLong(NEVER_REPORTED)
+
+    /** Re-baselines the responsiveness clock, e.g. at start() so a construction->start gap isn't a block. */
+    fun resetBaseline() {
+        lastResponseTime.set(now())
+    }
+
+    /** Records that the main thread ran the heartbeat runnable. */
+    fun recordHeartbeat() {
+        lastResponseTime.set(now())
+    }
+
+    /**
+     * Evaluates a single watchdog iteration given how long the watchdog's own sleep actually took and
+     * the current app state. Returns the action the shell should take; all dedup bookkeeping is done
+     * here so the shell only performs side effects.
+     */
+    fun evaluate(actualSleepMs: Long, inForeground: Boolean): AnrCheckResult {
+        val timeSinceLastResponse = now() - lastResponseTime.get()
+
+        return when (
+            classifyBlock(
+                timeSinceLastResponseMs = timeSinceLastResponse,
+                actualSleepMs = actualSleepMs,
+                checkIntervalMs = checkIntervalMs,
+                frozenSlackMs = frozenSlackMs,
+                anrThresholdMs = anrThresholdMs,
+                backgroundThresholdMs = backgroundThresholdMs,
+                inForeground = inForeground,
+            )
+        ) {
+            BlockClassification.FROZEN_PROCESS -> {
+                // The watchdog thread itself was descheduled (Doze / cached-process freeze). Anything
+                // measured for the main thread is a freeze artifact, so re-baseline and treat as
+                // responsive to avoid firing on the next iteration.
+                lastResponseTime.set(now())
+                AnrCheckResult.FrozenProcess(actualSleepMs = actualSleepMs, expectedSleepMs = checkIntervalMs)
+            }
+            BlockClassification.RESPONSIVE -> {
+                clearReportTimestamps()
+                AnrCheckResult.Responsive
+            }
+            BlockClassification.FOREGROUND_ANR ->
+                reportOrDedup(timeSinceLastResponse, lastForegroundReportTime, inForeground = true)
+            BlockClassification.BACKGROUND_WARNING ->
+                reportOrDedup(timeSinceLastResponse, lastBackgroundReportTime, inForeground = false)
+        }
+    }
+
+    private fun reportOrDedup(
+        durationMs: Long,
+        lastReportHolder: AtomicLong,
+        inForeground: Boolean,
+    ): AnrCheckResult {
+        val nowMs = now()
+        val lastReport = lastReportHolder.get()
+
+        // Skip only if we actually reported this class of block recently. NEVER_REPORTED means we have
+        // not reported yet (or the main thread recovered), so we must not dedup — important shortly
+        // after boot when the monotonic clock is still small and `now - 0` would look "recent".
+        if (lastReport != NEVER_REPORTED && nowMs - lastReport <= dedupWindowMs) {
+            return AnrCheckResult.Deduped(durationMs = durationMs, sinceLastReportMs = nowMs - lastReport, inForeground = inForeground)
+        }
+        lastReportHolder.set(nowMs)
+        return if (inForeground) {
+            AnrCheckResult.ForegroundAnr(durationMs)
+        } else {
+            AnrCheckResult.BackgroundWarning(durationMs)
+        }
+    }
+
+    private fun clearReportTimestamps() {
+        // A recovered main thread should let the next real block report immediately, regardless of app state.
+        lastForegroundReportTime.set(NEVER_REPORTED)
+        lastBackgroundReportTime.set(NEVER_REPORTED)
+    }
+
+    companion object {
+        // Sentinel meaning "no block of this class reported yet / main thread is healthy".
+        private const val NEVER_REPORTED = 0L
+    }
+}
+
+/** The action the Android shell should take for one watchdog check. */
+internal sealed interface AnrCheckResult {
+    /** Main thread responded within the applicable threshold. */
+    object Responsive : AnrCheckResult
+
+    /** The watchdog's own sleep overran — the process was frozen, not the main thread. */
+    data class FrozenProcess(val actualSleepMs: Long, val expectedSleepMs: Long) : AnrCheckResult
+
+    /** A block of this class was already reported within the dedup window; suppress. */
+    data class Deduped(val durationMs: Long, val sinceLastReportMs: Long, val inForeground: Boolean) : AnrCheckResult
+
+    /** Foreground block beyond the ANR threshold: a real, user-visible ANR to report as a crash. */
+    data class ForegroundAnr(val durationMs: Long) : AnrCheckResult
+
+    /** Background block beyond the background threshold: record as a non-fatal warning, never an ANR. */
+    data class BackgroundWarning(val durationMs: Long) : AnrCheckResult
+}
+
+/**
+ * How a watchdog check is interpreted. Kept separate from side effects so the decision is a pure,
+ * deterministically testable function of the measured timings and app state.
+ */
+internal enum class BlockClassification {
+    /** Main thread responded within the applicable threshold. */
+    RESPONSIVE,
+
+    /** The watchdog thread's own sleep overran — the process was frozen, not the main thread. */
+    FROZEN_PROCESS,
+
+    /** Foreground block beyond the ANR threshold: a real, user-visible ANR. */
+    FOREGROUND_ANR,
+
+    /** Background block beyond the background threshold: not an ANR, recorded as a warning. */
+    BACKGROUND_WARNING,
+}
+
+/**
+ * Pure decision for a single watchdog check.
+ *
+ * Frozen-process detection wins first: if the watchdog's own sleep overran [checkIntervalMs] by more
+ * than [frozenSlackMs], the whole process was descheduled and any measured block is an artifact.
+ * Otherwise the applicable threshold depends on app state — [anrThresholdMs] in the foreground (where
+ * Android raises real ANRs) and the higher [backgroundThresholdMs] in the background.
+ */
+@Suppress("LongParameterList")
+internal fun classifyBlock(
+    timeSinceLastResponseMs: Long,
+    actualSleepMs: Long,
+    checkIntervalMs: Long,
+    frozenSlackMs: Long,
+    anrThresholdMs: Long,
+    backgroundThresholdMs: Long,
+    inForeground: Boolean,
+): BlockClassification {
+    val threshold = if (inForeground) anrThresholdMs else backgroundThresholdMs
+    return when {
+        actualSleepMs - checkIntervalMs > frozenSlackMs -> BlockClassification.FROZEN_PROCESS
+        timeSinceLastResponseMs <= threshold -> BlockClassification.RESPONSIVE
+        inForeground -> BlockClassification.FOREGROUND_ANR
+        else -> BlockClassification.BACKGROUND_WARNING
+    }
+}
+
+/**
+ * Compact fingerprint for a captured main-thread stack: the top frame plus the first OneSignal frame.
+ * Kept as a queryable summary so background blocks can be grouped/triaged without parsing the full
+ * stack. Pure (operates only on the array) so it is covered by plain JVM tests.
+ */
+internal fun buildBlockFingerprint(stackTrace: Array<StackTraceElement>): String {
+    val topFrame = stackTrace.firstOrNull()?.toString() ?: "unknown"
+    val oneSignalFrame = stackTrace.firstOrNull { it.className.startsWith("com.onesignal") }?.toString() ?: "none"
+    return "top=$topFrame|onesignal=$oneSignalFrame"
+}

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/debug/internal/crash/AnrConstants.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/debug/internal/crash/AnrConstants.kt
@@ -16,4 +16,14 @@ internal object AnrConstants {
      * The ANR detector checks the main thread responsiveness every 2 seconds.
      */
     const val DEFAULT_CHECK_INTERVAL_MS: Long = 2_000L
+
+    /**
+     * Threshold for main-thread blocks while the app is backgrounded.
+     *
+     * Android only raises a real, user-visible ANR while the app is in the foreground, so a
+     * backgrounded block is not an ANR — it is recorded as a lower-severity warning instead.
+     * A higher threshold than the foreground one absorbs the normal scheduling delays a
+     * backgrounded process sees, keeping the warning stream meaningful rather than noisy.
+     */
+    const val DEFAULT_BACKGROUND_BLOCK_THRESHOLD_MS: Long = 10_000L
 }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/debug/internal/crash/OtelAnrDetector.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/debug/internal/crash/OtelAnrDetector.kt
@@ -16,8 +16,17 @@ import java.util.concurrent.atomic.AtomicLong
  *
  * Uses a watchdog pattern to monitor the main thread:
  * - Posts a message to the main thread every check interval
- * - If the main thread doesn't respond within the ANR threshold, reports an ANR
- * - Captures the main thread's stack trace when ANR is detected
+ * - If the main thread doesn't respond within the threshold, classifies and records the block
+ * - Captures the main thread's stack trace when a block is detected
+ *
+ * Detection is app-state aware, because a blocked main thread does not mean the same thing in
+ * the foreground as in the background:
+ * - Foreground block > [anrThresholdMs]: a real, user-visible ANR — reported as a crash-class ANR.
+ * - Background block > [backgroundThresholdMs]: not an ANR (Android raises no ANR for a
+ *   backgrounded app) — recorded as a lower-severity warning so it stays out of the ANR metric.
+ * - If the watchdog thread's own sleep overran far beyond [checkIntervalMs], the whole process was
+ *   descheduled (Doze / cached-process freeze) rather than the main thread being stuck, so the
+ *   measured "block" is a freeze artifact and is suppressed.
  *
  * This is a standalone component that can be initialized independently of the crash handler.
  * It creates its own crash reporter to save ANR reports.
@@ -27,6 +36,8 @@ internal class OtelAnrDetector(
     private val logger: IOtelLogger,
     private val anrThresholdMs: Long = AnrConstants.DEFAULT_ANR_THRESHOLD_MS,
     private val checkIntervalMs: Long = AnrConstants.DEFAULT_CHECK_INTERVAL_MS,
+    private val backgroundThresholdMs: Long = AnrConstants.DEFAULT_BACKGROUND_BLOCK_THRESHOLD_MS,
+    private val isAppInForeground: () -> Boolean = { true },
 ) : IOtelAnrDetector {
     private val crashReporter: IOtelCrashReporter = OtelFactory.createCrashReporter(openTelemetryCrash, logger)
     private val mainHandler = Handler(Looper.getMainLooper())
@@ -40,8 +51,13 @@ internal class OtelAnrDetector(
     companion object {
         private const val TAG = "OtelAnrDetector"
 
-        // Minimum time between ANR reports (to avoid duplicate reports for the same ANR)
+        // Minimum time between reports (to avoid duplicate reports for the same ongoing block)
         private const val MIN_TIME_BETWEEN_ANR_REPORTS_MS = 30_000L // 30 seconds
+
+        // If the watchdog thread's own sleep overruns the check interval by more than this, the
+        // process itself was frozen/descheduled rather than the main thread being blocked, so the
+        // measurement is meaningless. Generous enough to tolerate GC pauses and CPU contention.
+        private const val FROZEN_PROCESS_SLACK_MS = 2_000L
     }
 
     override fun start() {
@@ -85,30 +101,67 @@ internal class OtelAnrDetector(
         val runnable = mainThreadRunnable ?: return
         mainHandler.post(runnable)
 
-        // Wait for the check interval
+        // Time the sleep itself: if our own thread oversleeps, the process was frozen, not blocked.
+        val sleepStart = System.currentTimeMillis()
         Thread.sleep(checkIntervalMs)
+        val actualSleepMs = System.currentTimeMillis() - sleepStart
 
-        // Check if main thread responded
+        val inForeground = resolveForeground()
         val timeSinceLastResponse = System.currentTimeMillis() - lastResponseTime.get()
-        if (timeSinceLastResponse > anrThresholdMs) {
-            handleAnrDetected(timeSinceLastResponse)
-        } else {
-            handleMainThreadResponsive()
+
+        when (
+            classifyBlock(
+                timeSinceLastResponseMs = timeSinceLastResponse,
+                actualSleepMs = actualSleepMs,
+                checkIntervalMs = checkIntervalMs,
+                frozenSlackMs = FROZEN_PROCESS_SLACK_MS,
+                anrThresholdMs = anrThresholdMs,
+                backgroundThresholdMs = backgroundThresholdMs,
+                inForeground = inForeground,
+            )
+        ) {
+            BlockClassification.FROZEN_PROCESS -> {
+                // The watchdog thread itself was descheduled (Doze / cached-process freeze). Anything
+                // we measured for the main thread is a freeze artifact, so skip it and treat the main
+                // thread as responsive to avoid firing on the next iteration.
+                logger.debug(
+                    "$TAG: Skipping check — watchdog overslept ${actualSleepMs}ms (expected ${checkIntervalMs}ms); process was frozen, not blocked",
+                )
+                lastResponseTime.set(System.currentTimeMillis())
+            }
+            BlockClassification.RESPONSIVE -> handleMainThreadResponsive()
+            BlockClassification.FOREGROUND_ANR -> reportBlockOnce(timeSinceLastResponse, inForeground = true)
+            BlockClassification.BACKGROUND_WARNING -> reportBlockOnce(timeSinceLastResponse, inForeground = false)
         }
     }
 
-    private fun handleAnrDetected(timeSinceLastResponse: Long) {
-        // Main thread hasn't responded - ANR detected!
+    @Suppress("TooGenericExceptionCaught")
+    private fun resolveForeground(): Boolean =
+        try {
+            isAppInForeground()
+        } catch (t: Throwable) {
+            // Unknown state: treat as foreground so a genuine ANR is never silently downgraded.
+            logger.debug("$TAG: Could not resolve app state (${t.message}), assuming foreground")
+            true
+        }
+
+    private fun reportBlockOnce(timeSinceLastResponse: Long, inForeground: Boolean) {
         val now = System.currentTimeMillis()
         val timeSinceLastReport = now - lastAnrReportTime.get()
 
-        // Only report if enough time has passed since last report (avoid duplicates)
-        if (timeSinceLastReport > MIN_TIME_BETWEEN_ANR_REPORTS_MS) {
-            logger.info("$TAG: ⚠️ ANR detected! Main thread unresponsive for ${timeSinceLastResponse}ms")
-            lastAnrReportTime.set(now)
+        // Only report if enough time has passed since the last report (avoid duplicates).
+        if (timeSinceLastReport <= MIN_TIME_BETWEEN_ANR_REPORTS_MS) {
+            logger.debug("$TAG: Block still ongoing (${timeSinceLastResponse}ms), already reported recently (${timeSinceLastReport}ms ago)")
+            return
+        }
+        lastAnrReportTime.set(now)
+
+        if (inForeground) {
+            logger.info("$TAG: ⚠️ ANR detected! Main thread unresponsive for ${timeSinceLastResponse}ms (foreground)")
             reportAnr(timeSinceLastResponse)
         } else {
-            logger.debug("$TAG: ANR still ongoing (${timeSinceLastResponse}ms), but already reported recently (${timeSinceLastReport}ms ago)")
+            logger.info("$TAG: Main thread blocked for ${timeSinceLastResponse}ms while backgrounded — recording warning, not ANR")
+            reportBackgroundBlock(timeSinceLastResponse)
         }
     }
 
@@ -183,6 +236,34 @@ internal class OtelAnrDetector(
     }
 
     /**
+     * Records a backgrounded main-thread block as a warning rather than an ANR.
+     *
+     * Android raises no ANR for a backgrounded app, so this is not a user-visible crash. We keep the
+     * captured stack trace for diagnostics but route it through the warning log stream so it stays
+     * out of the ANR/crash metric. Like [reportAnr], only OneSignal-induced blocks are recorded.
+     */
+    @Suppress("TooGenericExceptionCaught")
+    private fun reportBackgroundBlock(unresponsiveDurationMs: Long) {
+        try {
+            val mainThread = Looper.getMainLooper().thread
+            val stackTrace = mainThread.stackTrace
+
+            if (!com.onesignal.otel.crash.isOneSignalAtFault(stackTrace)) {
+                logger.debug("$TAG: Background block is not OneSignal-related, skipping")
+                return
+            }
+
+            val frames = stackTrace.joinToString("\n") { "    at $it" }
+            logger.warn(
+                "$TAG: OneSignal-related main-thread block for ${unresponsiveDurationMs}ms while " +
+                    "backgrounded (not a user-visible ANR)\n$frames",
+            )
+        } catch (t: Throwable) {
+            logger.error("$TAG: Failed to record background block: ${t.message} - ${t.javaClass.simpleName}")
+        }
+    }
+
+    /**
      * Custom exception type for ANRs.
      * This allows us to distinguish ANRs from regular crashes in the crash reporting system.
      */
@@ -199,6 +280,52 @@ internal class OtelAnrDetector(
 // Use the centralized isOneSignalAtFault from otel module
 
 /**
+ * How a watchdog check is interpreted. Kept separate from side effects so the decision is a pure,
+ * deterministically testable function of the measured timings and app state.
+ */
+internal enum class BlockClassification {
+    /** Main thread responded within the applicable threshold. */
+    RESPONSIVE,
+
+    /** The watchdog thread's own sleep overran — the process was frozen, not the main thread. */
+    FROZEN_PROCESS,
+
+    /** Foreground block beyond the ANR threshold: a real, user-visible ANR. */
+    FOREGROUND_ANR,
+
+    /** Background block beyond the background threshold: not an ANR, recorded as a warning. */
+    BACKGROUND_WARNING,
+}
+
+/**
+ * Pure decision for a single watchdog check.
+ *
+ * Frozen-process detection wins first: if the watchdog's own sleep overran [checkIntervalMs] by more
+ * than [frozenSlackMs], the whole process was descheduled and any measured block is an artifact.
+ * Otherwise the applicable threshold depends on app state — [anrThresholdMs] in the foreground (where
+ * Android raises real ANRs) and the higher [backgroundThresholdMs] in the background.
+ */
+@Suppress("LongParameterList")
+internal fun classifyBlock(
+    timeSinceLastResponseMs: Long,
+    actualSleepMs: Long,
+    checkIntervalMs: Long,
+    frozenSlackMs: Long,
+    anrThresholdMs: Long,
+    backgroundThresholdMs: Long,
+    inForeground: Boolean,
+): BlockClassification {
+    if (actualSleepMs - checkIntervalMs > frozenSlackMs) {
+        return BlockClassification.FROZEN_PROCESS
+    }
+    val threshold = if (inForeground) anrThresholdMs else backgroundThresholdMs
+    if (timeSinceLastResponseMs <= threshold) {
+        return BlockClassification.RESPONSIVE
+    }
+    return if (inForeground) BlockClassification.FOREGROUND_ANR else BlockClassification.BACKGROUND_WARNING
+}
+
+/**
  * Factory function to create an ANR detector for Android.
  * This is in the core module since it needs to access Android-specific classes.
  */
@@ -208,6 +335,7 @@ internal fun createAnrDetector(
     logger: IOtelLogger,
     anrThresholdMs: Long = AnrConstants.DEFAULT_ANR_THRESHOLD_MS,
     checkIntervalMs: Long = AnrConstants.DEFAULT_CHECK_INTERVAL_MS,
+    backgroundThresholdMs: Long = AnrConstants.DEFAULT_BACKGROUND_BLOCK_THRESHOLD_MS,
 ): IOtelAnrDetector {
     // Use the factory to create crash local instance (keeps implementation details internal)
     val crashLocal = OtelFactory.createCrashLocalTelemetry(platformProvider)
@@ -216,6 +344,10 @@ internal fun createAnrDetector(
         crashLocal,
         logger,
         anrThresholdMs,
-        checkIntervalMs
+        checkIntervalMs,
+        backgroundThresholdMs,
+        // appState is computed per access. Only "background" downgrades to a warning; "unknown"
+        // is treated as foreground so a genuine ANR is never silently dropped.
+        isAppInForeground = { platformProvider.appState != "background" },
     )
 }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/debug/internal/crash/OtelAnrDetector.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/debug/internal/crash/OtelAnrDetector.kt
@@ -230,11 +230,12 @@ internal class OtelAnrDetector(
      *
      * Android raises no ANR for a backgrounded app, so this is not a user-visible crash. We route it
      * through the same retained, disk-buffered crash telemetry as [reportAnr] (so it survives
-     * regardless of the remote log level and stays queryable), but tag it with a distinct exception
-     * type — [BackgroundMainThreadBlockException] — so the backend segments it into its own stream and
-     * keeps it out of the ANR/crash metric, exactly how ANRs are already segmented from crashes by
-     * type. The exception message carries a compact stack fingerprint (top frame + first OneSignal
-     * frame) for triage. Like [reportAnr], only OneSignal-induced blocks are recorded.
+     * regardless of the remote log level and stays queryable), but via [IOtelCrashReporter.saveNonFatal]
+     * so it is emitted at a non-fatal severity and tagged non-fatal — keeping it out of any
+     * severity-based crash/ANR metric rather than relying on the exception type alone. It is also
+     * given a distinct exception type — [BackgroundMainThreadBlockException] — so it can be segmented
+     * into its own stream, and the exception message carries a compact stack fingerprint (top frame +
+     * first OneSignal frame) for triage. Like [reportAnr], only OneSignal-induced blocks are recorded.
      */
     @Suppress("TooGenericExceptionCaught")
     private fun reportBackgroundBlock(unresponsiveDurationMs: Long) {
@@ -253,7 +254,7 @@ internal class OtelAnrDetector(
             )
 
             runBlocking {
-                crashReporter.saveCrash(mainThread, blockException)
+                crashReporter.saveNonFatal(mainThread, blockException)
             }
 
             logger.info("$TAG: ✅ Background block warning recorded")

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/debug/internal/crash/OtelAnrDetector.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/debug/internal/crash/OtelAnrDetector.kt
@@ -8,9 +8,9 @@ import com.onesignal.otel.IOtelLogger
 import com.onesignal.otel.IOtelOpenTelemetryCrash
 import com.onesignal.otel.OtelFactory
 import com.onesignal.otel.crash.IOtelAnrDetector
+import com.onesignal.otel.crash.isOneSignalAtFault
 import kotlinx.coroutines.runBlocking
 import java.util.concurrent.atomic.AtomicBoolean
-import java.util.concurrent.atomic.AtomicLong
 
 /**
  * Android-specific implementation of ANR detection.
@@ -24,34 +24,39 @@ import java.util.concurrent.atomic.AtomicLong
  * the foreground as in the background:
  * - Foreground block > [anrThresholdMs]: a real, user-visible ANR — reported as a crash-class ANR.
  * - Background block > [backgroundThresholdMs]: not an ANR (Android raises no ANR for a
- *   backgrounded app) — recorded as a lower-severity warning so it stays out of the ANR metric.
+ *   backgrounded app) — recorded under a distinct exception type so it stays out of the ANR metric
+ *   while remaining retained and queryable for real background regressions.
  * - If the watchdog thread's own sleep overran far beyond [checkIntervalMs], the whole process was
  *   descheduled (Doze / cached-process freeze) rather than the main thread being stuck, so the
  *   measured "block" is a freeze artifact and is suppressed.
  *
- * This is a standalone component that can be initialized independently of the crash handler.
- * It creates its own crash reporter to save ANR reports.
+ * Every timing/classification/dedup decision is delegated to [AnrCheckEvaluator] (pure, JVM-tested),
+ * and all Android touch points go through the injectable [AnrWatchdogPlatform] seam so the watchdog's
+ * behavior can be exercised deterministically off-device.
  */
 internal class OtelAnrDetector(
     openTelemetryCrash: IOtelOpenTelemetryCrash,
     private val logger: IOtelLogger,
     private val anrThresholdMs: Long = AnrConstants.DEFAULT_ANR_THRESHOLD_MS,
     private val checkIntervalMs: Long = AnrConstants.DEFAULT_CHECK_INTERVAL_MS,
-    private val backgroundThresholdMs: Long = AnrConstants.DEFAULT_BACKGROUND_BLOCK_THRESHOLD_MS,
+    backgroundThresholdMs: Long = AnrConstants.DEFAULT_BACKGROUND_BLOCK_THRESHOLD_MS,
     private val isAppInForeground: () -> Boolean = { true },
-    // Monotonic clock source, injectable so the heartbeat/check path is deterministically testable.
-    private val now: () -> Long = { SystemClock.uptimeMillis() },
+    // Android touch points (main-thread Handler, stack capture) plus the monotonic clock, injectable
+    // so the whole watchdog runs deterministically off-device.
+    private val platform: AnrWatchdogPlatform = AndroidAnrWatchdogPlatform(),
 ) : IOtelAnrDetector {
     private val crashReporter: IOtelCrashReporter = OtelFactory.createCrashReporter(openTelemetryCrash, logger)
-    private val mainHandler = Handler(Looper.getMainLooper())
     private val isMonitoring = AtomicBoolean(false)
 
-    // All durations here use the monotonic clock (default SystemClock.uptimeMillis) rather than
-    // wall-clock time: it can't be skewed by clock adjustments (NTP, manual time change, DST), it
-    // matches the clock the main Looper schedules with, and it pauses during deep sleep so a dozing
-    // device doesn't accumulate phantom "block" time.
-    private val lastResponseTime = AtomicLong(now())
-    private val lastAnrReportTime = AtomicLong(NEVER_REPORTED)
+    private val evaluator = AnrCheckEvaluator(
+        anrThresholdMs = anrThresholdMs,
+        checkIntervalMs = checkIntervalMs,
+        backgroundThresholdMs = backgroundThresholdMs,
+        frozenSlackMs = FROZEN_PROCESS_SLACK_MS,
+        dedupWindowMs = MIN_TIME_BETWEEN_ANR_REPORTS_MS,
+        now = { platform.now() },
+    )
+
     private var watchdogThread: Thread? = null
     private var watchdogRunnable: Runnable? = null
     private var mainThreadRunnable: Runnable? = null
@@ -66,9 +71,6 @@ internal class OtelAnrDetector(
         // process itself was frozen/descheduled rather than the main thread being blocked, so the
         // measurement is meaningless. Generous enough to tolerate GC pauses and CPU contention.
         private const val FROZEN_PROCESS_SLACK_MS = 2_000L
-
-        // Sentinel for lastAnrReportTime meaning "no block reported yet / main thread is healthy".
-        private const val NEVER_REPORTED = 0L
     }
 
     override fun start() {
@@ -80,7 +82,7 @@ internal class OtelAnrDetector(
         logger.info("$TAG: Starting ANR detection (threshold: ${anrThresholdMs}ms, check interval: ${checkIntervalMs}ms)")
 
         // Reset the baseline so a gap between construction and start() can't be read as a block.
-        lastResponseTime.set(now())
+        evaluator.resetBaseline()
         setupRunnables()
         startWatchdogThread()
 
@@ -110,53 +112,47 @@ internal class OtelAnrDetector(
         }
     }
 
-    private fun checkForAnr() {
+    internal fun checkForAnr() {
         val runnable = mainThreadRunnable ?: return
-        mainHandler.post(runnable)
+        platform.postToMainThread(runnable)
 
         // Time the sleep itself: if our own thread oversleeps, the process was frozen, not blocked.
-        val sleepStart = now()
+        val sleepStart = platform.now()
         Thread.sleep(checkIntervalMs)
-        evaluateCheck(actualSleepMs = now() - sleepStart)
+        evaluateCheck(actualSleepMs = platform.now() - sleepStart)
     }
 
     /** Records that the main thread ran our heartbeat runnable. */
     internal fun recordHeartbeat() {
-        lastResponseTime.set(now())
+        evaluator.recordHeartbeat()
     }
 
     /**
-     * Evaluates one watchdog iteration given how long the watchdog's own sleep actually took.
-     * Split from [checkForAnr] (which owns the thread + real sleep) so the heartbeat/classify/report
-     * wiring can be exercised deterministically with an injected clock.
+     * Runs one watchdog iteration's decision (via [AnrCheckEvaluator]) and performs the side effect.
+     * Split from [checkForAnr] (which owns the real sleep) so the wiring can be exercised
+     * deterministically with an injected clock and platform.
      */
     internal fun evaluateCheck(actualSleepMs: Long) {
         val inForeground = resolveForeground()
-        val timeSinceLastResponse = now() - lastResponseTime.get()
-
-        when (
-            classifyBlock(
-                timeSinceLastResponseMs = timeSinceLastResponse,
-                actualSleepMs = actualSleepMs,
-                checkIntervalMs = checkIntervalMs,
-                frozenSlackMs = FROZEN_PROCESS_SLACK_MS,
-                anrThresholdMs = anrThresholdMs,
-                backgroundThresholdMs = backgroundThresholdMs,
-                inForeground = inForeground,
-            )
-        ) {
-            BlockClassification.FROZEN_PROCESS -> {
-                // The watchdog thread itself was descheduled (Doze / cached-process freeze). Anything
-                // we measured for the main thread is a freeze artifact, so skip it and treat the main
-                // thread as responsive to avoid firing on the next iteration.
+        when (val result = evaluator.evaluate(actualSleepMs = actualSleepMs, inForeground = inForeground)) {
+            is AnrCheckResult.Responsive -> Unit
+            is AnrCheckResult.FrozenProcess ->
                 logger.debug(
-                    "$TAG: Skipping check — watchdog overslept ${actualSleepMs}ms (expected ${checkIntervalMs}ms); process was frozen, not blocked",
+                    "$TAG: Skipping check — watchdog overslept ${result.actualSleepMs}ms " +
+                        "(expected ${result.expectedSleepMs}ms); process was frozen, not blocked",
                 )
-                lastResponseTime.set(now())
+            is AnrCheckResult.Deduped ->
+                logger.debug(
+                    "$TAG: Block still ongoing (${result.durationMs}ms), already reported recently (${result.sinceLastReportMs}ms ago)",
+                )
+            is AnrCheckResult.ForegroundAnr -> {
+                logger.info("$TAG: ⚠️ ANR detected! Main thread unresponsive for ${result.durationMs}ms (foreground)")
+                reportAnr(result.durationMs)
             }
-            BlockClassification.RESPONSIVE -> handleMainThreadResponsive()
-            BlockClassification.FOREGROUND_ANR -> reportBlockOnce(timeSinceLastResponse, inForeground = true)
-            BlockClassification.BACKGROUND_WARNING -> reportBlockOnce(timeSinceLastResponse, inForeground = false)
+            is AnrCheckResult.BackgroundWarning -> {
+                logger.info("$TAG: Main thread blocked for ${result.durationMs}ms while backgrounded — recording warning, not ANR")
+                reportBackgroundBlock(result.durationMs)
+            }
         }
     }
 
@@ -169,36 +165,6 @@ internal class OtelAnrDetector(
             logger.debug("$TAG: Could not resolve app state (${t.message}), assuming foreground")
             true
         }
-
-    private fun reportBlockOnce(timeSinceLastResponse: Long, inForeground: Boolean) {
-        val nowMs = now()
-        val lastReport = lastAnrReportTime.get()
-
-        // Skip only if we actually reported recently. lastReport == NEVER_REPORTED means we have not
-        // reported yet (or the main thread recovered), so we must not dedup — important shortly after
-        // boot when the monotonic clock is still small and `now - 0` would look "recent".
-        if (lastReport != NEVER_REPORTED && nowMs - lastReport <= MIN_TIME_BETWEEN_ANR_REPORTS_MS) {
-            logger.debug("$TAG: Block still ongoing (${timeSinceLastResponse}ms), already reported recently (${nowMs - lastReport}ms ago)")
-            return
-        }
-        lastAnrReportTime.set(nowMs)
-
-        if (inForeground) {
-            logger.info("$TAG: ⚠️ ANR detected! Main thread unresponsive for ${timeSinceLastResponse}ms (foreground)")
-            reportAnr(timeSinceLastResponse)
-        } else {
-            logger.info("$TAG: Main thread blocked for ${timeSinceLastResponse}ms while backgrounded — recording warning, not ANR")
-            reportBackgroundBlock(timeSinceLastResponse)
-        }
-    }
-
-    private fun handleMainThreadResponsive() {
-        // Main thread is responsive - reset report time so we can detect new blocks
-        if (lastAnrReportTime.get() != NEVER_REPORTED) {
-            lastAnrReportTime.set(NEVER_REPORTED)
-            logger.debug("$TAG: Main thread recovered, ready to detect new ANRs")
-        }
-    }
 
     private fun startWatchdogThread() {
         // Start the watchdog thread
@@ -220,7 +186,7 @@ internal class OtelAnrDetector(
         watchdogThread = null
         watchdogRunnable = null
         // Remove pending callbacks before nulling to prevent execution after stop
-        mainThreadRunnable?.let { mainHandler.removeCallbacks(it) }
+        mainThreadRunnable?.let { platform.removeFromMainThread(it) }
         mainThreadRunnable = null
 
         logger.info("$TAG: ✅ ANR detection stopped")
@@ -231,14 +197,11 @@ internal class OtelAnrDetector(
         try {
             logger.info("$TAG: Checking if ANR is OneSignal-related (unresponsive for ${unresponsiveDurationMs}ms)")
 
-            // Get the main thread's stack trace
-            val mainThread = Looper.getMainLooper().thread
-            val stackTrace = mainThread.stackTrace
+            val mainThread = platform.mainThread()
+            val stackTrace = platform.mainThreadStackTrace()
 
             // Only report if OneSignal is at fault (uses centralized utility from otel module)
-            val isOneSignalAtFault = com.onesignal.otel.crash.isOneSignalAtFault(stackTrace)
-
-            if (!isOneSignalAtFault) {
+            if (!isOneSignalAtFault(stackTrace)) {
                 logger.debug("$TAG: ANR is not OneSignal-related, skipping report")
                 return
             }
@@ -248,7 +211,7 @@ internal class OtelAnrDetector(
             // Create an ANR exception with the stack trace
             val anrException = ApplicationNotRespondingException(
                 "Application Not Responding: Main thread blocked for ${unresponsiveDurationMs}ms",
-                stackTrace
+                stackTrace,
             )
 
             // Report it as a crash (but mark it as ANR)
@@ -263,28 +226,37 @@ internal class OtelAnrDetector(
     }
 
     /**
-     * Records a backgrounded main-thread block as a warning rather than an ANR.
+     * Records a backgrounded main-thread block as a retained warning rather than an ANR.
      *
-     * Android raises no ANR for a backgrounded app, so this is not a user-visible crash. We keep the
-     * captured stack trace for diagnostics but route it through the warning log stream so it stays
-     * out of the ANR/crash metric. Like [reportAnr], only OneSignal-induced blocks are recorded.
+     * Android raises no ANR for a backgrounded app, so this is not a user-visible crash. We route it
+     * through the same retained, disk-buffered crash telemetry as [reportAnr] (so it survives
+     * regardless of the remote log level and stays queryable), but tag it with a distinct exception
+     * type — [BackgroundMainThreadBlockException] — so the backend segments it into its own stream and
+     * keeps it out of the ANR/crash metric, exactly how ANRs are already segmented from crashes by
+     * type. The exception message carries a compact stack fingerprint (top frame + first OneSignal
+     * frame) for triage. Like [reportAnr], only OneSignal-induced blocks are recorded.
      */
     @Suppress("TooGenericExceptionCaught")
     private fun reportBackgroundBlock(unresponsiveDurationMs: Long) {
         try {
-            val mainThread = Looper.getMainLooper().thread
-            val stackTrace = mainThread.stackTrace
+            val mainThread = platform.mainThread()
+            val stackTrace = platform.mainThreadStackTrace()
 
-            if (!com.onesignal.otel.crash.isOneSignalAtFault(stackTrace)) {
+            if (!isOneSignalAtFault(stackTrace)) {
                 logger.debug("$TAG: Background block is not OneSignal-related, skipping")
                 return
             }
 
-            val frames = stackTrace.joinToString("\n") { "    at $it" }
-            logger.warn(
-                "$TAG: OneSignal-related main-thread block for ${unresponsiveDurationMs}ms while " +
-                    "backgrounded (not a user-visible ANR)\n$frames",
+            val blockException = BackgroundMainThreadBlockException(
+                "Background main-thread block for ${unresponsiveDurationMs}ms | ${buildBlockFingerprint(stackTrace)}",
+                stackTrace,
             )
+
+            runBlocking {
+                crashReporter.saveCrash(mainThread, blockException)
+            }
+
+            logger.info("$TAG: ✅ Background block warning recorded")
         } catch (t: Throwable) {
             logger.error("$TAG: Failed to record background block: ${t.message} - ${t.javaClass.simpleName}")
         }
@@ -296,7 +268,20 @@ internal class OtelAnrDetector(
      */
     private class ApplicationNotRespondingException(
         message: String,
-        stackTrace: Array<StackTraceElement>
+        stackTrace: Array<StackTraceElement>,
+    ) : RuntimeException(message) {
+        init {
+            this.stackTrace = stackTrace
+        }
+    }
+
+    /**
+     * Custom exception type for backgrounded main-thread blocks. A distinct type keeps these out of
+     * the ANR/crash buckets on the backend while remaining queryable as their own stream.
+     */
+    private class BackgroundMainThreadBlockException(
+        message: String,
+        stackTrace: Array<StackTraceElement>,
     ) : RuntimeException(message) {
         init {
             this.stackTrace = stackTrace
@@ -304,59 +289,51 @@ internal class OtelAnrDetector(
     }
 }
 
-// Use the centralized isOneSignalAtFault from otel module
-
 /**
- * How a watchdog check is interpreted. Kept separate from side effects so the decision is a pure,
- * deterministically testable function of the measured timings and app state.
+ * The platform touch points the watchdog needs: posting to the main thread, capturing its stack, and
+ * a monotonic clock. Injecting this keeps [OtelAnrDetector] free of hard Android references at test
+ * time so the watchdog logic can be driven on a plain JVM.
  */
-internal enum class BlockClassification {
-    /** Main thread responded within the applicable threshold. */
-    RESPONSIVE,
+internal interface AnrWatchdogPlatform {
+    fun postToMainThread(runnable: Runnable)
 
-    /** The watchdog thread's own sleep overran — the process was frozen, not the main thread. */
-    FROZEN_PROCESS,
+    fun removeFromMainThread(runnable: Runnable)
 
-    /** Foreground block beyond the ANR threshold: a real, user-visible ANR. */
-    FOREGROUND_ANR,
+    fun mainThread(): Thread
 
-    /** Background block beyond the background threshold: not an ANR, recorded as a warning. */
-    BACKGROUND_WARNING,
+    fun mainThreadStackTrace(): Array<StackTraceElement>
+
+    /**
+     * Monotonic time in ms. Backed by SystemClock.uptimeMillis in production: it can't be skewed by
+     * clock adjustments (NTP, manual time change, DST), it matches the clock the main Looper schedules
+     * with, and it pauses during deep sleep so a dozing device doesn't accumulate phantom block time.
+     */
+    fun now(): Long
 }
 
-/**
- * Pure decision for a single watchdog check.
- *
- * Frozen-process detection wins first: if the watchdog's own sleep overran [checkIntervalMs] by more
- * than [frozenSlackMs], the whole process was descheduled and any measured block is an artifact.
- * Otherwise the applicable threshold depends on app state — [anrThresholdMs] in the foreground (where
- * Android raises real ANRs) and the higher [backgroundThresholdMs] in the background.
- */
-@Suppress("LongParameterList")
-internal fun classifyBlock(
-    timeSinceLastResponseMs: Long,
-    actualSleepMs: Long,
-    checkIntervalMs: Long,
-    frozenSlackMs: Long,
-    anrThresholdMs: Long,
-    backgroundThresholdMs: Long,
-    inForeground: Boolean,
-): BlockClassification {
-    if (actualSleepMs - checkIntervalMs > frozenSlackMs) {
-        return BlockClassification.FROZEN_PROCESS
+/** Production [AnrWatchdogPlatform] backed by the app's main [Looper] and [SystemClock]. */
+private class AndroidAnrWatchdogPlatform : AnrWatchdogPlatform {
+    private val mainHandler = Handler(Looper.getMainLooper())
+
+    override fun postToMainThread(runnable: Runnable) {
+        mainHandler.post(runnable)
     }
-    val threshold = if (inForeground) anrThresholdMs else backgroundThresholdMs
-    if (timeSinceLastResponseMs <= threshold) {
-        return BlockClassification.RESPONSIVE
+
+    override fun removeFromMainThread(runnable: Runnable) {
+        mainHandler.removeCallbacks(runnable)
     }
-    return if (inForeground) BlockClassification.FOREGROUND_ANR else BlockClassification.BACKGROUND_WARNING
+
+    override fun mainThread(): Thread = Looper.getMainLooper().thread
+
+    override fun mainThreadStackTrace(): Array<StackTraceElement> = Looper.getMainLooper().thread.stackTrace
+
+    override fun now(): Long = SystemClock.uptimeMillis()
 }
 
 /**
  * Factory function to create an ANR detector for Android.
  * This is in the core module since it needs to access Android-specific classes.
  */
-
 internal fun createAnrDetector(
     platformProvider: com.onesignal.otel.IOtelPlatformProvider,
     logger: IOtelLogger,

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/debug/internal/crash/OtelAnrDetector.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/debug/internal/crash/OtelAnrDetector.kt
@@ -39,17 +39,19 @@ internal class OtelAnrDetector(
     private val checkIntervalMs: Long = AnrConstants.DEFAULT_CHECK_INTERVAL_MS,
     private val backgroundThresholdMs: Long = AnrConstants.DEFAULT_BACKGROUND_BLOCK_THRESHOLD_MS,
     private val isAppInForeground: () -> Boolean = { true },
+    // Monotonic clock source, injectable so the heartbeat/check path is deterministically testable.
+    private val now: () -> Long = { SystemClock.uptimeMillis() },
 ) : IOtelAnrDetector {
     private val crashReporter: IOtelCrashReporter = OtelFactory.createCrashReporter(openTelemetryCrash, logger)
     private val mainHandler = Handler(Looper.getMainLooper())
     private val isMonitoring = AtomicBoolean(false)
 
-    // All durations here use the monotonic SystemClock.uptimeMillis() rather than wall-clock time:
-    // it can't be skewed by clock adjustments (NTP, manual time change, DST), it matches the clock
-    // the main Looper schedules with, and it pauses during deep sleep so a dozing device doesn't
-    // accumulate phantom "block" time.
-    private val lastResponseTime = AtomicLong(SystemClock.uptimeMillis())
-    private val lastAnrReportTime = AtomicLong(0L)
+    // All durations here use the monotonic clock (default SystemClock.uptimeMillis) rather than
+    // wall-clock time: it can't be skewed by clock adjustments (NTP, manual time change, DST), it
+    // matches the clock the main Looper schedules with, and it pauses during deep sleep so a dozing
+    // device doesn't accumulate phantom "block" time.
+    private val lastResponseTime = AtomicLong(now())
+    private val lastAnrReportTime = AtomicLong(NEVER_REPORTED)
     private var watchdogThread: Thread? = null
     private var watchdogRunnable: Runnable? = null
     private var mainThreadRunnable: Runnable? = null
@@ -64,6 +66,9 @@ internal class OtelAnrDetector(
         // process itself was frozen/descheduled rather than the main thread being blocked, so the
         // measurement is meaningless. Generous enough to tolerate GC pauses and CPU contention.
         private const val FROZEN_PROCESS_SLACK_MS = 2_000L
+
+        // Sentinel for lastAnrReportTime meaning "no block reported yet / main thread is healthy".
+        private const val NEVER_REPORTED = 0L
     }
 
     override fun start() {
@@ -75,7 +80,7 @@ internal class OtelAnrDetector(
         logger.info("$TAG: Starting ANR detection (threshold: ${anrThresholdMs}ms, check interval: ${checkIntervalMs}ms)")
 
         // Reset the baseline so a gap between construction and start() can't be read as a block.
-        lastResponseTime.set(SystemClock.uptimeMillis())
+        lastResponseTime.set(now())
         setupRunnables()
         startWatchdogThread()
 
@@ -86,7 +91,7 @@ internal class OtelAnrDetector(
     private fun setupRunnables() {
         // Runnable that runs on the main thread to indicate it's responsive
         mainThreadRunnable = Runnable {
-            lastResponseTime.set(SystemClock.uptimeMillis())
+            recordHeartbeat()
         }
 
         // Runnable that runs on the watchdog thread to check for ANRs
@@ -110,12 +115,24 @@ internal class OtelAnrDetector(
         mainHandler.post(runnable)
 
         // Time the sleep itself: if our own thread oversleeps, the process was frozen, not blocked.
-        val sleepStart = SystemClock.uptimeMillis()
+        val sleepStart = now()
         Thread.sleep(checkIntervalMs)
-        val actualSleepMs = SystemClock.uptimeMillis() - sleepStart
+        evaluateCheck(actualSleepMs = now() - sleepStart)
+    }
 
+    /** Records that the main thread ran our heartbeat runnable. */
+    internal fun recordHeartbeat() {
+        lastResponseTime.set(now())
+    }
+
+    /**
+     * Evaluates one watchdog iteration given how long the watchdog's own sleep actually took.
+     * Split from [checkForAnr] (which owns the thread + real sleep) so the heartbeat/classify/report
+     * wiring can be exercised deterministically with an injected clock.
+     */
+    internal fun evaluateCheck(actualSleepMs: Long) {
         val inForeground = resolveForeground()
-        val timeSinceLastResponse = SystemClock.uptimeMillis() - lastResponseTime.get()
+        val timeSinceLastResponse = now() - lastResponseTime.get()
 
         when (
             classifyBlock(
@@ -135,7 +152,7 @@ internal class OtelAnrDetector(
                 logger.debug(
                     "$TAG: Skipping check — watchdog overslept ${actualSleepMs}ms (expected ${checkIntervalMs}ms); process was frozen, not blocked",
                 )
-                lastResponseTime.set(SystemClock.uptimeMillis())
+                lastResponseTime.set(now())
             }
             BlockClassification.RESPONSIVE -> handleMainThreadResponsive()
             BlockClassification.FOREGROUND_ANR -> reportBlockOnce(timeSinceLastResponse, inForeground = true)
@@ -154,15 +171,17 @@ internal class OtelAnrDetector(
         }
 
     private fun reportBlockOnce(timeSinceLastResponse: Long, inForeground: Boolean) {
-        val now = SystemClock.uptimeMillis()
-        val timeSinceLastReport = now - lastAnrReportTime.get()
+        val nowMs = now()
+        val lastReport = lastAnrReportTime.get()
 
-        // Only report if enough time has passed since the last report (avoid duplicates).
-        if (timeSinceLastReport <= MIN_TIME_BETWEEN_ANR_REPORTS_MS) {
-            logger.debug("$TAG: Block still ongoing (${timeSinceLastResponse}ms), already reported recently (${timeSinceLastReport}ms ago)")
+        // Skip only if we actually reported recently. lastReport == NEVER_REPORTED means we have not
+        // reported yet (or the main thread recovered), so we must not dedup — important shortly after
+        // boot when the monotonic clock is still small and `now - 0` would look "recent".
+        if (lastReport != NEVER_REPORTED && nowMs - lastReport <= MIN_TIME_BETWEEN_ANR_REPORTS_MS) {
+            logger.debug("$TAG: Block still ongoing (${timeSinceLastResponse}ms), already reported recently (${nowMs - lastReport}ms ago)")
             return
         }
-        lastAnrReportTime.set(now)
+        lastAnrReportTime.set(nowMs)
 
         if (inForeground) {
             logger.info("$TAG: ⚠️ ANR detected! Main thread unresponsive for ${timeSinceLastResponse}ms (foreground)")
@@ -174,9 +193,9 @@ internal class OtelAnrDetector(
     }
 
     private fun handleMainThreadResponsive() {
-        // Main thread is responsive - reset ANR report time so we can detect new ANRs
-        if (lastAnrReportTime.get() > 0) {
-            lastAnrReportTime.set(0L)
+        // Main thread is responsive - reset report time so we can detect new blocks
+        if (lastAnrReportTime.get() != NEVER_REPORTED) {
+            lastAnrReportTime.set(NEVER_REPORTED)
             logger.debug("$TAG: Main thread recovered, ready to detect new ANRs")
         }
     }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/debug/internal/crash/OtelAnrDetector.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/debug/internal/crash/OtelAnrDetector.kt
@@ -2,6 +2,7 @@ package com.onesignal.debug.internal.crash
 
 import android.os.Handler
 import android.os.Looper
+import android.os.SystemClock
 import com.onesignal.otel.IOtelCrashReporter
 import com.onesignal.otel.IOtelLogger
 import com.onesignal.otel.IOtelOpenTelemetryCrash
@@ -42,7 +43,12 @@ internal class OtelAnrDetector(
     private val crashReporter: IOtelCrashReporter = OtelFactory.createCrashReporter(openTelemetryCrash, logger)
     private val mainHandler = Handler(Looper.getMainLooper())
     private val isMonitoring = AtomicBoolean(false)
-    private val lastResponseTime = AtomicLong(System.currentTimeMillis())
+
+    // All durations here use the monotonic SystemClock.uptimeMillis() rather than wall-clock time:
+    // it can't be skewed by clock adjustments (NTP, manual time change, DST), it matches the clock
+    // the main Looper schedules with, and it pauses during deep sleep so a dozing device doesn't
+    // accumulate phantom "block" time.
+    private val lastResponseTime = AtomicLong(SystemClock.uptimeMillis())
     private val lastAnrReportTime = AtomicLong(0L)
     private var watchdogThread: Thread? = null
     private var watchdogRunnable: Runnable? = null
@@ -68,6 +74,8 @@ internal class OtelAnrDetector(
 
         logger.info("$TAG: Starting ANR detection (threshold: ${anrThresholdMs}ms, check interval: ${checkIntervalMs}ms)")
 
+        // Reset the baseline so a gap between construction and start() can't be read as a block.
+        lastResponseTime.set(SystemClock.uptimeMillis())
         setupRunnables()
         startWatchdogThread()
 
@@ -78,7 +86,7 @@ internal class OtelAnrDetector(
     private fun setupRunnables() {
         // Runnable that runs on the main thread to indicate it's responsive
         mainThreadRunnable = Runnable {
-            lastResponseTime.set(System.currentTimeMillis())
+            lastResponseTime.set(SystemClock.uptimeMillis())
         }
 
         // Runnable that runs on the watchdog thread to check for ANRs
@@ -102,12 +110,12 @@ internal class OtelAnrDetector(
         mainHandler.post(runnable)
 
         // Time the sleep itself: if our own thread oversleeps, the process was frozen, not blocked.
-        val sleepStart = System.currentTimeMillis()
+        val sleepStart = SystemClock.uptimeMillis()
         Thread.sleep(checkIntervalMs)
-        val actualSleepMs = System.currentTimeMillis() - sleepStart
+        val actualSleepMs = SystemClock.uptimeMillis() - sleepStart
 
         val inForeground = resolveForeground()
-        val timeSinceLastResponse = System.currentTimeMillis() - lastResponseTime.get()
+        val timeSinceLastResponse = SystemClock.uptimeMillis() - lastResponseTime.get()
 
         when (
             classifyBlock(
@@ -127,7 +135,7 @@ internal class OtelAnrDetector(
                 logger.debug(
                     "$TAG: Skipping check — watchdog overslept ${actualSleepMs}ms (expected ${checkIntervalMs}ms); process was frozen, not blocked",
                 )
-                lastResponseTime.set(System.currentTimeMillis())
+                lastResponseTime.set(SystemClock.uptimeMillis())
             }
             BlockClassification.RESPONSIVE -> handleMainThreadResponsive()
             BlockClassification.FOREGROUND_ANR -> reportBlockOnce(timeSinceLastResponse, inForeground = true)
@@ -146,7 +154,7 @@ internal class OtelAnrDetector(
         }
 
     private fun reportBlockOnce(timeSinceLastResponse: Long, inForeground: Boolean) {
-        val now = System.currentTimeMillis()
+        val now = SystemClock.uptimeMillis()
         val timeSinceLastReport = now - lastAnrReportTime.get()
 
         // Only report if enough time has passed since the last report (avoid duplicates).

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/debug/internal/crash/AnrCheckEvaluatorTest.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/debug/internal/crash/AnrCheckEvaluatorTest.kt
@@ -1,0 +1,204 @@
+package com.onesignal.debug.internal.crash
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Pure-JVM tests for the ANR decision core. These run without Robolectric so the logic is exercised
+ * on a real JVM (and therefore counted by coverage), unlike the Android shell in [OtelAnrDetector].
+ *
+ * Defaults mirror AnrConstants: 5s foreground ANR, 2s check interval, 2s frozen slack, 10s background
+ * warning, 30s dedup window.
+ */
+class AnrCheckEvaluatorTest : FunSpec({
+
+    class FakeClock(var nowMs: Long = 1_000L) {
+        fun advance(ms: Long) { nowMs += ms }
+    }
+
+    fun evaluator(clock: FakeClock) = AnrCheckEvaluator(
+        anrThresholdMs = 5_000L,
+        checkIntervalMs = 2_000L,
+        backgroundThresholdMs = 10_000L,
+        frozenSlackMs = 2_000L,
+        dedupWindowMs = 30_000L,
+        now = { clock.nowMs },
+    )
+
+    // ===== classifyBlock (pure) =====
+
+    fun classify(
+        timeSinceLastResponseMs: Long,
+        inForeground: Boolean,
+        actualSleepMs: Long = 2_000L,
+    ): BlockClassification = classifyBlock(
+        timeSinceLastResponseMs = timeSinceLastResponseMs,
+        actualSleepMs = actualSleepMs,
+        checkIntervalMs = 2_000L,
+        frozenSlackMs = 2_000L,
+        anrThresholdMs = 5_000L,
+        backgroundThresholdMs = 10_000L,
+        inForeground = inForeground,
+    )
+
+    test("foreground block past the ANR threshold is a foreground ANR") {
+        classify(6_000L, inForeground = true) shouldBe BlockClassification.FOREGROUND_ANR
+    }
+
+    test("foreground block within the ANR threshold is responsive") {
+        classify(4_000L, inForeground = true) shouldBe BlockClassification.RESPONSIVE
+    }
+
+    test("background block below the background threshold is responsive even past the fg threshold") {
+        classify(7_000L, inForeground = false) shouldBe BlockClassification.RESPONSIVE
+    }
+
+    test("background block past the background threshold is a background warning") {
+        classify(11_000L, inForeground = false) shouldBe BlockClassification.BACKGROUND_WARNING
+    }
+
+    test("watchdog oversleeping beyond the frozen slack is a frozen process") {
+        classify(60_000L, inForeground = true, actualSleepMs = 30_000L) shouldBe BlockClassification.FROZEN_PROCESS
+    }
+
+    test("frozen-process detection wins over a background warning") {
+        classify(60_000L, inForeground = false, actualSleepMs = 30_000L) shouldBe BlockClassification.FROZEN_PROCESS
+    }
+
+    test("sleep overrun within the slack is not treated as frozen") {
+        classify(6_000L, inForeground = true, actualSleepMs = 3_500L) shouldBe BlockClassification.FOREGROUND_ANR
+    }
+
+    // ===== evaluate: responsive / report paths =====
+
+    test("a fresh heartbeat keeps a foreground check responsive") {
+        val clock = FakeClock(5_000L)
+        val e = evaluator(clock)
+
+        e.recordHeartbeat()
+        clock.advance(4_000L)
+
+        e.evaluate(actualSleepMs = 2_000L, inForeground = true).shouldBeInstanceOf<AnrCheckResult.Responsive>()
+    }
+
+    test("a stale heartbeat past the threshold reports a foreground ANR") {
+        val clock = FakeClock(1_000L)
+        val e = evaluator(clock)
+
+        e.recordHeartbeat()
+        clock.advance(6_000L)
+
+        val r = e.evaluate(actualSleepMs = 2_000L, inForeground = true)
+        r.shouldBeInstanceOf<AnrCheckResult.ForegroundAnr>()
+        r.durationMs shouldBe 6_000L
+    }
+
+    test("a background block past the background threshold is a warning, not an ANR") {
+        val clock = FakeClock(1_000L)
+        val e = evaluator(clock)
+
+        e.recordHeartbeat()
+        clock.advance(11_000L)
+
+        e.evaluate(actualSleepMs = 2_000L, inForeground = false).shouldBeInstanceOf<AnrCheckResult.BackgroundWarning>()
+    }
+
+    test("a watchdog oversleep is reported as frozen and re-baselines so the next check is responsive") {
+        val clock = FakeClock(1_000L)
+        val e = evaluator(clock)
+
+        e.recordHeartbeat()
+        clock.advance(60_000L)
+        e.evaluate(actualSleepMs = 30_000L, inForeground = true).shouldBeInstanceOf<AnrCheckResult.FrozenProcess>()
+
+        // Baseline was reset to now, so a normal on-time check is responsive again.
+        e.evaluate(actualSleepMs = 2_000L, inForeground = true).shouldBeInstanceOf<AnrCheckResult.Responsive>()
+    }
+
+    // ===== dedup =====
+
+    test("an ongoing foreground block is deduped within the window, then reports again after it") {
+        val clock = FakeClock(1_000L)
+        val e = evaluator(clock)
+
+        e.recordHeartbeat()
+        clock.advance(6_000L)
+        e.evaluate(actualSleepMs = 2_000L, inForeground = true).shouldBeInstanceOf<AnrCheckResult.ForegroundAnr>()
+
+        clock.advance(2_000L) // still blocked, within the 30s dedup window
+        e.evaluate(actualSleepMs = 2_000L, inForeground = true).shouldBeInstanceOf<AnrCheckResult.Deduped>()
+
+        clock.advance(30_001L) // past the dedup window
+        e.evaluate(actualSleepMs = 2_000L, inForeground = true).shouldBeInstanceOf<AnrCheckResult.ForegroundAnr>()
+    }
+
+    test("foreground and background dedup are independent — a bg warning never suppresses a fg ANR") {
+        val clock = FakeClock(1_000L)
+        val e = evaluator(clock)
+
+        // Background warning fires first and sets the background dedup timestamp.
+        e.recordHeartbeat()
+        clock.advance(11_000L)
+        e.evaluate(actualSleepMs = 2_000L, inForeground = false).shouldBeInstanceOf<AnrCheckResult.BackgroundWarning>()
+
+        // Immediately after (well within the dedup window), a foreground block must still report.
+        e.evaluate(actualSleepMs = 2_000L, inForeground = true).shouldBeInstanceOf<AnrCheckResult.ForegroundAnr>()
+    }
+
+    test("recovering with a heartbeat clears dedup so the next block reports immediately") {
+        val clock = FakeClock(1_000L)
+        val e = evaluator(clock)
+
+        e.recordHeartbeat()
+        clock.advance(6_000L)
+        e.evaluate(actualSleepMs = 2_000L, inForeground = true).shouldBeInstanceOf<AnrCheckResult.ForegroundAnr>()
+
+        // Main thread recovers.
+        clock.advance(1_000L)
+        e.recordHeartbeat()
+        e.evaluate(actualSleepMs = 2_000L, inForeground = true).shouldBeInstanceOf<AnrCheckResult.Responsive>()
+
+        // A new block right away (within the old dedup window) still reports because recovery cleared it.
+        clock.advance(6_000L)
+        e.evaluate(actualSleepMs = 2_000L, inForeground = true).shouldBeInstanceOf<AnrCheckResult.ForegroundAnr>()
+    }
+
+    test("the very first block shortly after boot is not suppressed by the sentinel timestamp") {
+        // Clock starts small (near boot); `now - NEVER_REPORTED` would look "recent" if dedup didn't
+        // special-case the sentinel. It must still report.
+        val clock = FakeClock(500L)
+        val e = evaluator(clock)
+
+        e.recordHeartbeat()
+        clock.advance(6_000L)
+        e.evaluate(actualSleepMs = 2_000L, inForeground = true).shouldBeInstanceOf<AnrCheckResult.ForegroundAnr>()
+    }
+
+    // ===== fingerprint =====
+
+    test("buildBlockFingerprint surfaces the top frame and the first OneSignal frame") {
+        val stack = arrayOf(
+            StackTraceElement("android.os.MessageQueue", "nativePollOnce", "MessageQueue.java", 1),
+            StackTraceElement("com.onesignal.core.Foo", "bar", "Foo.kt", 42),
+            StackTraceElement("com.example.App", "onCreate", "App.kt", 7),
+        )
+
+        val fp = buildBlockFingerprint(stack)
+
+        fp shouldBe "top=android.os.MessageQueue.nativePollOnce(MessageQueue.java:1)|" +
+            "onesignal=com.onesignal.core.Foo.bar(Foo.kt:42)"
+    }
+
+    test("buildBlockFingerprint reports none when no OneSignal frame is present") {
+        val stack = arrayOf(
+            StackTraceElement("android.os.MessageQueue", "nativePollOnce", "MessageQueue.java", 1),
+        )
+
+        buildBlockFingerprint(stack) shouldBe "top=android.os.MessageQueue.nativePollOnce(MessageQueue.java:1)|onesignal=none"
+    }
+
+    test("buildBlockFingerprint handles an empty stack") {
+        buildBlockFingerprint(emptyArray()) shouldBe "top=unknown|onesignal=none"
+    }
+})

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/debug/internal/crash/OtelAnrDetectorTest.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/debug/internal/crash/OtelAnrDetectorTest.kt
@@ -1,383 +1,150 @@
 package com.onesignal.debug.internal.crash
 
-import android.os.Build
-import br.com.colman.kotest.android.extensions.robolectric.RobolectricTest
 import com.onesignal.otel.IOtelLogger
 import com.onesignal.otel.IOtelOpenTelemetryCrash
-import com.onesignal.otel.IOtelPlatformProvider
 import com.onesignal.otel.crash.IOtelAnrDetector
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
-import io.mockk.coEvery
-import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import org.robolectric.annotation.Config
 
-@RobolectricTest
-@Config(sdk = [Build.VERSION_CODES.O])
+/**
+ * Pure-JVM tests for the Android ANR watchdog shell. The Android touch points (main-thread Handler,
+ * main-thread stack capture) are injected via [AnrWatchdogPlatform], and the monotonic clock via a
+ * fake, so the whole watchdog runs off-device without Robolectric — which also means JaCoCo actually
+ * measures this code. Pure decision logic is covered separately in [AnrCheckEvaluatorTest].
+ */
 class OtelAnrDetectorTest : FunSpec({
 
-    val mockPlatformProvider = mockk<IOtelPlatformProvider>(relaxed = true)
-    val mockLogger = mockk<IOtelLogger>(relaxed = true)
-    val mockCrashTelemetry = mockk<IOtelOpenTelemetryCrash>(relaxed = true)
-
-    fun setupDefaultMocks() {
-        every { mockPlatformProvider.sdkBase } returns "android"
-        every { mockPlatformProvider.sdkBaseVersion } returns "1.0.0"
-        every { mockPlatformProvider.appPackageId } returns "com.test.app"
-        every { mockPlatformProvider.appVersion } returns "1.0"
-        every { mockPlatformProvider.deviceManufacturer } returns "Test"
-        every { mockPlatformProvider.deviceModel } returns "TestDevice"
-        every { mockPlatformProvider.osName } returns "Android"
-        every { mockPlatformProvider.osVersion } returns "10"
-        every { mockPlatformProvider.osBuildId } returns "TEST123"
-        every { mockPlatformProvider.sdkWrapper } returns null
-        every { mockPlatformProvider.sdkWrapperVersion } returns null
-        every { mockPlatformProvider.appId } returns "test-app-id"
-        every { mockPlatformProvider.onesignalId } returns null
-        every { mockPlatformProvider.pushSubscriptionId } returns null
-        every { mockPlatformProvider.appState } returns "foreground"
-        every { mockPlatformProvider.processUptime } returns 100L
-        every { mockPlatformProvider.currentThreadName } returns "main"
-        every { mockPlatformProvider.crashStoragePath } returns "/test/path"
-        every { mockPlatformProvider.minFileAgeForReadMillis } returns 5000L
-        every { mockPlatformProvider.remoteLogLevel } returns "ERROR"
-        every { mockPlatformProvider.appIdForHeaders } returns "test-app-id"
-        every { mockPlatformProvider.apiBaseUrl } returns "https://api.onesignal.com"
-        coEvery { mockPlatformProvider.getInstallId() } returns "test-install-id"
-    }
-
-    beforeEach {
-        setupDefaultMocks()
-    }
-
-    // ===== Factory Function Tests =====
-
-    test("createAnrDetector should return IOtelAnrDetector") {
-        // When
-        val detector = createAnrDetector(mockPlatformProvider, mockLogger)
-
-        // Then
-        detector.shouldBeInstanceOf<IOtelAnrDetector>()
-    }
-
-    test("createAnrDetector should create detector with default thresholds") {
-        // When
-        val detector = createAnrDetector(mockPlatformProvider, mockLogger)
-
-        // Then
-        detector shouldNotBe null
-    }
-
-    test("createAnrDetector should accept custom thresholds") {
-        // When
-        val detector = createAnrDetector(
-            mockPlatformProvider,
-            mockLogger,
-            anrThresholdMs = 10_000L,
-            checkIntervalMs = 2_000L
-        )
-
-        // Then
-        detector shouldNotBe null
-    }
-
-    test("createAnrDetector should accept custom background threshold") {
-        // When
-        val detector = createAnrDetector(
-            mockPlatformProvider,
-            mockLogger,
-            anrThresholdMs = 5_000L,
-            checkIntervalMs = 2_000L,
-            backgroundThresholdMs = 20_000L
-        )
-
-        // Then
-        detector shouldNotBe null
-    }
-
-    // ===== Start/Stop Tests =====
-
-    test("start should log info messages") {
-        // Given
-        val detector = createAnrDetector(mockPlatformProvider, mockLogger)
-
-        // When
-        detector.start()
-
-        // Then
-        verify { mockLogger.info(match { it.contains("Starting ANR detection") }) }
-
-        // Cleanup
-        detector.stop()
-    }
-
-    test("stop should log info messages") {
-        // Given
-        val detector = createAnrDetector(mockPlatformProvider, mockLogger)
-        detector.start()
-
-        // When
-        detector.stop()
-
-        // Then
-        verify { mockLogger.info(match { it.contains("Stopping ANR detection") }) }
-    }
-
-    test("start should warn when already monitoring") {
-        // Given
-        val detector = createAnrDetector(mockPlatformProvider, mockLogger)
-        detector.start()
-
-        // When - start again
-        detector.start()
-
-        // Then
-        verify { mockLogger.warn(match { it.contains("Already monitoring") }) }
-
-        // Cleanup
-        detector.stop()
-    }
-
-    test("stop should warn when not monitoring") {
-        // Given
-        val detector = createAnrDetector(mockPlatformProvider, mockLogger)
-
-        // When - stop without starting
-        detector.stop()
-
-        // Then
-        verify { mockLogger.warn(match { it.contains("Not monitoring") }) }
-    }
-
-    test("start and stop can be called multiple times safely") {
-        // Given
-        val detector = createAnrDetector(mockPlatformProvider, mockLogger)
-
-        // When
-        detector.start()
-        detector.stop()
-        detector.start()
-        detector.stop()
-
-        // Then - no exceptions thrown
-    }
-
-    // ===== OtelAnrDetector Internal Tests =====
-
-    test("OtelAnrDetector should implement IOtelAnrDetector") {
-        // Given
-        val detector = OtelAnrDetector(mockCrashTelemetry, mockLogger)
-
-        // Then
-        detector.shouldBeInstanceOf<IOtelAnrDetector>()
-    }
-
-    test("OtelAnrDetector should accept custom thresholds") {
-        // When
-        val detector = OtelAnrDetector(
-            mockCrashTelemetry,
-            mockLogger,
-            anrThresholdMs = 15_000L,
-            checkIntervalMs = 3_000L
-        )
-
-        // Then
-        detector shouldNotBe null
-    }
-
-    test("OtelAnrDetector start should initialize watchdog thread") {
-        // Given
-        val detector = OtelAnrDetector(
-            mockCrashTelemetry,
-            mockLogger,
-            anrThresholdMs = 100_000L, // Very long threshold to prevent actual ANR detection
-            checkIntervalMs = 100_000L // Very long interval
-        )
-
-        // When
-        detector.start()
-
-        // Then
-        verify { mockLogger.info(match { it.contains("ANR detection started successfully") }) }
-
-        // Cleanup
-        detector.stop()
-    }
-
-    test("OtelAnrDetector stop should stop watchdog thread") {
-        // Given
-        val detector = OtelAnrDetector(
-            mockCrashTelemetry,
-            mockLogger,
-            anrThresholdMs = 100_000L,
-            checkIntervalMs = 100_000L
-        )
-        detector.start()
-
-        // When
-        detector.stop()
-
-        // Then
-        verify { mockLogger.info(match { it.contains("ANR detection stopped") }) }
-    }
-
-    // ===== AnrConstants Tests =====
-
-    test("AnrConstants should have reasonable defaults") {
-        // Then
-        AnrConstants.DEFAULT_ANR_THRESHOLD_MS shouldBe 5_000L
-        AnrConstants.DEFAULT_CHECK_INTERVAL_MS shouldBe 2_000L
-        AnrConstants.DEFAULT_BACKGROUND_BLOCK_THRESHOLD_MS shouldBe 10_000L
-        // The background threshold must stay above the foreground ANR threshold so backgrounded
-        // blocks need to last longer before they are even recorded as a warning.
-        (AnrConstants.DEFAULT_BACKGROUND_BLOCK_THRESHOLD_MS > AnrConstants.DEFAULT_ANR_THRESHOLD_MS) shouldBe true
-    }
-
-    // ===== classifyBlock Tests =====
-
-    // Defaults mirror AnrConstants: 5s ANR, 2s check interval, 2s frozen slack, 10s background.
-    fun classify(
-        timeSinceLastResponseMs: Long,
-        inForeground: Boolean,
-        actualSleepMs: Long = 2_000L,
-    ): BlockClassification = classifyBlock(
-        timeSinceLastResponseMs = timeSinceLastResponseMs,
-        actualSleepMs = actualSleepMs,
-        checkIntervalMs = 2_000L,
-        frozenSlackMs = 2_000L,
-        anrThresholdMs = 5_000L,
-        backgroundThresholdMs = 10_000L,
-        inForeground = inForeground,
+    val oneSignalStack = arrayOf(
+        StackTraceElement("android.os.MessageQueue", "nativePollOnce", "MessageQueue.java", 1),
+        StackTraceElement("com.onesignal.core.Foo", "bar", "Foo.kt", 42),
     )
-
-    test("foreground block past the ANR threshold is a foreground ANR") {
-        classify(timeSinceLastResponseMs = 6_000L, inForeground = true) shouldBe BlockClassification.FOREGROUND_ANR
-    }
-
-    test("foreground block within the ANR threshold is responsive") {
-        classify(timeSinceLastResponseMs = 4_000L, inForeground = true) shouldBe BlockClassification.RESPONSIVE
-    }
-
-    test("background block past the foreground threshold but below the background threshold is responsive") {
-        // 7s would be a foreground ANR, but in the background it is below the 10s warning threshold.
-        classify(timeSinceLastResponseMs = 7_000L, inForeground = false) shouldBe BlockClassification.RESPONSIVE
-    }
-
-    test("background block past the background threshold is a background warning, not an ANR") {
-        classify(timeSinceLastResponseMs = 11_000L, inForeground = false) shouldBe BlockClassification.BACKGROUND_WARNING
-    }
-
-    test("watchdog oversleeping beyond the frozen slack is treated as a frozen process") {
-        // Even a huge measured block is suppressed when our own sleep overran (Doze / freeze).
-        classify(
-            timeSinceLastResponseMs = 60_000L,
-            inForeground = true,
-            actualSleepMs = 30_000L,
-        ) shouldBe BlockClassification.FROZEN_PROCESS
-    }
-
-    test("frozen-process detection wins over a foreground ANR") {
-        classify(
-            timeSinceLastResponseMs = 60_000L,
-            inForeground = false,
-            actualSleepMs = 30_000L,
-        ) shouldBe BlockClassification.FROZEN_PROCESS
-    }
-
-    test("sleep overrun within the slack is not treated as frozen") {
-        // 2s interval + 1.5s overrun = within the 2s slack, so a real foreground ANR still reports.
-        classify(
-            timeSinceLastResponseMs = 6_000L,
-            inForeground = true,
-            actualSleepMs = 3_500L,
-        ) shouldBe BlockClassification.FOREGROUND_ANR
-    }
-
-    // ===== Heartbeat / evaluateCheck integration (deterministic via injected clock) =====
-    //
-    // These drive the real recordHeartbeat -> clock -> evaluateCheck -> report wiring with a fake
-    // monotonic clock and a fresh logger per test, so there is no background thread, no real sleep,
-    // and no cross-test verify() pollution.
+    val nonOneSignalStack = arrayOf(
+        StackTraceElement("android.os.MessageQueue", "nativePollOnce", "MessageQueue.java", 1),
+        StackTraceElement("com.example.App", "onCreate", "App.kt", 7),
+    )
 
     class FakeClock(var nowMs: Long = 1_000L) {
         fun advance(ms: Long) { nowMs += ms }
     }
 
+    class FakePlatform(
+        var stack: Array<StackTraceElement>,
+        private val clock: FakeClock,
+        private val runPostsSynchronously: Boolean = true,
+    ) : AnrWatchdogPlatform {
+        override fun postToMainThread(runnable: Runnable) {
+            // Simulate a responsive main thread that immediately runs the heartbeat.
+            if (runPostsSynchronously) runnable.run()
+        }
+
+        override fun removeFromMainThread(runnable: Runnable) = Unit
+
+        override fun mainThread(): Thread = Thread.currentThread()
+
+        override fun mainThreadStackTrace(): Array<StackTraceElement> = stack
+
+        override fun now(): Long = clock.nowMs
+    }
+
     fun buildDetector(
         clock: FakeClock,
         logger: IOtelLogger,
-        inForeground: () -> Boolean,
+        platform: FakePlatform,
+        inForeground: () -> Boolean = { true },
+        checkIntervalMs: Long = 2_000L,
     ): OtelAnrDetector = OtelAnrDetector(
-        mockCrashTelemetry,
+        mockk<IOtelOpenTelemetryCrash>(relaxed = true),
         logger,
         anrThresholdMs = 5_000L,
-        checkIntervalMs = 2_000L,
+        checkIntervalMs = checkIntervalMs,
         backgroundThresholdMs = 10_000L,
         isAppInForeground = inForeground,
-        now = { clock.nowMs },
+        platform = platform,
     )
 
-    test("a fresh heartbeat keeps a foreground check responsive (no ANR)") {
-        val clock = FakeClock(nowMs = 5_000L)
-        val logger = mockk<IOtelLogger>(relaxed = true)
-        val detector = buildDetector(clock, logger) { true }
+    test("OtelAnrDetector implements IOtelAnrDetector") {
+        val clock = FakeClock()
+        val detector = buildDetector(clock, mockk(relaxed = true), FakePlatform(oneSignalStack, clock))
+        detector.shouldBeInstanceOf<IOtelAnrDetector>()
+    }
 
-        detector.recordHeartbeat() // main thread responded at t=5000
-        clock.advance(4_000L) // below the 5s threshold
+    // ===== evaluateCheck: decision -> side effect wiring =====
+
+    test("a fresh heartbeat keeps a foreground check responsive (no ANR)") {
+        val clock = FakeClock(5_000L)
+        val logger = mockk<IOtelLogger>(relaxed = true)
+        val detector = buildDetector(clock, logger, FakePlatform(oneSignalStack, clock))
+
+        detector.recordHeartbeat()
+        clock.advance(4_000L)
         detector.evaluateCheck(actualSleepMs = 2_000L)
 
         verify(exactly = 0) { logger.info(match { it.contains("Main thread unresponsive") }) }
     }
 
-    test("a stale heartbeat past the threshold reports a foreground ANR") {
-        val clock = FakeClock(nowMs = 1_000L)
+    test("a stale heartbeat past the threshold reports and saves a foreground ANR") {
+        val clock = FakeClock(1_000L)
         val logger = mockk<IOtelLogger>(relaxed = true)
-        val detector = buildDetector(clock, logger) { true }
+        val detector = buildDetector(clock, logger, FakePlatform(oneSignalStack, clock))
 
-        detector.recordHeartbeat() // main thread last responded at t=1000
-        clock.advance(6_000L) // 6s with no heartbeat, past the 5s threshold
+        detector.recordHeartbeat()
+        clock.advance(6_000L)
         detector.evaluateCheck(actualSleepMs = 2_000L)
 
         verify(exactly = 1) { logger.info(match { it.contains("Main thread unresponsive") && it.contains("foreground") }) }
+        verify { logger.info(match { it.contains("ANR report saved successfully") }) }
+    }
+
+    test("a foreground ANR whose stack is not OneSignal-related is not reported") {
+        val clock = FakeClock(1_000L)
+        val logger = mockk<IOtelLogger>(relaxed = true)
+        val detector = buildDetector(clock, logger, FakePlatform(nonOneSignalStack, clock))
+
+        detector.recordHeartbeat()
+        clock.advance(6_000L)
+        detector.evaluateCheck(actualSleepMs = 2_000L)
+
+        verify { logger.debug(match { it.contains("not OneSignal-related") }) }
+        verify(exactly = 0) { logger.info(match { it.contains("ANR report saved successfully") }) }
     }
 
     test("recovering with a heartbeat returns the detector to responsive") {
-        val clock = FakeClock(nowMs = 1_000L)
+        val clock = FakeClock(1_000L)
         val logger = mockk<IOtelLogger>(relaxed = true)
-        val detector = buildDetector(clock, logger) { true }
+        val detector = buildDetector(clock, logger, FakePlatform(oneSignalStack, clock))
 
         detector.recordHeartbeat()
         clock.advance(6_000L)
         detector.evaluateCheck(actualSleepMs = 2_000L) // fires once
 
-        detector.recordHeartbeat() // main thread recovers at t=7000
-        detector.evaluateCheck(actualSleepMs = 2_000L) // now responsive again
+        clock.advance(1_000L)
+        detector.recordHeartbeat() // main thread recovers
+        detector.evaluateCheck(actualSleepMs = 2_000L) // responsive again
 
-        // Still only the single ANR from before recovery.
         verify(exactly = 1) { logger.info(match { it.contains("Main thread unresponsive") }) }
     }
 
-    test("background block past the background threshold logs a warning, not an ANR") {
-        val clock = FakeClock(nowMs = 1_000L)
+    test("a background block past the background threshold records a warning, not an ANR") {
+        val clock = FakeClock(1_000L)
         val logger = mockk<IOtelLogger>(relaxed = true)
-        val detector = buildDetector(clock, logger) { false }
+        val detector = buildDetector(clock, logger, FakePlatform(oneSignalStack, clock), inForeground = { false })
 
         detector.recordHeartbeat()
-        clock.advance(11_000L) // past the 10s background threshold
+        clock.advance(11_000L)
         detector.evaluateCheck(actualSleepMs = 2_000L)
 
         verify(exactly = 1) { logger.info(match { it.contains("backgrounded") && it.contains("warning") }) }
+        verify { logger.info(match { it.contains("Background block warning recorded") }) }
         verify(exactly = 0) { logger.info(match { it.contains("Main thread unresponsive") }) }
     }
 
-    test("background block below the background threshold stays responsive") {
-        val clock = FakeClock(nowMs = 1_000L)
+    test("a background block below the background threshold stays responsive") {
+        val clock = FakeClock(1_000L)
         val logger = mockk<IOtelLogger>(relaxed = true)
-        val detector = buildDetector(clock, logger) { false }
+        val detector = buildDetector(clock, logger, FakePlatform(oneSignalStack, clock), inForeground = { false })
 
         detector.recordHeartbeat()
         clock.advance(7_000L) // would be a foreground ANR, but below the 10s background threshold
@@ -387,10 +154,23 @@ class OtelAnrDetectorTest : FunSpec({
         verify(exactly = 0) { logger.info(match { it.contains("backgrounded") }) }
     }
 
-    test("a watchdog oversleep is reported as a frozen process and resets the baseline") {
-        val clock = FakeClock(nowMs = 1_000L)
+    test("a background block whose stack is not OneSignal-related is skipped") {
+        val clock = FakeClock(1_000L)
         val logger = mockk<IOtelLogger>(relaxed = true)
-        val detector = buildDetector(clock, logger) { true }
+        val detector = buildDetector(clock, logger, FakePlatform(nonOneSignalStack, clock), inForeground = { false })
+
+        detector.recordHeartbeat()
+        clock.advance(11_000L)
+        detector.evaluateCheck(actualSleepMs = 2_000L)
+
+        verify { logger.debug(match { it.contains("Background block is not OneSignal-related") }) }
+        verify(exactly = 0) { logger.info(match { it.contains("Background block warning recorded") }) }
+    }
+
+    test("a watchdog oversleep is reported as a frozen process and resets the baseline") {
+        val clock = FakeClock(1_000L)
+        val logger = mockk<IOtelLogger>(relaxed = true)
+        val detector = buildDetector(clock, logger, FakePlatform(oneSignalStack, clock))
 
         detector.recordHeartbeat()
         clock.advance(60_000L) // huge apparent block...
@@ -399,23 +179,84 @@ class OtelAnrDetectorTest : FunSpec({
         verify(exactly = 1) { logger.debug(match { it.contains("frozen") }) }
         verify(exactly = 0) { logger.info(match { it.contains("Main thread unresponsive") }) }
 
-        // Baseline was reset to now, so the very next on-time check is responsive (no ANR).
         detector.evaluateCheck(actualSleepMs = 2_000L)
         verify(exactly = 0) { logger.info(match { it.contains("Main thread unresponsive") }) }
     }
 
     test("an ongoing block is reported only once within the dedup window") {
-        val clock = FakeClock(nowMs = 1_000L)
+        val clock = FakeClock(1_000L)
         val logger = mockk<IOtelLogger>(relaxed = true)
-        val detector = buildDetector(clock, logger) { true }
+        val detector = buildDetector(clock, logger, FakePlatform(oneSignalStack, clock))
 
         detector.recordHeartbeat()
         clock.advance(6_000L)
         detector.evaluateCheck(actualSleepMs = 2_000L) // first report
 
-        clock.advance(2_000L) // still blocked, 2s later — within the 30s dedup window
-        detector.evaluateCheck(actualSleepMs = 2_000L) // should be deduped
+        clock.advance(2_000L) // still blocked, within the 30s dedup window
+        detector.evaluateCheck(actualSleepMs = 2_000L) // deduped
 
         verify(exactly = 1) { logger.info(match { it.contains("Main thread unresponsive") }) }
+        verify { logger.debug(match { it.contains("already reported recently") }) }
+    }
+
+    test("an unknown app state is treated as foreground so a real ANR is never dropped") {
+        val clock = FakeClock(1_000L)
+        val logger = mockk<IOtelLogger>(relaxed = true)
+        val detector = buildDetector(clock, logger, FakePlatform(oneSignalStack, clock), inForeground = { error("no state") })
+
+        detector.recordHeartbeat()
+        clock.advance(6_000L)
+        detector.evaluateCheck(actualSleepMs = 2_000L)
+
+        verify { logger.debug(match { it.contains("Could not resolve app state") }) }
+        verify(exactly = 1) { logger.info(match { it.contains("Main thread unresponsive") && it.contains("foreground") }) }
+    }
+
+    // ===== start / stop lifecycle (real watchdog thread, fake platform + clock) =====
+
+    test("start then stop drives the watchdog loop and logs lifecycle") {
+        val clock = FakeClock(1_000L)
+        val logger = mockk<IOtelLogger>(relaxed = true)
+        // Small interval so the real watchdog thread iterates a few times before we stop it.
+        val detector = buildDetector(clock, logger, FakePlatform(oneSignalStack, clock), checkIntervalMs = 20L)
+
+        detector.start()
+        Thread.sleep(120L) // let the watchdog run a handful of responsive checks
+        detector.stop()
+
+        verify { logger.info(match { it.contains("ANR detection started successfully") }) }
+        verify { logger.info(match { it.contains("ANR detection stopped") }) }
+    }
+
+    test("start twice warns about already monitoring") {
+        val clock = FakeClock()
+        val logger = mockk<IOtelLogger>(relaxed = true)
+        val detector = buildDetector(clock, logger, FakePlatform(oneSignalStack, clock), checkIntervalMs = 100_000L)
+
+        detector.start()
+        detector.start()
+        verify { logger.warn(match { it.contains("Already monitoring") }) }
+
+        detector.stop()
+    }
+
+    test("stop without start warns about not monitoring") {
+        val clock = FakeClock()
+        val logger = mockk<IOtelLogger>(relaxed = true)
+        val detector = buildDetector(clock, logger, FakePlatform(oneSignalStack, clock))
+
+        detector.stop()
+        verify { logger.warn(match { it.contains("Not monitoring") }) }
+    }
+
+    // ===== AnrConstants =====
+
+    test("AnrConstants should have reasonable defaults") {
+        AnrConstants.DEFAULT_ANR_THRESHOLD_MS shouldBe 5_000L
+        AnrConstants.DEFAULT_CHECK_INTERVAL_MS shouldBe 2_000L
+        AnrConstants.DEFAULT_BACKGROUND_BLOCK_THRESHOLD_MS shouldBe 10_000L
+        // The background threshold must stay above the foreground ANR threshold so backgrounded
+        // blocks need to last longer before they are even recorded as a warning.
+        (AnrConstants.DEFAULT_BACKGROUND_BLOCK_THRESHOLD_MS > AnrConstants.DEFAULT_ANR_THRESHOLD_MS) shouldBe true
     }
 })

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/debug/internal/crash/OtelAnrDetectorTest.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/debug/internal/crash/OtelAnrDetectorTest.kt
@@ -85,6 +85,20 @@ class OtelAnrDetectorTest : FunSpec({
         detector shouldNotBe null
     }
 
+    test("createAnrDetector should accept custom background threshold") {
+        // When
+        val detector = createAnrDetector(
+            mockPlatformProvider,
+            mockLogger,
+            anrThresholdMs = 5_000L,
+            checkIntervalMs = 2_000L,
+            backgroundThresholdMs = 20_000L
+        )
+
+        // Then
+        detector shouldNotBe null
+    }
+
     // ===== Start/Stop Tests =====
 
     test("start should log info messages") {
@@ -217,5 +231,69 @@ class OtelAnrDetectorTest : FunSpec({
         // Then
         AnrConstants.DEFAULT_ANR_THRESHOLD_MS shouldBe 5_000L
         AnrConstants.DEFAULT_CHECK_INTERVAL_MS shouldBe 2_000L
+        AnrConstants.DEFAULT_BACKGROUND_BLOCK_THRESHOLD_MS shouldBe 10_000L
+        // The background threshold must stay above the foreground ANR threshold so backgrounded
+        // blocks need to last longer before they are even recorded as a warning.
+        (AnrConstants.DEFAULT_BACKGROUND_BLOCK_THRESHOLD_MS > AnrConstants.DEFAULT_ANR_THRESHOLD_MS) shouldBe true
+    }
+
+    // ===== classifyBlock Tests =====
+
+    // Defaults mirror AnrConstants: 5s ANR, 2s check interval, 2s frozen slack, 10s background.
+    fun classify(
+        timeSinceLastResponseMs: Long,
+        inForeground: Boolean,
+        actualSleepMs: Long = 2_000L,
+    ): BlockClassification = classifyBlock(
+        timeSinceLastResponseMs = timeSinceLastResponseMs,
+        actualSleepMs = actualSleepMs,
+        checkIntervalMs = 2_000L,
+        frozenSlackMs = 2_000L,
+        anrThresholdMs = 5_000L,
+        backgroundThresholdMs = 10_000L,
+        inForeground = inForeground,
+    )
+
+    test("foreground block past the ANR threshold is a foreground ANR") {
+        classify(timeSinceLastResponseMs = 6_000L, inForeground = true) shouldBe BlockClassification.FOREGROUND_ANR
+    }
+
+    test("foreground block within the ANR threshold is responsive") {
+        classify(timeSinceLastResponseMs = 4_000L, inForeground = true) shouldBe BlockClassification.RESPONSIVE
+    }
+
+    test("background block past the foreground threshold but below the background threshold is responsive") {
+        // 7s would be a foreground ANR, but in the background it is below the 10s warning threshold.
+        classify(timeSinceLastResponseMs = 7_000L, inForeground = false) shouldBe BlockClassification.RESPONSIVE
+    }
+
+    test("background block past the background threshold is a background warning, not an ANR") {
+        classify(timeSinceLastResponseMs = 11_000L, inForeground = false) shouldBe BlockClassification.BACKGROUND_WARNING
+    }
+
+    test("watchdog oversleeping beyond the frozen slack is treated as a frozen process") {
+        // Even a huge measured block is suppressed when our own sleep overran (Doze / freeze).
+        classify(
+            timeSinceLastResponseMs = 60_000L,
+            inForeground = true,
+            actualSleepMs = 30_000L,
+        ) shouldBe BlockClassification.FROZEN_PROCESS
+    }
+
+    test("frozen-process detection wins over a foreground ANR") {
+        classify(
+            timeSinceLastResponseMs = 60_000L,
+            inForeground = false,
+            actualSleepMs = 30_000L,
+        ) shouldBe BlockClassification.FROZEN_PROCESS
+    }
+
+    test("sleep overrun within the slack is not treated as frozen") {
+        // 2s interval + 1.5s overrun = within the 2s slack, so a real foreground ANR still reports.
+        classify(
+            timeSinceLastResponseMs = 6_000L,
+            inForeground = true,
+            actualSleepMs = 3_500L,
+        ) shouldBe BlockClassification.FOREGROUND_ANR
     }
 })

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/debug/internal/crash/OtelAnrDetectorTest.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/debug/internal/crash/OtelAnrDetectorTest.kt
@@ -296,4 +296,126 @@ class OtelAnrDetectorTest : FunSpec({
             actualSleepMs = 3_500L,
         ) shouldBe BlockClassification.FOREGROUND_ANR
     }
+
+    // ===== Heartbeat / evaluateCheck integration (deterministic via injected clock) =====
+    //
+    // These drive the real recordHeartbeat -> clock -> evaluateCheck -> report wiring with a fake
+    // monotonic clock and a fresh logger per test, so there is no background thread, no real sleep,
+    // and no cross-test verify() pollution.
+
+    class FakeClock(var nowMs: Long = 1_000L) {
+        fun advance(ms: Long) { nowMs += ms }
+    }
+
+    fun buildDetector(
+        clock: FakeClock,
+        logger: IOtelLogger,
+        inForeground: () -> Boolean,
+    ): OtelAnrDetector = OtelAnrDetector(
+        mockCrashTelemetry,
+        logger,
+        anrThresholdMs = 5_000L,
+        checkIntervalMs = 2_000L,
+        backgroundThresholdMs = 10_000L,
+        isAppInForeground = inForeground,
+        now = { clock.nowMs },
+    )
+
+    test("a fresh heartbeat keeps a foreground check responsive (no ANR)") {
+        val clock = FakeClock(nowMs = 5_000L)
+        val logger = mockk<IOtelLogger>(relaxed = true)
+        val detector = buildDetector(clock, logger) { true }
+
+        detector.recordHeartbeat() // main thread responded at t=5000
+        clock.advance(4_000L) // below the 5s threshold
+        detector.evaluateCheck(actualSleepMs = 2_000L)
+
+        verify(exactly = 0) { logger.info(match { it.contains("Main thread unresponsive") }) }
+    }
+
+    test("a stale heartbeat past the threshold reports a foreground ANR") {
+        val clock = FakeClock(nowMs = 1_000L)
+        val logger = mockk<IOtelLogger>(relaxed = true)
+        val detector = buildDetector(clock, logger) { true }
+
+        detector.recordHeartbeat() // main thread last responded at t=1000
+        clock.advance(6_000L) // 6s with no heartbeat, past the 5s threshold
+        detector.evaluateCheck(actualSleepMs = 2_000L)
+
+        verify(exactly = 1) { logger.info(match { it.contains("Main thread unresponsive") && it.contains("foreground") }) }
+    }
+
+    test("recovering with a heartbeat returns the detector to responsive") {
+        val clock = FakeClock(nowMs = 1_000L)
+        val logger = mockk<IOtelLogger>(relaxed = true)
+        val detector = buildDetector(clock, logger) { true }
+
+        detector.recordHeartbeat()
+        clock.advance(6_000L)
+        detector.evaluateCheck(actualSleepMs = 2_000L) // fires once
+
+        detector.recordHeartbeat() // main thread recovers at t=7000
+        detector.evaluateCheck(actualSleepMs = 2_000L) // now responsive again
+
+        // Still only the single ANR from before recovery.
+        verify(exactly = 1) { logger.info(match { it.contains("Main thread unresponsive") }) }
+    }
+
+    test("background block past the background threshold logs a warning, not an ANR") {
+        val clock = FakeClock(nowMs = 1_000L)
+        val logger = mockk<IOtelLogger>(relaxed = true)
+        val detector = buildDetector(clock, logger) { false }
+
+        detector.recordHeartbeat()
+        clock.advance(11_000L) // past the 10s background threshold
+        detector.evaluateCheck(actualSleepMs = 2_000L)
+
+        verify(exactly = 1) { logger.info(match { it.contains("backgrounded") && it.contains("warning") }) }
+        verify(exactly = 0) { logger.info(match { it.contains("Main thread unresponsive") }) }
+    }
+
+    test("background block below the background threshold stays responsive") {
+        val clock = FakeClock(nowMs = 1_000L)
+        val logger = mockk<IOtelLogger>(relaxed = true)
+        val detector = buildDetector(clock, logger) { false }
+
+        detector.recordHeartbeat()
+        clock.advance(7_000L) // would be a foreground ANR, but below the 10s background threshold
+        detector.evaluateCheck(actualSleepMs = 2_000L)
+
+        verify(exactly = 0) { logger.info(match { it.contains("Main thread unresponsive") }) }
+        verify(exactly = 0) { logger.info(match { it.contains("backgrounded") }) }
+    }
+
+    test("a watchdog oversleep is reported as a frozen process and resets the baseline") {
+        val clock = FakeClock(nowMs = 1_000L)
+        val logger = mockk<IOtelLogger>(relaxed = true)
+        val detector = buildDetector(clock, logger) { true }
+
+        detector.recordHeartbeat()
+        clock.advance(60_000L) // huge apparent block...
+        detector.evaluateCheck(actualSleepMs = 30_000L) // ...but our own sleep overran => frozen
+
+        verify(exactly = 1) { logger.debug(match { it.contains("frozen") }) }
+        verify(exactly = 0) { logger.info(match { it.contains("Main thread unresponsive") }) }
+
+        // Baseline was reset to now, so the very next on-time check is responsive (no ANR).
+        detector.evaluateCheck(actualSleepMs = 2_000L)
+        verify(exactly = 0) { logger.info(match { it.contains("Main thread unresponsive") }) }
+    }
+
+    test("an ongoing block is reported only once within the dedup window") {
+        val clock = FakeClock(nowMs = 1_000L)
+        val logger = mockk<IOtelLogger>(relaxed = true)
+        val detector = buildDetector(clock, logger) { true }
+
+        detector.recordHeartbeat()
+        clock.advance(6_000L)
+        detector.evaluateCheck(actualSleepMs = 2_000L) // first report
+
+        clock.advance(2_000L) // still blocked, 2s later — within the 30s dedup window
+        detector.evaluateCheck(actualSleepMs = 2_000L) // should be deduped
+
+        verify(exactly = 1) { logger.info(match { it.contains("Main thread unresponsive") }) }
+    }
 })

--- a/OneSignalSDK/onesignal/otel/src/main/java/com/onesignal/otel/IOtelCrashReporter.kt
+++ b/OneSignalSDK/onesignal/otel/src/main/java/com/onesignal/otel/IOtelCrashReporter.kt
@@ -4,5 +4,17 @@ package com.onesignal.otel
  * Platform-agnostic crash reporter interface.
  */
 interface IOtelCrashReporter {
+    /**
+     * Records a fatal, crash-class event on the retained, disk-buffered crash telemetry
+     * (Severity.FATAL). Use for real crashes and foreground ANRs.
+     */
     suspend fun saveCrash(thread: Thread, throwable: Throwable)
+
+    /**
+     * Records a non-fatal event on the same retained, disk-buffered crash telemetry, but at
+     * Severity.WARN and tagged as non-fatal, so it stays out of any severity-based crash/ANR metric
+     * while remaining queryable. Use for backgrounded main-thread blocks and other retained warnings
+     * that are not user-visible crashes.
+     */
+    suspend fun saveNonFatal(thread: Thread, throwable: Throwable)
 }

--- a/OneSignalSDK/onesignal/otel/src/main/java/com/onesignal/otel/crash/OtelCrashReporter.kt
+++ b/OneSignalSDK/onesignal/otel/src/main/java/com/onesignal/otel/crash/OtelCrashReporter.kt
@@ -15,11 +15,29 @@ internal class OtelCrashReporter(
         private const val OTEL_EXCEPTION_MESSAGE = "exception.message"
         private const val OTEL_EXCEPTION_STACKTRACE = "exception.stacktrace"
         private const val OTEL_EXCEPTION_THREAD_NAME = "ossdk.exception.thread.name"
+
+        // Explicit, SDK-owned fatal flag. The backend can segment crash/ANR metrics on this stable
+        // attribute rather than inferring intent from severity or exception.type alone, so a
+        // non-fatal record can never be double-counted as a crash even if a mapping changes.
+        private const val OTEL_FATAL = "ossdk.crash.fatal"
     }
 
-    override suspend fun saveCrash(thread: Thread, throwable: Throwable) {
+    override suspend fun saveCrash(thread: Thread, throwable: Throwable) =
+        save(thread, throwable, severity = Severity.FATAL, fatal = true)
+
+    override suspend fun saveNonFatal(thread: Thread, throwable: Throwable) =
+        save(thread, throwable, severity = Severity.WARN, fatal = false)
+
+    private suspend fun save(
+        thread: Thread,
+        throwable: Throwable,
+        severity: Severity,
+        fatal: Boolean,
+    ) {
+        // Capitalized so the fatal path keeps its existing "Crash report ..." log wording.
+        val label = if (fatal) "Crash report" else "Non-fatal report"
         try {
-            logger.info("OtelCrashReporter: Starting to save crash report for ${throwable.javaClass.simpleName}")
+            logger.info("OtelCrashReporter: Starting to save ${label.lowercase()} for ${throwable.javaClass.simpleName}")
 
             val attributes =
                 Attributes
@@ -30,22 +48,23 @@ internal class OtelCrashReporter(
                     // This matches the top level thread.name today, but it may not
                     // always if things are refactored to use a different thread.
                     .put(OTEL_EXCEPTION_THREAD_NAME, thread.name)
+                    .put(OTEL_FATAL, fatal)
                     .build()
 
             logger.debug("OtelCrashReporter: Creating log record with attributes...")
             openTelemetry
                 .getLogger()
                 .setAllAttributes(attributes)
-                .setSeverity(Severity.FATAL)
+                .setSeverity(severity)
                 .setTimestamp(Instant.now())
                 .emit()
 
-            logger.debug("OtelCrashReporter: Flushing crash report to disk...")
+            logger.debug("OtelCrashReporter: Flushing ${label.lowercase()} to disk...")
             openTelemetry.forceFlush()
 
             // Note: forceFlush() returns CompletableResultCode which is async
             // We wait for it in the implementation, so if we get here, it succeeded
-            logger.info("OtelCrashReporter: ✅ Crash report saved and flushed successfully to disk")
+            logger.info("OtelCrashReporter: ✅ $label saved and flushed successfully to disk")
         } catch (e: RuntimeException) {
             // If we fail to log the crash, at least try to log the failure
             logger.error("OtelCrashReporter: Failed to save crash report: ${e.message} - ${e.javaClass.simpleName}")

--- a/OneSignalSDK/onesignal/otel/src/test/java/com/onesignal/otel/crash/OtelCrashReporterTest.kt
+++ b/OneSignalSDK/onesignal/otel/src/test/java/com/onesignal/otel/crash/OtelCrashReporterTest.kt
@@ -5,13 +5,17 @@ import com.onesignal.otel.IOtelLogger
 import com.onesignal.otel.IOtelOpenTelemetryCrash
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.clearMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.logs.LogRecordBuilder
 import io.opentelemetry.api.logs.Severity
 import io.opentelemetry.sdk.common.CompletableResultCode
@@ -54,6 +58,46 @@ class OtelCrashReporterTest : FunSpec({
         coVerify(exactly = 1) { mockOpenTelemetry.getLogger() }
         coVerify(exactly = 1) { mockOpenTelemetry.forceFlush() }
         verify { mockLogRecordBuilder.setSeverity(Severity.FATAL) }
+        verify { mockLogRecordBuilder.emit() }
+    }
+
+    test("saveCrash should emit at FATAL severity and tag the record fatal") {
+        val attrsSlot = slot<Attributes>()
+        every { mockLogRecordBuilder.setAllAttributes(capture(attrsSlot)) } returns mockLogRecordBuilder
+        val crashReporter = OtelCrashReporter(mockOpenTelemetry, mockLogger)
+
+        runBlocking {
+            crashReporter.saveCrash(Thread.currentThread(), RuntimeException("boom"))
+        }
+
+        verify { mockLogRecordBuilder.setSeverity(Severity.FATAL) }
+        attrsSlot.captured.get(AttributeKey.booleanKey("ossdk.crash.fatal")) shouldBe true
+    }
+
+    test("saveNonFatal should emit at WARN severity and tag the record non-fatal") {
+        val attrsSlot = slot<Attributes>()
+        every { mockLogRecordBuilder.setAllAttributes(capture(attrsSlot)) } returns mockLogRecordBuilder
+        val crashReporter = OtelCrashReporter(mockOpenTelemetry, mockLogger)
+
+        runBlocking {
+            crashReporter.saveNonFatal(Thread.currentThread(), RuntimeException("background block"))
+        }
+
+        // A background block must never ride the fatal severity that feeds the crash/ANR metric.
+        verify { mockLogRecordBuilder.setSeverity(Severity.WARN) }
+        verify(exactly = 0) { mockLogRecordBuilder.setSeverity(Severity.FATAL) }
+        attrsSlot.captured.get(AttributeKey.booleanKey("ossdk.crash.fatal")) shouldBe false
+    }
+
+    test("saveNonFatal should still get logger, emit, and flush to the retained crash telemetry") {
+        val crashReporter = OtelCrashReporter(mockOpenTelemetry, mockLogger)
+
+        runBlocking {
+            crashReporter.saveNonFatal(Thread.currentThread(), RuntimeException("background block"))
+        }
+
+        coVerify(exactly = 1) { mockOpenTelemetry.getLogger() }
+        coVerify(exactly = 1) { mockOpenTelemetry.forceFlush() }
         verify { mockLogRecordBuilder.emit() }
     }
 


### PR DESCRIPTION
## Summary

The Otel ANR watchdog (`OtelAnrDetector`) monitored the main thread continuously with **no awareness of foreground/background**, so any backgrounded main-thread block was reported as a crash-class ANR. A pull of ~25k recent ANRs showed ~87.5% are backgrounded main-thread, and the long-duration reports (median block ~6 min, up to ~25h) are impossible as real hangs — they are freeze/suspension artifacts. The net effect was an ANR metric inflated well beyond what Android actually counts (user-perceived ANRs are foreground input-dispatch timeouts).

## Approach

Detection is now **app-state aware**, and background blocks are **downgraded but not discarded**:

- **Foreground** block > `5s` → crash-class ANR (unchanged).
- **Background** block > `10s` → recorded via a distinct `BackgroundMainThreadBlockException` on the **same retained, disk-buffered crash path**, so it stays out of the ANR/crash metric but remains queryable. `app.state` + SDK version are auto-attached, and the exception message carries a compact fingerprint (top frame + first OneSignal frame) for triage. This preserves visibility into real background regressions (broadcast `onReceive`, `JobScheduler`, main-thread SQLite, lock/binder waits) instead of dropping them.
- **Frozen-process guard:** if the watchdog thread's own sleep overran the check interval beyond a 2s slack, the process was descheduled (Doze / cached) rather than the main thread being stuck → the measurement is suppressed.
- **Monotonic clock** (`SystemClock.uptimeMillis`) instead of wall-clock, so NTP / DST / manual clock changes and deep sleep can't fabricate block time.
- **Independent foreground/background dedup** (see review thread): a stream of background warnings can never suppress a real foreground ANR.

Foreground state is derived from the existing `platformProvider.appState`; `"unknown"` is treated as foreground so a genuine ANR is never silently downgraded.

## Testability & coverage

- Timing / classification / dedup extracted into a pure, Android-free `AnrCheckEvaluator` (100% JVM-covered).
- Android touch points (main-thread `Handler`, stack capture, monotonic clock) abstracted behind an injectable `AnrWatchdogPlatform` seam so the whole detector runs under **plain-JVM tests instead of Robolectric** — which is what lets JaCoCo actually measure it. The shell went from **0% → ~73%**, and aggregate diff coverage is **~84%** (was 0%, which was failing the gate).

## Test plan

- [x] `./gradlew :OneSignal:core:testDebugUnitTest` — all pass
- [x] Diff coverage gate passes (~84% aggregate on touched lines)
- [x] Evaluator matrix: fg ANR, responsive, bg-warning threshold, frozen-process precedence + slack boundary, **independent fg/bg dedup**, post-boot dedup sentinel, fingerprint
- [x] Shell wiring: `reportAnr` (OneSignal-at-fault / not), background-warning path, start/stop lifecycle, unknown-state → foreground

Closes SDK-4822.

Made with [Cursor](https://cursor.com)
