### PR TITLE
feat: [SDK-5170] register push before FCM credentials upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ build/
 local.properties
 OneSignalSDK/local.properties
 examples/demo/local.properties
+google-services.json
 
 # macOS
 .DS_Store

--- a/OneSignalSDK/build.gradle
+++ b/OneSignalSDK/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         ]
         androidGradlePluginVersion = '8.8.2'
         detektVersion = '1.21.0'
-        googleServicesGradlePluginVersion = '4.3.10'
+        googleServicesGradlePluginVersion = '4.4.2'
         huaweiAgconnectVersion = '1.9.1.304'
         huaweiHMSPushVersion = '6.3.0.304'
         huaweiHMSLocationVersion = '4.0.0.300'

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/listeners/DeviceRegistrationListener.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/listeners/DeviceRegistrationListener.kt
@@ -16,6 +16,8 @@ import com.onesignal.user.internal.subscriptions.ISubscriptionManager
 import com.onesignal.user.internal.subscriptions.SubscriptionModel
 import com.onesignal.user.internal.subscriptions.SubscriptionStatus
 import com.onesignal.user.subscriptions.ISubscription
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
 /**
  * The device registration listener will subscribe to events and at the appropriate time will
@@ -33,6 +35,8 @@ internal class DeviceRegistrationListener(
     ISingletonModelStoreChangeHandler<ConfigModel>,
     IPermissionObserver,
     ISubscriptionChangedHandler {
+    private val pushTokenMutex = Mutex()
+
     override fun start() {
         _configModelStore.subscribe(this)
         _notificationsManager.addPermissionObserver(this)
@@ -94,12 +98,14 @@ internal class DeviceRegistrationListener(
         val pushSubscription = _subscriptionManager.subscriptions.push
 
         suspendifyOnIO {
-            val pushTokenAndStatus = _pushTokenManager.retrievePushToken()
-            val permission = _notificationsManager.permission
-            _subscriptionManager.addOrUpdatePushSubscriptionToken(
-                pushTokenAndStatus.token,
-                if (permission) pushTokenAndStatus.status else SubscriptionStatus.NO_PERMISSION,
-            )
+            pushTokenMutex.withLock {
+                val pushTokenAndStatus = _pushTokenManager.retrievePushToken()
+                val permission = _notificationsManager.permission
+                _subscriptionManager.addOrUpdatePushSubscriptionToken(
+                    pushTokenAndStatus.token,
+                    if (permission) pushTokenAndStatus.status else SubscriptionStatus.NO_PERMISSION,
+                )
+            }
         }
     }
 

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/pushtoken/PushTokenManager.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/pushtoken/PushTokenManager.kt
@@ -33,19 +33,10 @@ internal class PushTokenManager(
                 if (registerResult.status.value == SubscriptionStatus.SUBSCRIBED.value) {
                     pushTokenStatus = registerResult.status
                 } else if (registerResult.status.value < SubscriptionStatus.SUBSCRIBED.value) {
-                    // Only allow errored statuses if we have never gotten a token. This ensures the
-                    // device will not later be marked unsubscribed due to any inconsistencies returned
-                    // by Google Play services. Also do not override a config error status if we got a
-                    // runtime error
-                    if (pushToken == null &&
-                        (
-                            pushTokenStatus == SubscriptionStatus.NO_PERMISSION ||
-                                pushStatusRuntimeError(pushTokenStatus)
-                            )
-                    ) {
+                    if (shouldUpdateErrorStatus(registerResult.status)) {
                         pushTokenStatus = registerResult.status
                     }
-                } else if (pushStatusRuntimeError(pushTokenStatus)) {
+                } else if (pushTokenStatus.isRetryableTokenError) {
                     pushTokenStatus = registerResult.status
                 }
 
@@ -56,7 +47,10 @@ internal class PushTokenManager(
         return PushTokenResponse(pushToken, pushTokenStatus)
     }
 
-    private fun pushStatusRuntimeError(status: SubscriptionStatus): Boolean {
-        return status.value < -6
-    }
+    private fun shouldUpdateErrorStatus(newStatus: SubscriptionStatus): Boolean =
+        when {
+            !newStatus.isRetryableTokenError -> true
+            pushToken != null -> false
+            else -> pushTokenStatus == SubscriptionStatus.NO_PERMISSION || pushTokenStatus.isRetryableTokenError
+        }
 }

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorAbstractGoogle.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorAbstractGoogle.kt
@@ -51,6 +51,8 @@ internal abstract class PushRegistratorAbstractGoogle(
     @Throws(ExecutionException::class, InterruptedException::class, IOException::class)
     abstract suspend fun getToken(senderId: String): String
 
+    protected open fun resolveSenderId(configuredSenderId: String?): String? = configuredSenderId
+
     override suspend fun registerForPush(): IPushRegistrator.RegisterResult {
         if (!_configModelStore.model.isInitializedWithRemote) {
             return IPushRegistrator.RegisterResult(null, SubscriptionStatus.FIREBASE_FCM_INIT_ERROR)
@@ -61,7 +63,8 @@ internal abstract class PushRegistratorAbstractGoogle(
             return IPushRegistrator.RegisterResult(null, SubscriptionStatus.MISSING_FIREBASE_FCM_LIBRARY)
         }
 
-        return if (!isValidProjectNumber(_configModelStore.model.googleProjectNumber)) {
+        val senderId = resolveSenderId(_configModelStore.model.googleProjectNumber)
+        return if (!isValidProjectNumber(senderId)) {
             Logging.warn(
                 "Missing Google Project number!\nPlease enter a Google Project number / Sender ID on under App Settings > Android > Configuration on the OneSignal dashboard.",
             )
@@ -70,7 +73,7 @@ internal abstract class PushRegistratorAbstractGoogle(
                 SubscriptionStatus.INVALID_FCM_SENDER_ID,
             )
         } else {
-            internalRegisterForPush(_configModelStore.model.googleProjectNumber!!)
+            internalRegisterForPush(senderId!!)
         }
     }
 

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorAbstractGoogle.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorAbstractGoogle.kt
@@ -134,6 +134,8 @@ internal abstract class PushRegistratorAbstractGoogle(
                 registrationId,
                 SubscriptionStatus.SUBSCRIBED,
             )
+        } catch (e: FCMSenderIdMismatchException) {
+            return invalidSenderIdResult(e)
         } catch (e: IOException) {
             val pushStatus: SubscriptionStatus = pushStatusFromThrowable(e)
             val exceptionMessage: String? = AndroidUtils.getRootCauseMessage(e)
@@ -168,6 +170,14 @@ internal abstract class PushRegistratorAbstractGoogle(
         }
 
         return null
+    }
+
+    private fun invalidSenderIdResult(exception: FCMSenderIdMismatchException): IPushRegistrator.RegisterResult {
+        Logging.warn("FCM sender ID mismatch", exception)
+        return IPushRegistrator.RegisterResult(
+            null,
+            SubscriptionStatus.INVALID_FCM_SENDER_ID,
+        )
     }
 
     private fun pushStatusFromThrowable(throwable: Throwable): SubscriptionStatus {

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorAbstractGoogle.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorAbstractGoogle.kt
@@ -64,7 +64,7 @@ internal abstract class PushRegistratorAbstractGoogle(
         }
 
         val senderId = resolveSenderId(_configModelStore.model.googleProjectNumber)
-        return if (!isValidProjectNumber(senderId)) {
+        return if (senderId == null || !isValidProjectNumber(senderId)) {
             Logging.warn(
                 "Missing Google Project number!\nPlease enter a Google Project number / Sender ID on under App Settings > Android > Configuration on the OneSignal dashboard.",
             )
@@ -73,7 +73,7 @@ internal abstract class PushRegistratorAbstractGoogle(
                 SubscriptionStatus.INVALID_FCM_SENDER_ID,
             )
         } else {
-            internalRegisterForPush(senderId!!)
+            internalRegisterForPush(senderId)
         }
     }
 
@@ -183,21 +183,7 @@ internal abstract class PushRegistratorAbstractGoogle(
         }
     }
 
-    private fun isValidProjectNumber(senderId: String?): Boolean {
-        val isProjectNumberValidFormat: Boolean =
-            try {
-                senderId!!.toFloat()
-                true
-            } catch (t: Throwable) {
-                false
-            }
-
-        if (!isProjectNumberValidFormat) {
-            return false
-        }
-
-        return true
-    }
+    private fun isValidProjectNumber(senderId: String): Boolean = senderId.toFloatOrNull() != null
 
     companion object {
         private const val REGISTRATION_RETRY_COUNT = 5

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorFCM.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorFCM.kt
@@ -54,16 +54,28 @@ internal class PushRegistratorFCM(
 
     @Throws(ExecutionException::class, InterruptedException::class)
     override suspend fun getToken(senderId: String): String {
+        val defaultApp = defaultFirebaseApp()
         return FCMTokenProvider.getToken(
             senderId = senderId,
             installationIdEnabled = ::installationIdEnabled,
-            legacyToken = { getLegacyToken(senderId) },
+            legacyToken = { getLegacyToken(senderId, defaultApp) },
             installationIdApiAvailable = { FCMTokenProvider.hasRegisterMethod(FirebaseMessaging::class.java) },
-            installationIdRegistration = ::defaultAppRegistration,
+            installationIdRegistration = { defaultApp?.let(::installationIdRegistration) },
         )
     }
 
-    private fun getLegacyToken(senderId: String): Task<String> {
+    override fun resolveSenderId(configuredSenderId: String?): String? =
+        configuredSenderId ?: defaultFirebaseApp()?.let(::defaultSenderId)
+
+    private fun getLegacyToken(
+        senderId: String,
+        defaultApp: FirebaseApp?,
+    ): Task<String> {
+        val defaultSenderId = defaultApp?.let(::defaultSenderId)
+        if (defaultSenderId != null) {
+            FCMTokenProvider.validateSenderId(senderId, defaultSenderId)
+        }
+
         val app = initFirebaseApp(senderId)
         // We use the named app's FirebaseMessaging instance instead of FirebaseMessaging.getInstance()
         //   as the latter uses the default Firebase app. We need to use a custom Firebase app as
@@ -82,23 +94,24 @@ internal class PushRegistratorFCM(
     // Installation ID registration is rejected unless the sender id, app id, and api key all belong
     //   to the same Firebase project. Our own FirebaseApp pairs the app's sender id with OneSignal's
     //   shared project credentials, so only the host app's default FirebaseApp can be used for it.
-    private fun defaultAppRegistration(): FCMTokenProvider.InstallationIdRegistration? {
-        val defaultApp =
-            FirebaseApp
-                .getApps(_applicationService.appContext)
-                .firstOrNull { it.name == FirebaseApp.DEFAULT_APP_NAME } ?: return null
-        val defaultSenderId =
-            FCMTokenProvider.defaultSenderId(
-                defaultApp.options.gcmSenderId,
-                defaultApp.options.applicationId,
-            )
-
+    private fun installationIdRegistration(defaultApp: FirebaseApp): FCMTokenProvider.InstallationIdRegistration {
         return FCMTokenProvider.InstallationIdRegistration(
-            senderId = defaultSenderId,
+            senderId = defaultSenderId(defaultApp),
             register = { FCMTokenProvider.invokeRegister(defaultApp.get(FirebaseMessaging::class.java)) },
             installationId = { FirebaseInstallations.getInstance(defaultApp).id },
         )
     }
+
+    private fun defaultFirebaseApp(): FirebaseApp? =
+        FirebaseApp
+            .getApps(_applicationService.appContext)
+            .firstOrNull { it.name == FirebaseApp.DEFAULT_APP_NAME }
+
+    private fun defaultSenderId(defaultApp: FirebaseApp): String? =
+        FCMTokenProvider.defaultSenderId(
+            defaultApp.options.gcmSenderId,
+            defaultApp.options.applicationId,
+        )
 
     private fun initFirebaseApp(senderId: String): FirebaseApp {
         firebaseApp?.let { return it }
@@ -178,18 +191,22 @@ internal object FCMTokenProvider {
             )
         }
 
-        if (registration.senderId != senderId) {
-            throw IllegalStateException(
-                "Firebase Installation ID registration is enabled ($optedIn) but the default " +
-                    "FirebaseApp uses sender id ${registration.senderId}, while OneSignal is " +
-                    "configured with sender id $senderId. Point both at the same Firebase project, " +
-                    "or set firebase_messaging_installation_id_enabled to false in your manifest " +
-                    "to keep using the legacy FCM token API.",
-            )
-        }
+        validateSenderId(senderId, registration.senderId)
 
         await(registration.register())
         return await(registration.installationId())
+    }
+
+    fun validateSenderId(
+        senderId: String,
+        defaultSenderId: String?,
+    ) {
+        if (defaultSenderId == senderId) return
+
+        throw IllegalStateException(
+            "The default FirebaseApp uses sender id $defaultSenderId, while OneSignal is " +
+                "configured with sender id $senderId. Point both at the same Firebase project.",
+        )
     }
 
     /**

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorFCM.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorFCM.kt
@@ -40,6 +40,7 @@ internal class PushRegistratorFCM(
     private val apiKey: String
 
     private var firebaseApp: FirebaseApp? = null
+    private var firebaseAppSenderId: String? = null
     override val providerName: String
         get() = "FCM"
 
@@ -58,7 +59,7 @@ internal class PushRegistratorFCM(
         return FCMTokenProvider.getToken(
             senderId = senderId,
             installationIdEnabled = ::installationIdEnabled,
-            legacyToken = { getLegacyToken(senderId, defaultApp) },
+            legacyToken = { getLegacyToken(senderId) },
             installationIdApiAvailable = { FCMTokenProvider.hasRegisterMethod(FirebaseMessaging::class.java) },
             installationIdRegistration = { defaultApp?.let(::installationIdRegistration) },
         )
@@ -67,15 +68,7 @@ internal class PushRegistratorFCM(
     override fun resolveSenderId(configuredSenderId: String?): String? =
         configuredSenderId ?: defaultFirebaseApp()?.let(::defaultSenderId)
 
-    private fun getLegacyToken(
-        senderId: String,
-        defaultApp: FirebaseApp?,
-    ): Task<String> {
-        val defaultSenderId = defaultApp?.let(::defaultSenderId)
-        if (defaultSenderId != null) {
-            FCMTokenProvider.validateSenderId(senderId, defaultSenderId)
-        }
-
+    private fun getLegacyToken(senderId: String): Task<String> {
         val app = initFirebaseApp(senderId)
         // We use the named app's FirebaseMessaging instance instead of FirebaseMessaging.getInstance()
         //   as the latter uses the default Firebase app. We need to use a custom Firebase app as
@@ -114,7 +107,12 @@ internal class PushRegistratorFCM(
         )
 
     private fun initFirebaseApp(senderId: String): FirebaseApp {
-        firebaseApp?.let { return it }
+        firebaseApp?.let {
+            if (firebaseAppSenderId == senderId) return it
+            it.delete()
+            firebaseApp = null
+            firebaseAppSenderId = null
+        }
         val firebaseOptions =
             FirebaseOptions
                 .Builder()
@@ -124,7 +122,10 @@ internal class PushRegistratorFCM(
                 .setProjectId(projectId)
                 .build()
         return FirebaseApp.initializeApp(_applicationService.appContext, firebaseOptions, FCM_APP_NAME)
-            .also { firebaseApp = it }
+            .also {
+                firebaseApp = it
+                firebaseAppSenderId = senderId
+            }
     }
 }
 

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorFCM.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorFCM.kt
@@ -106,6 +106,10 @@ internal class PushRegistratorFCM(
             hostApp.options.applicationId,
         )
 
+    /**
+     * @param resolvedSenderId sender ID from the dashboard configuration, or the host Firebase app
+     * sender ID when the dashboard has not provided one.
+     */
     private fun initFirebaseApp(resolvedSenderId: String): FirebaseApp {
         firebaseApp?.let {
             if (firebaseAppSenderId == resolvedSenderId) return it

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorFCM.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorFCM.kt
@@ -106,9 +106,9 @@ internal class PushRegistratorFCM(
             hostApp.options.applicationId,
         )
 
-    private fun initFirebaseApp(senderId: String): FirebaseApp {
+    private fun initFirebaseApp(resolvedSenderId: String): FirebaseApp {
         firebaseApp?.let {
-            if (firebaseAppSenderId == senderId) return it
+            if (firebaseAppSenderId == resolvedSenderId) return it
             it.delete()
             firebaseApp = null
             firebaseAppSenderId = null
@@ -116,7 +116,7 @@ internal class PushRegistratorFCM(
         val firebaseOptions =
             FirebaseOptions
                 .Builder()
-                .setGcmSenderId(senderId)
+                .setGcmSenderId(resolvedSenderId)
                 .setApplicationId(appId)
                 .setApiKey(apiKey)
                 .setProjectId(projectId)
@@ -124,7 +124,7 @@ internal class PushRegistratorFCM(
         return FirebaseApp.initializeApp(_applicationService.appContext, firebaseOptions, FCM_APP_NAME)
             .also {
                 firebaseApp = it
-                firebaseAppSenderId = senderId
+                firebaseAppSenderId = resolvedSenderId
             }
     }
 }

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorFCM.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorFCM.kt
@@ -133,6 +133,8 @@ internal class PushRegistratorFCM(
     }
 }
 
+internal class FCMSenderIdMismatchException(message: String) : IllegalStateException(message)
+
 internal object FCMTokenProvider {
     fun firebaseAppSenderId(
         senderId: String?,
@@ -208,7 +210,7 @@ internal object FCMTokenProvider {
     ) {
         if (firebaseAppSenderId == senderId) return
 
-        throw IllegalStateException(
+        throw FCMSenderIdMismatchException(
             "The default FirebaseApp uses sender id $firebaseAppSenderId, while OneSignal is " +
                 "configured with sender id $senderId. Point both at the same Firebase project.",
         )

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorFCM.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorFCM.kt
@@ -55,18 +55,18 @@ internal class PushRegistratorFCM(
 
     @Throws(ExecutionException::class, InterruptedException::class)
     override suspend fun getToken(senderId: String): String {
-        val defaultApp = defaultFirebaseApp()
+        val hostApp = hostFirebaseApp()
         return FCMTokenProvider.getToken(
             senderId = senderId,
             installationIdEnabled = ::installationIdEnabled,
             legacyToken = { getLegacyToken(senderId) },
             installationIdApiAvailable = { FCMTokenProvider.hasRegisterMethod(FirebaseMessaging::class.java) },
-            installationIdRegistration = { defaultApp?.let(::installationIdRegistration) },
+            installationIdRegistration = { hostApp?.let(::installationIdRegistration) },
         )
     }
 
     override fun resolveSenderId(configuredSenderId: String?): String? =
-        configuredSenderId ?: defaultFirebaseApp()?.let(::defaultSenderId)
+        configuredSenderId ?: hostFirebaseApp()?.let(::hostFirebaseSenderId)
 
     private fun getLegacyToken(senderId: String): Task<String> {
         val app = initFirebaseApp(senderId)
@@ -87,23 +87,23 @@ internal class PushRegistratorFCM(
     // Installation ID registration is rejected unless the sender id, app id, and api key all belong
     //   to the same Firebase project. Our own FirebaseApp pairs the app's sender id with OneSignal's
     //   shared project credentials, so only the host app's default FirebaseApp can be used for it.
-    private fun installationIdRegistration(defaultApp: FirebaseApp): FCMTokenProvider.InstallationIdRegistration {
+    private fun installationIdRegistration(hostApp: FirebaseApp): FCMTokenProvider.InstallationIdRegistration {
         return FCMTokenProvider.InstallationIdRegistration(
-            senderId = defaultSenderId(defaultApp),
-            register = { FCMTokenProvider.invokeRegister(defaultApp.get(FirebaseMessaging::class.java)) },
-            installationId = { FirebaseInstallations.getInstance(defaultApp).id },
+            senderId = hostFirebaseSenderId(hostApp),
+            register = { FCMTokenProvider.invokeRegister(hostApp.get(FirebaseMessaging::class.java)) },
+            installationId = { FirebaseInstallations.getInstance(hostApp).id },
         )
     }
 
-    private fun defaultFirebaseApp(): FirebaseApp? =
+    private fun hostFirebaseApp(): FirebaseApp? =
         FirebaseApp
             .getApps(_applicationService.appContext)
             .firstOrNull { it.name == FirebaseApp.DEFAULT_APP_NAME }
 
-    private fun defaultSenderId(defaultApp: FirebaseApp): String? =
-        FCMTokenProvider.defaultSenderId(
-            defaultApp.options.gcmSenderId,
-            defaultApp.options.applicationId,
+    private fun hostFirebaseSenderId(hostApp: FirebaseApp): String? =
+        FCMTokenProvider.firebaseAppSenderId(
+            hostApp.options.gcmSenderId,
+            hostApp.options.applicationId,
         )
 
     private fun initFirebaseApp(senderId: String): FirebaseApp {
@@ -130,7 +130,7 @@ internal class PushRegistratorFCM(
 }
 
 internal object FCMTokenProvider {
-    fun defaultSenderId(
+    fun firebaseAppSenderId(
         senderId: String?,
         applicationId: String,
     ): String? =
@@ -200,12 +200,12 @@ internal object FCMTokenProvider {
 
     fun validateSenderId(
         senderId: String,
-        defaultSenderId: String?,
+        firebaseAppSenderId: String?,
     ) {
-        if (defaultSenderId == senderId) return
+        if (firebaseAppSenderId == senderId) return
 
         throw IllegalStateException(
-            "The default FirebaseApp uses sender id $defaultSenderId, while OneSignal is " +
+            "The default FirebaseApp uses sender id $firebaseAppSenderId, while OneSignal is " +
                 "configured with sender id $senderId. Point both at the same Firebase project.",
         )
     }

--- a/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/listeners/DeviceRegistrationListenerTests.kt
+++ b/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/listeners/DeviceRegistrationListenerTests.kt
@@ -1,5 +1,8 @@
 package com.onesignal.notifications.internal.listeners
 
+import com.onesignal.common.modeling.ModelChangeTags
+import com.onesignal.common.threading.suspendifyOnIO
+import com.onesignal.core.internal.config.ConfigModel
 import com.onesignal.core.internal.config.ConfigModelStore
 import com.onesignal.debug.LogLevel
 import com.onesignal.debug.internal.logging.Logging
@@ -14,11 +17,16 @@ import com.onesignal.user.internal.subscriptions.SubscriptionModel
 import com.onesignal.user.internal.subscriptions.SubscriptionStatus
 import com.onesignal.user.internal.subscriptions.SubscriptionType
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
 
 private const val NEW_TOKEN = "new-token"
 
@@ -269,5 +277,50 @@ class DeviceRegistrationListenerTests : FunSpec({
                 SubscriptionStatus.NO_PERMISSION,
             )
         }
+    }
+
+    test("serializes overlapping startup and hydration token retrievals") {
+        val harness =
+            Harness(
+                permission = true,
+                pushModel = uninitializedPushModel(),
+            )
+        val blocks = mutableListOf<suspend () -> Unit>()
+        every { suspendifyOnIO(any<suspend () -> Unit>()) } answers {
+            blocks += firstArg<suspend () -> Unit>()
+        }
+        val firstStarted = CompletableDeferred<Unit>()
+        val finishFirst = CompletableDeferred<Unit>()
+        var requestCount = 0
+        coEvery { harness.pushTokenManager.retrievePushToken() } coAnswers {
+            if (requestCount++ == 0) {
+                firstStarted.complete(Unit)
+                finishFirst.await()
+                PushTokenResponse("startup-token", SubscriptionStatus.SUBSCRIBED)
+            } else {
+                PushTokenResponse("hydrated-token", SubscriptionStatus.SUBSCRIBED)
+            }
+        }
+        val updates = mutableListOf<String?>()
+        every {
+            harness.subscriptionManager.addOrUpdatePushSubscriptionToken(any(), any())
+        } answers {
+            updates += firstArg<String?>()
+        }
+
+        harness.listener.start()
+        harness.listener.onModelReplaced(mockk<ConfigModel>(relaxed = true), ModelChangeTags.HYDRATE)
+
+        val startup = async(Dispatchers.Default) { blocks[0]() }
+        firstStarted.await()
+        val hydration =
+            async(Dispatchers.Default, start = CoroutineStart.UNDISPATCHED) {
+                blocks[1]()
+            }
+        finishFirst.complete(Unit)
+        startup.await()
+        hydration.await()
+
+        updates shouldBe listOf("startup-token", "hydrated-token")
     }
 })

--- a/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/pushtoken/PushTokenManagerTests.kt
+++ b/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/pushtoken/PushTokenManagerTests.kt
@@ -82,6 +82,24 @@ class PushTokenManagerTests : FunSpec({
         pushTokenStatus shouldBe SubscriptionStatus.SUBSCRIBED
     }
 
+    test("permanent configuration errors replace a previously successful token status") {
+        val mockPushRegistrator = mockk<IPushRegistrator>()
+        coEvery { mockPushRegistrator.registerForPush() } returns
+            IPushRegistrator.RegisterResult("host-fid", SubscriptionStatus.SUBSCRIBED) andThen
+            IPushRegistrator.RegisterResult(null, SubscriptionStatus.INVALID_FCM_SENDER_ID)
+        val mockDeviceService = MockHelper.deviceService()
+        every { mockDeviceService.jetpackLibraryStatus } returns IDeviceService.JetpackLibraryStatus.OK
+        val pushTokenManager = PushTokenManager(mockPushRegistrator, mockDeviceService)
+
+        pushTokenManager.retrievePushToken()
+        val response = pushTokenManager.retrievePushToken()
+
+        response.token shouldBe null
+        response.status shouldBe SubscriptionStatus.INVALID_FCM_SENDER_ID
+        pushTokenManager.pushToken shouldBe null
+        pushTokenManager.pushTokenStatus shouldBe SubscriptionStatus.INVALID_FCM_SENDER_ID
+    }
+
     test("retrievePushToken should fail with failure status from push registrator with config-type error") {
         // Given
         val mockPushRegistrator = mockk<IPushRegistrator>()

--- a/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/registration/impl/FCMTokenProviderTests.kt
+++ b/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/registration/impl/FCMTokenProviderTests.kt
@@ -38,11 +38,11 @@ private class WithoutRegister
 class FCMTokenProviderTests : FunSpec({
     val disabledLegacyApi = IllegalStateException("API disabled. Please use {@link #register()} instead.")
 
-    test("derives the default sender id the same way as Firebase Messaging") {
-        FCMTokenProvider.defaultSenderId(SENDER_ID, "ignored") shouldBe SENDER_ID
-        FCMTokenProvider.defaultSenderId(null, "1:$SENDER_ID:android:abc") shouldBe SENDER_ID
-        FCMTokenProvider.defaultSenderId(null, "legacy-application-id") shouldBe "legacy-application-id"
-        FCMTokenProvider.defaultSenderId(null, "1::android:abc") shouldBe null
+    test("derives the Firebase app sender id the same way as Firebase Messaging") {
+        FCMTokenProvider.firebaseAppSenderId(SENDER_ID, "ignored") shouldBe SENDER_ID
+        FCMTokenProvider.firebaseAppSenderId(null, "1:$SENDER_ID:android:abc") shouldBe SENDER_ID
+        FCMTokenProvider.firebaseAppSenderId(null, "legacy-application-id") shouldBe "legacy-application-id"
+        FCMTokenProvider.firebaseAppSenderId(null, "1::android:abc") shouldBe null
     }
 
     test("returns the legacy FCM token when installation id registration is unavailable") {

--- a/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorFCMTests.kt
+++ b/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorFCMTests.kt
@@ -88,6 +88,30 @@ class PushRegistratorFCMTests : FunSpec({
         token shouldBe "fcm-token"
     }
 
+    test("recreates OneSignal's FirebaseApp when the sender id changes") {
+        val firstMessaging = mockk<FirebaseMessaging>()
+        every { firstMessaging.token } returns Tasks.forResult("first-token")
+        val firstApp = mockk<FirebaseApp>(relaxed = true)
+        every { firstApp.get(FirebaseMessaging::class.java) } returns firstMessaging
+        val secondMessaging = mockk<FirebaseMessaging>()
+        every { secondMessaging.token } returns Tasks.forResult("second-token")
+        val secondApp = mockk<FirebaseApp>(relaxed = true)
+        every { secondApp.get(FirebaseMessaging::class.java) } returns secondMessaging
+        val initializedOptions = mutableListOf<FirebaseOptions>()
+        val registrator = registrator(legacyToken = Tasks.forResult("unused-token"))
+        every {
+            FirebaseApp.initializeApp(any(), capture(initializedOptions), any())
+        } returnsMany listOf(firstApp, secondApp)
+
+        val firstToken = withContext(Dispatchers.IO) { registrator.getToken(SENDER_ID) }
+        val secondToken = withContext(Dispatchers.IO) { registrator.getToken("999999999999") }
+
+        firstToken shouldBe "first-token"
+        secondToken shouldBe "second-token"
+        initializedOptions.map { it.gcmSenderId } shouldBe listOf(SENDER_ID, "999999999999")
+        verify(exactly = 1) { firstApp.delete() }
+    }
+
     test("registers a legacy FCM token using the locally derived sender id before the dashboard provides one") {
         val app = defaultApp(null)
         val configModelStore =
@@ -202,21 +226,19 @@ class PushRegistratorFCMTests : FunSpec({
         thrown.message!! shouldContain "sender id 999999999999"
     }
 
-    test("does not request a legacy token from a default FirebaseApp with a different sender id") {
+    test("uses OneSignal's FirebaseApp for a legacy token when the default app has a different sender id") {
         val messaging = mockk<FirebaseMessaging>()
         every { messaging.token } returns Tasks.forResult("wrong-project-token")
         val registrator =
             registrator(
-                legacyToken = Tasks.forResult("unused-fcm-token"),
+                legacyToken = Tasks.forResult("fcm-token"),
                 installedApps = listOf(defaultApp("999999999999", messaging)),
             )
 
-        val thrown =
-            withContext(Dispatchers.IO) {
-                shouldThrow<IllegalStateException> { registrator.getToken(SENDER_ID) }
-            }
+        val token = withContext(Dispatchers.IO) { registrator.getToken(SENDER_ID) }
 
-        thrown.message!! shouldContain "sender id 999999999999"
+        token shouldBe "fcm-token"
         verify(exactly = 0) { messaging.token }
+        verify(exactly = 1) { FirebaseApp.initializeApp(any(), any<FirebaseOptions>(), any()) }
     }
 })

--- a/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorFCMTests.kt
+++ b/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorFCMTests.kt
@@ -12,7 +12,10 @@ import com.google.firebase.installations.FirebaseInstallations
 import com.google.firebase.messaging.FirebaseMessaging
 import com.onesignal.common.AndroidUtils
 import com.onesignal.core.internal.application.IApplicationService
+import com.onesignal.core.internal.config.ConfigModelStore
+import com.onesignal.core.internal.device.IDeviceService
 import com.onesignal.mocks.MockHelper
+import com.onesignal.user.internal.subscriptions.SubscriptionStatus
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
@@ -47,6 +50,8 @@ private fun defaultApp(
 private fun registrator(
     legacyToken: Task<String>,
     installedApps: List<FirebaseApp> = emptyList(),
+    configModelStore: ConfigModelStore = MockHelper.configModelStore(),
+    deviceService: IDeviceService = mockk(relaxed = true),
 ): PushRegistratorFCM {
     val messaging = mockk<FirebaseMessaging>()
     every { messaging.token } returns legacyToken
@@ -62,10 +67,10 @@ private fun registrator(
     every { applicationService.appContext } returns ApplicationProvider.getApplicationContext<Context>()
 
     return PushRegistratorFCM(
-        MockHelper.configModelStore(),
+        configModelStore,
         applicationService,
         mockk(relaxed = true),
-        mockk(relaxed = true),
+        deviceService,
     )
 }
 
@@ -81,6 +86,31 @@ class PushRegistratorFCMTests : FunSpec({
         val token = withContext(Dispatchers.IO) { registrator.getToken(SENDER_ID) }
 
         token shouldBe "fcm-token"
+    }
+
+    test("registers a legacy FCM token using the locally derived sender id before the dashboard provides one") {
+        val app = defaultApp(null)
+        val configModelStore =
+            MockHelper.configModelStore {
+                it.isInitializedWithRemote = true
+                it.googleProjectNumber = null
+            }
+        val deviceService = mockk<IDeviceService>()
+        every { deviceService.hasFCMLibrary } returns true
+        every { deviceService.isGMSInstalledAndEnabled } returns true
+        val registrator =
+            registrator(
+                legacyToken = Tasks.forResult("fcm-token"),
+                installedApps = listOf(app),
+                configModelStore = configModelStore,
+                deviceService = deviceService,
+            )
+
+        val result = withContext(Dispatchers.IO) { registrator.registerForPush() }
+
+        result.id shouldBe "fcm-token"
+        result.status shouldBe SubscriptionStatus.SUBSCRIBED
+        verify(exactly = 1) { FirebaseApp.initializeApp(any(), any<FirebaseOptions>(), any()) }
     }
 
     test("registers the installation id through the matching default FirebaseApp") {
@@ -110,6 +140,41 @@ class PushRegistratorFCMTests : FunSpec({
         verify(exactly = 0) { FirebaseApp.initializeApp(any(), any<FirebaseOptions>(), any()) }
     }
 
+    test("registers an installation id before the dashboard has a sender id") {
+        val metaData = Bundle().apply { putBoolean("firebase_messaging_installation_id_enabled", true) }
+        mockkObject(AndroidUtils)
+        every { AndroidUtils.getManifestMetaBundle(any()) } returns metaData
+        val messaging = mockk<FirebaseMessaging>()
+        val app = defaultApp(null, messaging)
+        val installations = mockk<FirebaseInstallations>()
+        every { installations.id } returns Tasks.forResult("installation-id")
+        mockkStatic(FirebaseInstallations::class)
+        every { FirebaseInstallations.getInstance(app) } returns installations
+        mockkObject(FCMTokenProvider)
+        every { FCMTokenProvider.hasRegisterMethod(FirebaseMessaging::class.java) } returns true
+        every { FCMTokenProvider.invokeRegister(messaging) } returns Tasks.forResult(null)
+        val configModelStore =
+            MockHelper.configModelStore {
+                it.isInitializedWithRemote = true
+                it.googleProjectNumber = null
+            }
+        val deviceService = mockk<IDeviceService>()
+        every { deviceService.hasFCMLibrary } returns true
+        every { deviceService.isGMSInstalledAndEnabled } returns true
+        val registrator =
+            registrator(
+                legacyToken = Tasks.forResult("unused-fcm-token"),
+                installedApps = listOf(app),
+                configModelStore = configModelStore,
+                deviceService = deviceService,
+            )
+
+        val result = withContext(Dispatchers.IO) { registrator.registerForPush() }
+
+        result.id shouldBe "installation-id"
+        result.status shouldBe SubscriptionStatus.SUBSCRIBED
+    }
+
     test("explains the problem when the app has no default FirebaseApp to register with") {
         val registrator = registrator(legacyToken = Tasks.forException(disabledLegacyApi))
 
@@ -135,5 +200,23 @@ class PushRegistratorFCMTests : FunSpec({
             }
 
         thrown.message!! shouldContain "sender id 999999999999"
+    }
+
+    test("does not request a legacy token from a default FirebaseApp with a different sender id") {
+        val messaging = mockk<FirebaseMessaging>()
+        every { messaging.token } returns Tasks.forResult("wrong-project-token")
+        val registrator =
+            registrator(
+                legacyToken = Tasks.forResult("unused-fcm-token"),
+                installedApps = listOf(defaultApp("999999999999", messaging)),
+            )
+
+        val thrown =
+            withContext(Dispatchers.IO) {
+                shouldThrow<IllegalStateException> { registrator.getToken(SENDER_ID) }
+            }
+
+        thrown.message!! shouldContain "sender id 999999999999"
+        verify(exactly = 0) { messaging.token }
     }
 })

--- a/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorFCMTests.kt
+++ b/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorFCMTests.kt
@@ -211,19 +211,27 @@ class PushRegistratorFCMTests : FunSpec({
         thrown.message!! shouldContain "firebase_messaging_installation_id_enabled=not set"
     }
 
-    test("does not register against a default FirebaseApp with a different sender id") {
+    test("reports an invalid sender id when FID registration would use a different Firebase project") {
+        val configModelStore =
+            MockHelper.configModelStore {
+                it.isInitializedWithRemote = true
+                it.googleProjectNumber = SENDER_ID
+            }
+        val deviceService = mockk<IDeviceService>()
+        every { deviceService.hasFCMLibrary } returns true
+        every { deviceService.isGMSInstalledAndEnabled } returns true
         val registrator =
             registrator(
                 legacyToken = Tasks.forException(disabledLegacyApi),
                 installedApps = listOf(defaultApp("999999999999")),
+                configModelStore = configModelStore,
+                deviceService = deviceService,
             )
 
-        val thrown =
-            withContext(Dispatchers.IO) {
-                shouldThrow<IllegalStateException> { registrator.getToken(SENDER_ID) }
-            }
+        val result = withContext(Dispatchers.IO) { registrator.registerForPush() }
 
-        thrown.message!! shouldContain "sender id 999999999999"
+        result.id shouldBe null
+        result.status shouldBe SubscriptionStatus.INVALID_FCM_SENDER_ID
     }
 
     test("uses OneSignal's FirebaseApp for a legacy token when the default app has a different sender id") {

--- a/examples/demo/app/build.gradle.kts
+++ b/examples/demo/app/build.gradle.kts
@@ -32,6 +32,11 @@ if (taskRequests.contains("huawei")) {
     apply(plugin = "com.huawei.agconnect")
 }
 
+// Firebase configuration is local so the demo must remain buildable without it.
+if (file("google-services.json").exists()) {
+    apply(plugin = "com.google.gms.google-services")
+}
+
 // OneSignal SDK version - can be overridden via gradle property SDK_VERSION
 val sdkVersion: String = rootProject.findProperty("SDK_VERSION") as? String ?: "5.6.1"
 

--- a/examples/demo/build.gradle.kts
+++ b/examples/demo/build.gradle.kts
@@ -11,6 +11,7 @@ buildscript {
     }
     dependencies {
         classpath("com.android.tools.build:gradle:8.8.2")
+        classpath("com.google.gms:google-services:4.3.10")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
         classpath("com.huawei.agconnect:agcp:1.9.1.304")
     }

--- a/examples/demo/build.gradle.kts
+++ b/examples/demo/build.gradle.kts
@@ -11,7 +11,7 @@ buildscript {
     }
     dependencies {
         classpath("com.android.tools.build:gradle:8.8.2")
-        classpath("com.google.gms:google-services:4.3.10")
+        classpath("com.google.gms:google-services:4.4.2")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
         classpath("com.huawei.agconnect:agcp:1.9.1.304")
     }


### PR DESCRIPTION
# Description
## One Line Summary
Register Android push subscriptions from the host Firebase configuration before dashboard FCM credentials are uploaded.

## Details

### Motivation
A newly configured Android app currently receives no push token or Firebase Installation ID until its FCM service account is uploaded to OneSignal and the app launches again. This change derives the sender ID from the host default Firebase app when dashboard parameters do not provide one, allowing the identifier to be uploaded during the first app session.

### Scope
- Preserves the dashboard sender ID as the primary source when configured.
- Falls back to the host default Firebase app sender ID when dashboard parameters omit it.
- Supports both legacy FCM token and Firebase Installation ID registration.
- Detects sender-ID mismatches between the host Firebase app and OneSignal configuration.
- Keeps legacy dashboard-provided sender registration available when no default Firebase app exists.
- Makes local demo Firebase configuration optional and ignored by Git.

### Review focus
- Whether legacy token registration should reject a host/dashboard sender mismatch even though it uses OneSignal's isolated Firebase app.
- Correct behavior if the effective sender ID changes during the same process after remote parameter hydration.

# Testing
## Unit testing
Added coverage for sender-ID derivation, registration before a dashboard sender exists, legacy-token and FID paths, missing default Firebase apps, mismatches, reflective registration, and failures.

Ran:
- Focused FCM registration unit tests
- Full `testDebugUnitTest`
- Spotless
- Detekt
- Release assembly

## Manual testing
Built the GMS demo with a local `google-services.json` and confirmed the generated APK packages `google_app_id` and `gcm_defaultSenderId`. Final end-to-end validation of credential upload activating an existing subscription remains pending because the emulator disconnected before the rebuilt APK could be installed.

# Affected code checklist
   - [x] Notifications
      - [ ] Display
      - [ ] Open
      - [x] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

Made with [Cursor](https://cursor.com)