### PR TITLE
fix: [SDK-4513] display queued in-app messages on unpause when triggers still match

### DIFF
--- a/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/InAppMessagesManager.kt
+++ b/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/InAppMessagesManager.kt
@@ -178,6 +178,7 @@ internal class InAppMessagesManager(
         get() = _state.paused
         set(value) {
             Logging.debug("InAppMessagesManager.setPaused(value: $value)")
+            val wasPaused = _state.paused
             _state.paused = value
 
             // If paused is true and an In-App Message is showing, dismiss it
@@ -187,7 +188,9 @@ internal class InAppMessagesManager(
                 }
             }
 
-            if (!value) {
+            // Only run the prune/evaluate/drain path on an actual paused -> unpaused
+            // transition; a redundant `paused = false` should not mutate the queue.
+            if (wasPaused && !value) {
                 suspendifyOnDefault {
                     // Messages queued while paused are parked in the display queue. Unpausing
                     // should only resume delivery for messages that are still eligible, so drop

--- a/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/InAppMessagesManager.kt
+++ b/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/InAppMessagesManager.kt
@@ -189,7 +189,14 @@ internal class InAppMessagesManager(
 
             if (!value) {
                 suspendifyOnDefault {
+                    // Messages queued while paused are parked in the display queue. Unpausing
+                    // should only resume delivery for messages whose triggers currently evaluate
+                    // true, so drop stale entries before re-evaluating and draining the queue.
+                    messageDisplayQueueMutex.withLock {
+                        messageDisplayQueue.removeAll { !_triggerController.evaluateMessageTriggers(it) }
+                    }
                     evaluateInAppMessages()
+                    attemptToShowInAppMessage()
                 }
             }
         }

--- a/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/InAppMessagesManager.kt
+++ b/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/InAppMessagesManager.kt
@@ -190,10 +190,15 @@ internal class InAppMessagesManager(
             if (!value) {
                 suspendifyOnDefault {
                     // Messages queued while paused are parked in the display queue. Unpausing
-                    // should only resume delivery for messages whose triggers currently evaluate
-                    // true, so drop stale entries before re-evaluating and draining the queue.
+                    // should only resume delivery for messages that are still eligible, so drop
+                    // entries whose triggers no longer evaluate true, whose end time has passed,
+                    // or that were dismissed, before re-evaluating and draining the queue.
                     messageDisplayQueueMutex.withLock {
-                        messageDisplayQueue.removeAll { !_triggerController.evaluateMessageTriggers(it) }
+                        messageDisplayQueue.removeAll {
+                            !_triggerController.evaluateMessageTriggers(it) ||
+                                it.isFinished ||
+                                dismissedMessages.contains(it.messageId)
+                        }
                     }
                     evaluateInAppMessages()
                     attemptToShowInAppMessage()

--- a/OneSignalSDK/onesignal/in-app-messages/src/test/java/com/onesignal/inAppMessages/internal/InAppMessagesManagerTests.kt
+++ b/OneSignalSDK/onesignal/in-app-messages/src/test/java/com/onesignal/inAppMessages/internal/InAppMessagesManagerTests.kt
@@ -1005,6 +1005,112 @@ class InAppMessagesManagerTests : FunSpec({
     }
 
     context("Message Queue and Display") {
+        // Backs the InAppStateService mock with real state so the paused setter and the
+        // display flow (which reads/writes paused and inAppMessageIdShowing) behave like production.
+        fun statefulInAppState(initiallyPaused: Boolean) {
+            var pausedState = initiallyPaused
+            var showingId: String? = null
+            every { mocks.inAppStateService.paused } answers { pausedState }
+            every { mocks.inAppStateService.paused = any() } answers { pausedState = firstArg() }
+            every { mocks.inAppStateService.inAppMessageIdShowing } answers { showingId }
+            every { mocks.inAppStateService.inAppMessageIdShowing = any() } answers { showingId = firstArg() }
+        }
+
+        test("message queued while paused displays on unpause when triggers still evaluate true") {
+            // Given
+            val message = mocks.createInAppMessage()
+            statefulInAppState(initiallyPaused = true)
+            every { mocks.userManager.onesignalId } returns "onesignal-id"
+            every { mocks.applicationService.isInForeground } returns true
+            every { mocks.pushSubscription.id } returns "subscription-id"
+            every { mocks.triggerController.evaluateMessageTriggers(message) } returns true
+            every { mocks.triggerController.isTriggerOnMessage(any(), any()) } returns false
+            every { mocks.triggerController.messageHasOnlyDynamicTriggers(any()) } returns false
+            coEvery { mocks.applicationService.waitUntilSystemConditionsAvailable() } returns true
+            coEvery { mocks.backend.listInAppMessages(any(), any(), any(), any()) } returns listOf(message)
+            coEvery { mocks.inAppDisplayer.displayMessage(any()) } returns true
+
+            // Fetch while paused - message qualifies and is queued but blocked from display
+            mocks.inAppMessagesManager.onSessionStarted()
+            awaitIO()
+            coVerify(exactly = 0) { mocks.inAppDisplayer.displayMessage(any()) }
+
+            // When
+            mocks.inAppMessagesManager.paused = false
+            awaitIO()
+
+            // Then
+            coVerify(exactly = 1) { mocks.inAppDisplayer.displayMessage(message) }
+        }
+
+        test("message queued while paused does not display on unpause when triggers no longer evaluate true") {
+            // Given
+            val message = mocks.createInAppMessage()
+            statefulInAppState(initiallyPaused = true)
+            every { mocks.userManager.onesignalId } returns "onesignal-id"
+            every { mocks.applicationService.isInForeground } returns true
+            every { mocks.pushSubscription.id } returns "subscription-id"
+            every { mocks.triggerController.evaluateMessageTriggers(message) } returns true
+            every { mocks.triggerController.isTriggerOnMessage(any(), any()) } returns false
+            every { mocks.triggerController.messageHasOnlyDynamicTriggers(any()) } returns false
+            coEvery { mocks.applicationService.waitUntilSystemConditionsAvailable() } returns true
+            coEvery { mocks.backend.listInAppMessages(any(), any(), any(), any()) } returns listOf(message)
+            coEvery { mocks.inAppDisplayer.displayMessage(any()) } returns true
+
+            // Fetch while paused - message qualifies and is queued but blocked from display
+            mocks.inAppMessagesManager.onSessionStarted()
+            awaitIO()
+
+            // Trigger conditions change while still paused so the queued message no longer qualifies
+            every { mocks.triggerController.evaluateMessageTriggers(message) } returns false
+
+            // When
+            mocks.inAppMessagesManager.paused = false
+            awaitIO()
+
+            // Then - stale queued message is pruned, not displayed
+            coVerify(exactly = 0) { mocks.inAppDisplayer.displayMessage(any()) }
+
+            // And the message is not lost: it displays once its triggers evaluate true again
+            every { mocks.triggerController.evaluateMessageTriggers(message) } returns true
+            mocks.inAppMessagesManager.onTriggerChanged("some-trigger")
+            awaitIO()
+            coVerify(exactly = 1) { mocks.inAppDisplayer.displayMessage(message) }
+        }
+
+        test("message displays mid-session when trigger is satisfied after unpausing") {
+            // Reproduces the reported scenario: Paused = false is set first, then the
+            // qualifying trigger is added - the message must display without a new session.
+            // Given
+            val message = mocks.createInAppMessage()
+            statefulInAppState(initiallyPaused = true)
+            every { mocks.userManager.onesignalId } returns "onesignal-id"
+            every { mocks.applicationService.isInForeground } returns true
+            every { mocks.pushSubscription.id } returns "subscription-id"
+            every { mocks.triggerController.evaluateMessageTriggers(message) } returns false
+            every { mocks.triggerController.isTriggerOnMessage(any(), any()) } returns false
+            every { mocks.triggerController.messageHasOnlyDynamicTriggers(any()) } returns false
+            coEvery { mocks.applicationService.waitUntilSystemConditionsAvailable() } returns true
+            coEvery { mocks.backend.listInAppMessages(any(), any(), any(), any()) } returns listOf(message)
+            coEvery { mocks.inAppDisplayer.displayMessage(any()) } returns true
+
+            // Fetch while paused - message does not qualify yet
+            mocks.inAppMessagesManager.onSessionStarted()
+            awaitIO()
+
+            // When - unpause first (nothing qualifies yet), then the trigger becomes satisfied
+            mocks.inAppMessagesManager.paused = false
+            awaitIO()
+            coVerify(exactly = 0) { mocks.inAppDisplayer.displayMessage(any()) }
+
+            every { mocks.triggerController.evaluateMessageTriggers(message) } returns true
+            mocks.inAppMessagesManager.onTriggerChanged("view")
+            awaitIO()
+
+            // Then
+            coVerify(exactly = 1) { mocks.inAppDisplayer.displayMessage(message) }
+        }
+
         test("messages are not queued when paused") {
             // Given
             val message = mocks.createInAppMessage()

--- a/OneSignalSDK/onesignal/in-app-messages/src/test/java/com/onesignal/inAppMessages/internal/InAppMessagesManagerTests.kt
+++ b/OneSignalSDK/onesignal/in-app-messages/src/test/java/com/onesignal/inAppMessages/internal/InAppMessagesManagerTests.kt
@@ -129,13 +129,17 @@ private class Mocks {
     // Helper function to create InAppMessage with custom triggers (factory-style, returns new message each call)
     fun createInAppMessage(
         id: String = "test-message-${System.nanoTime()}", // Unique ID by default
-        triggers: List<Triple<String, String, String>> = emptyList() // List of (property, operator, value)
+        triggers: List<Triple<String, String, String>> = emptyList(), // List of (property, operator, value)
+        endTime: String? = null // ISO8601, e.g. "2000-01-01T00:00:00.000Z"
     ): InAppMessage {
         val json = JSONObject().apply {
             put("id", id)
             put("variants", JSONObject().apply {
                 put("all", JSONObject().apply { put("en", "variant-id-123") })
             })
+            if (endTime != null) {
+                put("end_time", endTime)
+            }
 
             if (triggers.isEmpty()) {
                 put("triggers", JSONArray())
@@ -173,6 +177,15 @@ private class Mocks {
             .first { it.name == "hasCompletedFirstFetch" }
         property.isAccessible = true
         return property.get(manager) as Boolean
+    }
+
+    // Helper function to access private messageDisplayQueue field for testing using Kotlin reflection
+    fun getMessageDisplayQueue(manager: InAppMessagesManager): MutableList<InAppMessage> {
+        val property = InAppMessagesManager::class.memberProperties
+            .first { it.name == "messageDisplayQueue" }
+        property.isAccessible = true
+        @Suppress("UNCHECKED_CAST")
+        return property.get(manager) as MutableList<InAppMessage>
     }
 
     // Helper function to create InAppMessagesManager with all dependencies
@@ -1076,6 +1089,31 @@ class InAppMessagesManagerTests : FunSpec({
             mocks.inAppMessagesManager.onTriggerChanged("some-trigger")
             awaitIO()
             coVerify(exactly = 1) { mocks.inAppDisplayer.displayMessage(message) }
+        }
+
+        test("message queued while paused does not display on unpause when its end time has passed") {
+            // Given
+            val expiredMessage = mocks.createInAppMessage(endTime = "2000-01-01T00:00:00.000Z")
+            val validMessage = mocks.createInAppMessage()
+            statefulInAppState(initiallyPaused = true)
+            every { mocks.triggerController.evaluateMessageTriggers(any()) } returns true
+            every { mocks.triggerController.isTriggerOnMessage(any(), any()) } returns false
+            every { mocks.triggerController.messageHasOnlyDynamicTriggers(any()) } returns false
+            coEvery { mocks.applicationService.waitUntilSystemConditionsAvailable() } returns true
+            coEvery { mocks.inAppDisplayer.displayMessage(any()) } returns true
+
+            // Both messages were queued before the end time passed. Evaluation never queues an
+            // already-expired message, so seed the queue directly to simulate expiry-while-paused.
+            mocks.getMessageDisplayQueue(mocks.inAppMessagesManager).add(expiredMessage)
+            mocks.getMessageDisplayQueue(mocks.inAppMessagesManager).add(validMessage)
+
+            // When
+            mocks.inAppMessagesManager.paused = false
+            awaitIO()
+
+            // Then - the expired message is pruned while the still-valid one displays
+            coVerify(exactly = 0) { mocks.inAppDisplayer.displayMessage(expiredMessage) }
+            coVerify(exactly = 1) { mocks.inAppDisplayer.displayMessage(validMessage) }
         }
 
         test("message displays mid-session when trigger is satisfied after unpausing") {

--- a/OneSignalSDK/onesignal/in-app-messages/src/test/java/com/onesignal/inAppMessages/internal/InAppMessagesManagerTests.kt
+++ b/OneSignalSDK/onesignal/in-app-messages/src/test/java/com/onesignal/inAppMessages/internal/InAppMessagesManagerTests.kt
@@ -188,6 +188,15 @@ private class Mocks {
         return property.get(manager) as MutableList<InAppMessage>
     }
 
+    // Helper function to access private dismissedMessages field for testing using Kotlin reflection
+    fun getDismissedMessages(manager: InAppMessagesManager): MutableSet<String> {
+        val property = InAppMessagesManager::class.memberProperties
+            .first { it.name == "dismissedMessages" }
+        property.isAccessible = true
+        @Suppress("UNCHECKED_CAST")
+        return property.get(manager) as MutableSet<String>
+    }
+
     // Helper function to create InAppMessagesManager with all dependencies
     val inAppMessagesManager = InAppMessagesManager(
         applicationService,
@@ -1114,6 +1123,50 @@ class InAppMessagesManagerTests : FunSpec({
             // Then - the expired message is pruned while the still-valid one displays
             coVerify(exactly = 0) { mocks.inAppDisplayer.displayMessage(expiredMessage) }
             coVerify(exactly = 1) { mocks.inAppDisplayer.displayMessage(validMessage) }
+        }
+
+        test("message queued while paused does not display on unpause when it was dismissed") {
+            // Given
+            val dismissedMessage = mocks.createInAppMessage()
+            val validMessage = mocks.createInAppMessage()
+            statefulInAppState(initiallyPaused = true)
+            every { mocks.triggerController.evaluateMessageTriggers(any()) } returns true
+            every { mocks.triggerController.isTriggerOnMessage(any(), any()) } returns false
+            every { mocks.triggerController.messageHasOnlyDynamicTriggers(any()) } returns false
+            coEvery { mocks.applicationService.waitUntilSystemConditionsAvailable() } returns true
+            coEvery { mocks.inAppDisplayer.displayMessage(any()) } returns true
+
+            // Seed the queue directly to simulate a message that was queued while paused
+            // and then dismissed (e.g. via a preview or another surface) before unpausing.
+            mocks.getMessageDisplayQueue(mocks.inAppMessagesManager).add(dismissedMessage)
+            mocks.getMessageDisplayQueue(mocks.inAppMessagesManager).add(validMessage)
+            mocks.getDismissedMessages(mocks.inAppMessagesManager).add(dismissedMessage.messageId)
+
+            // When
+            mocks.inAppMessagesManager.paused = false
+            awaitIO()
+
+            // Then - the dismissed message is pruned while the still-valid one displays
+            coVerify(exactly = 0) { mocks.inAppDisplayer.displayMessage(dismissedMessage) }
+            coVerify(exactly = 1) { mocks.inAppDisplayer.displayMessage(validMessage) }
+        }
+
+        test("redundant paused = false assignment does not prune or drain the queue") {
+            // Given - already unpaused, with a queued message whose triggers no longer hold
+            val message = mocks.createInAppMessage()
+            statefulInAppState(initiallyPaused = false)
+            every { mocks.triggerController.evaluateMessageTriggers(message) } returns false
+            coEvery { mocks.applicationService.waitUntilSystemConditionsAvailable() } returns true
+            coEvery { mocks.inAppDisplayer.displayMessage(any()) } returns true
+            mocks.getMessageDisplayQueue(mocks.inAppMessagesManager).add(message)
+
+            // When - setting paused = false without a paused -> unpaused transition
+            mocks.inAppMessagesManager.paused = false
+            awaitIO()
+
+            // Then - the queue is untouched and nothing is displayed
+            mocks.getMessageDisplayQueue(mocks.inAppMessagesManager) shouldBe listOf(message)
+            coVerify(exactly = 0) { mocks.inAppDisplayer.displayMessage(any()) }
         }
 
         test("message displays mid-session when trigger is satisfied after unpausing") {


### PR DESCRIPTION
# Description
## One Line Summary
Setting `InAppMessages.paused = false` now displays messages that were queued while paused (if their triggers still evaluate true) instead of leaving them parked until the next session.

## Details

### Motivation
Fixes #2647 ([SDK-4513](https://linear.app/onesignal/issue/SDK-4513)). Messages that qualified while paused are added to `messageDisplayQueue`, but `attemptToShowInAppMessage()` early-returns while paused, so they stay parked. On unpause, the setter only called `evaluateInAppMessages()`, which re-attempts display only when a message *currently* evaluates true — unpausing alone never resumed delivery mid-session, and the queued IAM only appeared after a session boundary (30+ seconds backgrounded). This contradicts the documented behavior: "Changing the value to false resumes normal message delivery for users who qualify based on their triggers."

The unpause branch now:
1. **Prunes** queue entries whose triggers no longer evaluate true — matching iOS, which never queues while paused and only re-evaluates current triggers on unpause. Without this, draining the queue could display an IAM on a screen where its trigger conditions no longer hold. Pruned messages are not lost; they remain in `messages` and display as soon as their triggers qualify again.
2. **Re-evaluates** all messages (`evaluateInAppMessages()`), which re-queues and displays anything that currently qualifies.
3. **Drains** any remaining valid queue entries (`attemptToShowInAppMessage()`).

This supersedes #2671, which unconditionally drained the queue on unpause — including messages whose triggers no longer evaluated true, diverging from iOS behavior.

### Scope
Only the `paused` setter's unpause path in `InAppMessagesManager`. Trigger evaluation, queueing, redisplay logic, and the pause/dismiss path are unchanged. Not addressed: the reporter's secondary claim that keeping `paused = false` at all times also fails — that could not be reproduced on Android (mid-session trigger-driven display works correctly in testing) and may be Unity-bridge-specific or environmental.

# Testing
## Unit testing
Three new tests in `InAppMessagesManagerTests.kt` ("Message Queue and Display" context), using a stateful `InAppStateService` mock so the paused/showing state behaves like production:
- message queued while paused displays on unpause when triggers still evaluate true
- message queued while paused does not display on unpause when triggers no longer evaluate true (and still displays later once its trigger re-qualifies, proving pruning is not destructive)
- message displays mid-session when trigger is satisfied after unpausing (the reported scenario's exact ordering: `paused = false` first, trigger added second)

All 67 module tests pass. `spotlessCheck`, `detekt`, and `assembleRelease` are clean.

## Manual testing
Tested on a Pixel 9 emulator (Android 16, ARM64, Play image) with the demo app built against this branch's SDK source (`./gradlew :app:assembleGmsDebug`), using the shared demo OneSignal app (`77e32082-ea27-42e3-a898-c72e141824ef`) and its pre-configured `iam_type`-triggered IAM campaigns. Logs observed via `adb logcat -s OneSignalSDK:V`.

**Scenario 1 — queued while paused, displays on unpause (the reported bug):**
1. Launch the demo app, wait for the push subscription to register and the IAM fetch to complete. Dismiss the "Display on App Open" IAM.
2. Toggle **Pause In-App Messages** ON (`setPaused(value: true)` in logs).
3. Tap **TOP BANNER** (adds trigger `iam_type=top_banner`). Logs show the message added to the queue followed by `In app messaging is currently paused, in app messages will not be shown!` — the parked state from the ticket.
4. Toggle **Pause In-App Messages** OFF.
5. ✅ The Top Banner IAM displays immediately mid-session (no session boundary), `onWillDisplay` fires, and the impression POST returns 200. Before this fix, nothing displayed until the app was backgrounded 30+ seconds.

**Scenario 2 — stale queued message is pruned, not displayed:**
1. Toggle **Pause In-App Messages** ON.
2. Tap **CENTER MODAL** (queues the `iam_type=center_modal` IAM; blocked by pause).
3. In the **Triggers** section, remove the `iam_type` trigger (the queued message's triggers no longer evaluate true).
4. Toggle **Pause In-App Messages** OFF.
5. ✅ Nothing displays; logs show `There are no IAMs left in the queue!` (the stale entry was pruned). #2671's approach would have wrongly displayed it here.
6. Tap **CENTER MODAL** again — the IAM displays immediately, confirming the pruned message was not lost.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [x] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs
## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible
## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item