### PR TITLE
fix: [SDK-4845] always finish base notification trampoline via finally

### DIFF
--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/activities/NotificationOpenedActivityBase.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/activities/NotificationOpenedActivityBase.kt
@@ -70,9 +70,8 @@ abstract class NotificationOpenedActivityBase :
                 // startActivity() must be called BEFORE finish(), otherwise
                 // the app is never foregrounded.
             } finally {
-                // Finish in finally, on the main thread, so the trampoline is always dismissed —
-                // including when init fails, we early-return, or processing throws. Running after
-                // processing (not before) preserves the Xiaomi startActivity()-before-finish() ordering.
+                // Always dismiss the trampoline, even if init fails or processing throws.
+                // Finishing after processing (not before) keeps the app foregrounding correctly on Xiaomi.
                 runOnUiThread {
                     AndroidUtils.finishSafely(this)
                 }

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/activities/NotificationOpenedActivityBase.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/activities/NotificationOpenedActivityBase.kt
@@ -58,21 +58,24 @@ abstract class NotificationOpenedActivityBase :
         // warm dispatchers before the first suspendifyOnDefault dispatch.
         OneSignalDispatchers.prewarm()
         suspendifyOnDefault {
-            if (!OneSignal.initWithContext(applicationContext)) {
-                return@suspendifyOnDefault
-            }
+            try {
+                if (!OneSignal.initWithContext(applicationContext)) {
+                    return@suspendifyOnDefault
+                }
 
-            val openedProcessor = OneSignal.getService<INotificationOpenedProcessor>()
-            openedProcessor.processFromContext(this, intent)
-            // KEEP: Xiaomi Compatibility:
-            // Must keep this Activity alive while trampolining, that is
-            // startActivity() must be called BEFORE finish(), otherwise
-            // the app is never foregrounded.
-
-            // Safely finish the activity on the main thread after processing is complete.
-            // This gives the system enough time to complete rendering before closing the Trampoline activity.
-            runOnUiThread {
-                AndroidUtils.finishSafely(this)
+                val openedProcessor = OneSignal.getService<INotificationOpenedProcessor>()
+                openedProcessor.processFromContext(this, intent)
+                // KEEP: Xiaomi Compatibility:
+                // Must keep this Activity alive while trampolining, that is
+                // startActivity() must be called BEFORE finish(), otherwise
+                // the app is never foregrounded.
+            } finally {
+                // Finish in finally, on the main thread, so the trampoline is always dismissed —
+                // including when init fails, we early-return, or processing throws. Running after
+                // processing (not before) preserves the Xiaomi startActivity()-before-finish() ordering.
+                runOnUiThread {
+                    AndroidUtils.finishSafely(this)
+                }
             }
         }
     }

--- a/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/activities/NotificationOpenedActivityBaseTest.kt
+++ b/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/activities/NotificationOpenedActivityBaseTest.kt
@@ -1,18 +1,29 @@
 package com.onesignal.notifications.activities
 
+import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
 import br.com.colman.kotest.android.extensions.robolectric.RobolectricTest
+import com.onesignal.OneSignal
+import com.onesignal.common.services.IServiceProvider
 import com.onesignal.common.threading.OneSignalDispatchers
 import com.onesignal.common.threading.suspendifyOnDefault
 import com.onesignal.mocks.IOMockHelper
+import com.onesignal.notifications.internal.open.INotificationOpenedProcessor
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.clearMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
 import io.mockk.verify
 import io.mockk.verifyOrder
+import kotlinx.coroutines.runBlocking
 import org.robolectric.Robolectric
 import org.robolectric.shadows.ShadowLooper
 
@@ -77,5 +88,59 @@ class NotificationOpenedActivityTest : FunSpec({
         val activity = controller.setup().get()
 
         activity.wasProcessIntentCalled shouldBe true
+    }
+
+    // Regression for SDK-4845: the base/GMS trampoline must always be finished after processing,
+    // and must not be finished before processing runs. suspendifyOnDefault is stubbed to capture
+    // (not run) its block so we can control exactly when the coroutine body executes.
+    test("does not finish the base trampoline until after open processing runs") {
+        val serviceProvider = mockk<IServiceProvider>(relaxed = true)
+        val processor = mockk<INotificationOpenedProcessor>(relaxed = true)
+        every { serviceProvider.getService(INotificationOpenedProcessor::class.java) } returns processor
+        mockkObject(OneSignal)
+        try {
+            every { OneSignal.services } returns serviceProvider
+            coEvery { OneSignal.initWithContext(any<Context>()) } returns true
+
+            var capturedBlock: (suspend () -> Unit)? = null
+            every { suspendifyOnDefault(any()) } answers { capturedBlock = firstArg() }
+
+            val activity = Robolectric.buildActivity(TestNotificationOpenedActivity::class.java).setup().get()
+
+            // The synchronous part of processIntent must NOT finish the activity or run processing yet.
+            activity.isFinishing shouldBe false
+            coVerify(exactly = 0) { processor.processFromContext(any(), any()) }
+
+            runBlocking { capturedBlock!!.invoke() }
+
+            coVerify(exactly = 1) { processor.processFromContext(activity, any()) }
+            activity.isFinishing shouldBe true
+        } finally {
+            unmockkObject(OneSignal)
+        }
+    }
+
+    test("always finishes the base trampoline even when initialization fails") {
+        val serviceProvider = mockk<IServiceProvider>(relaxed = true)
+        val processor = mockk<INotificationOpenedProcessor>(relaxed = true)
+        every { serviceProvider.getService(INotificationOpenedProcessor::class.java) } returns processor
+        mockkObject(OneSignal)
+        try {
+            every { OneSignal.services } returns serviceProvider
+            coEvery { OneSignal.initWithContext(any<Context>()) } returns false
+
+            var capturedBlock: (suspend () -> Unit)? = null
+            every { suspendifyOnDefault(any()) } answers { capturedBlock = firstArg() }
+
+            val activity = Robolectric.buildActivity(TestNotificationOpenedActivity::class.java).setup().get()
+
+            runBlocking { capturedBlock!!.invoke() }
+
+            // Early return on init failure must still dismiss the trampoline via the finally block.
+            coVerify(exactly = 0) { processor.processFromContext(any(), any()) }
+            activity.isFinishing shouldBe true
+        } finally {
+            unmockkObject(OneSignal)
+        }
     }
 })

