### PR TITLE
fix: [SDK-5154] stop mixing dashboard sender id with the shared FCM project

### DIFF
--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/registration/impl/FcmFirebaseConfigResolver.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/registration/impl/FcmFirebaseConfigResolver.kt
@@ -1,0 +1,164 @@
+package com.onesignal.notifications.internal.registration.impl
+
+/**
+ * Thrown when FCM registration cannot proceed because there is no single Firebase
+ * project whose sender id, project id, application id, and API key all belong
+ * together. Callers map this to [com.onesignal.user.internal.subscriptions.SubscriptionStatus.INVALID_FCM_SENDER_ID].
+ */
+internal class InvalidFcmProjectException(message: String) : Exception(message)
+
+/**
+ * Client-side Firebase project credentials used to register for FCM.
+ *
+ * Google requires the sender id, project id, application id, and API key to belong
+ * to the same Firebase project. FCM token APIs use the project in these fields, not
+ * the sender id alone — mixing a dashboard sender with OneSignal's shared project
+ * (`onesignal-shared-public` / `754795614042`) mints a token the customer's FCM v1
+ * credentials cannot send to, which the backend reports as Invalid Google Project
+ * Number (`-6`).
+ */
+internal data class FcmProjectCredentials(
+    val senderId: String,
+    val projectId: String,
+    val applicationId: String,
+    val apiKey: String,
+) {
+    val isComplete: Boolean
+        get() =
+            senderId.isNotBlank() &&
+                projectId.isNotBlank() &&
+                applicationId.isNotBlank() &&
+                apiKey.isNotBlank()
+
+    /**
+     * Project number embedded in a Firebase application id (`1:{number}:{platform}:{hash}`).
+     * Null when the id is missing or not in that form.
+     */
+    val projectNumber: String?
+        get() = projectNumberFromApplicationId(applicationId)
+
+    companion object {
+        fun projectNumberFromApplicationId(applicationId: String): String? {
+            val parts = applicationId.split(":")
+            val number = parts.getOrNull(1) ?: return null
+            return number.takeIf { it.isNotEmpty() && it.all(Char::isDigit) }
+        }
+    }
+}
+
+internal data class FcmFirebaseConfig(
+    val credentials: FcmProjectCredentials,
+    val source: Source,
+    val reuseDefaultApp: Boolean,
+) {
+    enum class Source {
+        /**
+         * Host app's default [com.google.firebase.FirebaseApp], initialized from
+         * `google-services.json`.
+         */
+        GOOGLE_SERVICES,
+
+        /** Complete `fcm` object from `android_params.js` for the customer's project. */
+        BACKEND,
+
+        /**
+         * OneSignal's shared public Firebase project. Only used when the dashboard
+         * sender id is that shared project's own sender — never mixed with a
+         * customer sender id.
+         */
+        SHARED_DEFAULT,
+    }
+}
+
+/**
+ * OneSignal's legacy shared public Firebase project. FCM token APIs
+ * use these project fields and ignore a mismatched dashboard sender, so they
+ * must only be selected when the dashboard sender is this project's sender
+ * (`754795614042`).
+ */
+internal object FcmSharedProject {
+    const val PROJECT_ID = "onesignal-shared-public"
+    const val SENDER_ID = "754795614042"
+    const val APPLICATION_ID = "1:754795614042:android:c682b8144a8dd52bc1ad63"
+
+    fun isShared(credentials: FcmProjectCredentials): Boolean {
+        return credentials.projectId == PROJECT_ID ||
+            credentials.projectNumber == SENDER_ID
+    }
+}
+
+/**
+ * Picks a single consistent Firebase project for FCM registration, or null when
+ * none of the sources agree with the dashboard sender.
+ *
+ * Preference order:
+ * 1. Host `google-services.json` when it is complete and compatible with the dashboard.
+ * 2. Backend `fcm` params when they are a complete *customer* project compatible with the dashboard.
+ * 3. OneSignal's shared project, only when the dashboard sender is the shared project's sender.
+ *
+ * A missing dashboard sender is compatible with a customer google-services / backend
+ * project (those supply the sender). It is not compatible with the shared fallback —
+ * that path is what used to create a subscription that did not care about sender id.
+ */
+internal object FcmFirebaseConfigResolver {
+    fun resolve(
+        dashboardSenderId: String?,
+        defaultApp: FcmProjectCredentials?,
+        backend: FcmProjectCredentials?,
+        sharedDefault: FcmProjectCredentials,
+    ): FcmFirebaseConfig? {
+        val dashboard = normalizeSender(dashboardSenderId)
+
+        val matchingDefaultApp =
+            defaultApp?.takeIf { it.isComplete && compatibleWithDashboard(it, dashboard) }
+        val matchingBackend =
+            backend?.takeIf {
+                it.isComplete &&
+                    !FcmSharedProject.isShared(it) &&
+                    compatibleWithDashboard(it, dashboard)
+            }
+        val useShared = dashboard == FcmSharedProject.SENDER_ID && sharedDefault.isComplete
+
+        return when {
+            matchingDefaultApp != null ->
+                FcmFirebaseConfig(
+                    credentials = matchingDefaultApp,
+                    source = FcmFirebaseConfig.Source.GOOGLE_SERVICES,
+                    reuseDefaultApp = true,
+                )
+            matchingBackend != null ->
+                FcmFirebaseConfig(
+                    credentials = matchingBackend,
+                    source = FcmFirebaseConfig.Source.BACKEND,
+                    reuseDefaultApp = false,
+                )
+            useShared ->
+                FcmFirebaseConfig(
+                    credentials = sharedDefault,
+                    source = FcmFirebaseConfig.Source.SHARED_DEFAULT,
+                    reuseDefaultApp = false,
+                )
+            else -> null
+        }
+    }
+
+    /**
+     * Compatible when there is no dashboard sender (the credentials supply it) or when
+     * the credentials' sender and application-id project number both match the dashboard.
+     */
+    internal fun compatibleWithDashboard(
+        credentials: FcmProjectCredentials,
+        dashboardSenderId: String?,
+    ): Boolean {
+        val fromAppId = credentials.projectNumber
+        return dashboardSenderId == null ||
+            (
+                credentials.senderId == dashboardSenderId &&
+                    (fromAppId == null || fromAppId == dashboardSenderId)
+                )
+    }
+
+    internal fun normalizeSender(senderId: String?): String? {
+        return senderId?.trim()?.takeIf { it.isNotEmpty() }
+    }
+}

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorAbstractGoogle.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorAbstractGoogle.kt
@@ -61,17 +61,15 @@ internal abstract class PushRegistratorAbstractGoogle(
             return IPushRegistrator.RegisterResult(null, SubscriptionStatus.MISSING_FIREBASE_FCM_LIBRARY)
         }
 
