### PR TITLE
fix: [SDK-5174] start the logger pipeline on API 21

### DIFF
--- a/OneSignalSDK/onesignal/core/src/main/AndroidManifest.xml
+++ b/OneSignalSDK/onesignal/core/src/main/AndroidManifest.xml
@@ -1,9 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <!-- Override the logger module's minSdk (23). Runtime also gates below that. -->
-    <uses-sdk tools:overrideLibrary="com.onesignal.logger" />
-
     <!-- Required so the device can access the internet. -->
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />

--- a/OneSignalSDK/onesignal/core/src/main/AndroidManifest.xml
+++ b/OneSignalSDK/onesignal/core/src/main/AndroidManifest.xml
@@ -1,8 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <!-- Override the logger module's minSdk requirement (26) since we have runtime checks -->
-    <!-- That module is only used on SDK 26+, so this is safe -->
+    <!-- Override the logger module's minSdk (23). Runtime also gates below that. -->
     <uses-sdk tools:overrideLibrary="com.onesignal.logger" />
 
     <!-- Required so the device can access the internet. -->

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/debug/internal/crash/ObservabilitySdkSupport.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/debug/internal/crash/ObservabilitySdkSupport.kt
@@ -4,8 +4,8 @@ import android.os.Build
 
 /** The single SDK-version gate for observability: crash reporting, ANR detection, log shipping. */
 internal object ObservabilitySdkSupport {
-    /** The shared logger module requires Android O (API 26) or above. */
-    const val MIN_SDK_VERSION = Build.VERSION_CODES.O // 26
+    /** The shared logger module requires Android M (API 23) or above. */
+    const val MIN_SDK_VERSION = Build.VERSION_CODES.M // 23
 
     /** Read-only in production; writable only so tests can flip the gate without Robolectric. */
     var isSupported: Boolean = Build.VERSION.SDK_INT >= MIN_SDK_VERSION

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/debug/internal/crash/ObservabilitySdkSupport.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/debug/internal/crash/ObservabilitySdkSupport.kt
@@ -4,8 +4,8 @@ import android.os.Build
 
 /** The single SDK-version gate for observability: crash reporting, ANR detection, log shipping. */
 internal object ObservabilitySdkSupport {
-    /** The shared logger module requires Android M (API 23) or above. */
-    const val MIN_SDK_VERSION = Build.VERSION_CODES.M // 23
+    /** Matches the host SDK minSdk. Tests flip [isSupported] without Robolectric. */
+    const val MIN_SDK_VERSION = Build.VERSION_CODES.LOLLIPOP // 21
 
     /** Read-only in production; writable only so tests can flip the gate without Robolectric. */
     var isSupported: Boolean = Build.VERSION.SDK_INT >= MIN_SDK_VERSION

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/debug/internal/logging/logger/android/LoggerPlatformProvider.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/debug/internal/logging/logger/android/LoggerPlatformProvider.kt
@@ -15,9 +15,6 @@ import java.io.File
 // Use this to enable/disable local exporter diagnostics in debug builds.
 internal const val EXPORTER_LOGGING_ENABLED = false
 
-// First load of this file. Process.getStartUptimeMillis() is API 24.
-private val processStartUptimeMs = SystemClock.uptimeMillis()
-
 /** Configuration for [LoggerPlatformProvider]. */
 internal data class LoggerPlatformProviderConfig(
     val crashStoragePath: String,
@@ -35,6 +32,10 @@ internal class LoggerPlatformProvider(
     config: LoggerPlatformProviderConfig,
     private val featureManagerProvider: () -> IFeatureManager,
 ) : ILoggerPlatformProvider {
+    companion object {
+        // First class load. Same monotonic clock as Process.getStartUptimeMillis() (API 24).
+        private val processStartUptimeMs = SystemClock.uptimeMillis()
+    }
     override val appPackageId: String = config.appPackageId
     override val appVersion: String = config.appVersion
     private val context: Context? = config.context
@@ -117,7 +118,6 @@ internal class LoggerPlatformProvider(
             "unknown"
         }
 
-    // Same clock as Process.getStartUptimeMillis(), which is API 24. Class-load is first touch.
     override val processUptime: Long
         get() = SystemClock.uptimeMillis() - processStartUptimeMs
 

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/debug/internal/logging/logger/android/LoggerPlatformProvider.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/debug/internal/logging/logger/android/LoggerPlatformProvider.kt
@@ -3,6 +3,7 @@ package com.onesignal.debug.internal.logging.logger.android
 import android.app.ActivityManager
 import android.content.Context
 import android.os.Build
+import android.os.SystemClock
 import com.onesignal.common.OneSignalUtils
 import com.onesignal.common.OneSignalWrapper
 import com.onesignal.core.internal.features.IFeatureManager
@@ -13,6 +14,9 @@ import java.io.File
 
 // Use this to enable/disable local exporter diagnostics in debug builds.
 internal const val EXPORTER_LOGGING_ENABLED = false
+
+// First load of this file. Process.getStartUptimeMillis() is API 24.
+private val processStartUptimeMs = SystemClock.uptimeMillis()
 
 /** Configuration for [LoggerPlatformProvider]. */
 internal data class LoggerPlatformProviderConfig(
@@ -113,9 +117,9 @@ internal class LoggerPlatformProvider(
             "unknown"
         }
 
-    // https://opentelemetry.io/docs/specs/semconv/system/process-metrics/#metric-processuptime
+    // Same clock as Process.getStartUptimeMillis(), which is API 24. Class-load is first touch.
     override val processUptime: Long
-        get() = android.os.SystemClock.uptimeMillis() - android.os.Process.getStartUptimeMillis()
+        get() = SystemClock.uptimeMillis() - processStartUptimeMs
 
     // https://opentelemetry.io/docs/specs/semconv/general/attributes/#general-thread-attributes
     override val currentThreadName: String

--- a/OneSignalSDK/onesignal/core/src/test/AndroidManifest.xml
+++ b/OneSignalSDK/onesignal/core/src/test/AndroidManifest.xml
@@ -2,6 +2,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
     <uses-sdk
-        android:minSdkVersion="26"
+        android:minSdkVersion="23"
         tools:overrideLibrary="com.onesignal.logger" />
 </manifest>

--- a/OneSignalSDK/onesignal/core/src/test/AndroidManifest.xml
+++ b/OneSignalSDK/onesignal/core/src/test/AndroidManifest.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools">
-    <uses-sdk
-        android:minSdkVersion="23"
-        tools:overrideLibrary="com.onesignal.logger" />
-</manifest>

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/debug/internal/crash/ObservabilitySdkSupportTest.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/debug/internal/crash/ObservabilitySdkSupportTest.kt
@@ -14,7 +14,7 @@ class ObservabilitySdkSupportTest : FunSpec({
         ObservabilitySdkSupport.reset()
     }
 
-    test("isSupported is true on SDK >= 23") {
+    test("isSupported is true on SDK >= 21") {
         ObservabilitySdkSupport.reset()
         ObservabilitySdkSupport.isSupported shouldBe true
     }
@@ -32,33 +32,20 @@ class ObservabilitySdkSupportTest : FunSpec({
         ObservabilitySdkSupport.isSupported shouldBe true
     }
 
-    test("MIN_SDK_VERSION is 23") {
-        ObservabilitySdkSupport.MIN_SDK_VERSION shouldBe 23
+    test("MIN_SDK_VERSION is 21") {
+        ObservabilitySdkSupport.MIN_SDK_VERSION shouldBe 21
     }
 })
 
 @RobolectricTest
-@Config(sdk = [23])
-class ObservabilitySdkSupportApi23Test : FunSpec({
+@Config(sdk = [21])
+class ObservabilitySdkSupportApi21Test : FunSpec({
     afterEach {
         ObservabilitySdkSupport.reset()
     }
 
-    test("isSupported is true on API 23") {
+    test("isSupported is true on API 21") {
         ObservabilitySdkSupport.reset()
         ObservabilitySdkSupport.isSupported shouldBe true
-    }
-})
-
-@RobolectricTest
-@Config(sdk = [22])
-class ObservabilitySdkSupportApi22Test : FunSpec({
-    afterEach {
-        ObservabilitySdkSupport.reset()
-    }
-
-    test("isSupported is false below API 23") {
-        ObservabilitySdkSupport.reset()
-        ObservabilitySdkSupport.isSupported shouldBe false
     }
 })

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/debug/internal/crash/ObservabilitySdkSupportTest.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/debug/internal/crash/ObservabilitySdkSupportTest.kt
@@ -14,7 +14,7 @@ class ObservabilitySdkSupportTest : FunSpec({
         ObservabilitySdkSupport.reset()
     }
 
-    test("isSupported is true on SDK >= 26") {
+    test("isSupported is true on SDK >= 23") {
         ObservabilitySdkSupport.reset()
         ObservabilitySdkSupport.isSupported shouldBe true
     }
@@ -32,7 +32,33 @@ class ObservabilitySdkSupportTest : FunSpec({
         ObservabilitySdkSupport.isSupported shouldBe true
     }
 
-    test("MIN_SDK_VERSION is 26") {
-        ObservabilitySdkSupport.MIN_SDK_VERSION shouldBe 26
+    test("MIN_SDK_VERSION is 23") {
+        ObservabilitySdkSupport.MIN_SDK_VERSION shouldBe 23
+    }
+})
+
+@RobolectricTest
+@Config(sdk = [23])
+class ObservabilitySdkSupportApi23Test : FunSpec({
+    afterEach {
+        ObservabilitySdkSupport.reset()
+    }
+
+    test("isSupported is true on API 23") {
+        ObservabilitySdkSupport.reset()
+        ObservabilitySdkSupport.isSupported shouldBe true
+    }
+})
+
+@RobolectricTest
+@Config(sdk = [22])
+class ObservabilitySdkSupportApi22Test : FunSpec({
+    afterEach {
+        ObservabilitySdkSupport.reset()
+    }
+
+    test("isSupported is false below API 23") {
+        ObservabilitySdkSupport.reset()
+        ObservabilitySdkSupport.isSupported shouldBe false
     }
 })

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/debug/internal/logging/logger/android/LoggerPlatformProviderTest.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/debug/internal/logging/logger/android/LoggerPlatformProviderTest.kt
@@ -958,9 +958,9 @@ class LoggerPlatformProviderTest : FunSpec({
 })
 
 @RobolectricTest
-@Config(sdk = [23])
-class LoggerPlatformProviderApi23Test : FunSpec({
-    test("processUptime is readable on API 23") {
+@Config(sdk = [21])
+class LoggerPlatformProviderApi21Test : FunSpec({
+    test("processUptime is readable on API 21") {
         val context = ApplicationProvider.getApplicationContext<Context>()
         val provider = createAndroidLoggerPlatformProvider(context) {
             mockk<IFeatureManager>().also { every { it.enabledFeatureKeys() } returns emptyList() }

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/debug/internal/logging/logger/android/LoggerPlatformProviderTest.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/debug/internal/logging/logger/android/LoggerPlatformProviderTest.kt
@@ -437,11 +437,14 @@ class LoggerPlatformProviderTest : FunSpec({
         val provider = createAndroidLoggerPlatformProvider(appContext!!) { emptyFeatureManager() }
 
         // When
-        val result = provider.processUptime
+        val first = provider.processUptime
+        Thread.sleep(10)
+        val second = provider.processUptime
 
         // Then
-        (result >= 0) shouldBe true
-        (result < 1000000.0) shouldBe true // Reasonable upper bound
+        (first >= 0) shouldBe true
+        (first < 1_000_000) shouldBe true
+        (second >= first) shouldBe true
     }
 
     // ===== currentThreadName Tests =====
@@ -951,6 +954,19 @@ class LoggerPlatformProviderTest : FunSpec({
 
         // Then
         provider.appVersion shouldBe "unknown"
+    }
+})
+
+@RobolectricTest
+@Config(sdk = [23])
+class LoggerPlatformProviderApi23Test : FunSpec({
+    test("processUptime is readable on API 23") {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val provider = createAndroidLoggerPlatformProvider(context) {
+            mockk<IFeatureManager>().also { every { it.enabledFeatureKeys() } returns emptyList() }
+        }
+
+        (provider.processUptime >= 0) shouldBe true
     }
 })
 


### PR DESCRIPTION
## One Line Summary
Drop the leftover OpenTelemetry API 26 floor so remote logging, crash capture, and ANR detection start on every API the SDK supports (21+).

## Details

### Motivation
The API 26 gate existed because OpenTelemetry required Android O. That dependency is gone. Custom logging does not need 26.

`Process.getStartUptimeMillis()` is API 24, so `process.uptime` uses a `SystemClock.uptimeMillis()` class-load baseline (API 1). The runtime floor is 21, the same as the host SDK. `overrideLibrary` is no longer needed.

Linear: https://linear.app/onesignal/issue/SDK-5174/lower-observability-min-sdk-from-26-to-23

Depends on the KMP pin in this PR. Merge that KMP PR first, or with this one.

### Scope
- `ObservabilitySdkSupport.MIN_SDK_VERSION` is 21
- Logger / crash / ANR pipeline can start on API 21+
- No public API changes

# Testing
## Unit testing
- `ObservabilitySdkSupport` is true on 21
- `processUptime` is readable under `@Config(sdk = [21])`

## Manual testing
Not device-tested. Robolectric covers the gate and the API 21 `processUptime` read.

# Affected code checklist
   - [ ] Notifications
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item