### PR TITLE
fix: [SDK-4983] destroy IAM WebView on dismiss to stop Activity leaks

### DIFF
--- a/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/display/impl/InAppDisplayer.kt
+++ b/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/display/impl/InAppDisplayer.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import java.io.UnsupportedEncodingException
+import java.util.concurrent.atomic.AtomicReference
 
 // Manages WebView instances by pre-loading them, displaying them, and closing them when dismissed.
 //   Includes a static map for pre-loading, showing, and dismissed so these events can't be duplicated.
@@ -41,7 +42,12 @@ internal class InAppDisplayer(
     private val _languageContext: ILanguageContext,
     private val _time: ITime,
 ) : IInAppDisplayer {
-    private var lastInstance: WebViewManager? = null
+    /**
+     * The currently displaying manager, if any. Atomic because dismissal clears it from a
+     * background thread: readers must claim it with [AtomicReference.getAndSet] rather than
+     * checking for null and dereferencing separately.
+     */
+    private val lastInstance = AtomicReference<WebViewManager?>(null)
 
     override suspend fun displayMessage(message: InAppMessage): Boolean? {
         var response =
@@ -100,14 +106,11 @@ internal class InAppDisplayer(
         if (currentActivity != null) {
             // Only a preview will be dismissed, this prevents normal messages from being
             // removed when a preview is sent into the app
-            if (lastInstance != null && message.isPreview) {
-                // Created a callback for dismissing a message and preparing the next one
-                lastInstance!!.dismissAndAwaitNextMessage()
-                lastInstance = null
-                initInAppMessage(currentActivity, message, content)
-            } else {
-                initInAppMessage(currentActivity, message, content)
+            if (message.isPreview) {
+                // Claim the instance in one step; a concurrent dismiss may have already cleared it.
+                lastInstance.getAndSet(null)?.dismissAndAwaitNextMessage()
             }
+            initInAppMessage(currentActivity, message, content)
             return
         }
 
@@ -116,9 +119,10 @@ internal class InAppDisplayer(
     }
 
     override fun dismissCurrentInAppMessage() {
-        Logging.debug("WebViewManager IAM dismissAndAwaitNextMessage lastInstance: $lastInstance")
+        val instance = lastInstance.get()
+        Logging.debug("WebViewManager IAM dismissAndAwaitNextMessage lastInstance: $instance")
 
-        lastInstance?.backgroundDismissAndAwaitNextMessage()
+        instance?.backgroundDismissAndAwaitNextMessage()
     }
 
     private suspend fun initInAppMessage(
@@ -135,11 +139,9 @@ internal class InAppDisplayer(
             val webViewManager = WebViewManager(message, currentActivity, content, _lifecycle, _applicationService, _promptFactory)
             // Clear lastInstance on every dismiss path so OSWebView cannot retain a destroyed Activity
             webViewManager.onDismissed = {
-                if (lastInstance === webViewManager) {
-                    lastInstance = null
-                }
+                lastInstance.compareAndSet(webViewManager, null)
             }
-            lastInstance = webViewManager
+            lastInstance.set(webViewManager)
 
             if (content.isFullBleed) {
                 webViewManager.setContentSafeAreaInsets(content, currentActivity)

--- a/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/display/impl/InAppDisplayer.kt
+++ b/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/display/impl/InAppDisplayer.kt
@@ -118,9 +118,7 @@ internal class InAppDisplayer(
     override fun dismissCurrentInAppMessage() {
         Logging.debug("WebViewManager IAM dismissAndAwaitNextMessage lastInstance: $lastInstance")
 
-        if (lastInstance != null) {
-            lastInstance!!.backgroundDismissAndAwaitNextMessage()
-        }
+        lastInstance?.backgroundDismissAndAwaitNextMessage()
     }
 
     private suspend fun initInAppMessage(
@@ -135,6 +133,12 @@ internal class InAppDisplayer(
                     Base64.NO_WRAP,
                 )
             val webViewManager = WebViewManager(message, currentActivity, content, _lifecycle, _applicationService, _promptFactory)
+            // Clear lastInstance on every dismiss path so OSWebView cannot retain a destroyed Activity
+            webViewManager.onDismissed = {
+                if (lastInstance === webViewManager) {
+                    lastInstance = null
+                }
+            }
             lastInstance = webViewManager
 
             if (content.isFullBleed) {

--- a/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/display/impl/WebViewManager.kt
+++ b/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/display/impl/WebViewManager.kt
@@ -274,43 +274,47 @@ internal class WebViewManager(
 
         val localWebView = webView
         if (dismissed || localWebView == null) {
+            // Dismissed while waiting for the activity; nothing left to measure/show.
+        } else {
+            // At time point the webView isn't attached to a view
+            // Set the WebView to the max screen size then run JS to evaluate the height.
+            setWebViewToMaxSize(activity, localWebView)
+            if (messageContent.isFullBleed) {
+                updateSafeAreaInsets()
+            }
+
+            localWebView.evaluateJavascript(GET_PAGE_META_DATA_JS_FUNCTION) { value ->
+                evaluatePageMetaDataForHeight(value)
+            }
+        }
+    }
+
+    private fun evaluatePageMetaDataForHeight(value: String?) {
+        // SDK-4494: `evaluateJavascript` returns the JSON-encoded result of the
+        // expression. When the JS function is undefined or returns `undefined`
+        // (e.g. WebView not fully loaded yet) the callback receives the literal
+        // string "null", which `JSONObject(...)` rejects. Bail out early instead
+        // of throwing+catching, and route any remaining surprise through Logging
+        // (was previously `e.printStackTrace()`, which bypassed our log pipeline).
+        if (value.isNullOrBlank() || value == "null") {
+            Logging.warn(
+                "calculateHeightAndShowWebViewAfterNewActivity: empty/null page metadata " +
+                    "from WebView; skipping height update",
+            )
             return
         }
+        try {
+            val pagePxHeight = pageRectToViewHeight(activity, JSONObject(value))
 
-        // At time point the webView isn't attached to a view
-        // Set the WebView to the max screen size then run JS to evaluate the height.
-        setWebViewToMaxSize(activity, localWebView)
-        if (messageContent.isFullBleed) {
-            updateSafeAreaInsets()
-        }
-
-        localWebView.evaluateJavascript(GET_PAGE_META_DATA_JS_FUNCTION) { value ->
-            // SDK-4494: `evaluateJavascript` returns the JSON-encoded result of the
-            // expression. When the JS function is undefined or returns `undefined`
-            // (e.g. WebView not fully loaded yet) the callback receives the literal
-            // string "null", which `JSONObject(...)` rejects. Bail out early instead
-            // of throwing+catching, and route any remaining surprise through Logging
-            // (was previously `e.printStackTrace()`, which bypassed our log pipeline).
-            if (value.isNullOrBlank() || value == "null") {
-                Logging.warn(
-                    "calculateHeightAndShowWebViewAfterNewActivity: empty/null page metadata " +
-                        "from WebView; skipping height update",
-                )
-                return@evaluateJavascript
+            suspendifyOnIO {
+                showMessageView(pagePxHeight)
             }
-            try {
-                val pagePxHeight = pageRectToViewHeight(activity, JSONObject(value))
-
-                suspendifyOnIO {
-                    showMessageView(pagePxHeight)
-                }
-            } catch (e: JSONException) {
-                Logging.warn(
-                    "calculateHeightAndShowWebViewAfterNewActivity: could not parse page metadata; " +
-                        "snippet=${bodySnippet(value)}",
-                    e,
-                )
-            }
+        } catch (e: JSONException) {
+            Logging.warn(
+                "calculateHeightAndShowWebViewAfterNewActivity: could not parse page metadata; " +
+                    "snippet=${bodySnippet(value)}",
+                e,
+            )
         }
     }
 
@@ -385,6 +389,39 @@ internal class WebViewManager(
         }
 
         enableWebViewRemoteDebugging()
+        val localWebView = createConfiguredWebView(currentActivity, isFullScreen)
+
+        val assigned =
+            synchronized(lifecycleLock) {
+                if (dismissed) {
+                    destroyWebViewInstance(localWebView)
+                    false
+                } else {
+                    webView = localWebView
+                    true
+                }
+            }
+        if (!assigned) {
+            return
+        }
+
+        _lifecycle.messageWillDisplay(message)
+        _applicationService.waitUntilActivityReady()
+
+        synchronized(lifecycleLock) {
+            if (dismissed || webView !== localWebView) {
+                destroyWebViewInstance(localWebView)
+            } else {
+                setWebViewToMaxSize(currentActivity, localWebView)
+                localWebView.loadData(base64Message, "text/html; charset=utf-8", "base64")
+            }
+        }
+    }
+
+    private fun createConfiguredWebView(
+        currentActivity: Activity,
+        isFullScreen: Boolean,
+    ): OSWebView {
         val localWebView = OSWebView(currentActivity)
         localWebView.overScrollMode = View.OVER_SCROLL_NEVER
         localWebView.isVerticalScrollBarEnabled = false
@@ -401,26 +438,7 @@ internal class WebViewManager(
                 localWebView.fitsSystemWindows = false
             }
         }
-
-        synchronized(lifecycleLock) {
-            if (dismissed) {
-                destroyWebViewInstance(localWebView)
-                return
-            }
-            webView = localWebView
-        }
-
-        _lifecycle.messageWillDisplay(message)
-        _applicationService.waitUntilActivityReady()
-
-        synchronized(lifecycleLock) {
-            if (dismissed || webView !== localWebView) {
-                destroyWebViewInstance(localWebView)
-                return
-            }
-            setWebViewToMaxSize(currentActivity, localWebView)
-            localWebView.loadData(base64Message, "text/html; charset=utf-8", "base64")
-        }
+        return localWebView
     }
 
     /**
@@ -457,7 +475,7 @@ internal class WebViewManager(
     //  set it's height to match.
     private fun setWebViewToMaxSize(
         activity: Activity,
-        targetWebView: OSWebView = webView!!,
+        targetWebView: OSWebView,
     ) {
         targetWebView.layout(0, 0, getWebViewMaxSizeX(activity), getWebViewMaxSizeY(activity))
     }
@@ -601,8 +619,8 @@ internal class WebViewManager(
                 view.stopLoading()
                 view.removeAllViews()
                 view.destroy()
-            } catch (t: Throwable) {
-                Logging.warn("Error destroying IAM WebView", t)
+            } catch (e: RuntimeException) {
+                Logging.warn("Error destroying IAM WebView", e)
             }
         }
         // WebView.destroy() must run on the main thread

--- a/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/display/impl/WebViewManager.kt
+++ b/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/display/impl/WebViewManager.kt
@@ -76,8 +76,19 @@ internal class WebViewManager(
     private var currentActivityName: String? = null
     private var lastPageHeight: Int? = null
 
-    // dismissFired prevents onDidDismiss from getting called multiple times
-    private var dismissFired = false
+    // Serializes setup / dismiss so a dismiss during WebView creation cannot leave orphans
+    // or race createNewInAppMessageView(webView!!).
+    private val lifecycleLock = Any()
+
+    // Terminal: once true, this WebViewManager never shows content again.
+    @Volatile
+    private var dismissed = false
+
+    // Ensures finishDismiss runs exactly once.
+    private var cleanedUp = false
+
+    // Ensures messageWasDismissed lifecycle is fired exactly once.
+    private var lifecycleDismissNotified = false
 
     // closing prevents IAM being redisplayed when the activity changes during an actionHandler
     private var closing = false
@@ -107,6 +118,9 @@ internal class WebViewManager(
         }
 
         private fun handleRenderComplete(jsonObject: JSONObject) {
+            if (dismissed) {
+                return
+            }
             val displayType = getDisplayLocation(jsonObject)
             val pageHeight =
                 if (displayType == Position.FULL_SCREEN) -1 else getPageHeightData(jsonObject)
@@ -225,6 +239,7 @@ internal class WebViewManager(
 
     private suspend fun updateSafeAreaInsets() {
         withContext(Dispatchers.Main) {
+            val localWebView = webView ?: return@withContext
             val insets = ViewUtils.getCutoutAndStatusBarInsets(activity)
             val safeAreaInsetsObject =
                 String.format(
@@ -239,14 +254,14 @@ internal class WebViewManager(
                     SET_SAFE_AREA_INSETS_JS_FUNCTION,
                     safeAreaInsetsObject,
                 )
-            webView!!.evaluateJavascript(safeAreaInsetsFunction, null)
+            localWebView.evaluateJavascript(safeAreaInsetsFunction, null)
         }
     }
 
     // Every time an Activity is shown we update the height of the WebView since the available
     //   screen size may have changed. (Expect for Fullscreen)
     private suspend fun calculateHeightAndShowWebViewAfterNewActivity() {
-        if (messageView == null) return
+        if (dismissed || messageView == null || webView == null) return
 
         // Don't need a CSS / HTML height update for fullscreen unless its fullbleed
         if (messageView!!.displayPosition == Position.FULL_SCREEN && !messageContent.isFullBleed) {
@@ -257,14 +272,19 @@ internal class WebViewManager(
 
         _applicationService.waitUntilActivityReady()
 
+        val localWebView = webView
+        if (dismissed || localWebView == null) {
+            return
+        }
+
         // At time point the webView isn't attached to a view
         // Set the WebView to the max screen size then run JS to evaluate the height.
-        setWebViewToMaxSize(activity)
+        setWebViewToMaxSize(activity, localWebView)
         if (messageContent.isFullBleed) {
             updateSafeAreaInsets()
         }
 
-        webView!!.evaluateJavascript(GET_PAGE_META_DATA_JS_FUNCTION) { value ->
+        localWebView.evaluateJavascript(GET_PAGE_META_DATA_JS_FUNCTION) { value ->
             // SDK-4494: `evaluateJavascript` returns the JSON-encoded result of the
             // expression. When the JS function is undefined or returns `undefined`
             // (e.g. WebView not fully loaded yet) the callback receives the literal
@@ -333,20 +353,25 @@ internal class WebViewManager(
 
     private suspend fun showMessageView(newHeight: Int?) {
         messageViewMutex.withLock {
-            if (messageView == null) {
+            if (dismissed) {
+                return
+            }
+            val localMessageView = messageView
+            val localWebView = webView
+            if (localMessageView == null || localWebView == null) {
                 Logging.warn("No messageView found to update a with a new height.")
                 return
             }
             Logging.debug("In app message, showing first one with height: $newHeight")
 
-            messageView?.setWebView(webView!!)
+            localMessageView.setWebView(localWebView)
             if (newHeight != null) {
                 lastPageHeight = newHeight
-                messageView?.updateHeight(newHeight)
+                localMessageView.updateHeight(newHeight)
             }
             // showView does not return until in-app is dismissed
-            messageView?.showView(activity)
-            messageView?.checkIfShouldDismiss()
+            localMessageView.showView(activity)
+            localMessageView.checkIfShouldDismiss()
         }
     }
 
@@ -355,28 +380,47 @@ internal class WebViewManager(
         base64Message: String,
         isFullScreen: Boolean,
     ) {
+        if (dismissed) {
+            return
+        }
+
         enableWebViewRemoteDebugging()
-        webView = OSWebView(currentActivity)
-        webView!!.overScrollMode = View.OVER_SCROLL_NEVER
-        webView!!.isVerticalScrollBarEnabled = false
-        webView!!.isHorizontalScrollBarEnabled = false
-        secureSetup(webView!!)
+        val localWebView = OSWebView(currentActivity)
+        localWebView.overScrollMode = View.OVER_SCROLL_NEVER
+        localWebView.isVerticalScrollBarEnabled = false
+        localWebView.isHorizontalScrollBarEnabled = false
+        secureSetup(localWebView)
 
         // Setup receiver for page events / data from JS
-        webView!!.addJavascriptInterface(OSJavaScriptInterface(), JS_OBJ_NAME)
+        localWebView.addJavascriptInterface(OSJavaScriptInterface(), JS_OBJ_NAME)
         if (isFullScreen) {
-            webView!!.systemUiVisibility = View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN or
+            localWebView.systemUiVisibility = View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN or
                 View.SYSTEM_UI_FLAG_IMMERSIVE or
                 View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                webView!!.fitsSystemWindows = false
+                localWebView.fitsSystemWindows = false
             }
+        }
+
+        synchronized(lifecycleLock) {
+            if (dismissed) {
+                destroyWebViewInstance(localWebView)
+                return
+            }
+            webView = localWebView
         }
 
         _lifecycle.messageWillDisplay(message)
         _applicationService.waitUntilActivityReady()
-        setWebViewToMaxSize(currentActivity)
-        webView!!.loadData(base64Message, "text/html; charset=utf-8", "base64")
+
+        synchronized(lifecycleLock) {
+            if (dismissed || webView !== localWebView) {
+                destroyWebViewInstance(localWebView)
+                return
+            }
+            setWebViewToMaxSize(currentActivity, localWebView)
+            localWebView.loadData(base64Message, "text/html; charset=utf-8", "base64")
+        }
     }
 
     /**
@@ -411,8 +455,11 @@ internal class WebViewManager(
     // A render complete or resize event will fire from JS to tell Java it's height and will then display
     //  it via this SDK's InAppMessageView class. If smaller than the screen it will correctly
     //  set it's height to match.
-    private fun setWebViewToMaxSize(activity: Activity) {
-        webView!!.layout(0, 0, getWebViewMaxSizeX(activity), getWebViewMaxSizeY(activity))
+    private fun setWebViewToMaxSize(
+        activity: Activity,
+        targetWebView: OSWebView = webView!!,
+    ) {
+        targetWebView.layout(0, 0, getWebViewMaxSizeX(activity), getWebViewMaxSizeY(activity))
     }
 
     private fun setMessageView(view: InAppMessageView?) {
@@ -420,32 +467,52 @@ internal class WebViewManager(
     }
 
     fun createNewInAppMessageView(dragToDismissDisabled: Boolean) {
-        lastPageHeight = messageContent.pageHeight
-        val hideGrayOverlay = AndroidUtils.getManifestMetaBoolean(_applicationService.appContext, "com.onesignal.inAppMessageHideGrayOverlay")
-        val newView = InAppMessageView(webView!!, messageContent, dragToDismissDisabled, hideGrayOverlay)
-        setMessageView(newView)
-        val self = this
-        messageView!!.setMessageController(
-            object : InAppMessageView.InAppMessageViewListener {
-                override fun onMessageWasDisplayed() {
-                    _lifecycle.messageWasDisplayed(message)
-                }
+        val currentWebView: OSWebView
+        synchronized(lifecycleLock) {
+            if (dismissed) {
+                return
+            }
+            currentWebView = webView ?: return
+            lastPageHeight = messageContent.pageHeight
+            val hideGrayOverlay =
+                AndroidUtils.getManifestMetaBoolean(
+                    _applicationService.appContext,
+                    "com.onesignal.inAppMessageHideGrayOverlay",
+                )
+            val newView = InAppMessageView(currentWebView, messageContent, dragToDismissDisabled, hideGrayOverlay)
+            setMessageView(newView)
+            val self = this
+            newView.setMessageController(
+                object : InAppMessageView.InAppMessageViewListener {
+                    override fun onMessageWasDisplayed() {
+                        _lifecycle.messageWasDisplayed(message)
+                    }
 
-                override fun onMessageWillDismiss() {
-                    _lifecycle.messageWillDismiss(message)
-                }
+                    override fun onMessageWillDismiss() {
+                        _lifecycle.messageWillDismiss(message)
+                    }
 
-                override fun onMessageWasDismissed() {
-                    _lifecycle.messageWasDismissed(message)
-                    // Destroy WebView here so every dismiss path (close button, back, drag,
-                    // timer, and dismissAndAwaitNextMessage) releases the Activity context.
-                    self.cleanupAfterDismiss()
-                }
-            },
-        )
+                    override fun onMessageWasDismissed() {
+                        // Mark dismissed first so in-flight setup cannot recreate content,
+                        // then finish cleanup + lifecycle notification exactly once.
+                        synchronized(self.lifecycleLock) {
+                            self.dismissed = true
+                            self.closing = true
+                        }
+                        self.finishDismiss()
+                    }
+                },
+            )
+        }
 
         // Fires event if available, which will call messageView.showInAppMessageView() for us.
-        _applicationService.addActivityLifecycleHandler(self)
+        _applicationService.addActivityLifecycleHandler(this)
+        synchronized(lifecycleLock) {
+            // Dismiss may have completed between view creation and registration.
+            if (dismissed) {
+                _applicationService.removeActivityLifecycleHandler(this)
+            }
+        }
     }
 
     private fun getWebViewMaxSizeX(activity: Activity): Int {
@@ -468,46 +535,66 @@ internal class WebViewManager(
     }
 
     /**
-     * Trigger the [.messageView] dismiss animation flow
+     * Trigger the [.messageView] dismiss animation flow when present, then always complete
+     * cleanup. Safe under concurrent callers: [dismissed] is terminal and [finishDismiss]
+     * runs once.
      */
     suspend fun dismissAndAwaitNextMessage() {
-        if (dismissFired) {
-            return
+        val locMessageView: InAppMessageView?
+        synchronized(lifecycleLock) {
+            if (dismissed) {
+                return
+            }
+            dismissed = true
+            closing = true
+            locMessageView = messageView
         }
 
-        dismissFired = true
-        try {
-            val locMessageView = messageView
-            if (locMessageView != null) {
-                _lifecycle.messageWillDismiss(message)
-                locMessageView.dismissAndAwaitNextMessage()
-            }
-            // Always run cleanup. Normal UI dismiss already called this from
-            // onMessageWasDismissed; the method is idempotent for that case.
-            // Also covers messageView-null and early view dismiss paths.
-            cleanupAfterDismiss()
-        } finally {
-            dismissFired = false
-        }
+        _lifecycle.messageWillDismiss(message)
+        locMessageView?.dismissAndAwaitNextMessage()
+        finishDismiss()
     }
 
     /**
-     * Drop view hierarchy refs and destroy the WebView so it cannot retain a destroyed Activity.
-     * Safe to call more than once.
+     * Completes dismiss exactly once: destroys the WebView, clears owner refs, and fires
+     * [IInAppLifecycleService.messageWasDismissed] so IAM queue state cannot get stuck.
      */
-    private fun cleanupAfterDismiss() {
-        _applicationService.removeActivityLifecycleHandler(this)
-        setMessageView(null)
-        destroyWebView()
+    private fun finishDismiss() {
+        val callback: (() -> Unit)?
+        val shouldNotifyLifecycle: Boolean
+        val viewToDestroy: OSWebView?
 
-        val callback = onDismissed
-        onDismissed = null
+        synchronized(lifecycleLock) {
+            dismissed = true
+            closing = true
+            if (cleanedUp) {
+                return
+            }
+            cleanedUp = true
+
+            shouldNotifyLifecycle = !lifecycleDismissNotified
+            lifecycleDismissNotified = true
+
+            _applicationService.removeActivityLifecycleHandler(this)
+            setMessageView(null)
+            viewToDestroy = webView
+            webView = null
+
+            callback = onDismissed
+            onDismissed = null
+        }
+
+        if (viewToDestroy != null) {
+            destroyWebViewInstance(viewToDestroy)
+        }
+
+        if (shouldNotifyLifecycle) {
+            _lifecycle.messageWasDismissed(message)
+        }
         callback?.invoke()
     }
 
-    private fun destroyWebView() {
-        val view = webView ?: return
-        webView = null
+    private fun destroyWebViewInstance(view: OSWebView) {
         val destroy = {
             try {
                 (view.parent as? ViewGroup)?.removeView(view)

--- a/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/display/impl/WebViewManager.kt
+++ b/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/display/impl/WebViewManager.kt
@@ -261,10 +261,12 @@ internal class WebViewManager(
     // Every time an Activity is shown we update the height of the WebView since the available
     //   screen size may have changed. (Expect for Fullscreen)
     private suspend fun calculateHeightAndShowWebViewAfterNewActivity() {
-        if (dismissed || messageView == null || webView == null) return
+        // Snapshot: a concurrent dismiss can clear these at any point.
+        val localMessageView = messageView
+        if (dismissed || localMessageView == null || webView == null) return
 
         // Don't need a CSS / HTML height update for fullscreen unless its fullbleed
-        if (messageView!!.displayPosition == Position.FULL_SCREEN && !messageContent.isFullBleed) {
+        if (localMessageView.displayPosition == Position.FULL_SCREEN && !messageContent.isFullBleed) {
             showMessageView(null)
             return
         }
@@ -330,9 +332,7 @@ internal class WebViewManager(
             } else if (lastActivityName != currentActivityName) {
                 if (!closing) {
                     // Navigate to new activity while displaying current IAM
-                    if (messageView != null) {
-                        messageView!!.removeAllViews()
-                    }
+                    messageView?.removeAllViews()
                     showMessageView(lastPageHeight)
                 }
             } else {
@@ -350,8 +350,8 @@ internal class WebViewManager(
             messageView: $messageView
             """.trimIndent(),
         )
-        if (messageView != null && activity.localClassName == currentActivityName) {
-            messageView!!.removeAllViews()
+        if (activity.localClassName == currentActivityName) {
+            messageView?.removeAllViews()
         }
     }
 

--- a/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/display/impl/WebViewManager.kt
+++ b/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/display/impl/WebViewManager.kt
@@ -3,7 +3,10 @@ package com.onesignal.inAppMessages.internal.display.impl
 import android.annotation.SuppressLint
 import android.app.Activity
 import android.os.Build
+import android.os.Handler
+import android.os.Looper
 import android.view.View
+import android.view.ViewGroup
 import android.webkit.JavascriptInterface
 import android.webkit.WebSettings
 import android.webkit.WebView
@@ -78,6 +81,9 @@ internal class WebViewManager(
 
     // closing prevents IAM being redisplayed when the activity changes during an actionHandler
     private var closing = false
+
+    // Invoked once after dismiss cleanup so owners can drop references (e.g. InAppDisplayer.lastInstance)
+    var onDismissed: (() -> Unit)? = null
 
     // Lets JS from the page send JSON payloads to this class
     internal inner class OSJavaScriptInterface {
@@ -431,7 +437,9 @@ internal class WebViewManager(
 
                 override fun onMessageWasDismissed() {
                     _lifecycle.messageWasDismissed(message)
-                    _applicationService.removeActivityLifecycleHandler(self)
+                    // Destroy WebView here so every dismiss path (close button, back, drag,
+                    // timer, and dismissAndAwaitNextMessage) releases the Activity context.
+                    self.cleanupAfterDismiss()
                 }
             },
         )
@@ -463,18 +471,59 @@ internal class WebViewManager(
      * Trigger the [.messageView] dismiss animation flow
      */
     suspend fun dismissAndAwaitNextMessage() {
-        val locMessageView = messageView
-
-        if (locMessageView == null || dismissFired) {
+        if (dismissFired) {
             return
         }
 
         dismissFired = true
-        _lifecycle.messageWillDismiss(message)
-        locMessageView.dismissAndAwaitNextMessage()
-        dismissFired = false
+        try {
+            val locMessageView = messageView
+            if (locMessageView != null) {
+                _lifecycle.messageWillDismiss(message)
+                locMessageView.dismissAndAwaitNextMessage()
+            }
+            // Always run cleanup. Normal UI dismiss already called this from
+            // onMessageWasDismissed; the method is idempotent for that case.
+            // Also covers messageView-null and early view dismiss paths.
+            cleanupAfterDismiss()
+        } finally {
+            dismissFired = false
+        }
+    }
 
+    /**
+     * Drop view hierarchy refs and destroy the WebView so it cannot retain a destroyed Activity.
+     * Safe to call more than once.
+     */
+    private fun cleanupAfterDismiss() {
+        _applicationService.removeActivityLifecycleHandler(this)
         setMessageView(null)
+        destroyWebView()
+
+        val callback = onDismissed
+        onDismissed = null
+        callback?.invoke()
+    }
+
+    private fun destroyWebView() {
+        val view = webView ?: return
+        webView = null
+        val destroy = {
+            try {
+                (view.parent as? ViewGroup)?.removeView(view)
+                view.stopLoading()
+                view.removeAllViews()
+                view.destroy()
+            } catch (t: Throwable) {
+                Logging.warn("Error destroying IAM WebView", t)
+            }
+        }
+        // WebView.destroy() must run on the main thread
+        if (AndroidUtils.isRunningOnMainThread()) {
+            destroy()
+        } else {
+            Handler(Looper.getMainLooper()).post(destroy)
+        }
     }
 
     fun setContentSafeAreaInsets(

--- a/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/display/impl/WebViewManager.kt
+++ b/OneSignalSDK/onesignal/in-app-messages/src/main/java/com/onesignal/inAppMessages/internal/display/impl/WebViewManager.kt
@@ -71,9 +71,16 @@ internal class WebViewManager(
             }
     }
 
+    // Written under lifecycleLock but read from the main, IO and JS-bridge threads.
+    @Volatile
     private var webView: OSWebView? = null
+
+    @Volatile
     private var messageView: InAppMessageView? = null
+
     private var currentActivityName: String? = null
+
+    @Volatile
     private var lastPageHeight: Int? = null
 
     // Serializes setup / dismiss so a dismiss during WebView creation cannot leave orphans
@@ -91,6 +98,7 @@ internal class WebViewManager(
     private var lifecycleDismissNotified = false
 
     // closing prevents IAM being redisplayed when the activity changes during an actionHandler
+    @Volatile
     private var closing = false
 
     // Invoked once after dismiss cleanup so owners can drop references (e.g. InAppDisplayer.lastInstance)
@@ -357,21 +365,33 @@ internal class WebViewManager(
 
     private suspend fun showMessageView(newHeight: Int?) {
         messageViewMutex.withLock {
-            if (dismissed) {
-                return
-            }
-            val localMessageView = messageView
-            val localWebView = webView
-            if (localMessageView == null || localWebView == null) {
+            // Claim the views under lifecycleLock, the same lock finishDismiss cleans up
+            // under, so a concurrent dismiss cannot leave a destroyed WebView attached to
+            // a view we are about to show.
+            val localMessageView =
+                synchronized(lifecycleLock) {
+                    val view = messageView
+                    val localWebView = webView
+                    if (dismissed || view == null || localWebView == null) {
+                        null
+                    } else {
+                        view.setWebView(localWebView)
+                        view
+                    }
+                }
+            if (localMessageView == null) {
                 Logging.warn("No messageView found to update a with a new height.")
                 return
             }
             Logging.debug("In app message, showing first one with height: $newHeight")
 
-            localMessageView.setWebView(localWebView)
             if (newHeight != null) {
                 lastPageHeight = newHeight
                 localMessageView.updateHeight(newHeight)
+            }
+            // Dismiss may have completed while the height was being applied.
+            if (dismissed) {
+                return
             }
             // showView does not return until in-app is dismissed
             localMessageView.showView(activity)
@@ -409,11 +429,16 @@ internal class WebViewManager(
         _applicationService.waitUntilActivityReady()
 
         synchronized(lifecycleLock) {
-            if (dismissed || webView !== localWebView) {
-                destroyWebViewInstance(localWebView)
-            } else {
+            val stillOwned = webView === localWebView
+            if (!dismissed && stillOwned) {
                 setWebViewToMaxSize(currentActivity, localWebView)
                 localWebView.loadData(base64Message, "text/html; charset=utf-8", "base64")
+            } else {
+                // Claim it before destroying so finishDismiss cannot destroy it a second time.
+                if (stillOwned) {
+                    webView = null
+                }
+                destroyWebViewInstance(localWebView)
             }
         }
     }
@@ -503,6 +528,12 @@ internal class WebViewManager(
             newView.setMessageController(
                 object : InAppMessageView.InAppMessageViewListener {
                     override fun onMessageWasDisplayed() {
+                        // The show animation can end after a dismiss already completed; reporting
+                        // a display then would fire onDidDisplay after onDidDismiss and record an
+                        // impression for a message the user never saw.
+                        if (self.dismissed) {
+                            return
+                        }
                         _lifecycle.messageWasDisplayed(message)
                     }
 
@@ -581,6 +612,7 @@ internal class WebViewManager(
         val callback: (() -> Unit)?
         val shouldNotifyLifecycle: Boolean
         val viewToDestroy: OSWebView?
+        val viewToDetach: InAppMessageView?
 
         synchronized(lifecycleLock) {
             dismissed = true
@@ -594,12 +626,19 @@ internal class WebViewManager(
             lifecycleDismissNotified = true
 
             _applicationService.removeActivityLifecycleHandler(this)
+            viewToDetach = messageView
             setMessageView(null)
             viewToDestroy = webView
             webView = null
 
             callback = onDismissed
             onDismissed = null
+        }
+
+        // Detach before dropping the reference: a show racing this dismiss would otherwise
+        // leave an orphaned PopupWindow that nothing is left holding to remove.
+        if (viewToDetach != null) {
+            runOnMainThread { viewToDetach.removeAllViews() }
         }
 
         if (viewToDestroy != null) {
@@ -613,7 +652,8 @@ internal class WebViewManager(
     }
 
     private fun destroyWebViewInstance(view: OSWebView) {
-        val destroy = {
+        // WebView.destroy() must run on the main thread
+        runOnMainThread {
             try {
                 (view.parent as? ViewGroup)?.removeView(view)
                 view.stopLoading()
@@ -623,11 +663,13 @@ internal class WebViewManager(
                 Logging.warn("Error destroying IAM WebView", e)
             }
         }
-        // WebView.destroy() must run on the main thread
+    }
+
+    private fun runOnMainThread(block: () -> Unit) {
         if (AndroidUtils.isRunningOnMainThread()) {
-            destroy()
+            block()
         } else {
-            Handler(Looper.getMainLooper()).post(destroy)
+            Handler(Looper.getMainLooper()).post(block)
         }
     }
 

--- a/OneSignalSDK/onesignal/in-app-messages/src/test/java/com/onesignal/inAppMessages/internal/display/InAppDisplayerDismissCleanupTests.kt
+++ b/OneSignalSDK/onesignal/in-app-messages/src/test/java/com/onesignal/inAppMessages/internal/display/InAppDisplayerDismissCleanupTests.kt
@@ -35,6 +35,7 @@ import kotlinx.coroutines.test.setMain
 import org.json.JSONObject
 import org.robolectric.Robolectric
 import org.robolectric.annotation.Config
+import java.util.concurrent.atomic.AtomicReference
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @Config(
@@ -55,33 +56,9 @@ class InAppDisplayerDismissCleanupTests : FunSpec({
 
     test("dismissCurrentInAppMessage clears lastInstance via onDismissed callback") {
         val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
-        val applicationService = mockk<IApplicationService>(relaxed = true)
-        every { applicationService.current } returns activity
-        coEvery { applicationService.waitUntilActivityReady() } returns true
-        every { applicationService.addActivityLifecycleHandler(any()) } just runs
-        every { applicationService.removeActivityLifecycleHandler(any()) } just runs
-
+        val applicationService = mockApplicationService(activity)
         val lifecycle = mockk<IInAppLifecycleService>(relaxed = true)
-        val backend = mockk<IInAppBackendService>()
-        val content =
-            InAppMessageContent(
-                JSONObject()
-                    .put("html", "<html></html>")
-                    .put("display_duration", 0),
-            )
-        coEvery { backend.getIAMData(any(), any(), any()) } returns GetIAMDataResponse(content, false)
-
-        val displayer =
-            InAppDisplayer(
-                applicationService,
-                lifecycle,
-                mockk<IInAppMessagePromptFactory>(relaxed = true),
-                backend,
-                mockk<IInfluenceManager>(relaxed = true),
-                MockHelper.configModelStore(),
-                MockHelper.languageContext(),
-                MockHelper.time(1),
-            )
+        val displayer = createDisplayer(applicationService, lifecycle, mockBackend())
 
         val message = InAppMessage("test-iam", MockHelper.time(1))
 
@@ -104,10 +81,98 @@ class InAppDisplayerDismissCleanupTests : FunSpec({
         getLastInstance(displayer).shouldBeNull()
         verify(atLeast = 1) { lifecycle.messageWasDismissed(message) }
     }
+
+    test("preview dismisses the displaying message and takes over lastInstance") {
+        val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+        val applicationService = mockApplicationService(activity)
+        val lifecycle = mockk<IInAppLifecycleService>(relaxed = true)
+        val backend = mockBackend()
+        val displayer = createDisplayer(applicationService, lifecycle, backend)
+        val message = InAppMessage("test-iam", MockHelper.time(1))
+
+        runBlocking {
+            displayer.displayMessage(message) shouldBe true
+            val displayingInstance = getLastInstance(displayer)
+            displayingInstance.shouldNotBeNull()
+
+            displayer.displayPreviewMessage("preview-uuid") shouldBe true
+
+            val previewInstance = getLastInstance(displayer)
+            previewInstance.shouldNotBeNull()
+            (previewInstance === displayingInstance) shouldBe false
+        }
+
+        verify(exactly = 1) { lifecycle.messageWasDismissed(message) }
+    }
+
+    test("preview still displays when the previous instance was already cleared by dismissal") {
+        val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+        val applicationService = mockApplicationService(activity)
+        val lifecycle = mockk<IInAppLifecycleService>(relaxed = true)
+        val backend = mockBackend()
+        val displayer = createDisplayer(applicationService, lifecycle, backend)
+
+        runBlocking {
+            displayer.displayMessage(InAppMessage("test-iam", MockHelper.time(1))) shouldBe true
+
+            displayer.dismissCurrentInAppMessage()
+            var attempts = 0
+            while (getLastInstance(displayer) != null && attempts < 50) {
+                delay(20)
+                attempts++
+            }
+            getLastInstance(displayer).shouldBeNull()
+
+            // The preview path must tolerate lastInstance already being null.
+            displayer.displayPreviewMessage("preview-uuid") shouldBe true
+            getLastInstance(displayer).shouldNotBeNull()
+        }
+    }
 })
+
+private fun mockApplicationService(activity: Activity): IApplicationService {
+    val applicationService = mockk<IApplicationService>(relaxed = true)
+    every { applicationService.current } returns activity
+    coEvery { applicationService.waitUntilActivityReady() } returns true
+    every { applicationService.addActivityLifecycleHandler(any()) } just runs
+    every { applicationService.removeActivityLifecycleHandler(any()) } just runs
+    return applicationService
+}
+
+private fun mockBackend(): IInAppBackendService {
+    val backend = mockk<IInAppBackendService>()
+    val content =
+        InAppMessageContent(
+            JSONObject()
+                .put("html", "<html></html>")
+                .put("display_duration", 0),
+        )
+    coEvery { backend.getIAMData(any(), any(), any()) } returns GetIAMDataResponse(content, false)
+    coEvery { backend.getIAMPreviewData(any(), any()) } returns content
+    return backend
+}
+
+private fun createDisplayer(
+    applicationService: IApplicationService,
+    lifecycle: IInAppLifecycleService,
+    backend: IInAppBackendService,
+): InAppDisplayer =
+    InAppDisplayer(
+        applicationService,
+        lifecycle,
+        mockk<IInAppMessagePromptFactory>(relaxed = true),
+        backend,
+        mockk<IInfluenceManager>(relaxed = true),
+        MockHelper.configModelStore(),
+        MockHelper.languageContext(),
+        MockHelper.time(1),
+    )
 
 private fun getLastInstance(displayer: InAppDisplayer): WebViewManager? {
     val field = InAppDisplayer::class.java.getDeclaredField("lastInstance")
     field.isAccessible = true
-    return field.get(displayer) as WebViewManager?
+
+    @Suppress("UNCHECKED_CAST")
+    val reference = field.get(displayer) as AtomicReference<WebViewManager?>
+    return reference.get()
 }

--- a/OneSignalSDK/onesignal/in-app-messages/src/test/java/com/onesignal/inAppMessages/internal/display/InAppDisplayerDismissCleanupTests.kt
+++ b/OneSignalSDK/onesignal/in-app-messages/src/test/java/com/onesignal/inAppMessages/internal/display/InAppDisplayerDismissCleanupTests.kt
@@ -1,0 +1,113 @@
+package com.onesignal.inAppMessages.internal.display
+
+import android.app.Activity
+import br.com.colman.kotest.android.extensions.robolectric.RobolectricTest
+import com.onesignal.core.internal.application.IApplicationService
+import com.onesignal.debug.LogLevel
+import com.onesignal.debug.internal.logging.Logging
+import com.onesignal.inAppMessages.internal.InAppMessage
+import com.onesignal.inAppMessages.internal.InAppMessageContent
+import com.onesignal.inAppMessages.internal.backend.GetIAMDataResponse
+import com.onesignal.inAppMessages.internal.backend.IInAppBackendService
+import com.onesignal.inAppMessages.internal.display.impl.InAppDisplayer
+import com.onesignal.inAppMessages.internal.display.impl.WebViewManager
+import com.onesignal.inAppMessages.internal.lifecycle.IInAppLifecycleService
+import com.onesignal.inAppMessages.internal.prompt.IInAppMessagePromptFactory
+import com.onesignal.mocks.MockHelper
+import com.onesignal.session.internal.influence.IInfluenceManager
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.json.JSONObject
+import org.robolectric.Robolectric
+import org.robolectric.annotation.Config
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@Config(
+    packageName = "com.onesignal.example",
+    sdk = [34],
+)
+@RobolectricTest
+class InAppDisplayerDismissCleanupTests : FunSpec({
+    beforeAny {
+        Logging.logLevel = LogLevel.NONE
+        // Create after Robolectric has initialized Looper.
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+    }
+
+    afterAny {
+        Dispatchers.resetMain()
+    }
+
+    test("dismissCurrentInAppMessage clears lastInstance via onDismissed callback") {
+        val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+        val applicationService = mockk<IApplicationService>(relaxed = true)
+        every { applicationService.current } returns activity
+        coEvery { applicationService.waitUntilActivityReady() } returns true
+        every { applicationService.addActivityLifecycleHandler(any()) } just runs
+        every { applicationService.removeActivityLifecycleHandler(any()) } just runs
+
+        val lifecycle = mockk<IInAppLifecycleService>(relaxed = true)
+        val backend = mockk<IInAppBackendService>()
+        val content =
+            InAppMessageContent(
+                JSONObject()
+                    .put("html", "<html></html>")
+                    .put("display_duration", 0),
+            )
+        coEvery { backend.getIAMData(any(), any(), any()) } returns GetIAMDataResponse(content, false)
+
+        val displayer =
+            InAppDisplayer(
+                applicationService,
+                lifecycle,
+                mockk<IInAppMessagePromptFactory>(relaxed = true),
+                backend,
+                mockk<IInfluenceManager>(relaxed = true),
+                MockHelper.configModelStore(),
+                MockHelper.languageContext(),
+                MockHelper.time(1),
+            )
+
+        val message = InAppMessage("test-iam", MockHelper.time(1))
+
+        runBlocking {
+            displayer.displayMessage(message) shouldBe true
+
+            getLastInstance(displayer).shouldNotBeNull()
+
+            // Early dismiss before rendering_complete: messageView is still null.
+            displayer.dismissCurrentInAppMessage()
+
+            // backgroundDismissAndAwaitNextMessage is async on Default; wait briefly.
+            var attempts = 0
+            while (getLastInstance(displayer) != null && attempts < 50) {
+                delay(20)
+                attempts++
+            }
+        }
+
+        getLastInstance(displayer).shouldBeNull()
+        verify(atLeast = 1) { lifecycle.messageWasDismissed(message) }
+    }
+})
+
+private fun getLastInstance(displayer: InAppDisplayer): WebViewManager? {
+    val field = InAppDisplayer::class.java.getDeclaredField("lastInstance")
+    field.isAccessible = true
+    return field.get(displayer) as WebViewManager?
+}

--- a/OneSignalSDK/onesignal/in-app-messages/src/test/java/com/onesignal/inAppMessages/internal/display/WebViewManagerDismissCleanupTests.kt
+++ b/OneSignalSDK/onesignal/in-app-messages/src/test/java/com/onesignal/inAppMessages/internal/display/WebViewManagerDismissCleanupTests.kt
@@ -15,8 +15,11 @@ import com.onesignal.mocks.MockHelper
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.runBlocking
 import org.json.JSONObject
 import org.robolectric.Robolectric
@@ -32,26 +35,14 @@ class WebViewManagerDismissCleanupTests : FunSpec({
         Logging.logLevel = LogLevel.NONE
     }
 
-    test("dismissAndAwaitNextMessage destroys WebView and invokes onDismissed when messageView is null") {
+    test("early dismiss with null messageView destroys WebView and fires lifecycle dismissed") {
         val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
         val applicationService = mockk<IApplicationService>(relaxed = true)
         val lifecycle = mockk<IInAppLifecycleService>(relaxed = true)
-        val promptFactory = mockk<IInAppMessagePromptFactory>(relaxed = true)
         val message = InAppMessage("test-iam", MockHelper.time(1))
-        val content = InAppMessageContent(JSONObject().put("html", "<html></html>"))
+        val manager = createManager(activity, applicationService, lifecycle, message)
 
-        val manager =
-            WebViewManager(
-                message,
-                activity,
-                content,
-                lifecycle,
-                applicationService,
-                promptFactory,
-            )
-
-        val webView = OSWebView(activity)
-        setWebViewField(manager, webView)
+        setWebViewField(manager, OSWebView(activity))
 
         var dismissed = false
         manager.onDismissed = { dismissed = true }
@@ -62,21 +53,17 @@ class WebViewManagerDismissCleanupTests : FunSpec({
 
         getWebViewField(manager).shouldBeNull()
         dismissed shouldBe true
+        verify(exactly = 1) { lifecycle.messageWillDismiss(message) }
+        verify(exactly = 1) { lifecycle.messageWasDismissed(message) }
         verify(exactly = 1) { applicationService.removeActivityLifecycleHandler(manager) }
     }
 
     test("cleanup is idempotent across repeated dismiss calls") {
         val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
         val applicationService = mockk<IApplicationService>(relaxed = true)
-        val manager =
-            WebViewManager(
-                InAppMessage("test-iam", MockHelper.time(1)),
-                activity,
-                InAppMessageContent(JSONObject().put("html", "<html></html>")),
-                mockk(relaxed = true),
-                applicationService,
-                mockk(relaxed = true),
-            )
+        val lifecycle = mockk<IInAppLifecycleService>(relaxed = true)
+        val message = InAppMessage("test-iam", MockHelper.time(1))
+        val manager = createManager(activity, applicationService, lifecycle, message)
 
         setWebViewField(manager, OSWebView(activity))
 
@@ -90,8 +77,94 @@ class WebViewManagerDismissCleanupTests : FunSpec({
 
         getWebViewField(manager).shouldBeNull()
         dismissCount shouldBe 1
+        verify(exactly = 1) { lifecycle.messageWasDismissed(message) }
+    }
+
+    test("concurrent dismiss only completes cleanup and lifecycle once") {
+        val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+        val applicationService = mockk<IApplicationService>(relaxed = true)
+        val lifecycle = mockk<IInAppLifecycleService>(relaxed = true)
+        val message = InAppMessage("test-iam", MockHelper.time(1))
+        val manager = createManager(activity, applicationService, lifecycle, message)
+
+        setWebViewField(manager, OSWebView(activity))
+
+        var dismissCount = 0
+        manager.onDismissed = { dismissCount++ }
+
+        runBlocking {
+            (1..8).map {
+                async { manager.dismissAndAwaitNextMessage() }
+            }.awaitAll()
+        }
+
+        getWebViewField(manager).shouldBeNull()
+        dismissCount shouldBe 1
+        verify(exactly = 1) { lifecycle.messageWasDismissed(message) }
+        verify(atMost = 1) { applicationService.removeActivityLifecycleHandler(manager) }
+    }
+
+    test("setupWebView after dismiss does not retain a WebView") {
+        val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+        val applicationService = mockk<IApplicationService>(relaxed = true)
+        coEvery { applicationService.waitUntilActivityReady() } returns true
+        val lifecycle = mockk<IInAppLifecycleService>(relaxed = true)
+        val manager =
+            createManager(
+                activity,
+                applicationService,
+                lifecycle,
+                InAppMessage("test-iam", MockHelper.time(1)),
+            )
+
+        runBlocking {
+            manager.dismissAndAwaitNextMessage()
+            manager.setupWebView(activity, "", false)
+        }
+
+        getWebViewField(manager).shouldBeNull()
+    }
+
+    test("createNewInAppMessageView after dismiss is a no-op") {
+        val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+        val applicationService = mockk<IApplicationService>(relaxed = true)
+        val manager =
+            createManager(
+                activity,
+                applicationService,
+                mockk(relaxed = true),
+                InAppMessage("test-iam", MockHelper.time(1)),
+            )
+
+        setWebViewField(manager, OSWebView(activity))
+
+        runBlocking {
+            manager.dismissAndAwaitNextMessage()
+        }
+
+        manager.createNewInAppMessageView(false)
+
+        getMessageViewField(manager).shouldBeNull()
+        verify(exactly = 0) { applicationService.addActivityLifecycleHandler(manager) }
     }
 })
+
+private fun createManager(
+    activity: Activity,
+    applicationService: IApplicationService,
+    lifecycle: IInAppLifecycleService,
+    message: InAppMessage,
+    promptFactory: IInAppMessagePromptFactory = mockk(relaxed = true),
+): WebViewManager {
+    return WebViewManager(
+        message,
+        activity,
+        InAppMessageContent(JSONObject().put("html", "<html></html>")),
+        lifecycle,
+        applicationService,
+        promptFactory,
+    )
+}
 
 private fun setWebViewField(
     manager: WebViewManager,
@@ -104,6 +177,12 @@ private fun setWebViewField(
 
 private fun getWebViewField(manager: WebViewManager): Any? {
     val field = WebViewManager::class.java.getDeclaredField("webView")
+    field.isAccessible = true
+    return field.get(manager)
+}
+
+private fun getMessageViewField(manager: WebViewManager): Any? {
+    val field = WebViewManager::class.java.getDeclaredField("messageView")
     field.isAccessible = true
     return field.get(manager)
 }

--- a/OneSignalSDK/onesignal/in-app-messages/src/test/java/com/onesignal/inAppMessages/internal/display/WebViewManagerDismissCleanupTests.kt
+++ b/OneSignalSDK/onesignal/in-app-messages/src/test/java/com/onesignal/inAppMessages/internal/display/WebViewManagerDismissCleanupTests.kt
@@ -7,6 +7,7 @@ import com.onesignal.debug.LogLevel
 import com.onesignal.debug.internal.logging.Logging
 import com.onesignal.inAppMessages.internal.InAppMessage
 import com.onesignal.inAppMessages.internal.InAppMessageContent
+import com.onesignal.inAppMessages.internal.display.impl.InAppMessageView
 import com.onesignal.inAppMessages.internal.display.impl.OSWebView
 import com.onesignal.inAppMessages.internal.display.impl.WebViewManager
 import com.onesignal.inAppMessages.internal.lifecycle.IInAppLifecycleService
@@ -14,17 +15,31 @@ import com.onesignal.inAppMessages.internal.prompt.IInAppMessagePromptFactory
 import com.onesignal.mocks.MockHelper
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.runs
 import io.mockk.verify
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
 import org.json.JSONObject
 import org.robolectric.Robolectric
 import org.robolectric.annotation.Config
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @Config(
     packageName = "com.onesignal.example",
     sdk = [34],
@@ -33,11 +48,17 @@ import org.robolectric.annotation.Config
 class WebViewManagerDismissCleanupTests : FunSpec({
     beforeAny {
         Logging.logLevel = LogLevel.NONE
+        // After Robolectric Looper init; setupWebView must run on a Main looper thread.
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+    }
+
+    afterAny {
+        Dispatchers.resetMain()
     }
 
     test("early dismiss with null messageView destroys WebView and fires lifecycle dismissed") {
         val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
-        val applicationService = mockk<IApplicationService>(relaxed = true)
+        val applicationService = mockApplicationService(activity)
         val lifecycle = mockk<IInAppLifecycleService>(relaxed = true)
         val message = InAppMessage("test-iam", MockHelper.time(1))
         val manager = createManager(activity, applicationService, lifecycle, message)
@@ -60,7 +81,7 @@ class WebViewManagerDismissCleanupTests : FunSpec({
 
     test("cleanup is idempotent across repeated dismiss calls") {
         val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
-        val applicationService = mockk<IApplicationService>(relaxed = true)
+        val applicationService = mockApplicationService(activity)
         val lifecycle = mockk<IInAppLifecycleService>(relaxed = true)
         val message = InAppMessage("test-iam", MockHelper.time(1))
         val manager = createManager(activity, applicationService, lifecycle, message)
@@ -80,9 +101,9 @@ class WebViewManagerDismissCleanupTests : FunSpec({
         verify(exactly = 1) { lifecycle.messageWasDismissed(message) }
     }
 
-    test("concurrent dismiss only completes cleanup and lifecycle once") {
+    test("concurrent dismiss on Default dispatcher only completes cleanup once") {
         val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
-        val applicationService = mockk<IApplicationService>(relaxed = true)
+        val applicationService = mockApplicationService(activity)
         val lifecycle = mockk<IInAppLifecycleService>(relaxed = true)
         val message = InAppMessage("test-iam", MockHelper.time(1))
         val manager = createManager(activity, applicationService, lifecycle, message)
@@ -93,21 +114,27 @@ class WebViewManagerDismissCleanupTests : FunSpec({
         manager.onDismissed = { dismissCount++ }
 
         runBlocking {
-            (1..8).map {
-                async { manager.dismissAndAwaitNextMessage() }
-            }.awaitAll()
+            withContext(Dispatchers.Default) {
+                (1..8).map {
+                    async(Dispatchers.Default) { manager.dismissAndAwaitNextMessage() }
+                }.awaitAll()
+            }
         }
 
         getWebViewField(manager).shouldBeNull()
         dismissCount shouldBe 1
         verify(exactly = 1) { lifecycle.messageWasDismissed(message) }
-        verify(atMost = 1) { applicationService.removeActivityLifecycleHandler(manager) }
     }
 
-    test("setupWebView after dismiss does not retain a WebView") {
+    test("dismiss during waitUntilActivityReady destroys in-flight WebView") {
         val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
-        val applicationService = mockk<IApplicationService>(relaxed = true)
-        coEvery { applicationService.waitUntilActivityReady() } returns true
+        val applicationService = mockApplicationService(activity)
+        val ready = CompletableDeferred<Boolean>()
+        val enteredWait = CompletableDeferred<Unit>()
+        coEvery { applicationService.waitUntilActivityReady() } coAnswers {
+            enteredWait.complete(Unit)
+            ready.await()
+        }
         val lifecycle = mockk<IInAppLifecycleService>(relaxed = true)
         val manager =
             createManager(
@@ -118,16 +145,28 @@ class WebViewManagerDismissCleanupTests : FunSpec({
             )
 
         runBlocking {
-            manager.dismissAndAwaitNextMessage()
-            manager.setupWebView(activity, "", false)
+            // Match production: WebView setup runs on Main; dismiss races from Default.
+            val setupJob =
+                async(Dispatchers.Main) {
+                    manager.setupWebView(activity, "", false)
+                }
+
+            withTimeout(2_000) { enteredWait.await() }
+            async(Dispatchers.Default) {
+                manager.dismissAndAwaitNextMessage()
+            }.await()
+            ready.complete(true)
+            setupJob.await()
         }
 
         getWebViewField(manager).shouldBeNull()
+        coVerify(exactly = 1) { applicationService.waitUntilActivityReady() }
+        verify(exactly = 1) { lifecycle.messageWasDismissed(any()) }
     }
 
     test("createNewInAppMessageView after dismiss is a no-op") {
         val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
-        val applicationService = mockk<IApplicationService>(relaxed = true)
+        val applicationService = mockApplicationService(activity)
         val manager =
             createManager(
                 activity,
@@ -147,7 +186,208 @@ class WebViewManagerDismissCleanupTests : FunSpec({
         getMessageViewField(manager).shouldBeNull()
         verify(exactly = 0) { applicationService.addActivityLifecycleHandler(manager) }
     }
+
+    test("message view dismiss path destroys WebView and notifies lifecycle once") {
+        val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+        val applicationService = mockApplicationService(activity)
+        val lifecycle = mockk<IInAppLifecycleService>(relaxed = true)
+        val message = InAppMessage("test-iam", MockHelper.time(1))
+        val content =
+            InAppMessageContent(
+                JSONObject()
+                    .put("html", "<html></html>")
+                    .put("display_duration", 0),
+            )
+        content.displayLocation = WebViewManager.Position.CENTER_MODAL
+        content.pageHeight = 100
+
+        val manager =
+            WebViewManager(
+                message,
+                activity,
+                content,
+                lifecycle,
+                applicationService,
+                mockk(relaxed = true),
+            )
+
+        setWebViewField(manager, OSWebView(activity))
+        manager.createNewInAppMessageView(false)
+        getMessageViewField(manager).shouldNotBeNull()
+
+        var dismissed = false
+        manager.onDismissed = { dismissed = true }
+
+        val controller = getMessageController(getMessageViewField(manager)!!)
+        controller.shouldNotBeNull()
+        controller!!.onMessageWasDismissed()
+
+        getWebViewField(manager).shouldBeNull()
+        getMessageViewField(manager).shouldBeNull()
+        dismissed shouldBe true
+        verify(exactly = 1) { lifecycle.messageWasDismissed(message) }
+        verify(exactly = 1) { applicationService.addActivityLifecycleHandler(manager) }
+        verify(atLeast = 1) { applicationService.removeActivityLifecycleHandler(manager) }
+    }
+
+    test("setupWebView after dismiss does not retain a WebView") {
+        val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+        val applicationService = mockApplicationService(activity)
+        coEvery { applicationService.waitUntilActivityReady() } returns true
+        val manager =
+            createManager(
+                activity,
+                applicationService,
+                mockk(relaxed = true),
+                InAppMessage("test-iam", MockHelper.time(1)),
+            )
+
+        runBlocking {
+            manager.dismissAndAwaitNextMessage()
+            manager.setupWebView(activity, "", false)
+        }
+
+        getWebViewField(manager).shouldBeNull()
+    }
+
+    test("successful setupWebView retains WebView until dismiss") {
+        val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+        val applicationService = mockApplicationService(activity)
+        coEvery { applicationService.waitUntilActivityReady() } returns true
+        val lifecycle = mockk<IInAppLifecycleService>(relaxed = true)
+        val manager =
+            createManager(
+                activity,
+                applicationService,
+                lifecycle,
+                InAppMessage("test-iam", MockHelper.time(1)),
+            )
+
+        runBlocking {
+            manager.setupWebView(activity, "", false)
+        }
+
+        getWebViewField(manager).shouldNotBeNull()
+        verify(exactly = 1) { lifecycle.messageWillDisplay(any()) }
+
+        runBlocking {
+            manager.dismissAndAwaitNextMessage()
+        }
+
+        getWebViewField(manager).shouldBeNull()
+    }
+
+    test("render complete after dismiss is ignored") {
+        val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+        val applicationService = mockApplicationService(activity)
+        val manager =
+            createManager(
+                activity,
+                applicationService,
+                mockk(relaxed = true),
+                InAppMessage("test-iam", MockHelper.time(1)),
+            )
+
+        runBlocking { manager.dismissAndAwaitNextMessage() }
+
+        val jsInterface = newJsInterface(manager)
+        jsInterface.postMessage(
+            """{"type":"rendering_complete","displayLocation":"CENTER_MODAL","pageMetaData":{"rect":{"height":120}},"dragToDismissDisabled":false}""",
+        )
+
+        getMessageViewField(manager).shouldBeNull()
+        verify(exactly = 0) { applicationService.addActivityLifecycleHandler(manager) }
+    }
+
+    test("showMessageView is a no-op after dismissed flag is set") {
+        val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+        val activityB = Robolectric.buildActivity(Activity::class.java).setup().get()
+        val applicationService = mockApplicationService(activity)
+        val lifecycle = mockk<IInAppLifecycleService>(relaxed = true)
+        val content =
+            InAppMessageContent(
+                JSONObject()
+                    .put("html", "<html></html>")
+                    .put("display_duration", 0)
+                    .put("styles", JSONObject().put("remove_height_margin", true)),
+            )
+        content.displayLocation = WebViewManager.Position.FULL_SCREEN
+        content.pageHeight = 200
+
+        val manager =
+            WebViewManager(
+                InAppMessage("test-iam", MockHelper.time(1)),
+                activity,
+                content,
+                lifecycle,
+                applicationService,
+                mockk(relaxed = true),
+            )
+        setWebViewField(manager, OSWebView(activity))
+        manager.createNewInAppMessageView(false)
+
+        // Mark dismissed without cleaning messageView, then exercise activity transition.
+        setDismissedField(manager, true)
+        manager.onActivityAvailable(activityB)
+
+        getMessageViewField(manager).shouldNotBeNull()
+    }
+
+    test("message lifecycle callbacks and finishDismiss are single-flight") {
+        val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+        val applicationService = mockApplicationService(activity)
+        val lifecycle = mockk<IInAppLifecycleService>(relaxed = true)
+        val message = InAppMessage("test-iam", MockHelper.time(1))
+        val content =
+            InAppMessageContent(
+                JSONObject()
+                    .put("html", "<html></html>")
+                    .put("display_duration", 0),
+            )
+        content.displayLocation = WebViewManager.Position.CENTER_MODAL
+        content.pageHeight = 100
+
+        val manager =
+            WebViewManager(
+                message,
+                activity,
+                content,
+                lifecycle,
+                applicationService,
+                mockk(relaxed = true),
+            )
+        setWebViewField(manager, OSWebView(activity))
+        manager.createNewInAppMessageView(false)
+
+        val controller = getMessageController(getMessageViewField(manager)!!)!!
+        controller.onMessageWasDisplayed()
+        controller.onMessageWillDismiss()
+
+        runBlocking {
+            withContext(Dispatchers.Default) {
+                listOf(
+                    async(Dispatchers.Default) { controller.onMessageWasDismissed() },
+                    async(Dispatchers.Default) { manager.dismissAndAwaitNextMessage() },
+                ).awaitAll()
+            }
+        }
+
+        verify(exactly = 1) { lifecycle.messageWasDisplayed(message) }
+        verify(atLeast = 1) { lifecycle.messageWillDismiss(message) }
+        verify(exactly = 1) { lifecycle.messageWasDismissed(message) }
+        getWebViewField(manager).shouldBeNull()
+    }
 })
+
+private fun mockApplicationService(activity: Activity): IApplicationService {
+    val applicationService = mockk<IApplicationService>(relaxed = true)
+    every { applicationService.current } returns activity
+    every { applicationService.appContext } returns activity.applicationContext
+    every { applicationService.addActivityLifecycleHandler(any()) } just runs
+    every { applicationService.removeActivityLifecycleHandler(any()) } just runs
+    coEvery { applicationService.waitUntilActivityReady() } returns true
+    return applicationService
+}
 
 private fun createManager(
     activity: Activity,
@@ -181,8 +421,39 @@ private fun getWebViewField(manager: WebViewManager): Any? {
     return field.get(manager)
 }
 
-private fun getMessageViewField(manager: WebViewManager): Any? {
+private fun getMessageViewField(manager: WebViewManager): InAppMessageView? {
     val field = WebViewManager::class.java.getDeclaredField("messageView")
     field.isAccessible = true
-    return field.get(manager)
+    return field.get(manager) as InAppMessageView?
+}
+
+private fun getMessageController(messageView: InAppMessageView): InAppMessageView.InAppMessageViewListener? {
+    val field = InAppMessageView::class.java.getDeclaredField("messageController")
+    field.isAccessible = true
+    return field.get(messageView) as InAppMessageView.InAppMessageViewListener?
+}
+
+private fun setDismissedField(
+    manager: WebViewManager,
+    value: Boolean,
+) {
+    val field = WebViewManager::class.java.getDeclaredField("dismissed")
+    field.isAccessible = true
+    field.setBoolean(manager, value)
+}
+
+private fun newJsInterface(manager: WebViewManager): Any {
+    val ifaceClass =
+        WebViewManager::class.java.declaredClasses.first {
+            it.simpleName == "OSJavaScriptInterface"
+        }
+    val ctor = ifaceClass.getDeclaredConstructor(WebViewManager::class.java)
+    ctor.isAccessible = true
+    val instance = ctor.newInstance(manager)
+    return instance
+}
+
+private fun Any.postMessage(message: String) {
+    val method = this.javaClass.getMethod("postMessage", String::class.java)
+    method.invoke(this, message)
 }

--- a/OneSignalSDK/onesignal/in-app-messages/src/test/java/com/onesignal/inAppMessages/internal/display/WebViewManagerDismissCleanupTests.kt
+++ b/OneSignalSDK/onesignal/in-app-messages/src/test/java/com/onesignal/inAppMessages/internal/display/WebViewManagerDismissCleanupTests.kt
@@ -414,6 +414,44 @@ class WebViewManagerDismissCleanupTests : FunSpec({
         verify(exactly = 1) { lifecycle.messageWasDismissed(message) }
     }
 
+    test("finishDismiss detaches the message view so a racing show cannot orphan it") {
+        val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+        val applicationService = mockApplicationService(activity)
+        val message = InAppMessage("test-iam", MockHelper.time(1))
+        val content =
+            InAppMessageContent(
+                JSONObject()
+                    .put("html", "<html></html>")
+                    .put("display_duration", 0),
+            )
+        content.displayLocation = WebViewManager.Position.CENTER_MODAL
+        content.pageHeight = 100
+
+        val manager =
+            WebViewManager(
+                message,
+                activity,
+                content,
+                mockk(relaxed = true),
+                applicationService,
+                mockk(relaxed = true),
+            )
+        setWebViewField(manager, OSWebView(activity))
+        manager.createNewInAppMessageView(false)
+
+        val view = getMessageViewField(manager)
+        view.shouldNotBeNull()
+        setWebViewOnMessageView(view, OSWebView(activity))
+
+        // System dismiss (OSPopupWindow.PopupWindowListener.onDismiss) calls straight into
+        // onMessageWasDismissed without running removeAllViews first, so finishDismiss is the
+        // only thing that can tear the view down before dropping the reference to it.
+        getMessageController(view)!!.onMessageWasDismissed()
+
+        getMessageViewField(manager).shouldBeNull()
+        getWebViewOnMessageView(view).shouldBeNull()
+    }
+
     test("message lifecycle callbacks and finishDismiss are single-flight") {
         val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
         val applicationService = mockApplicationService(activity)
@@ -521,6 +559,21 @@ private fun setDismissedField(
     val field = WebViewManager::class.java.getDeclaredField("dismissed")
     field.isAccessible = true
     field.setBoolean(manager, value)
+}
+
+private fun setWebViewOnMessageView(
+    messageView: InAppMessageView,
+    webView: OSWebView,
+) {
+    val field = InAppMessageView::class.java.getDeclaredField("webView")
+    field.isAccessible = true
+    field.set(messageView, webView)
+}
+
+private fun getWebViewOnMessageView(messageView: InAppMessageView): Any? {
+    val field = InAppMessageView::class.java.getDeclaredField("webView")
+    field.isAccessible = true
+    return field.get(messageView)
 }
 
 private fun evaluatePageMetaData(

--- a/OneSignalSDK/onesignal/in-app-messages/src/test/java/com/onesignal/inAppMessages/internal/display/WebViewManagerDismissCleanupTests.kt
+++ b/OneSignalSDK/onesignal/in-app-messages/src/test/java/com/onesignal/inAppMessages/internal/display/WebViewManagerDismissCleanupTests.kt
@@ -29,6 +29,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
@@ -333,6 +334,86 @@ class WebViewManagerDismissCleanupTests : FunSpec({
         getMessageViewField(manager).shouldNotBeNull()
     }
 
+    test("full screen setup applies immersive flags and still cleans up on dismiss") {
+        val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+        val applicationService = mockApplicationService(activity)
+        val manager =
+            createManager(
+                activity,
+                applicationService,
+                mockk(relaxed = true),
+                InAppMessage("test-iam", MockHelper.time(1)),
+            )
+
+        runBlocking {
+            manager.setupWebView(activity, "", true)
+        }
+
+        getWebViewField(manager).shouldNotBeNull()
+
+        runBlocking { manager.dismissAndAwaitNextMessage() }
+
+        getWebViewField(manager).shouldBeNull()
+    }
+
+    test("page metadata callback ignores empty payloads and bad JSON") {
+        val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+        val applicationService = mockApplicationService(activity)
+        val manager =
+            createManager(
+                activity,
+                applicationService,
+                mockk(relaxed = true),
+                InAppMessage("test-iam", MockHelper.time(1)),
+            )
+
+        // "null" is what evaluateJavascript reports when the JS function is undefined.
+        evaluatePageMetaData(manager, null)
+        evaluatePageMetaData(manager, "")
+        evaluatePageMetaData(manager, "null")
+        evaluatePageMetaData(manager, "{not-json")
+
+        getMessageViewField(manager).shouldBeNull()
+    }
+
+    test("page metadata callback with a valid height reaches showMessageView") {
+        val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+        val applicationService = mockApplicationService(activity)
+        val lifecycle = mockk<IInAppLifecycleService>(relaxed = true)
+        val manager =
+            createManager(
+                activity,
+                applicationService,
+                lifecycle,
+                InAppMessage("test-iam", MockHelper.time(1)),
+            )
+
+        setWebViewField(manager, OSWebView(activity))
+        evaluatePageMetaData(manager, """{"rect":{"height":140}}""")
+
+        // showMessageView is dispatched on IO; it must bail out safely with no messageView.
+        runBlocking { withTimeout(2_000) { while (getMessageViewField(manager) != null) delay(10) } }
+
+        getMessageViewField(manager).shouldBeNull()
+    }
+
+    test("dismiss completes even when destroying the WebView throws") {
+        val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+        val applicationService = mockApplicationService(activity)
+        val lifecycle = mockk<IInAppLifecycleService>(relaxed = true)
+        val message = InAppMessage("test-iam", MockHelper.time(1))
+        val manager = createManager(activity, applicationService, lifecycle, message)
+
+        val failingWebView = mockk<OSWebView>(relaxed = true)
+        every { failingWebView.stopLoading() } throws RuntimeException("WebView already destroyed")
+        setWebViewField(manager, failingWebView)
+
+        runBlocking { manager.dismissAndAwaitNextMessage() }
+
+        getWebViewField(manager).shouldBeNull()
+        verify(exactly = 1) { lifecycle.messageWasDismissed(message) }
+    }
+
     test("message lifecycle callbacks and finishDismiss are single-flight") {
         val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
         val applicationService = mockApplicationService(activity)
@@ -440,6 +521,19 @@ private fun setDismissedField(
     val field = WebViewManager::class.java.getDeclaredField("dismissed")
     field.isAccessible = true
     field.setBoolean(manager, value)
+}
+
+private fun evaluatePageMetaData(
+    manager: WebViewManager,
+    value: String?,
+) {
+    val method =
+        WebViewManager::class.java.getDeclaredMethod(
+            "evaluatePageMetaDataForHeight",
+            String::class.java,
+        )
+    method.isAccessible = true
+    method.invoke(manager, value)
 }
 
 private fun newJsInterface(manager: WebViewManager): Any {

--- a/OneSignalSDK/onesignal/in-app-messages/src/test/java/com/onesignal/inAppMessages/internal/display/WebViewManagerDismissCleanupTests.kt
+++ b/OneSignalSDK/onesignal/in-app-messages/src/test/java/com/onesignal/inAppMessages/internal/display/WebViewManagerDismissCleanupTests.kt
@@ -1,0 +1,109 @@
+package com.onesignal.inAppMessages.internal.display
+
+import android.app.Activity
+import br.com.colman.kotest.android.extensions.robolectric.RobolectricTest
+import com.onesignal.core.internal.application.IApplicationService
+import com.onesignal.debug.LogLevel
+import com.onesignal.debug.internal.logging.Logging
+import com.onesignal.inAppMessages.internal.InAppMessage
+import com.onesignal.inAppMessages.internal.InAppMessageContent
+import com.onesignal.inAppMessages.internal.display.impl.OSWebView
+import com.onesignal.inAppMessages.internal.display.impl.WebViewManager
+import com.onesignal.inAppMessages.internal.lifecycle.IInAppLifecycleService
+import com.onesignal.inAppMessages.internal.prompt.IInAppMessagePromptFactory
+import com.onesignal.mocks.MockHelper
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.runBlocking
+import org.json.JSONObject
+import org.robolectric.Robolectric
+import org.robolectric.annotation.Config
+
+@Config(
+    packageName = "com.onesignal.example",
+    sdk = [34],
+)
+@RobolectricTest
+class WebViewManagerDismissCleanupTests : FunSpec({
+    beforeAny {
+        Logging.logLevel = LogLevel.NONE
+    }
+
+    test("dismissAndAwaitNextMessage destroys WebView and invokes onDismissed when messageView is null") {
+        val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+        val applicationService = mockk<IApplicationService>(relaxed = true)
+        val lifecycle = mockk<IInAppLifecycleService>(relaxed = true)
+        val promptFactory = mockk<IInAppMessagePromptFactory>(relaxed = true)
+        val message = InAppMessage("test-iam", MockHelper.time(1))
+        val content = InAppMessageContent(JSONObject().put("html", "<html></html>"))
+
+        val manager =
+            WebViewManager(
+                message,
+                activity,
+                content,
+                lifecycle,
+                applicationService,
+                promptFactory,
+            )
+
+        val webView = OSWebView(activity)
+        setWebViewField(manager, webView)
+
+        var dismissed = false
+        manager.onDismissed = { dismissed = true }
+
+        runBlocking {
+            manager.dismissAndAwaitNextMessage()
+        }
+
+        getWebViewField(manager).shouldBeNull()
+        dismissed shouldBe true
+        verify(exactly = 1) { applicationService.removeActivityLifecycleHandler(manager) }
+    }
+
+    test("cleanup is idempotent across repeated dismiss calls") {
+        val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+        val applicationService = mockk<IApplicationService>(relaxed = true)
+        val manager =
+            WebViewManager(
+                InAppMessage("test-iam", MockHelper.time(1)),
+                activity,
+                InAppMessageContent(JSONObject().put("html", "<html></html>")),
+                mockk(relaxed = true),
+                applicationService,
+                mockk(relaxed = true),
+            )
+
+        setWebViewField(manager, OSWebView(activity))
+
+        var dismissCount = 0
+        manager.onDismissed = { dismissCount++ }
+
+        runBlocking {
+            manager.dismissAndAwaitNextMessage()
+            manager.dismissAndAwaitNextMessage()
+        }
+
+        getWebViewField(manager).shouldBeNull()
+        dismissCount shouldBe 1
+    }
+})
+
+private fun setWebViewField(
+    manager: WebViewManager,
+    value: OSWebView?,
+) {
+    val field = WebViewManager::class.java.getDeclaredField("webView")
+    field.isAccessible = true
+    field.set(manager, value)
+}
+
+private fun getWebViewField(manager: WebViewManager): Any? {
+    val field = WebViewManager::class.java.getDeclaredField("webView")
+    field.isAccessible = true
+    return field.get(manager)
+}


### PR DESCRIPTION
## Summary
- Fixes LeakCanary Activity leak from `OSWebView` after In-App Message dismiss ([#2312](https://github.com/OneSignal/OneSignal-Android-SDK/issues/2312), [SDK-4983](https://linear.app/onesignal/issue/SDK-4983/android-sdk-fix-oswebview-activity-leak-after-in-app-message-dismiss)).
- Destroy and null the IAM `WebView` on all dismiss paths (back/system PopupWindow, close action, drag, timer, programmatic), and clear `InAppDisplayer.lastInstance` via an `onDismissed` callback.
- Adds unit coverage for destroy/callback behavior and idempotent repeated dismiss.

## Test plan
- [ ] `./gradlew :OneSignal:in-app-messages:testOriginalUnitTest --tests com.onesignal.inAppMessages.internal.display.WebViewManagerDismissCleanupTests`
- [ ] Reproduce [#2312](https://github.com/OneSignal/OneSignal-Android-SDK/issues/2312): show IAM on Activity A → dismiss (Back) → start Activity B → confirm LeakCanary no longer reports `OSWebView` retaining Activity A
- [ ] Sanity-check IAM still displays/dismisses correctly across close button, drag-to-dismiss, timed dismiss, and activity rotation while showing


<img width="590" height="1294" alt="Kapture 2026-08-05 at 10 25 27" src="https://github.com/user-attachments/assets/f39afff2-18d8-4de8-ab6a-6ce7b1852346" />
