### PR TITLE
fix(ci): checkout Android SDK explicitly in bump-kmp reusable workflow

### DIFF
--- a/.github/workflows/bump-kmp-submodule.yml
+++ b/.github/workflows/bump-kmp-submodule.yml
@@ -50,6 +50,11 @@ jobs:
       - name: "[Checkout] Android SDK"
         uses: actions/checkout@v4
         with:
+          # Reusable workflows keep the caller's github context, so the default
+          # checkout target is the caller (OneSignal-KMP-SDK), not this repo.
+          # Always pin the Android SDK when called via workflow_call.
+          repository: OneSignal/OneSignal-Android-SDK
+          ref: main
           fetch-depth: 0
           token: ${{ secrets.GH_PUSH_TOKEN || github.token }}
           # Only the mode-160000 gitlink SHA is rewritten, so the submodule contents


### PR DESCRIPTION
## Summary

The KMP Release → `bump-android` job failed after tagging [v0.1.1](https://github.com/OneSignal/OneSignal-KMP-SDK/releases/tag/v0.1.1):

`Permission to OneSignal/OneSignal-KMP-SDK.git denied to onesignal-deploy`

Root cause: in a `workflow_call` reusable workflow, `actions/checkout` defaults to the **caller** repo (`OneSignal-KMP-SDK`), not the repo that owns the workflow. The bump step then created a self-submodule gitlink in KMP and tried to push there.

## Fix

Pin `repository: OneSignal/OneSignal-Android-SDK` and `ref: main` in the checkout step.

## Follow-up

After this lands, re-run the KMP Release bump (or dispatch this workflow with `kmp_version=v0.1.1` / `kmp_sha=4864ae1…`) to open the submodule bump PR. The tag/GitHub Release already succeeded.

## Test plan

- [ ] Merge this PR
- [ ] Dispatch `Bump KMP Submodule` with `v0.1.1` / SHA from the KMP release, or re-run the failed bump job after a no-op release retry path
- [ ] Confirm the opened PR targets `OneSignal-Android-SDK` and updates the `OneSignal-KMP-SDK` gitlink only


Made with [Cursor](https://cursor.com)