### PR TITLE
fix: [SDK-4820] ship consumer dontwarn rule for OpenTelemetry to prevent R8 missing-class build failures

### DIFF
--- a/OneSignalSDK/onesignal/otel/consumer-rules.pro
+++ b/OneSignalSDK/onesignal/otel/consumer-rules.pro
@@ -5,3 +5,12 @@
 # OTel (e.g. sdk-logs AutoValue-generated types) references Google Auto Value annotations that are
 # not on the app classpath. Wildcard covers inner types and extensions (e.g. Memoized).
 -dontwarn com.google.auto.value.**
+
+# Another SDK in the app (e.g. one pulling a newer opentelemetry-bom) can upgrade OneSignal's
+# transitive OTel artifacts to a version where internal classes have moved or been removed, while
+# the transitively-pulled -alpha "incubator" artifact still references the old internals (e.g.
+# io.opentelemetry.api.internal.ApiUsageLogger, referenced by ExtendedDefaultTracer in
+# opentelemetry-api-incubator). That cross-version skew surfaces as fatal R8 "Missing class" errors
+# in the consuming app even though the code path is never executed. Suppress those missing-class
+# warnings so a third-party OTel bump can't break the host app's build.
+-dontwarn io.opentelemetry.**

--- a/OneSignalSDK/onesignal/otel/consumer-rules.pro
+++ b/OneSignalSDK/onesignal/otel/consumer-rules.pro
@@ -6,12 +6,11 @@
 # not on the app classpath. Wildcard covers inner types and extensions (e.g. Memoized).
 -dontwarn com.google.auto.value.**
 
-# Another SDK in the app (e.g. one pulling a newer opentelemetry-bom) can upgrade OneSignal's
-# transitive OTel artifacts to a version where internal classes have moved or been removed, while
-# the transitively-pulled -alpha "incubator" artifact still references the old internals (e.g.
-# io.opentelemetry.api.internal.ApiUsageLogger, referenced by ExtendedDefaultTracer in
-# opentelemetry-api-incubator). That cross-version skew surfaces as fatal R8 "Missing class" errors
-# in the consuming app even though the code path is never executed. Scope the suppression to the
-# unused incubator artifact (the source of the dangling reference) so R8 still warns about
-# OneSignal's own actively-used OTel classes (api.logs, sdk, exporter) if a bump breaks them.
+# Suppress R8 missing-class errors from OpenTelemetry version skew. When a host app bumps the
+# transitive opentelemetry-bom, removed internal classes (e.g. io.opentelemetry.api.internal.ApiUsageLogger)
+# leave dangling references from the unused opentelemetry-api-incubator alpha (ExtendedDefaultTracer).
+# R8 suppresses a "Missing class" diagnostic when the MISSING class matches -dontwarn, so match the
+# internal packages directly (referrer-independent). Keep the incubator rule too so warnings for
+# OneSignal's actively-used OTel classes (api.logs, sdk, exporter) still surface.
 -dontwarn io.opentelemetry.api.incubator.**
+-dontwarn io.opentelemetry.**.internal.**

--- a/OneSignalSDK/onesignal/otel/consumer-rules.pro
+++ b/OneSignalSDK/onesignal/otel/consumer-rules.pro
@@ -10,7 +10,8 @@
 # transitive opentelemetry-bom, removed internal classes (e.g. io.opentelemetry.api.internal.ApiUsageLogger)
 # leave dangling references from the unused opentelemetry-api-incubator alpha (ExtendedDefaultTracer).
 # R8 suppresses a "Missing class" diagnostic when the MISSING class matches -dontwarn, so match the
-# internal packages directly (referrer-independent). Keep the incubator rule too so warnings for
-# OneSignal's actively-used OTel classes (api.logs, sdk, exporter) still surface.
+# io.opentelemetry.api.internal package directly (referrer-independent). Scoped to api.internal (not a
+# broad **.internal.** wildcard) so genuine missing-class errors in the sdk/exporter internals that
+# OneSignal actively uses still surface. The incubator rule covers the unused ExtendedDefaultTracer path.
 -dontwarn io.opentelemetry.api.incubator.**
--dontwarn io.opentelemetry.**.internal.**
+-dontwarn io.opentelemetry.api.internal.**

--- a/OneSignalSDK/onesignal/otel/consumer-rules.pro
+++ b/OneSignalSDK/onesignal/otel/consumer-rules.pro
@@ -11,6 +11,7 @@
 # the transitively-pulled -alpha "incubator" artifact still references the old internals (e.g.
 # io.opentelemetry.api.internal.ApiUsageLogger, referenced by ExtendedDefaultTracer in
 # opentelemetry-api-incubator). That cross-version skew surfaces as fatal R8 "Missing class" errors
-# in the consuming app even though the code path is never executed. Suppress those missing-class
-# warnings so a third-party OTel bump can't break the host app's build.
--dontwarn io.opentelemetry.**
+# in the consuming app even though the code path is never executed. Scope the suppression to the
+# unused incubator artifact (the source of the dangling reference) so R8 still warns about
+# OneSignal's own actively-used OTel classes (api.logs, sdk, exporter) if a bump breaks them.
+-dontwarn io.opentelemetry.api.incubator.**


### PR DESCRIPTION
## Summary

- **Root cause:** When a third-party SDK in the host app bumps `opentelemetry-bom` (e.g. Embrace -> `1.62.0`), it upgrades OneSignal's transitive OpenTelemetry artifacts to a version where `io.opentelemetry.api.internal.ApiUsageLogger` has been removed. The transitively-pulled `opentelemetry-api-incubator` alpha (via `ExtendedDefaultTracer`) still references that class, so the cross-version skew surfaces as fatal R8 `Missing class io.opentelemetry.api.internal.ApiUsageLogger` errors in consuming apps even though the code path is never executed.
- **Fix:** Ship `-dontwarn` rules in the `otel` module's `consumer-rules.pro`. R8 suppresses a "Missing class" diagnostic when the *missing* class itself matches a `-dontwarn`, so we match the internal packages directly with `-dontwarn io.opentelemetry.**.internal.**` — this is referrer-independent and robustly covers `ApiUsageLogger` regardless of which artifact references it. We keep `-dontwarn io.opentelemetry.api.incubator.**` alongside it so R8 still surfaces warnings for OneSignal's own actively-used OTel classes (`api.logs`, `sdk`, `exporter`) if a bump ever breaks them. Because consumer rules ship inside the published AAR, this applies to every consuming app automatically — clients don't have to add their own keep/dontwarn rules to build.
- **Risk:** Low. This only suppresses R8 missing-class warnings for internal/incubator classes that aren't on the executed code path; it doesn't change runtime behavior.

The shipped rules are:

```
-dontwarn io.opentelemetry.api.incubator.**
-dontwarn io.opentelemetry.**.internal.**
```

This is the low-risk **Option A**. A longer-term **Option B** — aligning OneSignal's OpenTelemetry dependency versions (so the incubator alpha and core artifacts can't drift across versions) — is recommended as a follow-up.

## Test plan

- [ ] Verify the `-dontwarn io.opentelemetry.api.incubator.**` and `-dontwarn io.opentelemetry.**.internal.**` rules ship in the published `otel` AAR's consumer ProGuard rules.
- [ ] Build a minified / R8-enabled app that also pulls a newer `opentelemetry-bom` (e.g. via Embrace) and confirm there is no `Missing class io.opentelemetry.api.internal.ApiUsageLogger` error.

Made with [Cursor](https://cursor.com)