### PR TITLE
fix: [SDK-4734] move HMS notification finish() inside coroutine so entryState is set before trampoline stops

### DIFF
--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/NotificationOpenedActivityHMS.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/NotificationOpenedActivityHMS.kt
@@ -30,6 +30,7 @@ package com.onesignal
 import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
+import com.onesignal.common.AndroidUtils
 import com.onesignal.common.threading.OneSignalDispatchers
 import com.onesignal.common.threading.suspendifyOnDefault
 import com.onesignal.core.internal.application.OneSignalInternalActivity
@@ -75,11 +76,6 @@ class NotificationOpenedActivityHMS :
     }
 
     private fun processIntent() {
-        processOpen(intent)
-        finish()
-    }
-
-    private fun processOpen(intent: Intent?) {
         // HMS notification-open trampoline runs on the main thread and can cold-start the process;
         // warm dispatchers before the first suspendifyOnDefault dispatch.
         OneSignalDispatchers.prewarm()
@@ -89,8 +85,16 @@ class NotificationOpenedActivityHMS :
             }
 
             val notificationPayloadProcessorHMS = OneSignal.getService<INotificationOpenedProcessorHMS>()
-            val self = this
-            notificationPayloadProcessorHMS.handleHMSNotificationOpenIntent(self, intent)
+            notificationPayloadProcessorHMS.handleHMSNotificationOpenIntent(this, intent)
+
+            // Finish only after the open is fully processed, on the main thread. Finishing
+            // synchronously (before this background work) lets the trampoline's onStop reach
+            // ApplicationService while entryState is still APP_CLOSE, so the stale-entry reset is
+            // skipped and the NOTIFICATION_CLICK set here lingers — mis-attributing the next organic
+            // launch as a direct notification session.
+            runOnUiThread {
+                AndroidUtils.finishSafely(this)
+            }
         }
     }
 }

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/NotificationOpenedActivityHMS.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/NotificationOpenedActivityHMS.kt
@@ -80,20 +80,24 @@ class NotificationOpenedActivityHMS :
         // warm dispatchers before the first suspendifyOnDefault dispatch.
         OneSignalDispatchers.prewarm()
         suspendifyOnDefault {
-            if (!OneSignal.initWithContext(applicationContext)) {
-                return@suspendifyOnDefault
-            }
+            try {
+                if (!OneSignal.initWithContext(applicationContext)) {
+                    return@suspendifyOnDefault
+                }
 
-            val notificationPayloadProcessorHMS = OneSignal.getService<INotificationOpenedProcessorHMS>()
-            notificationPayloadProcessorHMS.handleHMSNotificationOpenIntent(this, intent)
-
-            // Finish only after the open is fully processed, on the main thread. Finishing
-            // synchronously (before this background work) lets the trampoline's onStop reach
-            // ApplicationService while entryState is still APP_CLOSE, so the stale-entry reset is
-            // skipped and the NOTIFICATION_CLICK set here lingers — mis-attributing the next organic
-            // launch as a direct notification session.
-            runOnUiThread {
-                AndroidUtils.finishSafely(this)
+                val notificationPayloadProcessorHMS = OneSignal.getService<INotificationOpenedProcessorHMS>()
+                notificationPayloadProcessorHMS.handleHMSNotificationOpenIntent(this, intent)
+            } finally {
+                // Finish only after the open is fully processed (or an early return / failure),
+                // on the main thread. Finishing synchronously (before this background work) lets the
+                // trampoline's onStop reach ApplicationService while entryState is still APP_CLOSE, so
+                // the stale-entry reset is skipped and the NOTIFICATION_CLICK set here lingers —
+                // mis-attributing the next organic launch as a direct notification session. Running in
+                // finally guarantees the trampoline is always dismissed even when init fails or
+                // processing throws (suspendifyWithCompletion catches and logs exceptions).
+                runOnUiThread {
+                    AndroidUtils.finishSafely(this)
+                }
             }
         }
     }

