### PR TITLE
fix: [SDK-4841] prewarm dispatchers at process start via ActivityLifecycleInitializer

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/threading/OneSignalDispatchers.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/threading/OneSignalDispatchers.kt
@@ -252,6 +252,7 @@ object OneSignalDispatchers {
      * The known main-thread cold-start entry points:
      * | Entry point | Class |
      * |---|---|
+     * | process-start activity lifecycle registration | `core.internal.application.impl.ActivityLifecycleInitializer` |
      * | `initWithContext` / `initWithContextSuspend` | `OneSignalImp` |
      * | `onStartJob` | `core.services.SyncJobService` |
      * | `onReceive` | `FCMBroadcastReceiver`, `NotificationDismissReceiver`, `BootUpReceiver`, `UpgradeReceiver` |

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/application/impl/ActivityLifecycleInitializer.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/application/impl/ActivityLifecycleInitializer.kt
@@ -3,6 +3,7 @@ package com.onesignal.core.internal.application.impl
 import android.app.Application
 import android.content.Context
 import androidx.startup.Initializer
+import com.onesignal.common.threading.OneSignalDispatchers
 import com.onesignal.core.internal.application.IApplicationService
 
 /**
@@ -15,10 +16,12 @@ import com.onesignal.core.internal.application.IApplicationService
  * full lifecycle regardless of when init later happens.
  *
  * This intentionally does NOT initialize the SDK or require an App ID; it only attaches lifecycle
- * observation. App ID / consent gating remains in the runtime `initWithContext` path.
+ * observation and starts pure dispatcher warmup. App ID / consent gating remains in the runtime
+ * `initWithContext` path.
  */
 class ActivityLifecycleInitializer : Initializer<IApplicationService> {
     override fun create(context: Context): IApplicationService {
+        OneSignalDispatchers.prewarm()
         val applicationService = ApplicationService.getInstance()
         (context.applicationContext as? Application)?.let { application ->
             applicationService.attachToApplication(application)

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/application/impl/ActivityLifecycleInitializerTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/application/impl/ActivityLifecycleInitializerTests.kt
@@ -3,22 +3,34 @@ package com.onesignal.core.internal.application.impl
 import android.app.Application
 import android.content.Context
 import com.onesignal.common.threading.OneSignalDispatchers
-import com.onesignal.mocks.IOMockHelper
 import io.kotest.core.spec.style.FunSpec
-import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
 import io.mockk.verify
 import io.mockk.verifyOrder
 
+/**
+ * Verifies ActivityLifecycleInitializer.create() prewarms OneSignalDispatchers at process start,
+ * before it registers activity lifecycle callbacks.
+ *
+ * Intentionally self-contained (does NOT use IOMockHelper). It only needs prewarm() stubbed to a
+ * no-op so the real prewarm daemon isn't spawned. It must NOT install IOMockHelper's global
+ * launchOn*/suspendify* stubs: this spec sorts lexicographically before sibling specs such as
+ * BackgroundManagerTests, and those stubs would leak into the shared OneSignalDispatchers object
+ * mock and run dispatched blocks inline in the next spec. Stubbing only prewarm() keeps the leak
+ * surface empty.
+ */
 class ActivityLifecycleInitializerTests : FunSpec({
-    listener(IOMockHelper)
+    beforeTest {
+        mockkObject(OneSignalDispatchers)
+        every { OneSignalDispatchers.prewarm() } returns Unit
+        resetSharedApplicationService()
+    }
 
-    beforeAny {
-        // IOMockHelper owns the OneSignalDispatchers object mock and stubs prewarm() to a no-op.
-        // Clear only recorded calls so this spec verifies initializer ordering without spawning the
-        // real OneSignal-prewarm daemon thread.
-        clearMocks(OneSignalDispatchers, answers = false)
+    afterTest {
+        unmockkObject(OneSignalDispatchers)
         resetSharedApplicationService()
     }
 

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/application/impl/ActivityLifecycleInitializerTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/application/impl/ActivityLifecycleInitializerTests.kt
@@ -17,10 +17,10 @@ import io.mockk.verifyOrder
  *
  * Intentionally self-contained (does NOT use IOMockHelper). It only needs prewarm() stubbed to a
  * no-op so the real prewarm daemon isn't spawned. It must NOT install IOMockHelper's global
- * launchOn*/suspendify* stubs: this spec sorts lexicographically before sibling specs such as
- * BackgroundManagerTests, and those stubs would leak into the shared OneSignalDispatchers object
- * mock and run dispatched blocks inline in the next spec. Stubbing only prewarm() keeps the leak
- * surface empty.
+ * launchOnSerialIO and suspendify stubs: this spec sorts lexicographically before sibling specs
+ * such as BackgroundManagerTests, and those stubs would leak into the shared OneSignalDispatchers
+ * object mock and run dispatched blocks inline in the next spec. Stubbing only prewarm() keeps the
+ * leak surface empty.
  */
 class ActivityLifecycleInitializerTests : FunSpec({
     beforeTest {

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/application/impl/ActivityLifecycleInitializerTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/application/impl/ActivityLifecycleInitializerTests.kt
@@ -1,0 +1,56 @@
+package com.onesignal.core.internal.application.impl
+
+import android.app.Application
+import android.content.Context
+import com.onesignal.common.threading.OneSignalDispatchers
+import com.onesignal.mocks.IOMockHelper
+import io.kotest.core.spec.style.FunSpec
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.mockk.verifyOrder
+
+class ActivityLifecycleInitializerTests : FunSpec({
+    listener(IOMockHelper)
+
+    beforeAny {
+        // IOMockHelper owns the OneSignalDispatchers object mock and stubs prewarm() to a no-op.
+        // Clear only recorded calls so this spec verifies initializer ordering without spawning the
+        // real OneSignal-prewarm daemon thread.
+        clearMocks(OneSignalDispatchers, answers = false)
+        resetSharedApplicationService()
+    }
+
+    test("create prewarms before registering activity lifecycle callbacks") {
+        val application = mockk<Application>(relaxed = true)
+        every { application.applicationContext } returns application
+
+        ActivityLifecycleInitializer().create(application)
+
+        verify(exactly = 1) { OneSignalDispatchers.prewarm() }
+        verify(exactly = 1) {
+            application.registerActivityLifecycleCallbacks(any<Application.ActivityLifecycleCallbacks>())
+        }
+        verifyOrder {
+            OneSignalDispatchers.prewarm()
+            application.registerActivityLifecycleCallbacks(any<Application.ActivityLifecycleCallbacks>())
+        }
+    }
+
+    test("create prewarms even when application context is unavailable") {
+        val context = mockk<Context>(relaxed = true)
+        every { context.applicationContext } returns context
+
+        ActivityLifecycleInitializer().create(context)
+
+        verify(exactly = 1) { OneSignalDispatchers.prewarm() }
+    }
+})
+
+private fun resetSharedApplicationService() {
+    ApplicationService::class.java.getDeclaredField("sharedInstance").apply {
+        isAccessible = true
+        set(null, null)
+    }
+}


### PR DESCRIPTION
Prewarms `OneSignalDispatchers` as the first step of `ActivityLifecycleInitializer.create()`, before activity lifecycle callbacks are registered, so the process-start lifecycle path gets the same dispatcher warmup head start as the other cold-start entry points.

Also updates the `prewarm()` KDoc entry-point table and adds focused unit coverage verifying the initializer calls `prewarm()` before lifecycle callback registration while stubbing the real warmup via `IOMockHelper`.

Verification note: attempted `:OneSignal:core:testOriginalDebugUnitTest --tests 'com.onesignal.core.internal.application.impl.ActivityLifecycleInitializerTests'` and `:OneSignal:core:detekt`, but this sandbox has no `java` on `PATH` and `JAVA_HOME` is unset.