--- a/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/activities/NotificationOpenedActivityBaseTest.kt
+++ b/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/activities/NotificationOpenedActivityBaseTest.kt
@@ -90,10 +90,11 @@ class NotificationOpenedActivityTest : FunSpec({
         activity.wasProcessIntentCalled shouldBe true
     }
 
-    // Regression for SDK-4845: the base/GMS trampoline must always be finished after processing,
-    // and must not be finished before processing runs. suspendifyOnDefault is stubbed to capture
-    // (not run) its block so we can control exactly when the coroutine body executes.
-    test("does not finish the base trampoline until after open processing runs") {
+    // Ordering guard (not the SDK-4845 regression itself): the trampoline must not be finished by
+    // the synchronous part of processIntent, and on the success path finish() must run only after
+    // processFromContext (preserving the Xiaomi startActivity()-before-finish() ordering).
+    // suspendifyOnDefault is stubbed to capture (not run) its block so we control when it executes.
+    test("finishes the base trampoline only after open processing completes") {
         val serviceProvider = mockk<IServiceProvider>(relaxed = true)
         val processor = mockk<INotificationOpenedProcessor>(relaxed = true)
         every { serviceProvider.getService(INotificationOpenedProcessor::class.java) } returns processor
@@ -112,6 +113,7 @@ class NotificationOpenedActivityTest : FunSpec({
             coVerify(exactly = 0) { processor.processFromContext(any(), any()) }
 
             runBlocking { capturedBlock!!.invoke() }
+            ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
 
             coVerify(exactly = 1) { processor.processFromContext(activity, any()) }
             activity.isFinishing shouldBe true
@@ -120,6 +122,7 @@ class NotificationOpenedActivityTest : FunSpec({
         }
     }
 
+    // Core SDK-4845 regression: the init-failure early-return path must still dismiss the trampoline.
     test("always finishes the base trampoline even when initialization fails") {
         val serviceProvider = mockk<IServiceProvider>(relaxed = true)
         val processor = mockk<INotificationOpenedProcessor>(relaxed = true)
@@ -135,9 +138,39 @@ class NotificationOpenedActivityTest : FunSpec({
             val activity = Robolectric.buildActivity(TestNotificationOpenedActivity::class.java).setup().get()
 
             runBlocking { capturedBlock!!.invoke() }
+            ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
 
             // Early return on init failure must still dismiss the trampoline via the finally block.
             coVerify(exactly = 0) { processor.processFromContext(any(), any()) }
+            activity.isFinishing shouldBe true
+        } finally {
+            unmockkObject(OneSignal)
+        }
+    }
+
+    // Core SDK-4845 regression: when open processing throws, the trampoline must still be dismissed.
+    // The exception propagates (suspendifyWithCompletion catches/logs it in production), but the
+    // finally block must have finished the activity before it unwinds.
+    test("always finishes the base trampoline even when open processing throws") {
+        val serviceProvider = mockk<IServiceProvider>(relaxed = true)
+        val processor = mockk<INotificationOpenedProcessor>(relaxed = true)
+        every { serviceProvider.getService(INotificationOpenedProcessor::class.java) } returns processor
+        coEvery { processor.processFromContext(any(), any()) } throws RuntimeException("boom")
+        mockkObject(OneSignal)
+        try {
+            every { OneSignal.services } returns serviceProvider
+            coEvery { OneSignal.initWithContext(any<Context>()) } returns true
+
+            var capturedBlock: (suspend () -> Unit)? = null
+            every { suspendifyOnDefault(any()) } answers { capturedBlock = firstArg() }
+
+            val activity = Robolectric.buildActivity(TestNotificationOpenedActivity::class.java).setup().get()
+
+            val result = runCatching { runBlocking { capturedBlock!!.invoke() } }
+            ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+
+            result.isFailure shouldBe true
+            coVerify(exactly = 1) { processor.processFromContext(activity, any()) }
             activity.isFinishing shouldBe true
         } finally {
             unmockkObject(OneSignal)

--- a/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/activities/NotificationOpenedActivityBaseTest.kt
+++ b/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/activities/NotificationOpenedActivityBaseTest.kt
@@ -90,10 +90,8 @@ class NotificationOpenedActivityTest : FunSpec({
         activity.wasProcessIntentCalled shouldBe true
     }
 
-    // Ordering guard (not the SDK-4845 regression itself): the trampoline must not be finished by
-    // the synchronous part of processIntent, and on the success path finish() must run only after
-    // processFromContext (preserving the Xiaomi startActivity()-before-finish() ordering).
-    // suspendifyOnDefault is stubbed to capture (not run) its block so we control when it executes.
+    // Ordering guard: finish() must run only after processFromContext, never from the synchronous
+    // part of processIntent. suspendifyOnDefault is captured (not run) so we control when it executes.
     test("finishes the base trampoline only after open processing completes") {
         val serviceProvider = mockk<IServiceProvider>(relaxed = true)
         val processor = mockk<INotificationOpenedProcessor>(relaxed = true)
@@ -122,7 +120,7 @@ class NotificationOpenedActivityTest : FunSpec({
         }
     }
 
-    // Core SDK-4845 regression: the init-failure early-return path must still dismiss the trampoline.
+    // The init-failure early return must still dismiss the trampoline.
     test("always finishes the base trampoline even when initialization fails") {
         val serviceProvider = mockk<IServiceProvider>(relaxed = true)
         val processor = mockk<INotificationOpenedProcessor>(relaxed = true)
@@ -148,9 +146,8 @@ class NotificationOpenedActivityTest : FunSpec({
         }
     }
 
-    // Core SDK-4845 regression: when open processing throws, the trampoline must still be dismissed.
-    // The exception propagates (suspendifyWithCompletion catches/logs it in production), but the
-    // finally block must have finished the activity before it unwinds.
+    // When processing throws, the exception still propagates (production logs it via
+    // suspendifyWithCompletion), but the trampoline must be finished before it unwinds.
     test("always finishes the base trampoline even when open processing throws") {
         val serviceProvider = mockk<IServiceProvider>(relaxed = true)
         val processor = mockk<INotificationOpenedProcessor>(relaxed = true)


### PR DESCRIPTION
## Summary

Follow-up to [SDK-4734](https://linear.app/onesignal/issue/SDK-4734) / #2678, addressing @fadi-george's review comment on that PR.

PR #2678 fixed the **HMS** trampoline so `finish()` always runs (via `try/finally`) even when init fails or processing throws. `NotificationOpenedActivityBase` — the **GMS / base** trampoline used by `NotificationOpenedActivity` and `NotificationOpenedActivityAndroid22AndOlder` — still had the same early-return-before-finish shape:

- If `OneSignal.initWithContext(...)` returns `false`, the coroutine early-returns and `AndroidUtils.finishSafely(...)` is skipped.
- If `openedProcessor.processFromContext(...)` throws, `finishSafely(...)` is likewise skipped.

In both cases the transient trampoline activity is never dismissed and lingers in its task. Not a crash (`suspendifyOnDefault` catches/logs and the init branch is a plain early return), but a real, low-frequency lifecycle strand that is inconsistent with the now-fixed HMS path.

## Fix

Wrap the coroutine body in `try { ... } finally { runOnUiThread { AndroidUtils.finishSafely(this) } }` so the trampoline is always dismissed on the main thread after processing, an early return, or an exception. Keeping `finish()` in `finally` (after `processFromContext`) preserves the documented Xiaomi requirement that `startActivity()` runs before `finish()`.

## Test plan

Added two regression tests to `NotificationOpenedActivityBaseTest` mirroring the HMS coverage:

- [x] `does not finish the base trampoline until after open processing runs` — asserts the synchronous part does not finish the activity, and it finishes only after `processFromContext` runs.
- [x] `always finishes the base trampoline even when initialization fails` — asserts the activity is finished on the `initWithContext == false` early-return path (the core regression) without invoking `processFromContext`.

Full module unit tests and detekt pass locally.

Made with [Cursor](https://cursor.com)