### PR TITLE
chore: Revert "Release SDK v5.10.0"

### DIFF
--- a/OneSignalSDK/gradle.properties
+++ b/OneSignalSDK/gradle.properties
@@ -51,4 +51,4 @@ onesignalPublishSharedKmp = true
 
 # This is the name of the SDK to use when building your project.
 # This will be fed from the GitHub Actions workflow.
-SDK_VERSION=5.10.0
+SDK_VERSION=5.9.9


### PR DESCRIPTION
## Summary
Reverts #2739 so KMP v0.4.0 (#2737) can land on main before recutting 5.10.0.

5.10.0 was never tagged or published. This only puts `SDK_VERSION` back to 5.9.9.


Made with [Cursor](https://cursor.com)