### PR TITLE
refactor: delegate KMP bumps to shared workflow

### DIFF
--- a/.github/workflows/bump-kmp-submodule.yml
+++ b/.github/workflows/bump-kmp-submodule.yml
@@ -1,14 +1,5 @@
 name: Bump KMP Submodule
 
-# Reusable workflow: re-points the OneSignal-KMP-SDK git submodule to a released tag
-# and opens a PR. Called by the KMP repo's Release workflow (the fan-out pattern used
-# by OneSignal/sdk-shared), or run manually via workflow_dispatch.
-#
-# Cross-repo callers authenticate by passing the shared org push token as
-# GH_PUSH_TOKEN: a workflow triggered from the KMP repo runs with the KMP repo's
-# GITHUB_TOKEN, which cannot write here, so GH_PUSH_TOKEN (used across the OneSignal
-# SDK repos) is required for the checkout/push/PR to target this repo.
-
 on:
   workflow_call:
     inputs:
@@ -19,7 +10,7 @@ on:
     secrets:
       GH_PUSH_TOKEN:
         required: false
-        description: Cross-repo push token (contents + pull-requests write)
+        description: Cross-repository token with contents and pull-request write access
   workflow_dispatch:
     inputs:
       kmp_version:
@@ -27,129 +18,11 @@ on:
         required: true
         type: string
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   bump:
-    runs-on: ubuntu-latest
-    env:
-      SUBMODULE_PATH: OneSignal-KMP-SDK
-      VERSION: ${{ inputs.kmp_version }}
-    steps:
-      - name: "[Checkout] Android SDK"
-        uses: actions/checkout@v7
-        with:
-          # Reusable workflows keep the caller's github context, so the default
-          # checkout target is the caller (OneSignal-KMP-SDK), not this repo.
-          # Always pin the Android SDK when called via workflow_call.
-          repository: OneSignal/OneSignal-Android-SDK
-          ref: main
-          fetch-depth: 0
-          token: ${{ secrets.GH_PUSH_TOKEN || github.token }}
-          # Only the mode-160000 gitlink SHA is rewritten, so the submodule contents
-          # are not needed (no recursive checkout).
-
-      - name: "[Setup] Git user"
-        uses: OneSignal/sdk-shared/.github/actions/setup-git-user@main
-
-      - name: "[Resolve] KMP release tag"
-        env:
-          KMP_REMOTE: https://github.com/OneSignal/OneSignal-KMP-SDK.git
-        run: |
-          set -euo pipefail
-
-          if [[ ! "$VERSION" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
-            echo "::error::Invalid KMP version '$VERSION'. Expected a release tag such as v0.2.0."
-            exit 1
-          fi
-
-          if ! git ls-remote --exit-code --refs "$KMP_REMOTE" "refs/tags/${VERSION}" >/dev/null; then
-            echo "::error::KMP release tag '$VERSION' does not exist or could not be resolved."
-            exit 1
-          fi
-
-          tag_repo="$(mktemp -d)"
-          trap 'rm -rf "$tag_repo"' EXIT
-          git -C "$tag_repo" init --bare --quiet
-          if ! git -C "$tag_repo" fetch --quiet --depth=1 "$KMP_REMOTE" "refs/tags/${VERSION}"; then
-            echo "::error::Failed to fetch KMP release tag '$VERSION'."
-            exit 1
-          fi
-
-          new_sha="$(git -C "$tag_repo" rev-parse 'FETCH_HEAD^{commit}')"
-          if ! git -C "$tag_repo" cat-file -e "${new_sha}^{commit}"; then
-            echo "::error::KMP release tag '$VERSION' does not resolve to a commit."
-            exit 1
-          fi
-
-          echo "Resolved $VERSION to $new_sha."
-          echo "NEW_SHA=$new_sha" >> "$GITHUB_ENV"
-
-      - name: "[Bump] Re-point submodule gitlink"
-        id: bump
-        run: |
-          set -euo pipefail
-          branch="chore/bump-kmp-${VERSION}"
-          echo "branch=$branch" >> "$GITHUB_OUTPUT"
-
-          git checkout -b "$branch"
-          # Update the mode-160000 gitlink entry to the commit the tag points at.
-          git update-index --add --cacheinfo "160000,${NEW_SHA},${SUBMODULE_PATH}"
-
-          # No-op guard: if the pointer already matches (e.g. the very first release,
-          # where main already points at the tagged commit), skip the commit/PR
-          # instead of failing on an empty commit.
-          if git diff --cached --quiet; then
-            echo "Submodule already at ${NEW_SHA}; nothing to bump."
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          echo "changed=true" >> "$GITHUB_OUTPUT"
-          git commit -m "chore(logger): bump ${SUBMODULE_PATH} submodule to ${VERSION}"
-          git push origin "$branch" --force-with-lease
-
-      - name: "[PR] Open or update bump PR"
-        if: ${{ steps.bump.outputs.changed == 'true' }}
-        env:
-          GH_TOKEN: ${{ secrets.GH_PUSH_TOKEN || github.token }}
-        run: |
-          set -euo pipefail
-          branch="${{ steps.bump.outputs.branch }}"
-          notes_url="https://github.com/OneSignal/OneSignal-KMP-SDK/releases/tag/${VERSION}"
-
-          # Best-effort: pull the published release notes for this tag so the reviewer can
-          # read exactly what the new version contains before merging the bump, without
-          # leaving the PR. Reading another repo's release needs cross-repo access, which
-          # GH_PUSH_TOKEN has; on any failure (missing token, release not yet visible) we
-          # fall back to just linking the release page.
-          notes="$(gh release view "$VERSION" --repo OneSignal/OneSignal-KMP-SDK --json body --jq .body 2>/dev/null || true)"
-
-          body_file="$RUNNER_TEMP/bump_pr_body.md"
-          {
-            printf 'Automated bump of the `%s` submodule to **%s** (`%s`).\n\n' "$SUBMODULE_PATH" "$VERSION" "$NEW_SHA"
-            printf '## Release notes — %s\n\n' "$VERSION"
-            if [ -n "$notes" ]; then
-              printf '%s\n\n' "$notes"
-              printf '_Source: [%s](%s)_\n\n' "$VERSION" "$notes_url"
-            else
-              printf 'See [%s](%s).\n\n' "$VERSION" "$notes_url"
-            fi
-            printf 'After merge, run `git submodule update --init --recursive` locally to sync.\n'
-          } > "$body_file"
-
-          # Reuse the PR if one is already open for this branch (re-runs refresh title/body).
-          if gh pr view "$branch" >/dev/null 2>&1; then
-            echo "PR already exists for $branch; refreshing title and release notes."
-            gh pr edit "$branch" \
-              --title "chore(logger): bump shared KMP logger to ${VERSION}" \
-              --body-file "$body_file"
-          else
-            gh pr create \
-              --base main \
-              --head "$branch" \
-              --title "chore(logger): bump shared KMP logger to ${VERSION}" \
-              --body-file "$body_file"
-          fi
+    uses: OneSignal/sdk-shared/.github/workflows/bump-kmp-submodule.yml@main
+    with:
+      target_repository: OneSignal/OneSignal-Android-SDK
+      kmp_version: ${{ inputs.kmp_version }}
+    secrets:
+      GH_PUSH_TOKEN: ${{ secrets.GH_PUSH_TOKEN }}

--- a/.github/workflows/bump-kmp-submodule.yml
+++ b/.github/workflows/bump-kmp-submodule.yml
@@ -18,6 +18,10 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   bump:
     uses: OneSignal/sdk-shared/.github/workflows/bump-kmp-submodule.yml@main


### PR DESCRIPTION
# Description
## One Line Summary
Delegate KMP submodule bump releases to the shared SDK workflow.

## Details
### Motivation
Remove duplicated release automation while retaining the Android workflow entry point and closed-PR recovery behavior.

### Scope
Only the KMP bump workflow changes. Runtime SDK behavior and public APIs are unaffected.

### Dependency
Merge [sdk-shared PR #55](https://github.com/OneSignal/sdk-shared/pull/55) first because this workflow references the shared workflow on `main`.

# Testing
## Unit testing
No unit tests are needed for this workflow-only change. All involved workflows pass `actionlint`; shared PR-state behavior was tested with mocked open, closed, merged, and missing PRs.

## Manual testing
Device testing is not applicable to release automation.

# Affected code checklist
- [ ] Notifications
- [ ] Outcomes
- [ ] Sessions
- [ ] In-App Messaging
- [ ] REST API requests
- [ ] Public API changes

# Checklist
## Overview
- [x] I have filled out all required sections above
- [x] PR does one thing
- [x] Any Public API changes are explained and conform to existing APIs

## Testing
- [x] I have included test coverage or explained why it is not needed
- [x] All applicable automated tests pass
- [x] Device testing is not applicable and is explained above

## Final pass
- [x] Code is as readable as possible
- [x] I have reviewed this PR myself

Made with [Cursor](https://cursor.com)