### PR TITLE
fix: [SDK-4946] register with Firebase Installation ID when the legacy FCM token API is disabled

### DIFF
--- a/OneSignalSDK/coverage/jacoco.gradle
+++ b/OneSignalSDK/coverage/jacoco.gradle
@@ -16,6 +16,16 @@ subprojects {
                     testCoverageEnabled = true
                 }
             }
+
+            testOptions {
+                // Robolectric loads classes through its own classloader, which leaves them without
+                //   a code source location. JaCoCo skips those by default, so Robolectric tests
+                //   would contribute no coverage at all.
+                unitTests.all { test ->
+                    test.jacoco.includeNoLocationClasses = true
+                    test.jacoco.excludes = ['jdk.internal.*']
+                }
+            }
         }
         
         def coverageExcludes = [

--- a/OneSignalSDK/onesignal/notifications/build.gradle
+++ b/OneSignalSDK/onesignal/notifications/build.gradle
@@ -76,6 +76,8 @@ dependencies {
 
     // NOTE: firebase-messaging:24.0.0 requires customer's project to use
     //   compileSdkVersion 34 or higher.
+    // `require` is intentionally non-strict: this module compiles against the preferred 24.0.0,
+    //   while an app can select a newer version through Gradle conflict resolution.
     api('com.google.firebase:firebase-messaging') {
         version {
             require '[23.0.8, 24.0.99]'

--- a/OneSignalSDK/onesignal/notifications/consumer-rules.pro
+++ b/OneSignalSDK/onesignal/notifications/consumer-rules.pro
@@ -25,6 +25,16 @@
 -dontwarn com.google.firebase.**
 -dontwarn com.google.android.gms.**
 
+# PushRegistratorFCM looks up FirebaseMessaging.register() by name, because this module compiles
+# against firebase-messaging 24.x where the method does not exist yet. Nothing references it
+# symbolically, it carries no @Keep, and firebase-messaging ships no consumer rules, so R8 full mode
+# (AGP 8+) renames it along with the rest of the class, causing:
+# java.lang.NoSuchMethodException: com.google.firebase.messaging.FirebaseMessaging.register []
+# keepclassmembers rather than keep, so Huawei apps that exclude firebase-messaging are unaffected.
+-keepclassmembers class com.google.firebase.messaging.FirebaseMessaging {
+    public *** register();
+}
+
 # ADM handlers are instantiated by name from the app manifest AND their on* lifecycle callbacks
 # (onMessage/onRegistered/onRegistrationError/onUnregistered) are invoked by the ADM framework, not
 # the SDK, so keep both constructors and those methods. (Amazon-device-only path, untestable in CI.)

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorFCM.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorFCM.kt
@@ -1,9 +1,11 @@
 package com.onesignal.notifications.internal.registration.impl
 
 import android.util.Base64
+import com.google.android.gms.tasks.Task
 import com.google.android.gms.tasks.Tasks
 import com.google.firebase.FirebaseApp
 import com.google.firebase.FirebaseOptions
+import com.google.firebase.installations.FirebaseInstallations
 import com.google.firebase.messaging.FirebaseMessaging
 import com.onesignal.core.internal.application.IApplicationService
 import com.onesignal.core.internal.config.ConfigModelStore
@@ -49,22 +51,40 @@ internal class PushRegistratorFCM(
     @Throws(ExecutionException::class, InterruptedException::class)
     override suspend fun getToken(senderId: String): String {
         initFirebaseApp(senderId)
-        return getTokenWithClassFirebaseMessaging()
+        return getTokenWithClassFirebaseMessaging(senderId)
     }
 
     @Throws(ExecutionException::class, InterruptedException::class)
-    private fun getTokenWithClassFirebaseMessaging(): String {
+    private fun getTokenWithClassFirebaseMessaging(senderId: String): String {
         // We use firebaseApp.get(FirebaseMessaging.class) instead of FirebaseMessaging.getInstance()
         //   as the latter uses the default Firebase app. We need to use a custom Firebase app as
         //   the senderId is provided at runtime.
         val fcmInstance = firebaseApp!!.get(FirebaseMessaging::class.java)
-        // FirebaseMessaging.getToken API was introduced in firebase-messaging:21.0.0
-        val tokenTask = fcmInstance.token
-        try {
-            return Tasks.await(tokenTask)
-        } catch (e: ExecutionException) {
-            throw tokenTask.exception ?: e
-        }
+        return FCMTokenProvider.getToken(senderId, { fcmInstance.token }, ::defaultAppRegistration)
+    }
+
+    // Installation ID registration is rejected unless the sender id, app id, and api key all belong
+    //   to the same Firebase project. Our own FirebaseApp pairs the app's sender id with OneSignal's
+    //   shared project credentials, so only the host app's default FirebaseApp can be used for it.
+    private fun defaultAppRegistration(): FCMTokenProvider.InstallationIdRegistration? {
+        val defaultApp =
+            FirebaseApp
+                .getApps(_applicationService.appContext)
+                .firstOrNull { it.name == FirebaseApp.DEFAULT_APP_NAME } ?: return null
+
+        return FCMTokenProvider.InstallationIdRegistration(
+            senderId = defaultApp.options.gcmSenderId,
+            register = { register(defaultApp.get(FirebaseMessaging::class.java)) },
+            installationId = { FirebaseInstallations.getInstance(defaultApp).id },
+        )
+    }
+
+    // FirebaseMessaging.register was added in firebase-messaging:25.1.0, which is newer than the
+    //   version this module compiles against.
+    private fun register(firebaseMessaging: FirebaseMessaging): Task<*> {
+        return firebaseMessaging.javaClass
+            .getMethod("register")
+            .invoke(firebaseMessaging) as Task<*>
     }
 
     private fun initFirebaseApp(senderId: String) {
@@ -78,5 +98,76 @@ internal class PushRegistratorFCM(
                 .setProjectId(projectId)
                 .build()
         firebaseApp = FirebaseApp.initializeApp(_applicationService.appContext, firebaseOptions, FCM_APP_NAME)
+    }
+}
+
+internal object FCMTokenProvider {
+    /**
+     * The Firebase Installation ID registration that replaces the legacy token API, along with the
+     * sender id of the Firebase project it would register against.
+     */
+    class InstallationIdRegistration(
+        val senderId: String?,
+        val register: () -> Task<*>,
+        val installationId: () -> Task<String>,
+    )
+
+    /**
+     * Retrieves an FCM token for [senderId], falling back to Firebase Installation ID registration
+     * when the host app has opted into it. Opting in disables the legacy token API for the whole
+     * app, not just the FirebaseApp that opted in.
+     */
+    fun getToken(
+        senderId: String,
+        legacyToken: () -> Task<String>,
+        installationIdRegistration: () -> InstallationIdRegistration?,
+    ): String {
+        return try {
+            await(legacyToken())
+        } catch (e: IllegalStateException) {
+            if (!isLegacyTokenApiDisabled(e)) throw e
+
+            registerInstallationId(senderId, installationIdRegistration())
+        }
+    }
+
+    private fun registerInstallationId(
+        senderId: String,
+        registration: InstallationIdRegistration?,
+    ): String {
+        if (registration == null) {
+            throw IllegalStateException(
+                "Firebase Installation ID registration is enabled but this app has no default " +
+                    "FirebaseApp to register with. Add your Firebase configuration " +
+                    "(google-services.json), or remove firebase_messaging_installation_id_enabled " +
+                    "from your manifest to keep using the legacy FCM token API.",
+            )
+        }
+
+        if (registration.senderId != senderId) {
+            throw IllegalStateException(
+                "Firebase Installation ID registration is enabled but the default FirebaseApp uses " +
+                    "sender id ${registration.senderId}, while OneSignal is configured with sender " +
+                    "id $senderId. Point both at the same Firebase project, or remove " +
+                    "firebase_messaging_installation_id_enabled from your manifest to keep using " +
+                    "the legacy FCM token API.",
+            )
+        }
+
+        await(registration.register())
+        return await(registration.installationId())
+    }
+
+    private fun isLegacyTokenApiDisabled(exception: IllegalStateException): Boolean {
+        val message = exception.message ?: return false
+        return message.contains("API disabled") && message.contains("register()")
+    }
+
+    private fun <T> await(task: Task<T>): T {
+        try {
+            return Tasks.await(task)
+        } catch (e: ExecutionException) {
+            throw task.exception ?: e
+        }
     }
 }

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorFCM.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorFCM.kt
@@ -79,8 +79,9 @@ internal class PushRegistratorFCM(
         )
     }
 
-    // FirebaseMessaging.register was added in firebase-messaging:25.1.0, which is newer than the
-    //   version this module compiles against.
+    // FirebaseMessaging.register was added in firebase-messaging:25.1.0. This module compiles
+    //   against the preferred 24.0.0, but the non-strict Gradle constraint lets apps select newer
+    //   versions through conflict resolution.
     private fun register(firebaseMessaging: FirebaseMessaging): Task<*> {
         return firebaseMessaging.javaClass
             .getMethod("register")

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorFCM.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorFCM.kt
@@ -156,7 +156,6 @@ internal object FCMTokenProvider {
      * 25.1.0. This module compiles against the preferred 24.0.0, but the non-strict Gradle
      * constraint lets apps select newer versions through conflict resolution.
      */
-    @Suppress("SwallowedException")
     fun invokeRegister(target: Any): Task<*> {
         val register =
             try {
@@ -175,7 +174,7 @@ internal object FCMTokenProvider {
         return try {
             register.invoke(target) as Task<*>
         } catch (e: InvocationTargetException) {
-            throw e.targetException
+            throw e.targetException ?: e
         }
     }
 

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorFCM.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorFCM.kt
@@ -10,6 +10,7 @@ import com.google.firebase.messaging.FirebaseMessaging
 import com.onesignal.core.internal.application.IApplicationService
 import com.onesignal.core.internal.config.ConfigModelStore
 import com.onesignal.core.internal.device.IDeviceService
+import java.lang.reflect.InvocationTargetException
 import java.util.concurrent.ExecutionException
 
 internal class PushRegistratorFCM(
@@ -74,18 +75,9 @@ internal class PushRegistratorFCM(
 
         return FCMTokenProvider.InstallationIdRegistration(
             senderId = defaultApp.options.gcmSenderId,
-            register = { register(defaultApp.get(FirebaseMessaging::class.java)) },
+            register = { FCMTokenProvider.invokeRegister(defaultApp.get(FirebaseMessaging::class.java)) },
             installationId = { FirebaseInstallations.getInstance(defaultApp).id },
         )
-    }
-
-    // FirebaseMessaging.register was added in firebase-messaging:25.1.0. This module compiles
-    //   against the preferred 24.0.0, but the non-strict Gradle constraint lets apps select newer
-    //   versions through conflict resolution.
-    private fun register(firebaseMessaging: FirebaseMessaging): Task<*> {
-        return firebaseMessaging.javaClass
-            .getMethod("register")
-            .invoke(firebaseMessaging) as Task<*>
     }
 
     private fun initFirebaseApp(senderId: String) {
@@ -157,6 +149,34 @@ internal object FCMTokenProvider {
 
         await(registration.register())
         return await(registration.installationId())
+    }
+
+    /**
+     * Calls register() reflectively. FirebaseMessaging.register was added in firebase-messaging
+     * 25.1.0. This module compiles against the preferred 24.0.0, but the non-strict Gradle
+     * constraint lets apps select newer versions through conflict resolution.
+     */
+    @Suppress("SwallowedException")
+    fun invokeRegister(target: Any): Task<*> {
+        val register =
+            try {
+                target.javaClass.getMethod("register")
+            } catch (e: NoSuchMethodException) {
+                throw IllegalStateException(
+                    "Firebase Installation ID registration is enabled but " +
+                        "FirebaseMessaging.register() was not found. It requires firebase-messaging " +
+                        "25.1.0 or newer, and has to survive minification, so check that OneSignal's " +
+                        "consumer ProGuard rules are applied.",
+                    e,
+                )
+            }
+
+        // invoke() wraps anything register() throws synchronously, which would hide the cause.
+        return try {
+            register.invoke(target) as Task<*>
+        } catch (e: InvocationTargetException) {
+            throw e.targetException
+        }
     }
 
     private fun isLegacyTokenApiDisabled(exception: IllegalStateException): Boolean {

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorFCM.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorFCM.kt
@@ -7,6 +7,7 @@ import com.google.firebase.FirebaseApp
 import com.google.firebase.FirebaseOptions
 import com.google.firebase.installations.FirebaseInstallations
 import com.google.firebase.messaging.FirebaseMessaging
+import com.onesignal.common.AndroidUtils
 import com.onesignal.core.internal.application.IApplicationService
 import com.onesignal.core.internal.config.ConfigModelStore
 import com.onesignal.core.internal.device.IDeviceService
@@ -21,6 +22,8 @@ internal class PushRegistratorFCM(
 ) : PushRegistratorAbstractGoogle(deviceService, _configModelStore, upgradePrompt) {
     companion object {
         private const val FCM_APP_NAME = "ONESIGNAL_SDK_FCM_APP_NAME"
+
+        private const val INSTALLATION_ID_ENABLED_METADATA = "firebase_messaging_installation_id_enabled"
 
         // project_info.project_id
         private const val FCM_DEFAULT_PROJECT_ID = "onesignal-shared-public"
@@ -61,7 +64,20 @@ internal class PushRegistratorFCM(
         //   as the latter uses the default Firebase app. We need to use a custom Firebase app as
         //   the senderId is provided at runtime.
         val fcmInstance = firebaseApp!!.get(FirebaseMessaging::class.java)
-        return FCMTokenProvider.getToken(senderId, { fcmInstance.token }, ::defaultAppRegistration)
+        return FCMTokenProvider.getToken(
+            senderId,
+            ::installationIdEnabled,
+            { fcmInstance.token },
+            ::defaultAppRegistration,
+        )
+    }
+
+    // Manifest merging means the flag can arrive from a dependency instead of the app's own
+    //   manifest, so report what the app actually resolved to. Read as a raw value because a
+    //   string "true" reads as false when asked for a boolean.
+    private fun installationIdEnabled(): String {
+        val metaData = AndroidUtils.getManifestMetaBundle(_applicationService.appContext)
+        return metaData?.get(INSTALLATION_ID_ENABLED_METADATA)?.toString() ?: "not set"
     }
 
     // Installation ID registration is rejected unless the sender id, app id, and api key all belong
@@ -112,6 +128,7 @@ internal object FCMTokenProvider {
      */
     fun getToken(
         senderId: String,
+        installationIdEnabled: () -> String,
         legacyToken: () -> Task<String>,
         installationIdRegistration: () -> InstallationIdRegistration?,
     ): String {
@@ -120,30 +137,33 @@ internal object FCMTokenProvider {
         } catch (e: IllegalStateException) {
             if (!isLegacyTokenApiDisabled(e)) throw e
 
-            registerInstallationId(senderId, installationIdRegistration())
+            registerInstallationId(senderId, installationIdEnabled(), installationIdRegistration())
         }
     }
 
     private fun registerInstallationId(
         senderId: String,
+        installationIdEnabled: String,
         registration: InstallationIdRegistration?,
     ): String {
+        val optedIn = "firebase_messaging_installation_id_enabled=$installationIdEnabled"
+
         if (registration == null) {
             throw IllegalStateException(
-                "Firebase Installation ID registration is enabled but this app has no default " +
-                    "FirebaseApp to register with. Add your Firebase configuration " +
-                    "(google-services.json), or remove firebase_messaging_installation_id_enabled " +
-                    "from your manifest to keep using the legacy FCM token API.",
+                "Firebase Installation ID registration is enabled ($optedIn) but this app has no " +
+                    "default FirebaseApp to register with. Add your Firebase configuration " +
+                    "(google-services.json), or set firebase_messaging_installation_id_enabled to " +
+                    "false in your manifest to keep using the legacy FCM token API.",
             )
         }
 
         if (registration.senderId != senderId) {
             throw IllegalStateException(
-                "Firebase Installation ID registration is enabled but the default FirebaseApp uses " +
-                    "sender id ${registration.senderId}, while OneSignal is configured with sender " +
-                    "id $senderId. Point both at the same Firebase project, or remove " +
-                    "firebase_messaging_installation_id_enabled from your manifest to keep using " +
-                    "the legacy FCM token API.",
+                "Firebase Installation ID registration is enabled ($optedIn) but the default " +
+                    "FirebaseApp uses sender id ${registration.senderId}, while OneSignal is " +
+                    "configured with sender id $senderId. Point both at the same Firebase project, " +
+                    "or set firebase_messaging_installation_id_enabled to false in your manifest " +
+                    "to keep using the legacy FCM token API.",
             )
         }
 

--- a/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/registration/impl/FCMTokenProviderTests.kt
+++ b/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/registration/impl/FCMTokenProviderTests.kt
@@ -41,7 +41,7 @@ class FCMTokenProviderTests : FunSpec({
     test("returns the legacy FCM token when the API is enabled") {
         val token =
             withContext(Dispatchers.IO) {
-                FCMTokenProvider.getToken(SENDER_ID, { Tasks.forResult("fcm-token") }) {
+                FCMTokenProvider.getToken(SENDER_ID, { "true" }, { Tasks.forResult("fcm-token") }) {
                     throw AssertionError("should not fall back to installation id registration")
                 }
             }
@@ -53,7 +53,7 @@ class FCMTokenProviderTests : FunSpec({
         var registered = false
         val token =
             withContext(Dispatchers.IO) {
-                FCMTokenProvider.getToken(SENDER_ID, { Tasks.forException(disabledLegacyApi) }) {
+                FCMTokenProvider.getToken(SENDER_ID, { "true" }, { Tasks.forException(disabledLegacyApi) }) {
                     registration(register = {
                         registered = true
                         completedTask()
@@ -71,7 +71,7 @@ class FCMTokenProviderTests : FunSpec({
         val thrown =
             withContext(Dispatchers.IO) {
                 shouldThrow<IllegalStateException> {
-                    FCMTokenProvider.getToken(SENDER_ID, { Tasks.forException(unrelated) }) {
+                    FCMTokenProvider.getToken(SENDER_ID, { "true" }, { Tasks.forException(unrelated) }) {
                         throw AssertionError("should not fall back to installation id registration")
                     }
                 }
@@ -84,18 +84,29 @@ class FCMTokenProviderTests : FunSpec({
         val thrown =
             withContext(Dispatchers.IO) {
                 shouldThrow<IllegalStateException> {
-                    FCMTokenProvider.getToken(SENDER_ID, { Tasks.forException(disabledLegacyApi) }) { null }
+                    FCMTokenProvider.getToken(SENDER_ID, { "true" }, { Tasks.forException(disabledLegacyApi) }) { null }
                 }
             }
 
         thrown.message!! shouldContain "no default FirebaseApp"
     }
 
+    test("reports the manifest flag value it resolved, including when the app never set it") {
+        val thrown =
+            withContext(Dispatchers.IO) {
+                shouldThrow<IllegalStateException> {
+                    FCMTokenProvider.getToken(SENDER_ID, { "not set" }, { Tasks.forException(disabledLegacyApi) }) { null }
+                }
+            }
+
+        thrown.message!! shouldContain "firebase_messaging_installation_id_enabled=not set"
+    }
+
     test("explains the problem when the default FirebaseApp uses a different sender id") {
         val thrown =
             withContext(Dispatchers.IO) {
                 shouldThrow<IllegalStateException> {
-                    FCMTokenProvider.getToken(SENDER_ID, { Tasks.forException(disabledLegacyApi) }) {
+                    FCMTokenProvider.getToken(SENDER_ID, { "true" }, { Tasks.forException(disabledLegacyApi) }) {
                         registration(
                             senderId = "999999999999",
                             register = { throw AssertionError("should not register on a sender id mismatch") },
@@ -113,7 +124,7 @@ class FCMTokenProviderTests : FunSpec({
         val thrown =
             withContext(Dispatchers.IO) {
                 shouldThrow<IllegalStateException> {
-                    FCMTokenProvider.getToken(SENDER_ID, { Tasks.forException(disabledLegacyApi) }) {
+                    FCMTokenProvider.getToken(SENDER_ID, { "true" }, { Tasks.forException(disabledLegacyApi) }) {
                         registration(
                             register = { failedTask(registrationFailure) },
                             installationId = { throw AssertionError("should not run after registration fails") },

--- a/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/registration/impl/FCMTokenProviderTests.kt
+++ b/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/registration/impl/FCMTokenProviderTests.kt
@@ -1,0 +1,117 @@
+package com.onesignal.notifications.internal.registration.impl
+
+import br.com.colman.kotest.android.extensions.robolectric.RobolectricTest
+import com.google.android.gms.tasks.Task
+import com.google.android.gms.tasks.TaskCompletionSource
+import com.google.android.gms.tasks.Tasks
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+private const val SENDER_ID = "388536902528"
+
+private fun completedTask(): Task<Void> = TaskCompletionSource<Void>().apply { setResult(null) }.task
+
+private fun failedTask(exception: Exception): Task<Void> =
+    TaskCompletionSource<Void>().apply { setException(exception) }.task
+
+private fun registration(
+    senderId: String? = SENDER_ID,
+    register: () -> Task<*> = { completedTask() },
+    installationId: () -> Task<String> = { Tasks.forResult("installation-id") },
+) = FCMTokenProvider.InstallationIdRegistration(senderId, register, installationId)
+
+@RobolectricTest
+class FCMTokenProviderTests : FunSpec({
+    val disabledLegacyApi = IllegalStateException("API disabled. Please use {@link #register()} instead.")
+
+    test("returns the legacy FCM token when the API is enabled") {
+        val token =
+            withContext(Dispatchers.IO) {
+                FCMTokenProvider.getToken(SENDER_ID, { Tasks.forResult("fcm-token") }) {
+                    throw AssertionError("should not fall back to installation id registration")
+                }
+            }
+
+        token shouldBe "fcm-token"
+    }
+
+    test("registers the installation id when the legacy API is disabled") {
+        var registered = false
+        val token =
+            withContext(Dispatchers.IO) {
+                FCMTokenProvider.getToken(SENDER_ID, { Tasks.forException(disabledLegacyApi) }) {
+                    registration(register = {
+                        registered = true
+                        completedTask()
+                    })
+                }
+            }
+
+        token shouldBe "installation-id"
+        registered shouldBe true
+    }
+
+    test("does not register for unrelated IllegalStateExceptions") {
+        val unrelated = IllegalStateException("Firebase is not initialized")
+
+        val thrown =
+            withContext(Dispatchers.IO) {
+                shouldThrow<IllegalStateException> {
+                    FCMTokenProvider.getToken(SENDER_ID, { Tasks.forException(unrelated) }) {
+                        throw AssertionError("should not fall back to installation id registration")
+                    }
+                }
+            }
+
+        thrown shouldBe unrelated
+    }
+
+    test("explains the problem when there is no default FirebaseApp to register with") {
+        val thrown =
+            withContext(Dispatchers.IO) {
+                shouldThrow<IllegalStateException> {
+                    FCMTokenProvider.getToken(SENDER_ID, { Tasks.forException(disabledLegacyApi) }) { null }
+                }
+            }
+
+        thrown.message!! shouldContain "no default FirebaseApp"
+    }
+
+    test("explains the problem when the default FirebaseApp uses a different sender id") {
+        val thrown =
+            withContext(Dispatchers.IO) {
+                shouldThrow<IllegalStateException> {
+                    FCMTokenProvider.getToken(SENDER_ID, { Tasks.forException(disabledLegacyApi) }) {
+                        registration(
+                            senderId = "999999999999",
+                            register = { throw AssertionError("should not register on a sender id mismatch") },
+                        )
+                    }
+                }
+            }
+
+        thrown.message!! shouldContain "sender id 999999999999"
+    }
+
+    test("propagates registration failures") {
+        val registrationFailure = IllegalStateException("Registration failed")
+
+        val thrown =
+            withContext(Dispatchers.IO) {
+                shouldThrow<IllegalStateException> {
+                    FCMTokenProvider.getToken(SENDER_ID, { Tasks.forException(disabledLegacyApi) }) {
+                        registration(
+                            register = { failedTask(registrationFailure) },
+                            installationId = { throw AssertionError("should not run after registration fails") },
+                        )
+                    }
+                }
+            }
+
+        thrown shouldBe registrationFailure
+    }
+})

--- a/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/registration/impl/FCMTokenProviderTests.kt
+++ b/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/registration/impl/FCMTokenProviderTests.kt
@@ -8,6 +8,7 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
@@ -23,6 +24,15 @@ private fun registration(
     register: () -> Task<*> = { completedTask() },
     installationId: () -> Task<String> = { Tasks.forResult("installation-id") },
 ) = FCMTokenProvider.InstallationIdRegistration(senderId, register, installationId)
+
+private class Registrar(private val exception: Exception? = null) {
+    fun register(): Task<Void> {
+        exception?.let { throw it }
+        return completedTask()
+    }
+}
+
+private class WithoutRegister
 
 @RobolectricTest
 class FCMTokenProviderTests : FunSpec({
@@ -113,5 +123,24 @@ class FCMTokenProviderTests : FunSpec({
             }
 
         thrown shouldBe registrationFailure
+    }
+
+    test("invokes register reflectively") {
+        FCMTokenProvider.invokeRegister(Registrar()).isSuccessful shouldBe true
+    }
+
+    test("unwraps what register throws instead of surfacing the reflection wrapper") {
+        val cause = IllegalStateException("register blew up")
+
+        val thrown = shouldThrow<IllegalStateException> { FCMTokenProvider.invokeRegister(Registrar(cause)) }
+
+        thrown shouldBe cause
+    }
+
+    test("explains the problem when register is missing") {
+        val thrown = shouldThrow<IllegalStateException> { FCMTokenProvider.invokeRegister(WithoutRegister()) }
+
+        thrown.message!! shouldContain "25.1.0 or newer"
+        thrown.cause.shouldBeInstanceOf<NoSuchMethodException>()
     }
 })

--- a/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorFCMTests.kt
+++ b/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorFCMTests.kt
@@ -1,6 +1,7 @@
 package com.onesignal.notifications.internal.registration.impl
 
 import android.content.Context
+import androidx.test.core.app.ApplicationProvider
 import br.com.colman.kotest.android.extensions.robolectric.RobolectricTest
 import com.google.android.gms.tasks.Task
 import com.google.android.gms.tasks.Tasks
@@ -48,7 +49,7 @@ private fun registrator(
     every { FirebaseApp.getApps(any()) } returns installedApps
 
     val applicationService = mockk<IApplicationService>()
-    every { applicationService.appContext } returns mockk<Context>()
+    every { applicationService.appContext } returns ApplicationProvider.getApplicationContext<Context>()
 
     return PushRegistratorFCM(
         MockHelper.configModelStore(),
@@ -81,6 +82,7 @@ class PushRegistratorFCMTests : FunSpec({
             }
 
         thrown.message!! shouldContain "no default FirebaseApp"
+        thrown.message!! shouldContain "firebase_messaging_installation_id_enabled=not set"
     }
 
     test("does not register against a default FirebaseApp with a different sender id") {

--- a/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorFCMTests.kt
+++ b/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorFCMTests.kt
@@ -1,0 +1,100 @@
+package com.onesignal.notifications.internal.registration.impl
+
+import android.content.Context
+import br.com.colman.kotest.android.extensions.robolectric.RobolectricTest
+import com.google.android.gms.tasks.Task
+import com.google.android.gms.tasks.Tasks
+import com.google.firebase.FirebaseApp
+import com.google.firebase.FirebaseOptions
+import com.google.firebase.messaging.FirebaseMessaging
+import com.onesignal.core.internal.application.IApplicationService
+import com.onesignal.mocks.MockHelper
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+private const val SENDER_ID = "388536902528"
+
+private fun defaultApp(senderId: String): FirebaseApp {
+    val options = mockk<FirebaseOptions>()
+    every { options.gcmSenderId } returns senderId
+
+    val app = mockk<FirebaseApp>()
+    every { app.name } returns FirebaseApp.DEFAULT_APP_NAME
+    every { app.options } returns options
+
+    return app
+}
+
+private fun registrator(
+    legacyToken: Task<String>,
+    installedApps: List<FirebaseApp> = emptyList(),
+): PushRegistratorFCM {
+    val messaging = mockk<FirebaseMessaging>()
+    every { messaging.token } returns legacyToken
+
+    val onesignalApp = mockk<FirebaseApp>()
+    every { onesignalApp.get(FirebaseMessaging::class.java) } returns messaging
+
+    mockkStatic(FirebaseApp::class)
+    every { FirebaseApp.initializeApp(any(), any<FirebaseOptions>(), any()) } returns onesignalApp
+    every { FirebaseApp.getApps(any()) } returns installedApps
+
+    val applicationService = mockk<IApplicationService>()
+    every { applicationService.appContext } returns mockk<Context>()
+
+    return PushRegistratorFCM(
+        MockHelper.configModelStore(),
+        applicationService,
+        mockk(relaxed = true),
+        mockk(relaxed = true),
+    )
+}
+
+@RobolectricTest
+class PushRegistratorFCMTests : FunSpec({
+    val disabledLegacyApi = IllegalStateException("API disabled. Please use {@link #register()} instead.")
+
+    afterEach { unmockkAll() }
+
+    test("returns the FCM token from OneSignal's own FirebaseApp") {
+        val registrator = registrator(legacyToken = Tasks.forResult("fcm-token"))
+
+        val token = withContext(Dispatchers.IO) { registrator.getToken(SENDER_ID) }
+
+        token shouldBe "fcm-token"
+    }
+
+    test("explains the problem when the app has no default FirebaseApp to register with") {
+        val registrator = registrator(legacyToken = Tasks.forException(disabledLegacyApi))
+
+        val thrown =
+            withContext(Dispatchers.IO) {
+                shouldThrow<IllegalStateException> { registrator.getToken(SENDER_ID) }
+            }
+
+        thrown.message!! shouldContain "no default FirebaseApp"
+    }
+
+    test("does not register against a default FirebaseApp with a different sender id") {
+        val registrator =
+            registrator(
+                legacyToken = Tasks.forException(disabledLegacyApi),
+                installedApps = listOf(defaultApp("999999999999")),
+            )
+
+        val thrown =
+            withContext(Dispatchers.IO) {
+                shouldThrow<IllegalStateException> { registrator.getToken(SENDER_ID) }
+            }
+
+        thrown.message!! shouldContain "sender id 999999999999"
+    }
+})


### PR DESCRIPTION
# Description
## One Line Summary
Fall back to Firebase Installation ID registration when an app has disabled the legacy FCM token API, instead of failing to register for push.

## Details

### Motivation
Firebase Messaging 25.1.0 deprecated `getToken()`, `deleteToken()`, and `onNewToken()` in favor of Firebase Installation ID (FID) registration. An app opts in by adding `firebase_messaging_installation_id_enabled` to its manifest, and that flag disables the legacy token API for the entire process, not just the `FirebaseApp` that opted in.

That means OneSignal's own `getToken()` call fails with `IllegalStateException: API disabled`, and the device never registers for push. Apps can hit this without doing anything deliberate, since any dependency that sets the flag turns it on for everyone.

### Scope
Only affects the FCM registration path when the legacy token API has been disabled. Apps that have not opted in keep using `getToken()` exactly as before, so there is no behavior change for the vast majority of integrations.

### Apps that set the flag need their own google-services.json
Worth calling out because it is a new requirement, though only for apps that opt in.

Setting `firebase_messaging_installation_id_enabled` to `true` makes FID registration the only way to register. A FID is issued by a Firebase project and is only meaningful within it, and on Android it comes from the app's default `FirebaseApp`, which is initialized from `google-services.json` by the google-services Gradle plugin. OneSignal's own `FirebaseApp` cannot issue a usable one, for the credential reasons described below.

So an app that sets the flag has to ship a `google-services.json` for its own Firebase project, and that project's sender id has to match the sender id configured in the OneSignal dashboard. If either piece is missing, this PR fails registration with an error that says exactly which one.

Apps that leave the flag alone, which is the default, still need nothing beyond their sender id. Nothing here asks existing integrations to add Firebase configuration.

### Why registration runs against the default FirebaseApp
FID registration requires the sender id, app id, and api key to all belong to a single Firebase project. Our `FirebaseApp` deliberately pairs the app's sender id with OneSignal's shared project credentials, so calling `register()` on it is rejected by Play Services with an opaque `ApiException: 8: Internal error encountered.`

When the legacy API is disabled we therefore look for the host app's default `FirebaseApp`, verify its sender id matches the one OneSignal is configured with, and register through it. If there is no default app, or the sender ids disagree, we throw an error that names the problem and how to fix it rather than letting the opaque Play Services error surface.

`FirebaseMessaging.register()` is called reflectively because it was added in firebase-messaging 25.1.0, which is newer than the version this module compiles against.

### Also in this PR: JaCoCo now records Robolectric coverage
The diff coverage gate reported 0% on `PushRegistratorFCM.kt` even though the tests exercise it and pass. JaCoCo was recording nothing from Robolectric tests, because Robolectric loads classes through its own classloader and JaCoCo skips classes with no code source location by default. Every file with recorded coverage in this module was tested by a non-Robolectric test, and Robolectric-tested classes like `NotificationChannelManager` sat at exactly 0.

`coverage/jacoco.gradle` now sets `includeNoLocationClasses` on unit test tasks. These tests have to be Robolectric, since `Tasks.await()` needs `Looper.getMainLooper()` and the `PushRegistratorFCM` constructor decodes the default api key with `android.util.Base64`.

Worth knowing that this changes reported coverage repo wide, not just here. The notifications module goes from 11.4% to 30.3% with no new tests, because a large share of this repo's tests are Robolectric and none of them were being counted. Existing coverage numbers were understated rather than this PR inflating them. Happy to split this into its own PR if reviewers would rather keep the fix isolated.

# Testing
## Unit testing
`FCMTokenProviderTests` covers ten paths through the new logic: the legacy token when the API is enabled, successful FID registration when it is disabled, unrelated `IllegalStateException`s passing through untouched, the missing default app and sender id mismatch diagnostics along with the resolved manifest flag value they report, registration failures propagating, and the three reflection behaviors (invoking `register()`, unwrapping what it throws rather than surfacing the wrapper, and explaining a missing method). `PushRegistratorFCMTests` covers the same wiring through Robolectric against real manifest metadata.

Coverage on the changed lines is 100%, 53 of 53.

## Manual testing
Tested on an Android 16 emulator using the `fadi/SDK-4946-firebase-25-demo` branch. That branch is this fix with the reproduction setup layered on top, since the bug cannot be triggered with the example app as it ships today. It pins the example app to firebase-messaging 25.1.1, sets `firebase_messaging_installation_id_enabled` to `true` in the gms manifest, and applies the google-services plugin so the app has a default `FirebaseApp` to register against. It is a test harness and is not meant to merge.

`google-services.json` is gitignored there since it is specific to one Firebase project, so drop in your own to reproduce the opt-in path, using a project whose sender id matches the one in your OneSignal dashboard. Without the file the plugin is skipped and gms builds still work, they just take the legacy token path.

With the flag on:

- Without this fix, registration fails with `IllegalStateException: API disabled`.
- With this fix and `google-services.json` in place, the app registers and receives notifications sent from the dashboard. The token is a FID, for example `ctmBeCwtQDuDsClbyr6d3z`.
- With this fix and `google-services.json` removed, the new "no default FirebaseApp" error appears instead of a silent failure.

With the flag off, which is the default and covers every existing integration, both on firebase-messaging 25.1.1:

- With `google-services.json` present, registration returns a normal FCM token, for example `fWAQuU2QRcyO-MCoWP5l4D:APA91bF...`. The new code path is never entered.
- With no `google-services.json` and the google-services plugin not applied, which is what a typical OneSignal app looks like, registration also returns a normal FCM token. `FirebaseInitProvider` logs that there is no default app, and it does not matter because nothing asks for one.

I also confirmed the default-app redirect is the part that makes the opt-in case work. Reverting just `PushRegistratorFCM.kt` to an earlier version that called `register()` on OneSignal's own `FirebaseApp`, while leaving a valid `google-services.json` in place, still fails with `ApiException: 8`.

### Firebase version and minification
Ran the flag both ways on firebase-messaging 24.0.0 as well, since that is where most apps sit today and `register()` does not exist in the class there. Legacy token both times, which is expected because the flag does nothing before 25.1.0.

Both flag states also run in a minified release build, which is what exercises the new consumer ProGuard rule. Behavior is the same as debug and there is no `NoSuchMethodException`.

### Token conversions on an existing install
Flipping the flag on an install that already holds a token, without clearing app data:

- Legacy token to FID, the direction an app takes when it adopts the flag: the subscription id is preserved, the token swaps from `dN8Ya5MTR2OO-0BXdqimCI:APA91bFw...` to the FID `cXp9fY-TRFCLSy9kVTqorZ`, and a push sent to that subscription still arrives.
- FID back to legacy token: works when the rollback ships as an app version bump, which is how it would actually reach users. FCM issues a fresh token, the subscription id is unchanged, and delivery works.

Worth knowing before testing the rollback locally: if you flip the flag off by rebuilding at the same `versionCode`, `getToken()` hands back Firebase's cached pre-FID token, which FCM has already invalidated. The backend then gets an unregistered response and parks the subscription at `notification_types: -10`, which our own enum documents as "server side detection only from FCM that the app is no longer installed", so push stops silently while the SDK keeps re-asserting the same dead token. Bumping `versionCode` or clearing app data fixes it. This PR does not change the flag-off path, we return whatever Firebase gives us, but it looks like a bug in the fix if you hit it.

# Affected code checklist
   - [x] Notifications
      - [ ] Display
      - [ ] Open
      - [x] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item