-        return if (!isValidProjectNumber(_configModelStore.model.googleProjectNumber)) {
+        val dashboardSenderId = _configModelStore.model.googleProjectNumber ?: ""
+        if (!isValidProjectNumber(dashboardSenderId)) {
             Logging.warn(
-                "Missing Google Project number!\nPlease enter a Google Project number / Sender ID on under App Settings > Android > Configuration on the OneSignal dashboard.",
+                "Missing or invalid Google Project number from the OneSignal dashboard. " +
+                    "FCM registration will use this app's google-services.json or backend Firebase " +
+                    "credentials when they form a complete project.",
             )
-            IPushRegistrator.RegisterResult(
-                null,
-                SubscriptionStatus.INVALID_FCM_SENDER_ID,
-            )
-        } else {
-            internalRegisterForPush(_configModelStore.model.googleProjectNumber!!)
         }
+        return internalRegisterForPush(dashboardSenderId)
     }
 
     override suspend fun fireCallback(id: String?) {
@@ -131,6 +129,8 @@ internal abstract class PushRegistratorAbstractGoogle(
                 registrationId,
                 SubscriptionStatus.SUBSCRIBED,
             )
+        } catch (e: InvalidFcmProjectException) {
+            return invalidFcmProjectResult(e)
         } catch (e: IOException) {
             val pushStatus: SubscriptionStatus = pushStatusFromThrowable(e)
             val exceptionMessage: String? = AndroidUtils.getRootCauseMessage(e)
@@ -165,6 +165,14 @@ internal abstract class PushRegistratorAbstractGoogle(
         }
 
         return null
+    }
+
+    private fun invalidFcmProjectResult(e: InvalidFcmProjectException): IPushRegistrator.RegisterResult {
+        Logging.warn(e.message ?: "Missing Google Project number!")
+        return IPushRegistrator.RegisterResult(
+            null,
+            SubscriptionStatus.INVALID_FCM_SENDER_ID,
+        )
     }
 
     private fun pushStatusFromThrowable(throwable: Throwable): SubscriptionStatus {

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorFCM.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorFCM.kt
@@ -1,5 +1,6 @@
 package com.onesignal.notifications.internal.registration.impl
 
+import android.content.Context
 import android.util.Base64
 import com.google.android.gms.tasks.Tasks
 import com.google.firebase.FirebaseApp
@@ -8,6 +9,7 @@ import com.google.firebase.messaging.FirebaseMessaging
 import com.onesignal.core.internal.application.IApplicationService
 import com.onesignal.core.internal.config.ConfigModelStore
 import com.onesignal.core.internal.device.IDeviceService
+import com.onesignal.debug.internal.logging.Logging
 import java.util.concurrent.ExecutionException
 
 internal class PushRegistratorFCM(
@@ -15,50 +17,77 @@ internal class PushRegistratorFCM(
     val _applicationService: IApplicationService,
     upgradePrompt: GooglePlayServicesUpgradePrompt,
     deviceService: IDeviceService,
+    private val defaultFirebaseApp: (Context) -> FirebaseApp? = { hostDefaultFirebaseApp(it) },
 ) : PushRegistratorAbstractGoogle(deviceService, _configModelStore, upgradePrompt) {
     companion object {
         private const val FCM_APP_NAME = "ONESIGNAL_SDK_FCM_APP_NAME"
 
-        // project_info.project_id
-        private const val FCM_DEFAULT_PROJECT_ID = "onesignal-shared-public"
-
-        // client.client_info.mobilesdk_app_id
-        private const val FCM_DEFAULT_APP_ID = "1:754795614042:android:c682b8144a8dd52bc1ad63"
-
-        // client.api_key.current_key
+        // client.api_key.current_key from OneSignal's shared public google-services.json
         private const val FCM_DEFAULT_API_KEY_BASE64 = "QUl6YVN5QW5UTG41LV80TWMyYTJQLWRLVWVFLWFCdGd5Q3JqbFlV"
+
+        /**
+         * The host app's default Firebase app, created from `google-services.json` when present.
+         *
+         * Prefer a read-only lookup of an already-initialized default app (FirebaseInitProvider
+         * or the host app). Only call [FirebaseApp.initializeApp] with a [Context] when that
+         * lookup fails: that path reads the string resources the google-services Gradle plugin
+         * generated. If those resources are missing it returns null.
+         */
+        internal fun hostDefaultFirebaseApp(context: Context): FirebaseApp? {
+            try {
+                return FirebaseApp.getInstance()
+            } catch (_: IllegalStateException) {
+                // Default app not initialized yet.
+            }
+            return try {
+                FirebaseApp.initializeApp(context)
+            } catch (e: IllegalStateException) {
+                Logging.debug("Unable to initialize the default FirebaseApp from google-services.json", e)
+                FirebaseApp.getApps(context).firstOrNull { it.name == FirebaseApp.DEFAULT_APP_NAME }
+            }
+        }
+
+        internal fun credentialsFrom(options: FirebaseOptions?): FcmProjectCredentials? {
+            if (options == null) return null
+            val credentials =
+                FcmProjectCredentials(
+                    senderId = options.gcmSenderId.orEmpty(),
+                    projectId = options.projectId.orEmpty(),
+                    applicationId = options.applicationId,
+                    apiKey = options.apiKey,
+                )
+            return credentials.takeIf { it.isComplete }
+        }
+
+        internal fun sharedDefaultCredentials(): FcmProjectCredentials {
+            val defaultApiKey = String(Base64.decode(FCM_DEFAULT_API_KEY_BASE64, Base64.DEFAULT))
+            return FcmProjectCredentials(
+                senderId = FcmSharedProject.SENDER_ID,
+                projectId = FcmSharedProject.PROJECT_ID,
+                applicationId = FcmSharedProject.APPLICATION_ID,
+                apiKey = defaultApiKey,
+            )
+        }
     }
 
-    private val projectId: String
-    private val appId: String
-    private val apiKey: String
-
+    private val firebaseLock = Any()
     private var firebaseApp: FirebaseApp? = null
+
     override val providerName: String
         get() = "FCM"
 
-    init {
-        val fcpParams = _configModelStore.model.fcmParams
-
-        this.projectId = fcpParams.projectId ?: FCM_DEFAULT_PROJECT_ID
-        this.appId = fcpParams.appId ?: FCM_DEFAULT_APP_ID
-        val defaultApiKey = String(Base64.decode(FCM_DEFAULT_API_KEY_BASE64, Base64.DEFAULT))
-        this.apiKey = fcpParams.apiKey ?: defaultApiKey
-    }
-
-    @Throws(ExecutionException::class, InterruptedException::class)
+    @Throws(ExecutionException::class, InterruptedException::class, InvalidFcmProjectException::class)
     override suspend fun getToken(senderId: String): String {
-        initFirebaseApp(senderId)
-        return getTokenWithClassFirebaseMessaging()
+        val app = initFirebaseApp(senderId)
+        return getTokenWithClassFirebaseMessaging(app)
     }
 
     @Throws(ExecutionException::class, InterruptedException::class)
-    private fun getTokenWithClassFirebaseMessaging(): String {
-        // We use firebaseApp.get(FirebaseMessaging.class) instead of FirebaseMessaging.getInstance()
-        //   as the latter uses the default Firebase app. We need to use a custom Firebase app as
-        //   the senderId is provided at runtime.
-        val fcmInstance = firebaseApp!!.get(FirebaseMessaging::class.java)
-        // FirebaseMessaging.getToken API was introduced in firebase-messaging:21.0.0
+    private fun getTokenWithClassFirebaseMessaging(app: FirebaseApp): String {
+        // Use firebaseApp.get(FirebaseMessaging.class) instead of FirebaseMessaging.getInstance()
+        // so registration is against the project we resolved, not whatever default app the host
+        // happens to have.
+        val fcmInstance = app.get(FirebaseMessaging::class.java)
         val tokenTask = fcmInstance.token
         try {
             return Tasks.await(tokenTask)
@@ -67,16 +96,146 @@ internal class PushRegistratorFCM(
         }
     }
 
-    private fun initFirebaseApp(senderId: String) {
-        if (firebaseApp != null) return
-        val firebaseOptions =
-            FirebaseOptions
-                .Builder()
-                .setGcmSenderId(senderId)
-                .setApplicationId(appId)
-                .setApiKey(apiKey)
-                .setProjectId(projectId)
-                .build()
-        firebaseApp = FirebaseApp.initializeApp(_applicationService.appContext, firebaseOptions, FCM_APP_NAME)
+    private fun initFirebaseApp(dashboardSenderId: String): FirebaseApp {
+        synchronized(firebaseLock) {
+            val context = _applicationService.appContext
+            val hostApp = defaultFirebaseApp(context)
+            val hostCredentials = credentialsFrom(hostApp?.options)
+            logIfHostSenderMismatches(dashboardSenderId, hostCredentials)
+
+            val resolved =
+                FcmFirebaseConfigResolver.resolve(
+                    dashboardSenderId = dashboardSenderId,
+                    defaultApp = hostCredentials,
+                    backend = backendCredentials(dashboardSenderId),
+                    sharedDefault = sharedDefaultCredentials(),
+                ) ?: throw InvalidFcmProjectException(missingProjectMessage(dashboardSenderId))
+
+            logResolvedConfig(resolved)
+
+            val current = firebaseApp
+            val app =
+                when {
+                    current != null && credentialsMatch(current.options, resolved.credentials) ->
+                        current
+                    resolved.reuseDefaultApp -> {
+                        val host =
+                            hostApp
+                                ?: throw InvalidFcmProjectException(missingProjectMessage(dashboardSenderId))
+                        deleteNamedAppIfPresent(current)
+                        host
+                    }
+                    else -> {
+                        deleteNamedAppIfPresent(current)
+                        FirebaseApp.initializeApp(
+                            context,
+                            resolved.credentials.toFirebaseOptions(),
+                            FCM_APP_NAME,
+                        )
+                    }
+                }
+            firebaseApp = app
+            return app
+        }
     }
+
+    private fun deleteNamedAppIfPresent(current: FirebaseApp?) {
+        if (current != null && current.name == FCM_APP_NAME) {
+            current.delete()
+            firebaseApp = null
+        }
+    }
+
+    private fun backendCredentials(dashboardSenderId: String): FcmProjectCredentials? {
+        val fcmParams = _configModelStore.model.fcmParams
+        val projectId = fcmParams.projectId
+        val appId = fcmParams.appId
+        val apiKey = fcmParams.apiKey
+        if (projectId.isNullOrBlank() || appId.isNullOrBlank() || apiKey.isNullOrBlank()) {
+            return null
+        }
+        val senderFromAppId = FcmProjectCredentials.projectNumberFromApplicationId(appId)
+        val dashboard = FcmFirebaseConfigResolver.normalizeSender(dashboardSenderId)
+        val senderId =
+            when {
+                dashboard != null && (senderFromAppId == null || senderFromAppId == dashboard) -> dashboard
+                senderFromAppId != null -> senderFromAppId
+                else -> dashboard ?: ""
+            }
+        return FcmProjectCredentials(
+            senderId = senderId,
+            projectId = projectId,
+            applicationId = appId,
+            apiKey = apiKey,
+        )
+    }
+
+    private fun logIfHostSenderMismatches(
+        dashboardSenderId: String,
+        hostCredentials: FcmProjectCredentials?,
+    ) {
+        val dashboard = FcmFirebaseConfigResolver.normalizeSender(dashboardSenderId) ?: return
+        if (hostCredentials == null || hostCredentials.senderId == dashboard) return
+        Logging.warn(
+            "google-services.json sender id ${hostCredentials.senderId} does not match the " +
+                "OneSignal dashboard sender id $dashboard. FCM will not use the host " +
+                "Firebase project until they match. Point both at the same Firebase project.",
+        )
+    }
+
+    private fun logResolvedConfig(resolved: FcmFirebaseConfig) {
+        val credentials = resolved.credentials
+        when (resolved.source) {
+            FcmFirebaseConfig.Source.GOOGLE_SERVICES ->
+                Logging.info(
+                    "FCM registration is using this app's google-services.json " +
+                        "(project=${credentials.projectId}, sender=${credentials.senderId}).",
+                )
+            FcmFirebaseConfig.Source.BACKEND ->
+                Logging.info(
+                    "FCM registration is using Firebase credentials from OneSignal " +
+                        "(project=${credentials.projectId}, sender=${credentials.senderId}).",
+                )
+            FcmFirebaseConfig.Source.SHARED_DEFAULT ->
+                Logging.info(
+                    "FCM registration is using OneSignal's shared Firebase project " +
+                        "(${credentials.projectId} / ${credentials.senderId}).",
+                )
+        }
+    }
+
+    private fun missingProjectMessage(dashboardSenderId: String): String {
+        val dashboard = FcmFirebaseConfigResolver.normalizeSender(dashboardSenderId)
+        return if (dashboard == null) {
+            "Missing Google Project number!\n" +
+                "Please enter a Google Project number / Sender ID under App Settings > Android > " +
+                "Configuration on the OneSignal dashboard, or add this app's google-services.json " +
+                "so FCM registration uses your Firebase project."
+        } else {
+            "FCM registration cannot mix sender id $dashboard with OneSignal's shared Firebase " +
+                "project (${FcmSharedProject.PROJECT_ID} / ${FcmSharedProject.SENDER_ID}). " +
+                "Add this app's google-services.json (same sender id as the OneSignal dashboard) " +
+                "or complete Android FCM configuration on the dashboard so tokens belong to your project."
+        }
+    }
+}
+
+internal fun FcmProjectCredentials.toFirebaseOptions(): FirebaseOptions {
+    return FirebaseOptions
+        .Builder()
+        .setGcmSenderId(senderId)
+        .setApplicationId(applicationId)
+        .setApiKey(apiKey)
+        .setProjectId(projectId)
+        .build()
+}
+
+internal fun credentialsMatch(
+    options: FirebaseOptions,
+    credentials: FcmProjectCredentials,
+): Boolean {
+    return options.gcmSenderId == credentials.senderId &&
+        options.projectId == credentials.projectId &&
+        options.applicationId == credentials.applicationId &&
+        options.apiKey == credentials.apiKey
 }

--- a/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/registration/impl/FcmFirebaseConfigResolverTests.kt
+++ b/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/registration/impl/FcmFirebaseConfigResolverTests.kt
@@ -1,0 +1,236 @@
+package com.onesignal.notifications.internal.registration.impl
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+private const val DASHBOARD_SENDER_ID = "388536902528"
+private const val SHARED_SENDER_ID = FcmSharedProject.SENDER_ID
+
+private fun credentials(
+    senderId: String = DASHBOARD_SENDER_ID,
+    projectId: String = "customer-project",
+    applicationId: String = "1:$senderId:android:abc",
+    apiKey: String = "AIza-customer",
+) = FcmProjectCredentials(senderId, projectId, applicationId, apiKey)
+
+private val sharedDefault =
+    credentials(
+        senderId = SHARED_SENDER_ID,
+        projectId = FcmSharedProject.PROJECT_ID,
+        applicationId = FcmSharedProject.APPLICATION_ID,
+        apiKey = "AIza-shared",
+    )
+
+class FcmFirebaseConfigResolverTests : FunSpec({
+    test("prefers the host google-services.json FirebaseApp when its sender id matches the dashboard") {
+        val host = credentials()
+        val backend = credentials(projectId = "backend-project")
+
+        val resolved =
+            FcmFirebaseConfigResolver.resolve(
+                dashboardSenderId = DASHBOARD_SENDER_ID,
+                defaultApp = host,
+                backend = backend,
+                sharedDefault = sharedDefault,
+            )
+
+        resolved!!.source shouldBe FcmFirebaseConfig.Source.GOOGLE_SERVICES
+        resolved.reuseDefaultApp shouldBe true
+        resolved.credentials shouldBe host
+    }
+
+    test("uses host google-services.json when the dashboard sender id is missing") {
+        val host = credentials()
+
+        val resolved =
+            FcmFirebaseConfigResolver.resolve(
+                dashboardSenderId = null,
+                defaultApp = host,
+                backend = null,
+                sharedDefault = sharedDefault,
+            )
+
+        resolved!!.source shouldBe FcmFirebaseConfig.Source.GOOGLE_SERVICES
+        resolved.credentials shouldBe host
+    }
+
+    test("does not use the host FirebaseApp when its sender id does not match the dashboard") {
+        val host = credentials(senderId = SHARED_SENDER_ID)
+        val backend = credentials(projectId = "backend-project")
+
+        val resolved =
+            FcmFirebaseConfigResolver.resolve(
+                dashboardSenderId = DASHBOARD_SENDER_ID,
+                defaultApp = host,
+                backend = backend,
+                sharedDefault = sharedDefault,
+            )
+
+        resolved!!.source shouldBe FcmFirebaseConfig.Source.BACKEND
+        resolved.reuseDefaultApp shouldBe false
+        resolved.credentials shouldBe backend
+    }
+
+    test("does not use incomplete host Firebase options") {
+        val host = credentials(projectId = " ")
+        val backend = credentials(projectId = "backend-project")
+
+        val resolved =
+            FcmFirebaseConfigResolver.resolve(
+                dashboardSenderId = DASHBOARD_SENDER_ID,
+                defaultApp = host,
+                backend = backend,
+                sharedDefault = sharedDefault,
+            )
+
+        resolved!!.source shouldBe FcmFirebaseConfig.Source.BACKEND
+        resolved.credentials shouldBe backend
+    }
+
+    test("uses complete backend FCM params when google-services.json is absent") {
+        val backend = credentials(projectId = "backend-project")
+
+        val resolved =
+            FcmFirebaseConfigResolver.resolve(
+                dashboardSenderId = DASHBOARD_SENDER_ID,
+                defaultApp = null,
+                backend = backend,
+                sharedDefault = sharedDefault,
+            )
+
+        resolved!!.source shouldBe FcmFirebaseConfig.Source.BACKEND
+        resolved.reuseDefaultApp shouldBe false
+        resolved.credentials shouldBe backend
+    }
+
+    test("uses backend FCM params when the dashboard sender id is missing") {
+        val backend = credentials(projectId = "backend-project")
+
+        val resolved =
+            FcmFirebaseConfigResolver.resolve(
+                dashboardSenderId = "",
+                defaultApp = null,
+                backend = backend,
+                sharedDefault = sharedDefault,
+            )
+
+        resolved!!.source shouldBe FcmFirebaseConfig.Source.BACKEND
+        resolved.credentials shouldBe backend
+    }
+
+    test("does not use backend credentials whose application id belongs to a different sender") {
+        val backend =
+            credentials(
+                senderId = DASHBOARD_SENDER_ID,
+                applicationId = "1:$SHARED_SENDER_ID:android:mixed",
+            )
+
+        val resolved =
+            FcmFirebaseConfigResolver.resolve(
+                dashboardSenderId = DASHBOARD_SENDER_ID,
+                defaultApp = null,
+                backend = backend,
+                sharedDefault = sharedDefault,
+            )
+
+        resolved shouldBe null
+    }
+
+    test("does not treat the shared public project as backend credentials") {
+        val backend = sharedDefault.copy(senderId = DASHBOARD_SENDER_ID)
+
+        val resolved =
+            FcmFirebaseConfigResolver.resolve(
+                dashboardSenderId = DASHBOARD_SENDER_ID,
+                defaultApp = null,
+                backend = backend,
+                sharedDefault = sharedDefault,
+            )
+
+        resolved shouldBe null
+    }
+
+    test("does not use incomplete backend FCM params") {
+        val backend = credentials(apiKey = "")
+
+        val resolved =
+            FcmFirebaseConfigResolver.resolve(
+                dashboardSenderId = DASHBOARD_SENDER_ID,
+                defaultApp = null,
+                backend = backend,
+                sharedDefault = sharedDefault,
+            )
+
+        resolved shouldBe null
+    }
+
+    test("does not mix a customer dashboard sender with OneSignal's shared Firebase project") {
+        val resolved =
+            FcmFirebaseConfigResolver.resolve(
+                dashboardSenderId = DASHBOARD_SENDER_ID,
+                defaultApp = null,
+                backend = null,
+                sharedDefault = sharedDefault,
+            )
+
+        resolved shouldBe null
+    }
+
+    test("uses the shared Firebase project only when the dashboard sender is the shared sender") {
+        val resolved =
+            FcmFirebaseConfigResolver.resolve(
+                dashboardSenderId = SHARED_SENDER_ID,
+                defaultApp = null,
+                backend = null,
+                sharedDefault = sharedDefault,
+            )
+
+        resolved!!.source shouldBe FcmFirebaseConfig.Source.SHARED_DEFAULT
+        resolved.reuseDefaultApp shouldBe false
+        resolved.credentials shouldBe sharedDefault
+    }
+
+    test("does not fall back to the shared project when the dashboard sender is missing") {
+        val resolved =
+            FcmFirebaseConfigResolver.resolve(
+                dashboardSenderId = null,
+                defaultApp = null,
+                backend = null,
+                sharedDefault = sharedDefault,
+            )
+
+        resolved shouldBe null
+    }
+
+    test("treats blank credential fields as incomplete") {
+        credentials(senderId = " ").isComplete shouldBe false
+        credentials(projectId = "").isComplete shouldBe false
+        credentials(applicationId = " ").isComplete shouldBe false
+        credentials(apiKey = "").isComplete shouldBe false
+        credentials().isComplete shouldBe true
+    }
+
+    test("extracts the project number from a Firebase application id") {
+        FcmProjectCredentials.projectNumberFromApplicationId("1:388536902528:android:abc") shouldBe "388536902528"
+        FcmProjectCredentials.projectNumberFromApplicationId("not-an-app-id") shouldBe null
+        FcmProjectCredentials.projectNumberFromApplicationId("") shouldBe null
+        credentials().projectNumber shouldBe DASHBOARD_SENDER_ID
+    }
+
+    test("recognizes OneSignal's shared public project") {
+        FcmSharedProject.isShared(sharedDefault) shouldBe true
+        FcmSharedProject.isShared(credentials()) shouldBe false
+        FcmSharedProject.isShared(
+            credentials(applicationId = "1:$SHARED_SENDER_ID:android:other"),
+        ) shouldBe true
+    }
+
+    test("compatibleWithDashboard allows any complete customer project when the dashboard sender is absent") {
+        FcmFirebaseConfigResolver.compatibleWithDashboard(credentials(), null) shouldBe true
+        FcmFirebaseConfigResolver.compatibleWithDashboard(credentials(), DASHBOARD_SENDER_ID) shouldBe true
+        FcmFirebaseConfigResolver.compatibleWithDashboard(
+            credentials(senderId = SHARED_SENDER_ID),
+            DASHBOARD_SENDER_ID,
+        ) shouldBe false
+    }
+})

--- a/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorFCMTests.kt
+++ b/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorFCMTests.kt
@@ -1,0 +1,470 @@
+package com.onesignal.notifications.internal.registration.impl
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import br.com.colman.kotest.android.extensions.robolectric.RobolectricTest
+import com.google.android.gms.tasks.Task
+import com.google.android.gms.tasks.Tasks
+import com.google.firebase.FirebaseApp
+import com.google.firebase.FirebaseOptions
+import com.google.firebase.messaging.FirebaseMessaging
+import com.onesignal.core.internal.application.IApplicationService
+import com.onesignal.core.internal.config.ConfigModelStore
+import com.onesignal.core.internal.device.IDeviceService
+import com.onesignal.debug.LogLevel
+import com.onesignal.debug.internal.logging.Logging
+import com.onesignal.mocks.MockHelper
+import com.onesignal.user.internal.subscriptions.SubscriptionStatus
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.mockk.CapturingSlot
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.runs
+import io.mockk.slot
+import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+private const val SENDER_ID = "388536902528"
+private const val HOST_PROJECT_ID = "customer-project"
+private const val HOST_APP_ID = "1:388536902528:android:abc"
+private const val HOST_API_KEY = "AIza-customer"
+
+private fun firebaseOptions(
+    senderId: String = SENDER_ID,
+    projectId: String = HOST_PROJECT_ID,
+    applicationId: String = HOST_APP_ID,
+    apiKey: String = HOST_API_KEY,
+): FirebaseOptions {
+    return FirebaseOptions
+        .Builder()
+        .setGcmSenderId(senderId)
+        .setProjectId(projectId)
+        .setApplicationId(applicationId)
+        .setApiKey(apiKey)
+        .build()
+}
+
+private fun defaultApp(
+    senderId: String = SENDER_ID,
+    messaging: FirebaseMessaging? = null,
+): FirebaseApp {
+    val app = mockk<FirebaseApp>()
+    every { app.name } returns FirebaseApp.DEFAULT_APP_NAME
+    every { app.options } returns firebaseOptions(senderId = senderId)
+    if (messaging != null) {
+        every { app.get(FirebaseMessaging::class.java) } returns messaging
+    }
+    return app
+}
+
+private fun namedApp(messaging: FirebaseMessaging): FirebaseApp {
+    val app = mockk<FirebaseApp>()
+    every { app.name } returns "ONESIGNAL_SDK_FCM_APP_NAME"
+    every { app.get(FirebaseMessaging::class.java) } returns messaging
+    every { app.options } returns firebaseOptions()
+    every { app.delete() } just runs
+    return app
+}
+
+private fun applicationService(): IApplicationService {
+    val applicationService = mockk<IApplicationService>()
+    every { applicationService.appContext } returns ApplicationProvider.getApplicationContext<Context>()
+    return applicationService
+}
+
+private fun deviceService(
+    hasFcm: Boolean = true,
+    gmsEnabled: Boolean = true,
+) = MockHelper.deviceService().also {
+    every { it.hasFCMLibrary } returns hasFcm
+    every { it.isGMSInstalledAndEnabled } returns gmsEnabled
+    every { it.isAndroidDeviceType } returns true
+}
+
+private fun registrator(
+    legacyToken: Task<String>,
+    hostApp: FirebaseApp? = null,
+    captureNamedOptions: CapturingSlot<FirebaseOptions>? = null,
+    configStore: ConfigModelStore = MockHelper.configModelStore(),
+    device: IDeviceService = deviceService(),
+): PushRegistratorFCM {
+    val messaging = mockk<FirebaseMessaging>()
+    every { messaging.token } returns legacyToken
+    val named = namedApp(messaging)
+
+    mockkStatic(FirebaseApp::class)
+    if (captureNamedOptions != null) {
+        every {
+            FirebaseApp.initializeApp(any<Context>(), capture(captureNamedOptions), any<String>())
+        } returns named
+    } else {
+        every {
+            FirebaseApp.initializeApp(any<Context>(), any<FirebaseOptions>(), any<String>())
+        } returns named
+    }
+
+    return PushRegistratorFCM(
+        configStore,
+        applicationService(),
+        mockk(relaxed = true),
+        device,
+        defaultFirebaseApp = { hostApp },
+    )
+}
+
+@RobolectricTest
+class PushRegistratorFCMTests : FunSpec({
+    beforeEach {
+        Logging.logLevel = LogLevel.NONE
+    }
+
+    afterEach { unmockkAll() }
+
+    test("reuses the host FirebaseApp when google-services.json matches the dashboard sender id") {
+        val hostMessaging = mockk<FirebaseMessaging>()
+        every { hostMessaging.token } returns Tasks.forResult("host-token")
+        val hostApp = defaultApp(messaging = hostMessaging)
+        val registrator = registrator(legacyToken = Tasks.forResult("unused"), hostApp = hostApp)
+
+        val token = withContext(Dispatchers.IO) { registrator.getToken(SENDER_ID) }
+
+        token shouldBe "host-token"
+        verify(exactly = 0) { FirebaseApp.initializeApp(any<Context>(), any<FirebaseOptions>(), any<String>()) }
+    }
+
+    test("initializes a named FirebaseApp from backend FCM params when google-services.json is absent") {
+        val optionsSlot = slot<FirebaseOptions>()
+        val configStore =
+            MockHelper.configModelStore {
+                it.fcmParams.projectId = "backend-project"
+                it.fcmParams.appId = "1:388536902528:android:backend"
+                it.fcmParams.apiKey = "AIza-backend"
+            }
+        val registrator =
+            registrator(
+                legacyToken = Tasks.forResult("backend-token"),
+                hostApp = null,
+                captureNamedOptions = optionsSlot,
+                configStore = configStore,
+            )
+
+        val token = withContext(Dispatchers.IO) { registrator.getToken(SENDER_ID) }
+
+        token shouldBe "backend-token"
+        optionsSlot.captured.projectId shouldBe "backend-project"
+        optionsSlot.captured.gcmSenderId shouldBe SENDER_ID
+        optionsSlot.captured.applicationId shouldBe "1:388536902528:android:backend"
+        optionsSlot.captured.apiKey shouldBe "AIza-backend"
+    }
+
+    test("does not mint a token from the shared project when the dashboard sender belongs to a customer project") {
+        val registrator = registrator(legacyToken = Tasks.forResult("shared-token"), hostApp = null)
+
+        val thrown =
+            withContext(Dispatchers.IO) {
+                shouldThrow<InvalidFcmProjectException> { registrator.getToken(SENDER_ID) }
+            }
+
+        val message = thrown.message
+        message shouldContain "cannot mix sender id $SENDER_ID"
+        message shouldContain FcmSharedProject.PROJECT_ID
+        verify(exactly = 0) { FirebaseApp.initializeApp(any<Context>(), any<FirebaseOptions>(), any<String>()) }
+    }
+
+    test("uses OneSignal's shared Firebase project only when the dashboard sender is the shared sender") {
+        val optionsSlot = slot<FirebaseOptions>()
+        val registrator =
+            registrator(
+                legacyToken = Tasks.forResult("shared-token"),
+                hostApp = null,
+                captureNamedOptions = optionsSlot,
+            )
+
+        val token = withContext(Dispatchers.IO) { registrator.getToken(FcmSharedProject.SENDER_ID) }
+
+        token shouldBe "shared-token"
+        optionsSlot.captured.projectId shouldBe FcmSharedProject.PROJECT_ID
+        optionsSlot.captured.gcmSenderId shouldBe FcmSharedProject.SENDER_ID
+        optionsSlot.captured.applicationId shouldBe FcmSharedProject.APPLICATION_ID
+    }
+
+    test("does not reuse a host FirebaseApp whose sender id differs from the dashboard") {
+        val hostApp = defaultApp(senderId = "999999999999")
+        val registrator = registrator(legacyToken = Tasks.forResult("named-token"), hostApp = hostApp)
+
+        val thrown =
+            withContext(Dispatchers.IO) {
+                shouldThrow<InvalidFcmProjectException> { registrator.getToken(SENDER_ID) }
+            }
+
+        thrown.message shouldContain "cannot mix sender id $SENDER_ID"
+    }
+
+    test("initializes the FirebaseApp only once when credentials are unchanged") {
+        val hostMessaging = mockk<FirebaseMessaging>()
+        every { hostMessaging.token } returns Tasks.forResult("host-token")
+        val hostApp = defaultApp(messaging = hostMessaging)
+        val registrator = registrator(legacyToken = Tasks.forResult("unused"), hostApp = hostApp)
+
+        withContext(Dispatchers.IO) { registrator.getToken(SENDER_ID) }
+        val token = withContext(Dispatchers.IO) { registrator.getToken(SENDER_ID) }
+
+        token shouldBe "host-token"
+    }
+
+    test("maps FirebaseOptions into FCM project credentials") {
+        val credentials = PushRegistratorFCM.credentialsFrom(firebaseOptions())
+
+        credentials!!.senderId shouldBe SENDER_ID
+        credentials.projectId shouldBe HOST_PROJECT_ID
+        credentials.applicationId shouldBe HOST_APP_ID
+        credentials.apiKey shouldBe HOST_API_KEY
+    }
+
+    test("returns null credentials when FirebaseOptions are missing a sender id") {
+        val options =
+            FirebaseOptions
+                .Builder()
+                .setProjectId(HOST_PROJECT_ID)
+                .setApplicationId(HOST_APP_ID)
+                .setApiKey(HOST_API_KEY)
+                .build()
+
+        PushRegistratorFCM.credentialsFrom(options) shouldBe null
+        PushRegistratorFCM.credentialsFrom(null) shouldBe null
+    }
+
+    test("returns null credentials when FirebaseOptions are missing a project id") {
+        val options =
+            FirebaseOptions
+                .Builder()
+                .setGcmSenderId(SENDER_ID)
+                .setApplicationId(HOST_APP_ID)
+                .setApiKey(HOST_API_KEY)
+                .build()
+
+        PushRegistratorFCM.credentialsFrom(options) shouldBe null
+    }
+
+    test("reads backend FCM params at registration time rather than construction") {
+        val optionsSlot = slot<FirebaseOptions>()
+        val configStore = MockHelper.configModelStore()
+        val registrator =
+            registrator(
+                legacyToken = Tasks.forResult("late-backend-token"),
+                hostApp = null,
+                captureNamedOptions = optionsSlot,
+                configStore = configStore,
+            )
+
+        configStore.model.fcmParams.projectId = "late-backend-project"
+        configStore.model.fcmParams.appId = "1:388536902528:android:late"
+        configStore.model.fcmParams.apiKey = "AIza-late"
+
+        val token = withContext(Dispatchers.IO) { registrator.getToken(SENDER_ID) }
+
+        token shouldBe "late-backend-token"
+        optionsSlot.captured.projectId shouldBe "late-backend-project"
+    }
+
+    test("re-resolves Firebase credentials when backend params change after the first registration") {
+        val optionsSlot = slot<FirebaseOptions>()
+        val configStore =
+            MockHelper.configModelStore {
+                it.fcmParams.projectId = "backend-project-a"
+                it.fcmParams.appId = "1:388536902528:android:a"
+                it.fcmParams.apiKey = "AIza-a"
+            }
+        val messaging = mockk<FirebaseMessaging>()
+        every { messaging.token } returns Tasks.forResult("token-a") andThen Tasks.forResult("token-b")
+        val firstNamed = namedApp(messaging)
+        every { firstNamed.options } returns
+            firebaseOptions(
+                projectId = "backend-project-a",
+                applicationId = "1:388536902528:android:a",
+                apiKey = "AIza-a",
+            )
+
+        mockkStatic(FirebaseApp::class)
+        every {
+            FirebaseApp.initializeApp(any<Context>(), capture(optionsSlot), any<String>())
+        } returns firstNamed
+
+        val registrator =
+            PushRegistratorFCM(
+                configStore,
+                applicationService(),
+                mockk(relaxed = true),
+                deviceService(),
+                defaultFirebaseApp = { null },
+            )
+
+        withContext(Dispatchers.IO) { registrator.getToken(SENDER_ID) }
+
+        configStore.model.fcmParams.projectId = "backend-project-b"
+        configStore.model.fcmParams.appId = "1:388536902528:android:b"
+        configStore.model.fcmParams.apiKey = "AIza-b"
+
+        val token = withContext(Dispatchers.IO) { registrator.getToken(SENDER_ID) }
+
+        token shouldBe "token-b"
+        verify(exactly = 1) { firstNamed.delete() }
+        optionsSlot.captured.projectId shouldBe "backend-project-b"
+    }
+
+    test("hostDefaultFirebaseApp prefers an already-initialized default FirebaseApp") {
+        mockkStatic(FirebaseApp::class)
+        val app = mockk<FirebaseApp>()
+        every { FirebaseApp.getInstance() } returns app
+
+        val result =
+            PushRegistratorFCM.hostDefaultFirebaseApp(
+                ApplicationProvider.getApplicationContext(),
+            )
+
+        result shouldBe app
+        verify(exactly = 0) { FirebaseApp.initializeApp(any<Context>()) }
+    }
+
+    test("hostDefaultFirebaseApp reads google-services.json via FirebaseApp.initializeApp") {
+        mockkStatic(FirebaseApp::class)
+        val app = mockk<FirebaseApp>()
+        every { FirebaseApp.getInstance() } throws IllegalStateException("no default")
+        every { FirebaseApp.initializeApp(any<Context>()) } returns app
+
+        val result =
+            PushRegistratorFCM.hostDefaultFirebaseApp(
+                ApplicationProvider.getApplicationContext(),
+            )
+
+        result shouldBe app
+    }
+
+    test("hostDefaultFirebaseApp falls back to getApps when initializeApp throws") {
+        mockkStatic(FirebaseApp::class)
+        every { FirebaseApp.getInstance() } throws IllegalStateException("no default")
+        every { FirebaseApp.initializeApp(any<Context>()) } throws IllegalStateException("failed")
+        val app = mockk<FirebaseApp>()
+        every { app.name } returns FirebaseApp.DEFAULT_APP_NAME
+        every { FirebaseApp.getApps(any()) } returns listOf(app)
+
+        val result =
+            PushRegistratorFCM.hostDefaultFirebaseApp(
+                ApplicationProvider.getApplicationContext(),
+            )
+
+        result shouldBe app
+    }
+
+    test("hostDefaultFirebaseApp returns null when initializeApp throws and no default app exists") {
+        mockkStatic(FirebaseApp::class)
+        every { FirebaseApp.getInstance() } throws IllegalStateException("no default")
+        every { FirebaseApp.initializeApp(any<Context>()) } throws IllegalStateException("failed")
+        val named = mockk<FirebaseApp>()
+        every { named.name } returns "ONESIGNAL_SDK_FCM_APP_NAME"
+        every { FirebaseApp.getApps(any()) } returns listOf(named)
+
+        val result =
+            PushRegistratorFCM.hostDefaultFirebaseApp(
+                ApplicationProvider.getApplicationContext(),
+            )
+
+        result shouldBe null
+    }
+
+    test("ignores incomplete backend FCM params") {
+        val configStore =
+            MockHelper.configModelStore {
+                it.fcmParams.projectId = "backend-project"
+            }
+        val registrator =
+            registrator(
+                legacyToken = Tasks.forResult("shared-token"),
+                hostApp = null,
+                configStore = configStore,
+            )
+
+        withContext(Dispatchers.IO) {
+            shouldThrow<InvalidFcmProjectException> { registrator.getToken(SENDER_ID) }
+        }
+    }
+
+    test("registerForPush reports INVALID_FCM_SENDER_ID instead of subscribing via the shared project") {
+        val configStore =
+            MockHelper.configModelStore {
+                it.isInitializedWithRemote = true
+                it.googleProjectNumber = SENDER_ID
+            }
+        val registrator =
+            registrator(
+                legacyToken = Tasks.forResult("shared-token"),
+                hostApp = null,
+                configStore = configStore,
+            )
+
+        val result = withContext(Dispatchers.IO) { registrator.registerForPush() }
+
+        result.id shouldBe null
+        result.status shouldBe SubscriptionStatus.INVALID_FCM_SENDER_ID
+    }
+
+    test("registerForPush succeeds when google-services.json matches the dashboard sender") {
+        val hostMessaging = mockk<FirebaseMessaging>()
+        every { hostMessaging.token } returns Tasks.forResult("host-token")
+        val hostApp = defaultApp(messaging = hostMessaging)
+        val configStore =
+            MockHelper.configModelStore {
+                it.isInitializedWithRemote = true
+                it.googleProjectNumber = SENDER_ID
+            }
+        val registrator =
+            registrator(
+                legacyToken = Tasks.forResult("unused"),
+                hostApp = hostApp,
+                configStore = configStore,
+            )
+
+        val result = withContext(Dispatchers.IO) { registrator.registerForPush() }
+
+        result.id shouldBe "host-token"
+        result.status shouldBe SubscriptionStatus.SUBSCRIBED
+    }
+
+    test("registerForPush uses google-services.json when the dashboard sender is missing") {
+        val hostMessaging = mockk<FirebaseMessaging>()
+        every { hostMessaging.token } returns Tasks.forResult("host-token")
+        val hostApp = defaultApp(messaging = hostMessaging)
+        val configStore =
+            MockHelper.configModelStore {
+                it.isInitializedWithRemote = true
+                it.googleProjectNumber = null
+            }
+        val registrator =
+            registrator(
+                legacyToken = Tasks.forResult("unused"),
+                hostApp = hostApp,
+                configStore = configStore,
+            )
+
+        val result = withContext(Dispatchers.IO) { registrator.registerForPush() }
+
+        result.id shouldBe "host-token"
+        result.status shouldBe SubscriptionStatus.SUBSCRIBED
+    }
+
+    test("sharedDefaultCredentials uses the shared project's own sender rather than the dashboard sender") {
+        val credentials = PushRegistratorFCM.sharedDefaultCredentials()
+
+        credentials.senderId shouldBe FcmSharedProject.SENDER_ID
+        credentials.projectId shouldBe FcmSharedProject.PROJECT_ID
+        credentials.applicationId shouldBe FcmSharedProject.APPLICATION_ID
+        credentials.isComplete shouldBe true
+    }
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Description
## One Line Summary
Register Android FCM tokens against one consistent Firebase project so we stop minting shared-project tokens that the dashboard reports as Invalid Google Project Number (`-6`) or Never Subscribed.

## Details

### Motivation
`FirebaseMessaging.getToken()` uses the Firebase **project** in `FirebaseOptions` (application id / project id / API key), not `gcmSenderId`. The SDK was initializing its own `FirebaseApp` with:

- the customer's dashboard sender id
- OneSignal's shared public project (`onesignal-shared-public` / `754795614042`) when backend `fcm` params were missing **or snapshotted empty in the `PushRegistratorFCM` constructor** before `android_params.js` hydrated

That mixed config still produced a token (the shared project does not care about sender id), so a subscription was created. OneSignal then sends with the customer's FCM v1 credentials, the token's project does not match, and the dashboard shows **Invalid Google Project Number** (`notification_types = -6`) or **Never Subscribed**.

This is the SDK-5154 split of the google-services / consistent-project work from #2725, without the Firebase Installation ID / SDK-4946 path.

### Scope
FCM registration now picks **one** consistent project, in this order:

1. **Host `google-services.json`** — reuse the default `FirebaseApp` when it is complete and compatible with the dashboard sender (or when the dashboard sender is missing).
2. **Backend `fcm` params** from `android_params.js`, read at registration time (not constructor snapshot). Rejected when they are actually the shared public project, or when the application id's project number does not match the dashboard sender.
3. **OneSignal shared project** only when the dashboard sender **is** `754795614042`. A customer sender is no longer paired with shared credentials.

If none of those form a consistent project, registration returns `INVALID_FCM_SENDER_ID` instead of uploading a token from the shared project.

Also:

- Prefer a read-only `FirebaseApp.getInstance()` lookup before `initializeApp(context)`.
- Re-resolve on later `getToken()` calls so hydrated backend params can replace an earlier config (named `FirebaseApp` is deleted when credentials change).
- No Installation ID / `FirebaseMessaging.register()` path (that stays on SDK-4946).

No public API changes.

# Testing
## Unit testing
- `FcmFirebaseConfigResolverTests` covers host match/mismatch, missing dashboard sender, backend consistency (including mixed application id / shared project classified as backend), and refusing to mix a customer sender with the shared project.
- `PushRegistratorFCMTests` covers host reuse, backend params (including after construction and after a first registration), shared-project refusal for customer senders, `INVALID_FCM_SENDER_ID` from `registerForPush`, and `hostDefaultFirebaseApp` lookup.

`:OneSignal:notifications:testDebugUnitTest --tests com.onesignal.notifications.internal.registration.impl.*`, Spotless, and Detekt pass locally.

## Manual testing
Not run on a device in this environment. To verify on a device:

1. App with `google-services.json` whose sender matches the OneSignal dashboard — logs should say registration is using that project, and a push should arrive.
2. App without `google-services.json` but with complete Android FCM config on the dashboard — registration should use backend `fcm` params after `android_params.js` hydrates (including first session).
3. App with a customer dashboard sender and neither google-services nor backend `fcm` params — should **not** subscribe via `onesignal-shared-public`; status should be Invalid Google Project Number rather than a silent shared-project token.

# Affected code checklist
   - [x] Notifications
      - [ ] Display
      - [ ] Open
      - [x] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing — FCM registration uses a consistent Firebase project
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible — see Manual testing

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5523c11e-ecd9-4f56-9fce-3ecd38b6a09f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5523c11e-ecd9-4f56-9fce-3ecd38b6a09f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

