### PR TITLE
feat(logger): [SDK-4939] adopt shared-module legacy purge (bump KMP submodule)

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/debug/internal/logging/logger/android/FileLogStore.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/debug/internal/logging/logger/android/FileLogStore.kt
@@ -105,15 +105,14 @@ internal class FileLogStore(
      * `*.otlp` owned records are left untouched so failed / too-young uploads can
      * still retry on the next launch.
      *
-     * This is a host-side, belt-and-suspenders sweep invoked after the logger's
-     * crash-upload pass; it is intentionally not on the [ILogFileStore] contract so
-     * it requires no change to the shared KMP module. Idempotent and safe to call
-     * repeatedly.
+     * Implements the shared [ILogFileStore] contract: the KMP `LogCrashUploader`
+     * invokes this after its owned-record upload pass. The host also calls it as a
+     * belt-and-suspenders sweep. Idempotent and safe to call repeatedly.
      *
      * @return number of unrecognized entries deleted
      */
     @Suppress("TooGenericExceptionCaught", "SwallowedException")
-    suspend fun deleteUnrecognizedEntries(): Int =
+    override suspend fun deleteUnrecognizedEntries(): Int =
         withContext(Dispatchers.IO) {
             try {
                 val foreign =


### PR DESCRIPTION
## Summary

Linear: [SDK-4939](https://linear.app/onesignal/issue/SDK-4939/harden-legacy-crash-file-cleanup-once-logger-module-is-active)

Follow-up that moves the legacy crash-file purge from host-side into the **shared KMP module**, so it runs for every host (iOS included), not just Android.

- Bumps `OneSignal-KMP-SDK` to the commit from [OneSignal-KMP-SDK#8](https://github.com/OneSignal/OneSignal-KMP-SDK/pull/8) (adds `ILogFileStore.deleteUnrecognizedEntries()` to the contract + a post-upload purge in `LogCrashUploader`).
- `FileLogStore.deleteUnrecognizedEntries()` now **overrides** the contract method, so it's invoked both by the shared uploader's sweep and by the host belt-and-suspenders call.

## Stacking / merge order

> **Stacked on #2691** (base branch = `ar/sdk-4939`). Merge order:
> 1. [OneSignal-KMP-SDK#8](https://github.com/OneSignal/OneSignal-KMP-SDK/pull/8)
> 2. [#2691](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2691)
> 3. this PR — I'll rebase onto `main` and re-pin the submodule to KMP#8's **merged** SHA (currently pinned to the branch commit `5c80f7b`).

## Test plan

- [x] `:OneSignal:core:compileDebugKotlin` (compiles against bumped submodule)
- [x] `:OneSignal:core:testDebugUnitTest --tests "*FileLogStoreTest*" --tests "*OneSignalCrashUploaderWrapperTest*"`
- [x] `:OneSignal:core:detekt` + `:OneSignal:core:spotlessKotlinCheck`
- [x] KMP side: `:kmp:testDebugUnitTest` (10/10 `LogCrashTest`) + `:kmp:spotlessCheck`

Made with [Cursor](https://cursor.com)