--- a/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/activities/NotificationOpenedActivityHMSTest.kt
+++ b/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/activities/NotificationOpenedActivityHMSTest.kt
@@ -1,0 +1,83 @@
+package com.onesignal.notifications.activities
+
+import android.content.Context
+import br.com.colman.kotest.android.extensions.robolectric.RobolectricTest
+import com.onesignal.NotificationOpenedActivityHMS
+import com.onesignal.OneSignal
+import com.onesignal.common.services.IServiceProvider
+import com.onesignal.common.threading.suspendifyOnDefault
+import com.onesignal.mocks.IOMockHelper
+import com.onesignal.notifications.internal.open.INotificationOpenedProcessorHMS
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import kotlinx.coroutines.runBlocking
+import org.robolectric.Robolectric
+
+/**
+ * Regression test for SDK-4734: the HMS notification-open trampoline must not be finished until
+ * after [INotificationOpenedProcessorHMS.handleHMSNotificationOpenIntent] has run (which sets
+ * entryState to NOTIFICATION_CLICK). Finishing synchronously before the background work let the
+ * trampoline's onStop reach ApplicationService while entryState was still stale, skipping the
+ * stale-entry reset and mis-attributing the next organic launch as a direct notification session.
+ *
+ * suspendifyOnDefault is stubbed to capture (not run) its block so the test faithfully reproduces
+ * the async gap: the synchronous part of processIntent runs first, then the coroutine body runs.
+ */
+@RobolectricTest
+class NotificationOpenedActivityHMSTest : FunSpec({
+    listener(IOMockHelper)
+
+    lateinit var serviceProvider: IServiceProvider
+    lateinit var processor: INotificationOpenedProcessorHMS
+
+    beforeAny {
+        processor = mockk(relaxed = true)
+        serviceProvider = mockk(relaxed = true)
+        every { serviceProvider.getService(INotificationOpenedProcessorHMS::class.java) } returns processor
+
+        mockkObject(OneSignal)
+        every { OneSignal.services } returns serviceProvider
+        coEvery { OneSignal.initWithContext(any<Context>()) } returns true
+    }
+
+    afterAny {
+        unmockkObject(OneSignal)
+    }
+
+    test("does not finish the HMS trampoline until after HMS open processing runs") {
+        var capturedBlock: (suspend () -> Unit)? = null
+        every { suspendifyOnDefault(any()) } answers { capturedBlock = firstArg() }
+
+        val activity = Robolectric.buildActivity(NotificationOpenedActivityHMS::class.java).setup().get()
+
+        // Regression assertion: the synchronous part of processIntent must NOT finish the activity
+        // and must NOT have run HMS processing yet. The buggy version called finish() here.
+        activity.isFinishing shouldBe false
+        coVerify(exactly = 0) { processor.handleHMSNotificationOpenIntent(any(), any()) }
+
+        runBlocking { capturedBlock!!.invoke() }
+
+        coVerify(exactly = 1) { processor.handleHMSNotificationOpenIntent(activity, any()) }
+        activity.isFinishing shouldBe true
+    }
+
+    test("always finishes the HMS trampoline even when initialization fails") {
+        coEvery { OneSignal.initWithContext(any<Context>()) } returns false
+
+        var capturedBlock: (suspend () -> Unit)? = null
+        every { suspendifyOnDefault(any()) } answers { capturedBlock = firstArg() }
+
+        val activity = Robolectric.buildActivity(NotificationOpenedActivityHMS::class.java).setup().get()
+
+        runBlocking { capturedBlock!!.invoke() }
+
+        coVerify(exactly = 0) { processor.handleHMSNotificationOpenIntent(any(), any()) }
+        activity.isFinishing shouldBe true
+    }
+})


### PR DESCRIPTION
## Summary

Fixes [SDK-4734](https://linear.app/onesignal/issue/SDK-4734).

The HMS notification-open trampoline (`NotificationOpenedActivityHMS`) previously called `finish()` **synchronously**, before the background coroutine processed the open. This created a race:

- The trampoline's `onStop` could reach `ApplicationService` while `entryState` was still `APP_CLOSE`.
- Because the entry state had not yet been set to `NOTIFICATION_CLICK`, the stale-entry reset path was skipped.
- The `NOTIFICATION_CLICK` that the coroutine later set then lingered, causing the **next organic launch to be mis-attributed as a DIRECT notification session**.

This change moves `finish()` inside the coroutine, running it on the main thread only **after** `handleHMSNotificationOpenIntent` completes. That guarantees `entryState` is `NOTIFICATION_CLICK` before `onStop` runs, so the reset path executes correctly and attribution is accurate.

## Test plan

This needs verification on **Huawei (HMS) hardware** since the trampoline path only runs on HMS devices. Manually verify the three scenarios:

- [ ] **URL / browser-only notification**: Tap an HMS push whose action opens a URL in the browser. Confirm the app does not retain a stale `NOTIFICATION_CLICK` entry, and a subsequent organic (launcher) app open is attributed as a normal session, not DIRECT.
- [ ] **Foreground-app notification**: With the app in the foreground, tap an HMS push. Confirm the open is processed correctly and the next organic launch is not mis-attributed as DIRECT.
- [ ] **Background-processed notification**: With the app backgrounded/closed, tap an HMS push so the trampoline cold-starts the process. Confirm the open is processed, the activity finishes only after processing, and a later organic launch is attributed correctly (not DIRECT).

Made with [Cursor](https://cursor.com)