### PR TITLE
fix: [SDK-5167] split FID census into flag= and reg=

### DIFF
--- a/OneSignalSDK/onesignal/core/consumer-rules.pro
+++ b/OneSignalSDK/onesignal/core/consumer-rules.pro
@@ -37,3 +37,12 @@
 
 # Fallback "misconfigured" managers are reflectively constructed when an optional module is absent.
 -keepclassmembers @com.onesignal.core.internal.minification.KeepStub class * { <init>(...); }
+
+# FidEnv looks these up by name. Core has no compile-time call, so R8 would strip them.
+-keepclassmembers class com.google.firebase.messaging.FirebaseMessaging {
+    *** register();
+}
+-keepclassmembers class com.google.firebase.FirebaseApp {
+    *** getApps(android.content.Context);
+    *** getName();
+}

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/device/impl/FidEnv.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/device/impl/FidEnv.kt
@@ -71,6 +71,16 @@ internal fun dashboardSenderForCensus(
 ): String? =
     if (hydrated && senderAppId == appId) sender else null
 
+@Suppress("TooGenericExceptionCaught")
+internal fun hasPublicNoArgMethod(className: String, methodName: String): Boolean {
+    return try {
+        Class.forName(className).getMethod(methodName)
+        true
+    } catch (_: Throwable) {
+        false
+    }
+}
+
 internal class AndroidFidEnvReader(
     private val context: Context,
 ) {
@@ -131,15 +141,8 @@ internal class AndroidFidEnvReader(
     }
 
     // 25.1+ exposes register(); older libraries ignore the metadata and keep getToken().
-    @Suppress("TooGenericExceptionCaught")
-    private fun hasFirebaseMessagingRegisterApi(): Boolean {
-        return try {
-            Class.forName(FIREBASE_MESSAGING).getMethod("register")
-            true
-        } catch (_: Throwable) {
-            false
-        }
-    }
+    private fun hasFirebaseMessagingRegisterApi(): Boolean =
+        hasPublicNoArgMethod(FIREBASE_MESSAGING, "register")
 
     @Suppress("TooGenericExceptionCaught")
     private fun fidFlagFromMetadata(): Boolean {

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/device/impl/FidEnv.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/device/impl/FidEnv.kt
@@ -18,6 +18,7 @@ internal data class FidEnvSnapshot(
     val googleServices: Boolean,
     val agpVersion: String?,
     val fidFlag: Boolean,
+    val fidRegisterApi: Boolean,
     val defaultFirebaseApp: Boolean,
     val firebaseInitProvider: Boolean,
     val minSdk: Int?,
@@ -29,6 +30,7 @@ internal data class FidEnvSnapshot(
             "gs=${googleServices.toBit()}",
             "agp=${agpVersion.sanitized()}",
             "flag=${fidFlag.toBit()}",
+            "reg=${fidRegisterApi.toBit()}",
             "def=${defaultFirebaseApp.toBit()}",
             "prov=${firebaseInitProvider.toBit()}",
             "min=${minSdk?.toString() ?: "-"}",
@@ -61,11 +63,6 @@ internal fun senderMatch(
         else -> resourceSender == dashboardSender
     }
 
-internal fun fidRegistrationEnabled(
-    hasRegisterApi: Boolean,
-    manifestFlag: Boolean,
-): Boolean = hasRegisterApi && manifestFlag
-
 internal fun dashboardSenderForCensus(
     hydrated: Boolean,
     appId: String,
@@ -94,7 +91,8 @@ internal class AndroidFidEnvReader(
         return FidEnvSnapshot(
             googleServices = !googleAppId.isNullOrBlank(),
             agpVersion = readApkEntry(AGP_METADATA_PATH)?.let { parseAgpVersion(it) },
-            fidFlag = fidRegistrationEnabled(hasFirebaseMessagingRegisterApi(), fidFlagFromMetadata()),
+            fidFlag = fidFlagFromMetadata(),
+            fidRegisterApi = hasFirebaseMessagingRegisterApi(),
             defaultFirebaseApp = false,
             firebaseInitProvider = hasFirebaseInitProvider(),
             minSdk = minSdk(),

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/device/impl/FidEnv.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/device/impl/FidEnv.kt
@@ -61,6 +61,11 @@ internal fun senderMatch(
         else -> resourceSender == dashboardSender
     }
 
+internal fun fidRegistrationEnabled(
+    hasRegisterApi: Boolean,
+    manifestFlag: Boolean,
+): Boolean = hasRegisterApi && manifestFlag
+
 internal fun dashboardSenderForCensus(
     hydrated: Boolean,
     appId: String,
@@ -89,7 +94,7 @@ internal class AndroidFidEnvReader(
         return FidEnvSnapshot(
             googleServices = !googleAppId.isNullOrBlank(),
             agpVersion = readApkEntry(AGP_METADATA_PATH)?.let { parseAgpVersion(it) },
-            fidFlag = AndroidUtils.getManifestMetaBoolean(context, FID_FLAG),
+            fidFlag = fidRegistrationEnabled(hasFirebaseMessagingRegisterApi(), fidFlagFromMetadata()),
             defaultFirebaseApp = false,
             firebaseInitProvider = hasFirebaseInitProvider(),
             minSdk = minSdk(),
@@ -124,6 +129,31 @@ internal class AndroidFidEnvReader(
         ZipFile(sourceDir).use { zip ->
             val entry = zip.getEntry(path) ?: return null
             return zip.getInputStream(entry).bufferedReader().use { it.readText() }
+        }
+    }
+
+    // 25.1+ exposes register(); older libraries ignore the metadata and keep getToken().
+    @Suppress("TooGenericExceptionCaught")
+    private fun hasFirebaseMessagingRegisterApi(): Boolean {
+        return try {
+            Class.forName(FIREBASE_MESSAGING).getMethod("register")
+            true
+        } catch (_: Throwable) {
+            false
+        }
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private fun fidFlagFromMetadata(): Boolean {
+        return try {
+            val meta =
+                context.packageManager.getApplicationInfo(
+                    context.packageName,
+                    PackageManager.GET_META_DATA,
+                ).metaData ?: return false
+            meta.containsKey(FID_FLAG) && meta.getBoolean(FID_FLAG)
+        } catch (_: Throwable) {
+            false
         }
     }
 
@@ -170,6 +200,7 @@ internal class AndroidFidEnvReader(
         private const val FIREBASE_INIT_PROVIDER = "com.google.firebase.provider.FirebaseInitProvider"
         private const val AGP_METADATA_PATH = "META-INF/com/android/build/gradle/app-metadata.properties"
         private const val FIREBASE_APP = "com.google.firebase.FirebaseApp"
+        private const val FIREBASE_MESSAGING = "com.google.firebase.messaging.FirebaseMessaging"
         private const val DEFAULT_APP_NAME = "[DEFAULT]"
     }
 }

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/device/FidEnvReaderTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/device/FidEnvReaderTests.kt
@@ -2,6 +2,7 @@ package com.onesignal.core.internal.device
 
 import android.content.Context
 import android.os.Build
+import android.os.Bundle
 import androidx.test.core.app.ApplicationProvider
 import br.com.colman.kotest.android.extensions.robolectric.RobolectricTest
 import com.onesignal.common.AndroidUtils
@@ -42,11 +43,18 @@ class FidEnvReaderTests : FunSpec({
         snapshot.agpVersion shouldBe null
     }
 
+    test("fid flag stays off when metadata is set but FirebaseMessaging.register is absent") {
+        val info = context.applicationInfo
+        if (info.metaData == null) info.metaData = Bundle()
+        info.metaData.putBoolean("firebase_messaging_installation_id_enabled", true)
+
+        AndroidFidEnvReader(context).collect(null).fidFlag shouldBe false
+    }
+
     test("gs and sender match follow google-services string resources") {
         mockkObject(AndroidUtils)
         every { AndroidUtils.getResourceString(context, "google_app_id", null) } returns "1:388536902528:android:abc"
         every { AndroidUtils.getResourceString(context, "gcm_defaultSenderId", null) } returns "388536902528"
-        every { AndroidUtils.getManifestMetaBoolean(context, any()) } returns false
 
         val snapshot = AndroidFidEnvReader(context).collect("388536902528")
 
@@ -58,7 +66,6 @@ class FidEnvReaderTests : FunSpec({
         mockkObject(AndroidUtils)
         every { AndroidUtils.getResourceString(context, "google_app_id", null) } returns "1:1:android:abc"
         every { AndroidUtils.getResourceString(context, "gcm_defaultSenderId", null) } returns "111"
-        every { AndroidUtils.getManifestMetaBoolean(context, any()) } returns false
 
         val snapshot = AndroidFidEnvReader(context).collect("999")
 

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/device/FidEnvReaderTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/device/FidEnvReaderTests.kt
@@ -35,6 +35,7 @@ class FidEnvReaderTests : FunSpec({
 
         snapshot.googleServices shouldBe false
         snapshot.fidFlag shouldBe false
+        snapshot.fidRegisterApi shouldBe false
         snapshot.defaultFirebaseApp shouldBe false
         snapshot.firebaseInitProvider shouldBe false
         snapshot.senderMatch shouldBe null
@@ -43,12 +44,14 @@ class FidEnvReaderTests : FunSpec({
         snapshot.agpVersion shouldBe null
     }
 
-    test("fid flag stays off when metadata is set but FirebaseMessaging.register is absent") {
+    test("manifest flag and register API are reported independently") {
         val info = context.applicationInfo
         if (info.metaData == null) info.metaData = Bundle()
         info.metaData.putBoolean("firebase_messaging_installation_id_enabled", true)
 
-        AndroidFidEnvReader(context).collect(null).fidFlag shouldBe false
+        val snapshot = AndroidFidEnvReader(context).collect(null)
+        snapshot.fidFlag shouldBe true
+        snapshot.fidRegisterApi shouldBe false
     }
 
     test("gs and sender match follow google-services string resources") {

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/device/FidEnvTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/device/FidEnvTests.kt
@@ -2,7 +2,6 @@ package com.onesignal.core.internal.device
 
 import com.onesignal.core.internal.device.impl.FidEnvSnapshot
 import com.onesignal.core.internal.device.impl.dashboardSenderForCensus
-import com.onesignal.core.internal.device.impl.fidRegistrationEnabled
 import com.onesignal.core.internal.device.impl.parseAgpVersion
 import com.onesignal.core.internal.device.impl.sanitizeToken
 import com.onesignal.core.internal.device.impl.senderMatch
@@ -16,6 +15,7 @@ class FidEnvTests : FunSpec({
                 googleServices = true,
                 agpVersion = "8.8.2",
                 fidFlag = false,
+                fidRegisterApi = true,
                 defaultFirebaseApp = true,
                 firebaseInitProvider = true,
                 minSdk = 24,
@@ -23,7 +23,7 @@ class FidEnvTests : FunSpec({
                 senderMatch = true,
             ).toHeaderValue()
 
-        header shouldBe "gs=1;agp=8.8.2;flag=0;def=1;prov=1;min=24;tgt=35;snd=1"
+        header shouldBe "gs=1;agp=8.8.2;flag=0;reg=1;def=1;prov=1;min=24;tgt=35;snd=1"
     }
 
     test("header uses dashes for unknown optional fields") {
@@ -32,6 +32,7 @@ class FidEnvTests : FunSpec({
                 googleServices = false,
                 agpVersion = null,
                 fidFlag = false,
+                fidRegisterApi = false,
                 defaultFirebaseApp = false,
                 firebaseInitProvider = false,
                 minSdk = null,
@@ -39,7 +40,7 @@ class FidEnvTests : FunSpec({
                 senderMatch = null,
             ).toHeaderValue()
 
-        header shouldBe "gs=0;agp=-;flag=0;def=0;prov=0;min=-;tgt=-;snd=-"
+        header shouldBe "gs=0;agp=-;flag=0;reg=0;def=0;prov=0;min=-;tgt=-;snd=-"
     }
 
     test("sanitizeToken strips header-unsafe characters and caps length") {
@@ -75,12 +76,6 @@ class FidEnvTests : FunSpec({
     test("senderMatch compares the google-services sender to the dashboard sender") {
         senderMatch("123", "123") shouldBe true
         senderMatch("123", "999") shouldBe false
-    }
-
-    test("fidRegistrationEnabled requires the 25.1 register API and the metadata flag") {
-        fidRegistrationEnabled(hasRegisterApi = false, manifestFlag = true) shouldBe false
-        fidRegistrationEnabled(hasRegisterApi = true, manifestFlag = false) shouldBe false
-        fidRegistrationEnabled(hasRegisterApi = true, manifestFlag = true) shouldBe true
     }
 
     test("dashboardSenderForCensus requires hydrated params for the current appId") {

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/device/FidEnvTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/device/FidEnvTests.kt
@@ -2,6 +2,7 @@ package com.onesignal.core.internal.device
 
 import com.onesignal.core.internal.device.impl.FidEnvSnapshot
 import com.onesignal.core.internal.device.impl.dashboardSenderForCensus
+import com.onesignal.core.internal.device.impl.fidRegistrationEnabled
 import com.onesignal.core.internal.device.impl.parseAgpVersion
 import com.onesignal.core.internal.device.impl.sanitizeToken
 import com.onesignal.core.internal.device.impl.senderMatch
@@ -74,6 +75,12 @@ class FidEnvTests : FunSpec({
     test("senderMatch compares the google-services sender to the dashboard sender") {
         senderMatch("123", "123") shouldBe true
         senderMatch("123", "999") shouldBe false
+    }
+
+    test("fidRegistrationEnabled requires the 25.1 register API and the metadata flag") {
+        fidRegistrationEnabled(hasRegisterApi = false, manifestFlag = true) shouldBe false
+        fidRegistrationEnabled(hasRegisterApi = true, manifestFlag = false) shouldBe false
+        fidRegistrationEnabled(hasRegisterApi = true, manifestFlag = true) shouldBe true
     }
 
     test("dashboardSenderForCensus requires hydrated params for the current appId") {

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/device/FidEnvTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/device/FidEnvTests.kt
@@ -2,6 +2,7 @@ package com.onesignal.core.internal.device
 
 import com.onesignal.core.internal.device.impl.FidEnvSnapshot
 import com.onesignal.core.internal.device.impl.dashboardSenderForCensus
+import com.onesignal.core.internal.device.impl.hasPublicNoArgMethod
 import com.onesignal.core.internal.device.impl.parseAgpVersion
 import com.onesignal.core.internal.device.impl.sanitizeToken
 import com.onesignal.core.internal.device.impl.senderMatch
@@ -98,4 +99,25 @@ class FidEnvTests : FunSpec({
             sender = "111",
         ) shouldBe "111"
     }
+
+    test("hasPublicNoArgMethod is true when the class exposes the method") {
+        hasPublicNoArgMethod(DummyWithRegister::class.java.name, "register") shouldBe true
+    }
+
+    test("hasPublicNoArgMethod is false when the class or method is missing") {
+        hasPublicNoArgMethod(DummyWithoutRegister::class.java.name, "register") shouldBe false
+        hasPublicNoArgMethod(DummyWithRegisterArg::class.java.name, "register") shouldBe false
+        hasPublicNoArgMethod("com.onesignal.missing.FirebaseMessaging", "register") shouldBe false
+    }
 })
+
+private class DummyWithRegister {
+    fun register() {}
+}
+
+private class DummyWithRegisterArg {
+    @Suppress("UNUSED_PARAMETER")
+    fun register(unused: String) {}
+}
+
+private class DummyWithoutRegister

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/http/HttpClientTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/http/HttpClientTests.kt
@@ -320,6 +320,6 @@ internal class FakeFidEnv(
     override fun headerValue(): String = value
 
     companion object {
-        const val VALUE = "gs=0;agp=8.8.2;flag=0;def=0;prov=0;min=21;tgt=34;snd=-"
+        const val VALUE = "gs=0;agp=8.8.2;flag=0;reg=0;def=0;prov=0;min=21;tgt=34;snd=-"
     }
 }


### PR DESCRIPTION
# Description
## One Line Summary
Split the FID census so we can count apps that have the FID manifest flag on but are still on the old `getToken()` path.

## Details

### Motivation
[SDK-5167](https://linear.app/onesignal/issue/SDK-5167/read-fid-flag-from-firebase-messaging-runtime-not-manifest-only), follow-up to [SDK-5146](https://linear.app/onesignal/issue/SDK-5146/add-logging-to-sdk-for-tracking-fid-requirements) / #2729.

#2729 sent a single `flag=` bit from the merged manifest (`firebase_messaging_installation_id_enabled`). That says "someone opted in via XML." It does not say whether Firebase Messaging actually honors it.

Firebase only honors that metadata in `firebase-messaging` 25.1+ (`FirebaseMessaging.register()`). Older libraries ignore it and keep `getToken()`. Braze (and host copy-paste) can still merge the XML onto those older libraries. Combining the two into one bit hid the group we need: **flag on, still off FID**.

### Scope
Header:

```
OneSignal-Fid-Env: gs=1;agp=8.8.2;flag=1;reg=1;def=1;prov=1;min=24;tgt=35;snd=1
```

| Key | What it answers |
| --- | --- |
| `flag` | Is `firebase_messaging_installation_id_enabled` true in the merged manifest? |
| `reg` | Is `FirebaseMessaging.register()` on the classpath (25.1+)? |

Read them together. Do not AND them in the SDK. Backend can count each slice:

| Header | Meaning |
| --- | --- |
| `flag=1;reg=1` | Flag on **and** on FID. `getToken()` throws (#2696). Already migrated. |
| `flag=1;reg=0` | Flag on, **still off** FID. Old FCM, still `getToken()`. This is the "how many have the flag turned on but are still off" number. |
| `flag=0;reg=1` | 25.1+ present, flag not set. Can opt in, not on FID yet. |
| `flag=0;reg=0` | No opt-in, no 25.1+. |

`flag` is read the same way Firebase does (`containsKey` + `getBoolean`), via a silent `PackageManager` probe. `AndroidUtils.getManifestMetaBoolean` is not used; it `Logging.error`s on `NameNotFoundException`.

`reg` is a `Class.forName` / `getMethod("register")` probe. We do not instantiate `FirebaseMessaging` (that can start token sync). `core` does not compile against `firebase-messaging`.

`core/consumer-rules.pro` keeps `FirebaseMessaging.register()`, `FirebaseApp.getApps(Context)`, and `FirebaseApp.getName()`. Core never compile-calls them, so R8 would strip the names and minified apps would send `reg=0` / `def=0`. Missing class (Huawei exclude) is an R8 info, not a fail.

No public API change. No FCM registration change.

# Testing
## Unit testing
- Header encoding includes `reg=`.
- Robolectric: metadata true without `register()` encodes `flag=1;reg=0`.
- `hasPublicNoArgMethod` covers the true branch (public no-arg `register()`) and false branches (missing class, missing method, method with args).

## Manual testing
Not run on a device. Unit tests cover encoding, the split, and the register lookup.

# Affected code checklist
   - [x] REST API requests
   - [ ] Notifications
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible

Device testing is not done for this telemetry-only header change. Core unit tests for FidEnv passed locally.

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item