### PR TITLE
feat: [SDK-4999] emit Kotlin version on remote log resource attrs

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/debug/internal/logging/logger/android/LoggerPlatformProviderAdapter.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/debug/internal/logging/logger/android/LoggerPlatformProviderAdapter.kt
@@ -28,6 +28,10 @@ internal class LoggerPlatformProviderAdapter(
     override val osBuildId: String get() = delegate.osBuildId
     override val sdkWrapper: String? get() = delegate.sdkWrapper
     override val sdkWrapperVersion: String? get() = delegate.sdkWrapperVersion
+    override val kotlinVersion: String? get() = delegate.kotlinVersion
+    override val swiftVersion: String? get() = delegate.swiftVersion
+    override val additionalVersionAttributes: Map<String, String>
+        get() = delegate.additionalVersionAttributes
     override val enabledFeatureFlags: List<String> get() = delegate.enabledFeatureFlags
 
     override val appId: String? get() = delegate.appId

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/debug/internal/logging/otel/android/OtelPlatformProvider.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/debug/internal/logging/otel/android/OtelPlatformProvider.kt
@@ -68,18 +68,18 @@ internal class OtelPlatformProvider(
     // KotlinVersion.CURRENT reflects the stdlib the SDK was compiled against.
     override val kotlinVersion: String? = KotlinVersion.CURRENT.toString()
 
+    // Android has no Swift toolchain.
+    override val swiftVersion: String? = null
+
     // Extra toolchain labels under ossdk.* for dashboard filtering. Prefer values that are
-    // stable for the process lifetime and cheap to read:
-    // - java_version: ART's reported Java language level (spec version, e.g. "17")
+    // stable for the process lifetime and cheap to read.
     // - android_api_level: device API level (SDK_INT) — complementary to os.version (RELEASE)
-    // Build-time-only values (AGP, compileSdk, NDK) are not available here at runtime.
+    // Do NOT emit java_version from System.getProperty("java.specification.version"):
+    // on-device ART hardcodes that property to "0.9" (see AndroidHardcodedSystemProperties).
+    // Robolectric returns the host JDK version and would mask that in unit tests.
+    // Build-time-only values (AGP, compileSdk, NDK, real javac target) are unavailable at runtime.
     override val additionalVersionAttributes: Map<String, String> =
-        buildMap {
-            System.getProperty("java.specification.version")
-                ?.takeIf { it.isNotBlank() }
-                ?.let { put("java_version", it) }
-            put("android_api_level", Build.VERSION.SDK_INT.toString())
-        }
+        mapOf("android_api_level" to Build.VERSION.SDK_INT.toString())
 
     // Read through the supplier on every access so per-event attributes always reflect the
     // current featureStates snapshot (including IMMEDIATE-mode flag changes). The supplier is

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/debug/internal/logging/otel/android/OtelPlatformProvider.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/debug/internal/logging/otel/android/OtelPlatformProvider.kt
@@ -68,6 +68,19 @@ internal class OtelPlatformProvider(
     // KotlinVersion.CURRENT reflects the stdlib the SDK was compiled against.
     override val kotlinVersion: String? = KotlinVersion.CURRENT.toString()
 
+    // Extra toolchain labels under ossdk.* for dashboard filtering. Prefer values that are
+    // stable for the process lifetime and cheap to read:
+    // - java_version: ART's reported Java language level (spec version, e.g. "17")
+    // - android_api_level: device API level (SDK_INT) — complementary to os.version (RELEASE)
+    // Build-time-only values (AGP, compileSdk, NDK) are not available here at runtime.
+    override val additionalVersionAttributes: Map<String, String> =
+        buildMap {
+            System.getProperty("java.specification.version")
+                ?.takeIf { it.isNotBlank() }
+                ?.let { put("java_version", it) }
+            put("android_api_level", Build.VERSION.SDK_INT.toString())
+        }
+
     // Read through the supplier on every access so per-event attributes always reflect the
     // current featureStates snapshot (including IMMEDIATE-mode flag changes). The supplier is
     // an immutable constructor val that resolves IFeatureManager lazily — this lets the OTel

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/debug/internal/logging/otel/android/OtelPlatformProvider.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/debug/internal/logging/otel/android/OtelPlatformProvider.kt
@@ -64,6 +64,10 @@ internal class OtelPlatformProvider(
 
     override val sdkWrapperVersion: String? = OneSignalWrapper.sdkVersion
 
+    // Host language version for remote-log dashboard filtering (ossdk.kotlin_version).
+    // KotlinVersion.CURRENT reflects the stdlib the SDK was compiled against.
+    override val kotlinVersion: String? = KotlinVersion.CURRENT.toString()
+
     // Read through the supplier on every access so per-event attributes always reflect the
     // current featureStates snapshot (including IMMEDIATE-mode flag changes). The supplier is
     // an immutable constructor val that resolves IFeatureManager lazily — this lets the OTel

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/debug/internal/logging/otel/android/OtelPlatformProvider.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/debug/internal/logging/otel/android/OtelPlatformProvider.kt
@@ -64,20 +64,13 @@ internal class OtelPlatformProvider(
 
     override val sdkWrapperVersion: String? = OneSignalWrapper.sdkVersion
 
-    // Host language version for remote-log dashboard filtering (ossdk.kotlin_version).
-    // KotlinVersion.CURRENT reflects the stdlib the SDK was compiled against.
+    // Compile-time Kotlin stdlib, not the host app's Kotlin.
     override val kotlinVersion: String? = KotlinVersion.CURRENT.toString()
 
-    // Android has no Swift toolchain.
     override val swiftVersion: String? = null
 
-    // Extra toolchain labels under ossdk.* for dashboard filtering. Prefer values that are
-    // stable for the process lifetime and cheap to read.
-    // - android_api_level: device API level (SDK_INT) — complementary to os.version (RELEASE)
-    // Do NOT emit java_version from System.getProperty("java.specification.version"):
-    // on-device ART hardcodes that property to "0.9" (see AndroidHardcodedSystemProperties).
-    // Robolectric returns the host JDK version and would mask that in unit tests.
-    // Build-time-only values (AGP, compileSdk, NDK, real javac target) are unavailable at runtime.
+    // Device API level; complementary to os.version (RELEASE).
+    // Do not emit java_version — ART hardcodes java.specification.version to "0.9".
     override val additionalVersionAttributes: Map<String, String> =
         mapOf("android_api_level" to Build.VERSION.SDK_INT.toString())
 

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/debug/internal/logging/otel/android/OtelPlatformProviderTest.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/debug/internal/logging/otel/android/OtelPlatformProviderTest.kt
@@ -218,6 +218,24 @@ class OtelPlatformProviderTest : FunSpec({
         result shouldBe null
     }
 
+    test("kotlinVersion returns KotlinVersion.CURRENT") {
+        val provider = createAndroidOtelPlatformProvider(appContext!!) { emptyFeatureManager() }
+
+        provider.kotlinVersion shouldBe KotlinVersion.CURRENT.toString()
+    }
+
+    test("swiftVersion defaults to null on Android") {
+        val provider = createAndroidOtelPlatformProvider(appContext!!) { emptyFeatureManager() }
+
+        provider.swiftVersion shouldBe null
+    }
+
+    test("additionalVersionAttributes defaults to empty on Android") {
+        val provider = createAndroidOtelPlatformProvider(appContext!!) { emptyFeatureManager() }
+
+        provider.additionalVersionAttributes shouldBe emptyMap()
+    }
+
     // ===== Lazy ID Properties Tests =====
 
     test("appId returns resolved appId from OtelIdResolver") {

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/debug/internal/logging/otel/android/OtelPlatformProviderTest.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/debug/internal/logging/otel/android/OtelPlatformProviderTest.kt
@@ -15,6 +15,7 @@ import com.onesignal.debug.LogLevel
 import com.onesignal.debug.internal.logging.Logging
 import com.onesignal.user.internal.backend.IdentityConstants
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
@@ -230,10 +231,17 @@ class OtelPlatformProviderTest : FunSpec({
         provider.swiftVersion shouldBe null
     }
 
-    test("additionalVersionAttributes defaults to empty on Android") {
+    test("additionalVersionAttributes includes java_version and android_api_level") {
         val provider = createAndroidOtelPlatformProvider(appContext!!) { emptyFeatureManager() }
+        val attrs = provider.additionalVersionAttributes
 
-        provider.additionalVersionAttributes shouldBe emptyMap()
+        attrs["android_api_level"] shouldBe Build.VERSION.SDK_INT.toString()
+        // Robolectric / ART expose a non-blank Java language level via the spec property.
+        val javaVersion = System.getProperty("java.specification.version")
+        if (!javaVersion.isNullOrBlank()) {
+            attrs["java_version"] shouldBe javaVersion
+        }
+        attrs.keys.shouldNotContain("kotlin_version")
     }
 
     // ===== Lazy ID Properties Tests =====

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/debug/internal/logging/otel/android/OtelPlatformProviderTest.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/debug/internal/logging/otel/android/OtelPlatformProviderTest.kt
@@ -231,16 +231,13 @@ class OtelPlatformProviderTest : FunSpec({
         provider.swiftVersion shouldBe null
     }
 
-    test("additionalVersionAttributes includes java_version and android_api_level") {
+    test("additionalVersionAttributes includes android_api_level only") {
         val provider = createAndroidOtelPlatformProvider(appContext!!) { emptyFeatureManager() }
         val attrs = provider.additionalVersionAttributes
 
-        attrs["android_api_level"] shouldBe Build.VERSION.SDK_INT.toString()
-        // Robolectric / ART expose a non-blank Java language level via the spec property.
-        val javaVersion = System.getProperty("java.specification.version")
-        if (!javaVersion.isNullOrBlank()) {
-            attrs["java_version"] shouldBe javaVersion
-        }
+        attrs shouldBe mapOf("android_api_level" to Build.VERSION.SDK_INT.toString())
+        // java.specification.version is hardcoded to "0.9" on-device ART — never emit it.
+        attrs.keys.shouldNotContain("java_version")
         attrs.keys.shouldNotContain("kotlin_version")
     }
 

--- a/OneSignalSDK/onesignal/otel/build.gradle
+++ b/OneSignalSDK/onesignal/otel/build.gradle
@@ -42,7 +42,8 @@ android {
 
 ext {
     projectName = "OneSignal SDK Otel"
-    projectDescription = "OneSignal Android SDK - OpenTelemetry Module"
+    // Published for SDK packaging only — not a supported public API for app/wrapper authors.
+    projectDescription = "OneSignal Android SDK - OpenTelemetry Module (internal; not for public use)"
 }
 
 dependencies {

--- a/OneSignalSDK/onesignal/otel/src/main/java/com/onesignal/otel/IOtelPlatformProvider.kt
+++ b/OneSignalSDK/onesignal/otel/src/main/java/com/onesignal/otel/IOtelPlatformProvider.kt
@@ -28,25 +28,30 @@ interface IOtelPlatformProvider {
     /**
      * Kotlin language / stdlib version of the host app when applicable
      * (e.g. [KotlinVersion.CURRENT]). Null on non-Kotlin hosts. Emitted as
-     * `ossdk.kotlin_version` when non-blank. Defaults to null for compatibility.
+     * `ossdk.kotlin_version` when non-blank.
+     *
+     * Required on implementors — Kotlin interface defaults are not reliable JVM
+     * default methods here (no `-Xjvm-default=all`), so a missing override on an
+     * older binary would throw [AbstractMethodError] when read. This interface
+     * ships with its Android implementor in the same artifact.
      */
     val kotlinVersion: String?
-        get() = null
 
     /**
      * Swift language version when applicable. Null on Android / non-Swift hosts.
-     * Emitted as `ossdk.swift_version` when non-blank. Defaults to null.
+     * Emitted as `ossdk.swift_version` when non-blank.
+     *
+     * Required for the same binary-compat reason as [kotlinVersion].
      */
     val swiftVersion: String?
-        get() = null
 
     /**
      * Extra static version labels for dashboard filtering (`ossdk.<key>`).
      * Dedicated [kotlinVersion] / [swiftVersion] and core resource attrs win on clash.
-     * Defaults to empty.
+     *
+     * Required for the same binary-compat reason as [kotlinVersion].
      */
     val additionalVersionAttributes: Map<String, String>
-        get() = emptyMap()
 
     /**
      * The canonical keys of feature flags currently enabled for this device, as resolved by

--- a/OneSignalSDK/onesignal/otel/src/main/java/com/onesignal/otel/IOtelPlatformProvider.kt
+++ b/OneSignalSDK/onesignal/otel/src/main/java/com/onesignal/otel/IOtelPlatformProvider.kt
@@ -3,6 +3,14 @@ package com.onesignal.otel
 /**
  * Platform-agnostic provider interface for injecting platform-specific values.
  * All Android/iOS specific values should be provided through this interface.
+ *
+ * **SDK-internal only — not a public implementor surface.** Although `:otel` is a
+ * published artifact and [OtelFactory] accepts this type, app and wrapper authors
+ * must not implement or depend on this interface. The sole production implementor
+ * is `OtelPlatformProvider` in `:core`.
+ *
+ * New abstract members are a deliberate source-compatibility break for any
+ * external implementor; there are no known consumers outside the SDK.
  */
 interface IOtelPlatformProvider {
     // Top-level attributes (static, calculated once)

--- a/OneSignalSDK/onesignal/otel/src/main/java/com/onesignal/otel/IOtelPlatformProvider.kt
+++ b/OneSignalSDK/onesignal/otel/src/main/java/com/onesignal/otel/IOtelPlatformProvider.kt
@@ -26,6 +26,29 @@ interface IOtelPlatformProvider {
     val sdkWrapperVersion: String?
 
     /**
+     * Kotlin language / stdlib version of the host app when applicable
+     * (e.g. [KotlinVersion.CURRENT]). Null on non-Kotlin hosts. Emitted as
+     * `ossdk.kotlin_version` when non-blank. Defaults to null for compatibility.
+     */
+    val kotlinVersion: String?
+        get() = null
+
+    /**
+     * Swift language version when applicable. Null on Android / non-Swift hosts.
+     * Emitted as `ossdk.swift_version` when non-blank. Defaults to null.
+     */
+    val swiftVersion: String?
+        get() = null
+
+    /**
+     * Extra static version labels for dashboard filtering (`ossdk.<key>`).
+     * Dedicated [kotlinVersion] / [swiftVersion] and core resource attrs win on clash.
+     * Defaults to empty.
+     */
+    val additionalVersionAttributes: Map<String, String>
+        get() = emptyMap()
+
+    /**
      * The canonical keys of feature flags currently enabled for this device, as resolved by
      * the platform's feature flag source (on Android, a constructor-injected `IFeatureManager`).
      * Read fresh on every access so per-event OTel attributes always reflect the current state.

--- a/OneSignalSDK/onesignal/otel/src/main/java/com/onesignal/otel/IOtelPlatformProvider.kt
+++ b/OneSignalSDK/onesignal/otel/src/main/java/com/onesignal/otel/IOtelPlatformProvider.kt
@@ -30,10 +30,9 @@ interface IOtelPlatformProvider {
      * (e.g. [KotlinVersion.CURRENT]). Null on non-Kotlin hosts. Emitted as
      * `ossdk.kotlin_version` when non-blank.
      *
-     * Required on implementors — Kotlin interface defaults are not reliable JVM
-     * default methods here (no `-Xjvm-default=all`), so a missing override on an
-     * older binary would throw [AbstractMethodError] when read. This interface
-     * ships with its Android implementor in the same artifact.
+     * SDK-internal injection seam only — the sole production implementor is
+     * `OtelPlatformProvider` in `:core`. Not a public compatibility surface for
+     * app or wrapper authors.
      */
     val kotlinVersion: String?
 
@@ -41,7 +40,7 @@ interface IOtelPlatformProvider {
      * Swift language version when applicable. Null on Android / non-Swift hosts.
      * Emitted as `ossdk.swift_version` when non-blank.
      *
-     * Required for the same binary-compat reason as [kotlinVersion].
+     * Same SDK-internal caveat as [kotlinVersion].
      */
     val swiftVersion: String?
 
@@ -49,7 +48,7 @@ interface IOtelPlatformProvider {
      * Extra static version labels for dashboard filtering (`ossdk.<key>`).
      * Dedicated [kotlinVersion] / [swiftVersion] and core resource attrs win on clash.
      *
-     * Required for the same binary-compat reason as [kotlinVersion].
+     * Same SDK-internal caveat as [kotlinVersion].
      */
     val additionalVersionAttributes: Map<String, String>
 

--- a/OneSignalSDK/onesignal/otel/src/main/java/com/onesignal/otel/OtelFactory.kt
+++ b/OneSignalSDK/onesignal/otel/src/main/java/com/onesignal/otel/OtelFactory.kt
@@ -10,6 +10,9 @@ import com.onesignal.otel.crash.OtelCrashUploader
  * Factory class for creating Otel components.
  * This allows for fast initialization of the crash handler with all dependencies
  * pre-populated.
+ *
+ * SDK-internal only — not for public use by app or wrapper authors. Callers must
+ * supply an [IOtelPlatformProvider] owned by the SDK (see that type's KDoc).
  */
 object OtelFactory {
     /**

--- a/OneSignalSDK/onesignal/otel/src/main/java/com/onesignal/otel/attributes/OtelFieldsTopLevel.kt
+++ b/OneSignalSDK/onesignal/otel/src/main/java/com/onesignal/otel/attributes/OtelFieldsTopLevel.kt
@@ -71,8 +71,8 @@ internal fun MutableMap<String, String>.putIfValueNotBlank(
 
 /**
  * Hosts may pass bare suffixes (`java_version`) or accidentally include the
- * `ossdk.` prefix; normalize to the bare suffix so we never emit
- * `ossdk.ossdk.*`.
+ * `ossdk.` prefix (with optional surrounding whitespace); trim first so
+ * `" ossdk.foo"` does not become `ossdk.ossdk.foo`.
  */
 internal fun normalizeOssdkAttributeSuffix(key: String): String =
-    key.removePrefix("ossdk.").trim()
+    key.trim().removePrefix("ossdk.").trim()

--- a/OneSignalSDK/onesignal/otel/src/main/java/com/onesignal/otel/attributes/OtelFieldsTopLevel.kt
+++ b/OneSignalSDK/onesignal/otel/src/main/java/com/onesignal/otel/attributes/OtelFieldsTopLevel.kt
@@ -7,13 +7,27 @@ import com.squareup.wire.internal.toUnmodifiableMap
  * Purpose: Fields to be included in every Otel request that goes out.
  * Requirements: Only include fields that can NOT change during runtime,
  * as these are only fetched once. (Calculated fields are ok)
+ *
+ * Optional host language / toolchain versions (`ossdk.kotlin_version`,
+ * `ossdk.swift_version`, plus any `additionalVersionAttributes`) ride along so
+ * dashboards can filter by the app's language stack — mirrors KMP LogFieldsTopLevel.
  */
 internal class OtelFieldsTopLevel(
     private val platformProvider: IOtelPlatformProvider,
 ) {
     suspend fun getAttributes(): Map<String, String> {
-        val attributes: MutableMap<String, String> =
-            mutableMapOf(
+        val attributes: MutableMap<String, String> = mutableMapOf()
+
+        // Extras first so dedicated / core fields below always win on clash.
+        for ((key, value) in platformProvider.additionalVersionAttributes) {
+            val suffix = normalizeOssdkAttributeSuffix(key)
+            if (suffix.isNotEmpty() && !value.isNullOrBlank()) {
+                attributes["ossdk.$suffix"] = value
+            }
+        }
+
+        attributes.putAll(
+            mapOf(
                 "ossdk.install_id" to platformProvider.getInstallId(),
                 "ossdk.sdk_base" to platformProvider.sdkBase,
                 "ossdk.sdk_base_version" to platformProvider.sdkBaseVersion,
@@ -24,11 +38,14 @@ internal class OtelFieldsTopLevel(
                 "os.name" to platformProvider.osName,
                 "os.version" to platformProvider.osVersion,
                 "os.build_id" to platformProvider.osBuildId,
-            )
+            ),
+        )
 
         attributes
             .putIfValueNotNull("ossdk.sdk_wrapper", platformProvider.sdkWrapper)
             .putIfValueNotNull("ossdk.sdk_wrapper_version", platformProvider.sdkWrapperVersion)
+            .putIfValueNotBlank("ossdk.kotlin_version", platformProvider.kotlinVersion)
+            .putIfValueNotBlank("ossdk.swift_version", platformProvider.swiftVersion)
 
         return attributes.toUnmodifiableMap()
     }
@@ -40,3 +57,22 @@ internal fun <K, V> MutableMap<K, V>.putIfValueNotNull(key: K, value: V?): Mutab
     }
     return this
 }
+
+/** Like [putIfValueNotNull], but also skips blank strings so filter attrs stay sparse. */
+internal fun MutableMap<String, String>.putIfValueNotBlank(
+    key: String,
+    value: String?,
+): MutableMap<String, String> {
+    if (!value.isNullOrBlank()) {
+        this[key] = value
+    }
+    return this
+}
+
+/**
+ * Hosts may pass bare suffixes (`java_version`) or accidentally include the
+ * `ossdk.` prefix; normalize to the bare suffix so we never emit
+ * `ossdk.ossdk.*`.
+ */
+internal fun normalizeOssdkAttributeSuffix(key: String): String =
+    key.removePrefix("ossdk.").trim()

--- a/OneSignalSDK/onesignal/otel/src/test/java/com/onesignal/otel/attributes/OtelFieldsTopLevelTest.kt
+++ b/OneSignalSDK/onesignal/otel/src/test/java/com/onesignal/otel/attributes/OtelFieldsTopLevelTest.kt
@@ -17,7 +17,10 @@ class OtelFieldsTopLevelTest : FunSpec({
     fun setupDefaultMocks(
         installId: String = "test-install-id",
         sdkWrapper: String? = null,
-        sdkWrapperVersion: String? = null
+        sdkWrapperVersion: String? = null,
+        kotlinVersion: String? = null,
+        swiftVersion: String? = null,
+        additionalVersionAttributes: Map<String, String> = emptyMap(),
     ) {
         coEvery { mockPlatformProvider.getInstallId() } returns installId
         every { mockPlatformProvider.sdkBase } returns "android"
@@ -31,6 +34,9 @@ class OtelFieldsTopLevelTest : FunSpec({
         every { mockPlatformProvider.osBuildId } returns "TEST123"
         every { mockPlatformProvider.sdkWrapper } returns sdkWrapper
         every { mockPlatformProvider.sdkWrapperVersion } returns sdkWrapperVersion
+        every { mockPlatformProvider.kotlinVersion } returns kotlinVersion
+        every { mockPlatformProvider.swiftVersion } returns swiftVersion
+        every { mockPlatformProvider.additionalVersionAttributes } returns additionalVersionAttributes
     }
 
     beforeEach { clearMocks(mockPlatformProvider) }
@@ -51,6 +57,8 @@ class OtelFieldsTopLevelTest : FunSpec({
             attributes["os.name"] shouldBe "Android"
             attributes["os.version"] shouldBe "10"
             attributes["os.build_id"] shouldBe "TEST123"
+            attributes.keys shouldNotContain "ossdk.kotlin_version"
+            attributes.keys shouldNotContain "ossdk.swift_version"
         }
     }
 
@@ -73,6 +81,53 @@ class OtelFieldsTopLevelTest : FunSpec({
 
             attributes.keys shouldNotContain "ossdk.sdk_wrapper"
             attributes.keys shouldNotContain "ossdk.sdk_wrapper_version"
+        }
+    }
+
+    test("getAttributes should include kotlin and swift versions when provided") {
+        setupDefaultMocks(kotlinVersion = "1.9.25", swiftVersion = "5.10")
+
+        runBlocking {
+            val attributes = fields.getAttributes()
+
+            attributes["ossdk.kotlin_version"] shouldBe "1.9.25"
+            attributes["ossdk.swift_version"] shouldBe "5.10"
+        }
+    }
+
+    test("getAttributes should omit blank language versions") {
+        setupDefaultMocks(kotlinVersion = "   ", swiftVersion = "")
+
+        runBlocking {
+            val attributes = fields.getAttributes()
+
+            attributes.keys shouldNotContain "ossdk.kotlin_version"
+            attributes.keys shouldNotContain "ossdk.swift_version"
+        }
+    }
+
+    test("getAttributes should merge additionalVersionAttributes under ossdk prefix") {
+        setupDefaultMocks(
+            kotlinVersion = "1.9.25",
+            additionalVersionAttributes =
+                mapOf(
+                    "java_version" to "17",
+                    "kotlin_version" to "should-not-win",
+                    "install_id" to "forged-install",
+                    "ossdk.ndk_version" to "26.1",
+                    "agp_version" to "  ",
+                ),
+        )
+
+        runBlocking {
+            val attributes = fields.getAttributes()
+
+            attributes["ossdk.java_version"] shouldBe "17"
+            attributes["ossdk.ndk_version"] shouldBe "26.1"
+            attributes["ossdk.kotlin_version"] shouldBe "1.9.25"
+            attributes["ossdk.install_id"] shouldBe "test-install-id"
+            attributes.keys shouldNotContain "ossdk.ossdk.ndk_version"
+            attributes.keys shouldNotContain "ossdk.agp_version"
         }
     }
 

--- a/OneSignalSDK/onesignal/otel/src/test/java/com/onesignal/otel/attributes/OtelFieldsTopLevelTest.kt
+++ b/OneSignalSDK/onesignal/otel/src/test/java/com/onesignal/otel/attributes/OtelFieldsTopLevelTest.kt
@@ -110,13 +110,13 @@ class OtelFieldsTopLevelTest : FunSpec({
         setupDefaultMocks(
             kotlinVersion = "1.9.25",
             additionalVersionAttributes =
-                mapOf(
-                    "java_version" to "17",
-                    "kotlin_version" to "should-not-win",
-                    "install_id" to "forged-install",
-                    "ossdk.ndk_version" to "26.1",
-                    "agp_version" to "  ",
-                ),
+            mapOf(
+                "java_version" to "17",
+                "kotlin_version" to "should-not-win",
+                "install_id" to "forged-install",
+                "ossdk.ndk_version" to "26.1",
+                "agp_version" to "  ",
+            ),
         )
 
         runBlocking {

--- a/OneSignalSDK/onesignal/otel/src/test/java/com/onesignal/otel/attributes/OtelFieldsTopLevelTest.kt
+++ b/OneSignalSDK/onesignal/otel/src/test/java/com/onesignal/otel/attributes/OtelFieldsTopLevelTest.kt
@@ -115,7 +115,9 @@ class OtelFieldsTopLevelTest : FunSpec({
                 "kotlin_version" to "should-not-win",
                 "install_id" to "forged-install",
                 "ossdk.ndk_version" to "26.1",
-                "agp_version" to "  ",
+                // Leading whitespace must still strip ossdk. (no ossdk.ossdk.*).
+                "  ossdk.agp_version" to "8.8.2",
+                "agp_blank" to "  ",
             ),
         )
 
@@ -124,10 +126,12 @@ class OtelFieldsTopLevelTest : FunSpec({
 
             attributes["ossdk.java_version"] shouldBe "17"
             attributes["ossdk.ndk_version"] shouldBe "26.1"
+            attributes["ossdk.agp_version"] shouldBe "8.8.2"
             attributes["ossdk.kotlin_version"] shouldBe "1.9.25"
             attributes["ossdk.install_id"] shouldBe "test-install-id"
             attributes.keys shouldNotContain "ossdk.ossdk.ndk_version"
-            attributes.keys shouldNotContain "ossdk.agp_version"
+            attributes.keys shouldNotContain "ossdk.ossdk.agp_version"
+            attributes.keys shouldNotContain "ossdk.agp_blank"
         }
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Android host follow-up for [OneSignal-KMP-SDK#17](https://github.com/OneSignal/OneSignal-KMP-SDK/pull/17) ([SDK-4999](https://linear.app/onesignal/issue/SDK-4999)): supply `KotlinVersion.CURRENT` so remote logs include `ossdk.kotlin_version` for dashboard filtering.

## Changes
- **Submodule** — pins `OneSignal-KMP-SDK` to KMP #17 (`267b460`, `ar/sdk-4999`).
- **`OtelPlatformProvider`** — `kotlinVersion = KotlinVersion.CURRENT.toString()`.
- **`IOtelPlatformProvider` / `LoggerPlatformProviderAdapter`** — add abstract `kotlinVersion` / `swiftVersion` / `additionalVersionAttributes` (adapter forwards to the logger path).
- **`OtelFieldsTopLevel`** — mirrors KMP `LogFieldsTopLevel` (extras first, blank skip, `ossdk.` prefix normalize) so the legacy otel path stays at parity while both modules coexist.
- **Tests** — provider returns `KotlinVersion.CURRENT`; top-level attrs cover emit / blank omit / extras merge / reserved-key protection.
- **Docs** — mark `:otel` / `IOtelPlatformProvider` / `OtelFactory` as SDK-internal (not for public use).

## Compatibility note
Adding the new abstract members on `IOtelPlatformProvider` is a **deliberate source-compatibility break** for any external implementor of that interface. `:otel` is published and `OtelFactory` accepts the type, but this is an SDK-internal injection seam — the only production implementor is `OtelPlatformProvider` in `:core`, and there are no known external consumers. We are not adding default methods or a capability interface for this reason.

## Merge order
1. Land [OneSignal-KMP-SDK#17](https://github.com/OneSignal/OneSignal-KMP-SDK/pull/17) first.
2. Merge this PR (re-pin submodule to the merged KMP SHA / release tag if the tip moves).

## Test plan
- [x] Code review vs KMP #17 contract
- [ ] `:OneSignal:core:testDebugUnitTest --tests "*OtelPlatformProviderTest*"`
- [ ] `:OneSignal:otel:testDebugUnitTest --tests "*OtelFieldsTopLevelTest*"`
- [ ] `:OneSignal:core:compileDebugKotlin` against pinned submodule
- [ ] After KMP merge: re-pin to merged SHA / tagged release via bump workflow when available

Made with [Cursor](https://cursor.com)
<!-- CURSOR_AGENT_PR_BODY_END -->