### PR TITLE
fix: [SDK-4877] preserve WorkDatabase constructor under R8

### DIFF
--- a/OneSignalSDK/onesignal/notifications/consumer-rules.pro
+++ b/OneSignalSDK/onesignal/notifications/consumer-rules.pro
@@ -49,3 +49,9 @@
 -keep class * extends androidx.work.InputMerger {
     public <init>();
 }
+
+# Room resolves WorkManager's generated database implementation by name and invokes its no-arg
+# constructor reflectively. R8 full mode can remove that constructor when using WorkManager 2.8.x.
+-keep class androidx.work.impl.WorkDatabase_Impl {
+    <init>();
+}


### PR DESCRIPTION
# Description
## One Line Summary
Preserve WorkManager’s generated database constructor so AGP 9 release builds do not crash during app startup.

## Details
### Motivation
Flutter 3.44 projects use AGP 9.0.1 and R8 full mode. With OneSignal’s WorkManager 2.8.1 dependency, R8 can remove the reflectively invoked `WorkDatabase_Impl` no-argument constructor. The resulting release APK builds successfully but crashes in `androidx.startup.InitializationProvider` before application initialization.

### Scope
Adds one targeted consumer ProGuard rule to the notifications artifact. This preserves Android API 21 support and does not change public APIs or runtime behavior outside minified builds.

Linear: [SDK-4877](https://linear.app/onesignal/issue/SDK-4877/bug-javalangruntimeexception-unable-to-get-provider)

# Testing
## Unit testing
No unit test was added because this behavior occurs in R8 output at application startup and cannot be exercised by the SDK unit-test process.

## Manual testing
- Reproduced the crash in a clean Flutter 3.44.1 / AGP 9.0.1 release app consuming Android SDK 5.9.6.
- Published the fixed SDK artifacts to a temporary local Maven repository and consumed them from the same AGP 9 release app. The app started successfully with no `AndroidRuntime` error.
- Ran `./gradlew spotlessCheck :OneSignal:notifications:assembleRelease :app:assembleGmsRelease :app:assembleHuaweiRelease --console=plain`.

# Affected code checklist
   - [x] Notifications
      - [ ] Display
      - [ ] Open
      - [x] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item