### PR TITLE
feat: [SDK-5024] add composite login(externalId, profile) as one Create User POST

### DIFF
--- a/OneSignalSDK/onesignal/core/api/core.api
+++ b/OneSignalSDK/onesignal/core/api/core.api
@@ -58,6 +58,7 @@ public abstract interface class com/onesignal/IOneSignal {
 	public abstract fun initWithContextSuspend (Landroid/content/Context;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun isInitialized ()Z
 	public abstract fun login (Ljava/lang/String;)V
+	public abstract fun login (Ljava/lang/String;Lcom/onesignal/OneSignalUserProfile;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun login (Ljava/lang/String;Ljava/lang/String;)V
 	public abstract fun loginSuspend (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun logout ()V
@@ -76,6 +77,7 @@ public abstract interface class com/onesignal/IOneSignal {
 public final class com/onesignal/IOneSignal$DefaultImpls {
 	public static synthetic fun initWithContextSuspend$default (Lcom/onesignal/IOneSignal;Landroid/content/Context;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static fun login (Lcom/onesignal/IOneSignal;Ljava/lang/String;)V
+	public static synthetic fun login$default (Lcom/onesignal/IOneSignal;Ljava/lang/String;Lcom/onesignal/OneSignalUserProfile;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun login$default (Lcom/onesignal/IOneSignal;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
 	public static synthetic fun loginSuspend$default (Lcom/onesignal/IOneSignal;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
@@ -90,8 +92,10 @@ public final class com/onesignal/InitData : com/onesignal/OneSignalResultData {
 }
 
 public final class com/onesignal/LoginData : com/onesignal/OneSignalResultData {
+	public final fun getEmailSubscriptionId ()Ljava/lang/String;
 	public final fun getExternalId ()Ljava/lang/String;
 	public final fun getOnesignalId ()Ljava/lang/String;
+	public final fun getSmsSubscriptionId ()Ljava/lang/String;
 	public fun toMap ()Ljava/util/Map;
 	public fun toString ()Ljava/lang/String;
 }
@@ -129,7 +133,10 @@ public final class com/onesignal/OneSignal {
 	public static synthetic fun initWithContextSuspend$default (Landroid/content/Context;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun isInitialized ()Z
 	public static final fun login (Ljava/lang/String;)V
+	public static final fun login (Ljava/lang/String;Lcom/onesignal/OneSignalUserProfile;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun login (Ljava/lang/String;Lcom/onesignal/OneSignalUserProfile;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun login (Ljava/lang/String;Ljava/lang/String;)V
+	public static synthetic fun login$default (Ljava/lang/String;Lcom/onesignal/OneSignalUserProfile;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun login$default (Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
 	public static final fun loginSuspend (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun loginSuspend$default (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
@@ -182,6 +189,40 @@ public final class com/onesignal/OneSignalResult {
 
 public abstract interface class com/onesignal/OneSignalResultData {
 	public abstract fun toMap ()Ljava/util/Map;
+}
+
+public final class com/onesignal/OneSignalUserProfile {
+	public static final field Companion Lcom/onesignal/OneSignalUserProfile$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun builder ()Lcom/onesignal/OneSignalUserProfile$Builder;
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun component4 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;)Lcom/onesignal/OneSignalUserProfile;
+	public static synthetic fun copy$default (Lcom/onesignal/OneSignalUserProfile;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;ILjava/lang/Object;)Lcom/onesignal/OneSignalUserProfile;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAliases ()Ljava/util/Map;
+	public final fun getEmail ()Ljava/lang/String;
+	public final fun getPhoneNumber ()Ljava/lang/String;
+	public final fun getTags ()Ljava/util/Map;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/onesignal/OneSignalUserProfile$Builder {
+	public fun <init> ()V
+	public final fun build ()Lcom/onesignal/OneSignalUserProfile;
+	public final fun setAliases (Ljava/util/Map;)Lcom/onesignal/OneSignalUserProfile$Builder;
+	public final fun setEmail (Ljava/lang/String;)Lcom/onesignal/OneSignalUserProfile$Builder;
+	public final fun setPhoneNumber (Ljava/lang/String;)Lcom/onesignal/OneSignalUserProfile$Builder;
+	public final fun setTags (Ljava/util/Map;)Lcom/onesignal/OneSignalUserProfile$Builder;
+}
+
+public final class com/onesignal/OneSignalUserProfile$Companion {
+	public final fun builder ()Lcom/onesignal/OneSignalUserProfile$Builder;
 }
 
 public final class com/onesignal/SyncJobService : android/app/job/JobService {
@@ -1214,8 +1255,10 @@ public abstract interface annotation class com/onesignal/core/internal/minificat
 }
 
 public final class com/onesignal/core/internal/operations/ExecutionResponse {
-	public fun <init> (Lcom/onesignal/core/internal/operations/ExecutionResult;Ljava/util/Map;Ljava/util/List;Ljava/lang/Integer;)V
-	public synthetic fun <init> (Lcom/onesignal/core/internal/operations/ExecutionResult;Ljava/util/Map;Ljava/util/List;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/onesignal/core/internal/operations/ExecutionResult;Ljava/util/Map;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;)V
+	public synthetic fun <init> (Lcom/onesignal/core/internal/operations/ExecutionResult;Ljava/util/Map;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getHttpResponse ()Ljava/lang/String;
+	public final fun getHttpStatusCode ()Ljava/lang/Integer;
 	public final fun getIdTranslations ()Ljava/util/Map;
 	public final fun getOperations ()Ljava/util/List;
 	public final fun getResult ()Lcom/onesignal/core/internal/operations/ExecutionResult;
@@ -1253,12 +1296,15 @@ public abstract interface class com/onesignal/core/internal/operations/IOperatio
 	public abstract fun awaitInitialized (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun containsInstanceOf (Lkotlin/reflect/KClass;)Z
 	public abstract fun enqueue (Lcom/onesignal/core/internal/operations/Operation;Z)V
+	public abstract fun enqueueAndAwaitResult (Lcom/onesignal/core/internal/operations/Operation;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun enqueueAndWait (Lcom/onesignal/core/internal/operations/Operation;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun forceExecuteOperations ()V
 }
 
 public final class com/onesignal/core/internal/operations/IOperationRepo$DefaultImpls {
 	public static synthetic fun enqueue$default (Lcom/onesignal/core/internal/operations/IOperationRepo;Lcom/onesignal/core/internal/operations/Operation;ZILjava/lang/Object;)V
+	public static synthetic fun enqueueAndAwaitResult$default (Lcom/onesignal/core/internal/operations/IOperationRepo;Lcom/onesignal/core/internal/operations/Operation;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static fun enqueueAndWait (Lcom/onesignal/core/internal/operations/IOperationRepo;Lcom/onesignal/core/internal/operations/Operation;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun enqueueAndWait$default (Lcom/onesignal/core/internal/operations/IOperationRepo;Lcom/onesignal/core/internal/operations/Operation;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
@@ -1274,6 +1320,14 @@ public abstract class com/onesignal/core/internal/operations/Operation : com/one
 	public fun getRequiresJwt ()Z
 	public fun toString ()Ljava/lang/String;
 	public fun translateIds (Ljava/util/Map;)V
+}
+
+public final class com/onesignal/core/internal/operations/OperationWaitResult {
+	public fun <init> (ZLjava/lang/Integer;Ljava/lang/String;)V
+	public synthetic fun <init> (ZLjava/lang/Integer;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getHttpResponse ()Ljava/lang/String;
+	public final fun getHttpStatusCode ()Ljava/lang/Integer;
+	public final fun getSuccess ()Z
 }
 
 public final class com/onesignal/core/internal/permissions/AlertDialogPrepromptForAndroidSettings {
@@ -2168,8 +2222,8 @@ public final class com/onesignal/user/internal/operations/LoginUserFromSubscript
 
 public final class com/onesignal/user/internal/operations/LoginUserOperation : com/onesignal/core/internal/operations/Operation {
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/onesignal/OneSignalUserProfile;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/onesignal/OneSignalUserProfile;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getAppId ()Ljava/lang/String;
 	public fun getApplyToRecordId ()Ljava/lang/String;
 	public fun getCanStartExecute ()Z

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/IOneSignal.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/IOneSignal.kt
@@ -251,6 +251,15 @@ interface IOneSignal {
     )
 
     /**
+     * Login with [externalId] plus [profile]. Email/SMS are additive; an alias owned by another user fails the request; email/phone already on another user transfers (JWT must include that address under IV). One malformed field fails the whole login.
+     */
+    suspend fun login(
+        externalId: String,
+        profile: OneSignalUserProfile,
+        jwtBearerToken: String? = null,
+    ): OneSignalResult<LoginData>
+
+    /**
      * Logout the current user (suspend version).
      */
     suspend fun logoutSuspend()

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/OneSignal.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/OneSignal.kt
@@ -425,6 +425,17 @@ object OneSignal {
     }
 
     /**
+     * Login with [externalId] plus [profile]. Email/SMS are additive; an alias owned by another user fails the request; email/phone already on another user transfers (JWT must include that address under IV). One malformed field fails the whole login.
+     */
+    @JvmStatic
+    @JvmOverloads
+    suspend fun login(
+        externalId: String,
+        profile: OneSignalUserProfile,
+        jwtBearerToken: String? = null,
+    ): OneSignalResult<LoginData> = oneSignal.login(externalId, profile, jwtBearerToken)
+
+    /**
      * Logout the current user without blocking the calling thread.
      * Suspends until the SDK is initialized if initialization is in progress.
      * This is the suspend-safe version of the [logout] method.

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/OneSignalResultData.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/OneSignalResultData.kt
@@ -30,28 +30,44 @@ class LoginData internal constructor(
     val onesignalId: String,
     /** The external ID that was logged in. */
     val externalId: String,
+    /** The email subscription created by this login, when the profile included an email. */
+    val emailSubscriptionId: String? = null,
+    /** The SMS subscription created by this login, when the profile included a phone number. */
+    val smsSubscriptionId: String? = null,
 ) : OneSignalResultData {
     override fun toMap(): Map<String, Any?> =
-        mapOf(
-            KEY_ONESIGNAL_ID to onesignalId,
-            KEY_EXTERNAL_ID to externalId,
-        )
+        buildMap {
+            put(KEY_ONESIGNAL_ID, onesignalId)
+            put(KEY_EXTERNAL_ID, externalId)
+            emailSubscriptionId?.let { put(KEY_EMAIL_SUBSCRIPTION_ID, it) }
+            smsSubscriptionId?.let { put(KEY_SMS_SUBSCRIPTION_ID, it) }
+        }
 
-    override fun toString(): String = "LoginData(onesignalId=$onesignalId, externalId=$externalId)"
+    override fun toString(): String =
+        "LoginData(onesignalId=$onesignalId, externalId=$externalId, emailSubscriptionId=$emailSubscriptionId, smsSubscriptionId=$smsSubscriptionId)"
 
     internal companion object {
         // Private because `const val` in an internal companion still compiles to a public static
         // field, which would leak the wire keys into the customer-facing API surface.
         private const val KEY_ONESIGNAL_ID = "onesignalId"
         private const val KEY_EXTERNAL_ID = "externalId"
+        private const val KEY_EMAIL_SUBSCRIPTION_ID = "emailSubscriptionId"
+        private const val KEY_SMS_SUBSCRIPTION_ID = "smsSubscriptionId"
 
         /** Null when [onesignalId] or [externalId] is missing, empty, or not a string. */
         fun fromMap(map: Map<*, *>): LoginData? {
             val onesignalId = map[KEY_ONESIGNAL_ID] as? String
             val externalId = map[KEY_EXTERNAL_ID] as? String
             if (onesignalId.isNullOrEmpty() || externalId.isNullOrEmpty()) return null
-            return LoginData(onesignalId, externalId)
+            return LoginData(
+                onesignalId,
+                externalId,
+                emailSubscriptionId = optionalString(map[KEY_EMAIL_SUBSCRIPTION_ID]),
+                smsSubscriptionId = optionalString(map[KEY_SMS_SUBSCRIPTION_ID]),
+            )
         }
+
+        private fun optionalString(value: Any?): String? = (value as? String)?.takeIf { it.isNotEmpty() }
     }
 }
 

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/OneSignalUserProfile.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/OneSignalUserProfile.kt
@@ -1,0 +1,41 @@
+package com.onesignal
+
+/**
+ * Profile fields applied at composite login. Email and SMS are additive subscriptions, not replaced traits.
+ */
+data class OneSignalUserProfile(
+    val email: String? = null,
+    /** SMS number in [E.164](https://documentation.onesignal.com/docs/sms-faq#what-is-the-e164-format) format. */
+    val phoneNumber: String? = null,
+    val tags: Map<String, String> = emptyMap(),
+    val aliases: Map<String, String> = emptyMap(),
+) {
+    /** Java builder. Use this instead of the constructor when only some fields are set. */
+    class Builder {
+        private var email: String? = null
+        private var phoneNumber: String? = null
+        private var tags: Map<String, String> = emptyMap()
+        private var aliases: Map<String, String> = emptyMap()
+
+        /** Sets the email subscription to create at login. */
+        fun setEmail(email: String?) = apply { this.email = email }
+
+        /** Sets the SMS subscription to create at login. Must be E.164 (e.g. +14155552671). */
+        fun setPhoneNumber(phoneNumber: String?) = apply { this.phoneNumber = phoneNumber }
+
+        /** Sets tags to apply at login. The map is copied. */
+        fun setTags(tags: Map<String, String>) = apply { this.tags = tags.toMap() }
+
+        /** Sets aliases to apply at login. The map is copied. */
+        fun setAliases(aliases: Map<String, String>) = apply { this.aliases = aliases.toMap() }
+
+        /** Builds the profile. */
+        fun build() = OneSignalUserProfile(email, phoneNumber, tags, aliases)
+    }
+
+    companion object {
+        /** Returns a new Java builder. */
+        @JvmStatic
+        fun builder() = Builder()
+    }
+}

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/OneSignalUserProfile.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/OneSignalUserProfile.kt
@@ -10,6 +10,13 @@ data class OneSignalUserProfile(
     val tags: Map<String, String> = emptyMap(),
     val aliases: Map<String, String> = emptyMap(),
 ) {
+    internal val hasFields: Boolean
+        get() =
+            !email.isNullOrBlank() ||
+                !phoneNumber.isNullOrBlank() ||
+                tags.isNotEmpty() ||
+                aliases.isNotEmpty()
+
     /** Java builder. Use this instead of the constructor when only some fields are set. */
     class Builder {
         private var email: String? = null

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/IOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/IOperationExecutor.kt
@@ -42,6 +42,8 @@ class ExecutionResponse(
      * The module handing this should delay any future requests by this time.
      */
     val retryAfterSeconds: Int? = null,
+    val httpStatusCode: Int? = null,
+    val httpResponse: String? = null,
 )
 
 enum class ExecutionResult {

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/IOperationRepo.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/IOperationRepo.kt
@@ -32,7 +32,15 @@ interface IOperationRepo {
     suspend fun enqueueAndWait(
         operation: Operation,
         flush: Boolean = false,
-    ): Boolean
+    ): Boolean = enqueueAndAwaitResult(operation, flush).success
+
+    /**
+     * Same as [enqueueAndWait], plus the HTTP status and body when the executor recorded a backend failure.
+     */
+    suspend fun enqueueAndAwaitResult(
+        operation: Operation,
+        flush: Boolean = false,
+    ): OperationWaitResult
 
     /**
      * Check if the queue contains a specific operation type
@@ -43,6 +51,12 @@ interface IOperationRepo {
 
     fun forceExecuteOperations()
 }
+
+class OperationWaitResult(
+    val success: Boolean,
+    val httpStatusCode: Int? = null,
+    val httpResponse: String? = null,
+)
 
 // Extension function so the syntax containsInstanceOf<Operation>() can be used over
 // containsInstanceOf(Operation::class)

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/impl/OperationRepo.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/impl/OperationRepo.kt
@@ -393,7 +393,7 @@ internal class OperationRepo(
                 ExecutionResult.SUCCESS -> {
                     // on success we remove the operation from the store and wake any waiters
                     ops.forEach { _operationModelStore.remove(it.operation.id) }
-                    ops.forEach { it.waiter?.wake(waitResult(true, response)) }
+                    ops.forEach { it.waiter?.wake(response.toWaitResult(true)) }
                 }
                 ExecutionResult.FAIL_UNAUTHORIZED -> {
                     // Outer gate: dispatch to IV extension only on new code paths.
@@ -422,7 +422,7 @@ internal class OperationRepo(
                     // remove the starting operation from the store and wake any waiters, then
                     // add back all but the starting op to the front of the queue to be re-executed
                     _operationModelStore.remove(startingOp.operation.id)
-                    startingOp.waiter?.wake(waitResult(true, response))
+                    startingOp.waiter?.wake(response.toWaitResult(true))
                     synchronized(queue) {
                         ops.filter { it != startingOp }.reversed().forEach { queue.add(0, it) }
                     }
@@ -444,7 +444,7 @@ internal class OperationRepo(
                     // keep the failed operation and pause the operation repo from executing
                     paused = true
                     // Unblock any enqueueAndWait callers so loginSuspend doesn't hang.
-                    ops.forEach { it.waiter?.wake(waitResult(false, response)) }
+                    ops.forEach { it.waiter?.wake(response.toWaitResult(false)) }
                     // Re-queue with waiter = null: the operation is preserved for retry
                     // on next cold start, but the original waiter is detached since it
                     // was already woken above.
@@ -486,13 +486,8 @@ internal class OperationRepo(
         response: ExecutionResponse? = null,
     ) {
         ops.forEach { _operationModelStore.remove(it.operation.id) }
-        ops.forEach { it.waiter?.wake(waitResult(false, response)) }
+        ops.forEach { it.waiter?.wake(response.toWaitResult(false)) }
     }
-
-    private fun waitResult(
-        success: Boolean,
-        response: ExecutionResponse? = null,
-    ) = OperationWaitResult(success, response?.httpStatusCode, response?.httpResponse)
 
     /**
      * Wait which ever is longer, retryAfterSeconds returned by the server,

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/impl/OperationRepo.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/impl/OperationRepo.kt
@@ -5,11 +5,13 @@ import com.onesignal.common.threading.WaiterWithValue
 import com.onesignal.common.threading.suspendifyOnIO
 import com.onesignal.core.internal.config.ConfigModelStore
 import com.onesignal.core.internal.config.impl.IdentityVerificationService
+import com.onesignal.core.internal.operations.ExecutionResponse
 import com.onesignal.core.internal.operations.ExecutionResult
 import com.onesignal.core.internal.operations.GroupComparisonType
 import com.onesignal.core.internal.operations.IOperationExecutor
 import com.onesignal.core.internal.operations.IOperationRepo
 import com.onesignal.core.internal.operations.Operation
+import com.onesignal.core.internal.operations.OperationWaitResult
 import com.onesignal.core.internal.startup.IStartableService
 import com.onesignal.core.internal.time.ITime
 import com.onesignal.debug.LogLevel
@@ -40,7 +42,7 @@ internal class OperationRepo(
 
     internal class OperationQueueItem(
         val operation: Operation,
-        var waiter: WaiterWithValue<Boolean>? = null, // waiter may transfer during operation de-dupe
+        var waiter: WaiterWithValue<OperationWaitResult>? = null,
         val bucket: Int,
         var retries: Int = 0,
     ) {
@@ -145,16 +147,16 @@ internal class OperationRepo(
         }
     }
 
-    override suspend fun enqueueAndWait(
+    override suspend fun enqueueAndAwaitResult(
         operation: Operation,
         flush: Boolean,
-    ): Boolean {
-        if (shouldSuppressAnonymousOp(operation)) return false
+    ): OperationWaitResult {
+        if (shouldSuppressAnonymousOp(operation)) return OperationWaitResult(false)
 
         Logging.log(LogLevel.DEBUG, "OperationRepo.enqueueAndWait(operation: $operation, force: $flush)")
 
         operation.id = UUID.randomUUID().toString()
-        val waiter = WaiterWithValue<Boolean>()
+        val waiter = WaiterWithValue<OperationWaitResult>()
         scope.launch {
             internalEnqueue(OperationQueueItem(operation, waiter, bucket = enqueueIntoBucket), flush, true)
         }
@@ -222,11 +224,12 @@ internal class OperationRepo(
                     } else {
                         Logging.debug("OperationRepo: internalEnqueue - LoginUserOperation for onesignalId: ${op.onesignalId} already exists in the queue.")
                     }
+                    existingOp.mergeProfileFrom(op)
                     // Transfer the waiter so enqueueAndWait callers see the queued op's real execution result.
                     if (queueItem.waiter != null && existing.waiter == null) {
                         existing.waiter = queueItem.waiter
                     } else {
-                        queueItem.waiter?.wake(true)
+                        queueItem.waiter?.wake(OperationWaitResult(true))
                     }
                     if (!addToStore) {
                         _operationModelStore.remove(queueItem.operation.id)
@@ -294,7 +297,7 @@ internal class OperationRepo(
         val removedIds: List<String> =
             synchronized(queue) {
                 val anonymous = queue.filter { it.operation.externalId == null }
-                anonymous.forEach { it.waiter?.wake(false) }
+                anonymous.forEach { it.waiter?.wake(OperationWaitResult(false)) }
                 queue.removeAll(anonymous)
                 // IV=ON never transfers anonymous state; clear existingOnesignalId so the
                 // executor takes the createUser (upsert) path. The merge-anon-into-identified
@@ -390,7 +393,7 @@ internal class OperationRepo(
                 ExecutionResult.SUCCESS -> {
                     // on success we remove the operation from the store and wake any waiters
                     ops.forEach { _operationModelStore.remove(it.operation.id) }
-                    ops.forEach { it.waiter?.wake(true) }
+                    ops.forEach { it.waiter?.wake(waitResult(true, response)) }
                 }
                 ExecutionResult.FAIL_UNAUTHORIZED -> {
                     // Outer gate: dispatch to IV extension only on new code paths.
@@ -401,24 +404,25 @@ internal class OperationRepo(
                                 ops,
                                 _jwtTokenStore,
                                 _identityVerificationService.ivBehaviorActive,
+                                response,
                             )
                     if (!handled) {
                         // IV inactive or anon op: drop and wake waiters, matching FAIL_NORETRY.
                         Logging.warn("Operation execution failed without retry: $operations")
-                        dropAndWake(ops)
+                        dropAndWake(ops, response)
                     }
                 }
                 ExecutionResult.FAIL_NORETRY,
                 ExecutionResult.FAIL_CONFLICT,
                 -> {
                     Logging.warn("Operation execution failed without retry: $operations")
-                    dropAndWake(ops)
+                    dropAndWake(ops, response)
                 }
                 ExecutionResult.SUCCESS_STARTING_ONLY -> {
                     // remove the starting operation from the store and wake any waiters, then
                     // add back all but the starting op to the front of the queue to be re-executed
                     _operationModelStore.remove(startingOp.operation.id)
-                    startingOp.waiter?.wake(true)
+                    startingOp.waiter?.wake(waitResult(true, response))
                     synchronized(queue) {
                         ops.filter { it != startingOp }.reversed().forEach { queue.add(0, it) }
                     }
@@ -440,7 +444,7 @@ internal class OperationRepo(
                     // keep the failed operation and pause the operation repo from executing
                     paused = true
                     // Unblock any enqueueAndWait callers so loginSuspend doesn't hang.
-                    ops.forEach { it.waiter?.wake(false) }
+                    ops.forEach { it.waiter?.wake(waitResult(false, response)) }
                     // Re-queue with waiter = null: the operation is preserved for retry
                     // on next cold start, but the original waiter is detached since it
                     // was already woken above.
@@ -476,11 +480,19 @@ internal class OperationRepo(
         }
     }
 
-    /** Drop ops from the persistent store and wake any waiters with `false` (failure). */
-    private fun dropAndWake(ops: List<OperationQueueItem>) {
+    /** Drop ops from the persistent store and wake any waiters with failure. */
+    private fun dropAndWake(
+        ops: List<OperationQueueItem>,
+        response: ExecutionResponse? = null,
+    ) {
         ops.forEach { _operationModelStore.remove(it.operation.id) }
-        ops.forEach { it.waiter?.wake(false) }
+        ops.forEach { it.waiter?.wake(waitResult(false, response)) }
     }
+
+    private fun waitResult(
+        success: Boolean,
+        response: ExecutionResponse? = null,
+    ) = OperationWaitResult(success, response?.httpStatusCode, response?.httpResponse)
 
     /**
      * Wait which ever is longer, retryAfterSeconds returned by the server,

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/impl/OperationRepoIvExtensions.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/impl/OperationRepoIvExtensions.kt
@@ -1,7 +1,6 @@
 package com.onesignal.core.internal.operations.impl
 
 import com.onesignal.core.internal.operations.ExecutionResponse
-import com.onesignal.core.internal.operations.OperationWaitResult
 import com.onesignal.debug.internal.logging.Logging
 import com.onesignal.user.internal.jwt.JwtTokenStore
 
@@ -62,7 +61,7 @@ internal fun OperationRepo.handleFailUnauthorized(
     // Wake enqueueAndWait callers; re-queue with waiter = null because the original waiter
     // is already woken.
     ops.forEach {
-        it.waiter?.wake(OperationWaitResult(false, response.httpStatusCode, response.httpResponse))
+        it.waiter?.wake(response.toWaitResult(false))
     }
     synchronized(queue) {
         ops.reversed().forEach {

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/impl/OperationRepoIvExtensions.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/impl/OperationRepoIvExtensions.kt
@@ -1,5 +1,7 @@
 package com.onesignal.core.internal.operations.impl
 
+import com.onesignal.core.internal.operations.ExecutionResponse
+import com.onesignal.core.internal.operations.OperationWaitResult
 import com.onesignal.debug.internal.logging.Logging
 import com.onesignal.user.internal.jwt.JwtTokenStore
 
@@ -43,6 +45,7 @@ internal fun OperationRepo.handleFailUnauthorized(
     ops: List<OperationRepo.OperationQueueItem>,
     jwtTokenStore: JwtTokenStore,
     ivBehaviorActive: Boolean,
+    response: ExecutionResponse,
 ): Boolean {
     if (!ivBehaviorActive) return false
     val externalId = startingOp.operation.externalId ?: return false
@@ -58,7 +61,9 @@ internal fun OperationRepo.handleFailUnauthorized(
     )
     // Wake enqueueAndWait callers; re-queue with waiter = null because the original waiter
     // is already woken.
-    ops.forEach { it.waiter?.wake(false) }
+    ops.forEach {
+        it.waiter?.wake(OperationWaitResult(false, response.httpStatusCode, response.httpResponse))
+    }
     synchronized(queue) {
         ops.reversed().forEach {
             queue.add(0, OperationRepo.OperationQueueItem(it.operation, waiter = null, bucket = it.bucket, retries = it.retries))

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/impl/OperationWaitResultExtensions.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/impl/OperationWaitResultExtensions.kt
@@ -1,0 +1,7 @@
+package com.onesignal.core.internal.operations.impl
+
+import com.onesignal.core.internal.operations.ExecutionResponse
+import com.onesignal.core.internal.operations.OperationWaitResult
+
+internal fun ExecutionResponse?.toWaitResult(success: Boolean) =
+    OperationWaitResult(success, this?.httpStatusCode, this?.httpResponse)

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
@@ -2,8 +2,12 @@ package com.onesignal.internal
 
 import android.content.Context
 import android.os.Build
+import com.onesignal.ErrorCode
 import com.onesignal.IOneSignal
 import com.onesignal.IUserJwtInvalidatedListener
+import com.onesignal.LoginData
+import com.onesignal.OneSignalResult
+import com.onesignal.OneSignalUserProfile
 import com.onesignal.common.AndroidUtils
 import com.onesignal.common.DeviceUtils
 import com.onesignal.common.OneSignalUtils
@@ -21,6 +25,7 @@ import com.onesignal.core.internal.config.ConfigModelStore
 import com.onesignal.core.internal.config.impl.IdentityVerificationService
 import com.onesignal.core.internal.features.IFeatureManager
 import com.onesignal.core.internal.operations.IOperationRepo
+import com.onesignal.core.internal.operations.OperationWaitResult
 import com.onesignal.core.internal.preferences.IPreferencesService
 import com.onesignal.core.internal.preferences.PreferenceStoreFix
 import com.onesignal.core.internal.startup.StartupService
@@ -43,7 +48,9 @@ import com.onesignal.user.internal.identity.IdentityModelStore
 import com.onesignal.user.internal.jwt.JwtTokenStore
 import com.onesignal.user.internal.properties.PropertiesModelStore
 import com.onesignal.user.internal.resolveAppId
+import com.onesignal.user.internal.subscriptions.SubscriptionModel
 import com.onesignal.user.internal.subscriptions.SubscriptionModelStore
+import com.onesignal.user.internal.subscriptions.SubscriptionType
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.runBlocking
@@ -801,6 +808,65 @@ internal class OneSignalImp : IOneSignal,
 
         val context = loginHelper.switchUser(externalId, jwtBearerToken) ?: return@withContext
         loginHelper.enqueueLogin(context)
+    }
+
+    override suspend fun login(
+        externalId: String,
+        profile: OneSignalUserProfile,
+        jwtBearerToken: String?,
+    ): OneSignalResult<LoginData> =
+        withContext(ioDispatcher) {
+            Logging.log(LogLevel.DEBUG, "login(externalId: $externalId, profile: $profile, jwtBearerToken: ...${jwtBearerToken?.takeLast(8)})")
+
+            suspendUntilInit(operationName = "login")
+
+            val context =
+                loginHelper.switchUser(externalId, jwtBearerToken)
+                    ?: if (profileHasFields(profile)) loginHelper.contextForCurrentUser(externalId) else null
+            if (context != null) {
+                val completed = loginHelper.enqueueLogin(context, profile)
+                if (!completed.success) {
+                    return@withContext OneSignalResult.failure(
+                        ErrorCode.BACKEND_ERROR,
+                        loginFailureMessage(completed),
+                        backendCode = completed.httpStatusCode,
+                    )
+                }
+            }
+            OneSignalResult.success(loginDataFromStores(externalId, profile))
+        }
+
+    private fun profileHasFields(profile: OneSignalUserProfile): Boolean =
+        !profile.email.isNullOrBlank() ||
+            !profile.phoneNumber.isNullOrBlank() ||
+            profile.tags.isNotEmpty() ||
+            profile.aliases.isNotEmpty()
+
+    private fun loginFailureMessage(wait: OperationWaitResult): String {
+        val body = wait.httpResponse?.takeIf { it.isNotBlank() }
+        return body ?: wait.httpStatusCode?.let { "Login did not complete (HTTP $it)." } ?: "Login did not complete."
+    }
+
+    private fun loginDataFromStores(
+        externalId: String,
+        profile: OneSignalUserProfile,
+    ): LoginData {
+        val subscriptions = subscriptionModelStore.list()
+        return LoginData(
+            onesignalId = identityModelStore.model.onesignalId,
+            externalId = externalId,
+            emailSubscriptionId = subscriptionId(subscriptions, SubscriptionType.EMAIL, profile.email),
+            smsSubscriptionId = subscriptionId(subscriptions, SubscriptionType.SMS, profile.phoneNumber),
+        )
+    }
+
+    private fun subscriptionId(
+        subscriptions: Collection<SubscriptionModel>,
+        type: SubscriptionType,
+        address: String?,
+    ): String? {
+        if (address.isNullOrBlank()) return null
+        return subscriptions.firstOrNull { it.type == type && it.address == address }?.id
     }
 
     override suspend fun updateUserJwtSuspend(

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt
@@ -48,9 +48,7 @@ import com.onesignal.user.internal.identity.IdentityModelStore
 import com.onesignal.user.internal.jwt.JwtTokenStore
 import com.onesignal.user.internal.properties.PropertiesModelStore
 import com.onesignal.user.internal.resolveAppId
-import com.onesignal.user.internal.subscriptions.SubscriptionModel
 import com.onesignal.user.internal.subscriptions.SubscriptionModelStore
-import com.onesignal.user.internal.subscriptions.SubscriptionType
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.runBlocking
@@ -228,6 +226,7 @@ internal class OneSignalImp : IOneSignal,
             configModel = configModel,
             jwtTokenStore = jwtTokenStore,
             lock = loginLogoutLock,
+            subscriptionModelStore = subscriptionModelStore,
         )
     }
 
@@ -822,7 +821,7 @@ internal class OneSignalImp : IOneSignal,
 
             val context =
                 loginHelper.switchUser(externalId, jwtBearerToken)
-                    ?: if (profileHasFields(profile)) loginHelper.contextForCurrentUser(externalId) else null
+                    ?: if (profile.hasFields) loginHelper.contextForCurrentUser(externalId) else null
             if (context != null) {
                 val completed = loginHelper.enqueueLogin(context, profile)
                 if (!completed.success) {
@@ -833,40 +832,12 @@ internal class OneSignalImp : IOneSignal,
                     )
                 }
             }
-            OneSignalResult.success(loginDataFromStores(externalId, profile))
+            OneSignalResult.success(loginHelper.loginDataFromStores(externalId, profile))
         }
-
-    private fun profileHasFields(profile: OneSignalUserProfile): Boolean =
-        !profile.email.isNullOrBlank() ||
-            !profile.phoneNumber.isNullOrBlank() ||
-            profile.tags.isNotEmpty() ||
-            profile.aliases.isNotEmpty()
 
     private fun loginFailureMessage(wait: OperationWaitResult): String {
         val body = wait.httpResponse?.takeIf { it.isNotBlank() }
         return body ?: wait.httpStatusCode?.let { "Login did not complete (HTTP $it)." } ?: "Login did not complete."
-    }
-
-    private fun loginDataFromStores(
-        externalId: String,
-        profile: OneSignalUserProfile,
-    ): LoginData {
-        val subscriptions = subscriptionModelStore.list()
-        return LoginData(
-            onesignalId = identityModelStore.model.onesignalId,
-            externalId = externalId,
-            emailSubscriptionId = subscriptionId(subscriptions, SubscriptionType.EMAIL, profile.email),
-            smsSubscriptionId = subscriptionId(subscriptions, SubscriptionType.SMS, profile.phoneNumber),
-        )
-    }
-
-    private fun subscriptionId(
-        subscriptions: Collection<SubscriptionModel>,
-        type: SubscriptionType,
-        address: String?,
-    ): String? {
-        if (address.isNullOrBlank()) return null
-        return subscriptions.firstOrNull { it.type == type && it.address == address }?.id
     }
 
     override suspend fun updateUserJwtSuspend(

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/LoginHelper.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/LoginHelper.kt
@@ -1,7 +1,9 @@
 package com.onesignal.user.internal
 
+import com.onesignal.OneSignalUserProfile
 import com.onesignal.core.internal.config.ConfigModel
 import com.onesignal.core.internal.operations.IOperationRepo
+import com.onesignal.core.internal.operations.OperationWaitResult
 import com.onesignal.debug.internal.logging.Logging
 import com.onesignal.user.internal.identity.IdentityModelStore
 import com.onesignal.user.internal.jwt.JwtRequirement
@@ -77,19 +79,32 @@ internal class LoginHelper(
     /**
      * Enqueues the [LoginUserOperation] and suspends until it completes.
      */
-    internal suspend fun enqueueLogin(context: LoginEnqueueContext) {
+    internal suspend fun enqueueLogin(
+        context: LoginEnqueueContext,
+        profile: OneSignalUserProfile? = null,
+    ): OperationWaitResult {
         val result =
-            operationRepo.enqueueAndWait(
+            operationRepo.enqueueAndAwaitResult(
                 LoginUserOperation(
                     context.appId,
                     context.newIdentityOneSignalId,
                     context.externalId,
                     context.existingOneSignalId,
+                    profile,
                 ),
             )
 
-        if (!result) {
-            Logging.warn("Could not login user")
+        if (!result.success) {
+            Logging.warn("Could not login user: HTTP ${result.httpStatusCode} ${result.httpResponse}")
         }
+        return result
     }
+
+    internal fun contextForCurrentUser(externalId: String): LoginEnqueueContext =
+        LoginEnqueueContext(
+            appId = configModel.appId,
+            newIdentityOneSignalId = identityModelStore.model.onesignalId,
+            externalId = externalId,
+            existingOneSignalId = null,
+        )
 }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/LoginHelper.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/LoginHelper.kt
@@ -1,5 +1,6 @@
 package com.onesignal.user.internal
 
+import com.onesignal.LoginData
 import com.onesignal.OneSignalUserProfile
 import com.onesignal.core.internal.config.ConfigModel
 import com.onesignal.core.internal.operations.IOperationRepo
@@ -9,6 +10,9 @@ import com.onesignal.user.internal.identity.IdentityModelStore
 import com.onesignal.user.internal.jwt.JwtRequirement
 import com.onesignal.user.internal.jwt.JwtTokenStore
 import com.onesignal.user.internal.operations.LoginUserOperation
+import com.onesignal.user.internal.subscriptions.SubscriptionModel
+import com.onesignal.user.internal.subscriptions.SubscriptionModelStore
+import com.onesignal.user.internal.subscriptions.SubscriptionType
 
 internal class LoginHelper(
     private val identityModelStore: IdentityModelStore,
@@ -17,6 +21,7 @@ internal class LoginHelper(
     private val configModel: ConfigModel,
     private val jwtTokenStore: JwtTokenStore,
     private val lock: Any,
+    private val subscriptionModelStore: SubscriptionModelStore,
 ) {
     internal data class LoginEnqueueContext(
         val appId: String,
@@ -107,4 +112,26 @@ internal class LoginHelper(
             externalId = externalId,
             existingOneSignalId = null,
         )
+
+    internal fun loginDataFromStores(
+        externalId: String,
+        profile: OneSignalUserProfile,
+    ): LoginData {
+        val subscriptions = subscriptionModelStore.list()
+        return LoginData(
+            onesignalId = identityModelStore.model.onesignalId,
+            externalId = externalId,
+            emailSubscriptionId = subscriptionId(subscriptions, SubscriptionType.EMAIL, profile.email),
+            smsSubscriptionId = subscriptionId(subscriptions, SubscriptionType.SMS, profile.phoneNumber),
+        )
+    }
+
+    private fun subscriptionId(
+        subscriptions: Collection<SubscriptionModel>,
+        type: SubscriptionType,
+        address: String?,
+    ): String? {
+        if (address.isNullOrBlank()) return null
+        return subscriptions.firstOrNull { it.type == type && it.address == address }?.id
+    }
 }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/backend/IUserBackendService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/backend/IUserBackendService.kt
@@ -23,7 +23,7 @@ interface IUserBackendService {
         appId: String,
         identities: Map<String, String>,
         subscriptions: List<SubscriptionObject>,
-        properties: Map<String, String>,
+        properties: Map<String, Any?>,
         jwt: String? = null,
     ): CreateUserResponse
     // TODO: Change to send only the push subscription, optimally

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/backend/impl/UserBackendService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/backend/impl/UserBackendService.kt
@@ -1,5 +1,6 @@
 package com.onesignal.user.internal.backend.impl
 
+import com.onesignal.common.JSONUtils
 import com.onesignal.common.consistency.RywData
 import com.onesignal.common.exceptions.BackendException
 import com.onesignal.common.putMap
@@ -36,7 +37,7 @@ internal class UserBackendService(
         }
 
         if (properties.isNotEmpty()) {
-            requestJSON.put("properties", propertiesToJson(properties))
+            requestJSON.put("properties", JSONUtils.mapToJson(properties))
         }
 
         requestJSON.put("refresh_device_metadata", true)
@@ -102,19 +103,5 @@ internal class UserBackendService(
         }
 
         return JSONConverter.convertToCreateUserResponse(JSONObject(response.payload))
-    }
-
-    private fun propertiesToJson(properties: Map<String, Any?>): JSONObject {
-        val json = JSONObject()
-        for ((key, value) in properties) {
-            when (value) {
-                is Map<*, *> -> {
-                    @Suppress("UNCHECKED_CAST")
-                    json.put(key, JSONObject().putMap(value as Map<String, Any?>))
-                }
-                else -> json.put(key, value ?: JSONObject.NULL)
-            }
-        }
-        return json
     }
 }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/backend/impl/UserBackendService.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/backend/impl/UserBackendService.kt
@@ -21,7 +21,7 @@ internal class UserBackendService(
         appId: String,
         identities: Map<String, String>,
         subscriptions: List<SubscriptionObject>,
-        properties: Map<String, String>,
+        properties: Map<String, Any?>,
         jwt: String?,
     ): CreateUserResponse {
         val requestJSON = JSONObject()
@@ -36,7 +36,7 @@ internal class UserBackendService(
         }
 
         if (properties.isNotEmpty()) {
-            requestJSON.put("properties", JSONObject().putMap(properties))
+            requestJSON.put("properties", propertiesToJson(properties))
         }
 
         requestJSON.put("refresh_device_metadata", true)
@@ -102,5 +102,19 @@ internal class UserBackendService(
         }
 
         return JSONConverter.convertToCreateUserResponse(JSONObject(response.payload))
+    }
+
+    private fun propertiesToJson(properties: Map<String, Any?>): JSONObject {
+        val json = JSONObject()
+        for ((key, value) in properties) {
+            when (value) {
+                is Map<*, *> -> {
+                    @Suppress("UNCHECKED_CAST")
+                    json.put(key, JSONObject().putMap(value as Map<String, Any?>))
+                }
+                else -> json.put(key, value ?: JSONObject.NULL)
+            }
+        }
+        return json
     }
 }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/LoginUserOperation.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/LoginUserOperation.kt
@@ -1,9 +1,13 @@
 package com.onesignal.user.internal.operations
 
+import com.onesignal.OneSignalUserProfile
 import com.onesignal.common.IDManager
+import com.onesignal.common.putMap
 import com.onesignal.core.internal.operations.GroupComparisonType
 import com.onesignal.core.internal.operations.Operation
+import com.onesignal.user.internal.backend.IdentityConstants
 import com.onesignal.user.internal.operations.impl.executors.LoginUserOperationExecutor
+import org.json.JSONObject
 
 /**
  * An [Operation] to login the user with the [externalId] provided.  Logging in a user will do the
@@ -43,17 +47,63 @@ class LoginUserOperation() : Operation(LoginUserOperationExecutor.LOGIN_USER) {
             setOptStringProperty(::existingOnesignalId.name, value)
         }
 
+    internal var email: String?
+        get() = getOptStringProperty(PROFILE_EMAIL)
+        set(value) {
+            setOptStringProperty(PROFILE_EMAIL, value)
+        }
+
+    internal var phoneNumber: String?
+        get() = getOptStringProperty(PROFILE_PHONE)
+        set(value) {
+            setOptStringProperty(PROFILE_PHONE, value)
+        }
+
+    internal var tags: Map<String, String>
+        get() = decodeMap(getOptStringProperty(PROFILE_TAGS))
+        set(value) {
+            setOptStringProperty(PROFILE_TAGS, encodeMap(value))
+        }
+
+    internal var aliases: Map<String, String>
+        get() = decodeMap(getOptStringProperty(PROFILE_ALIASES))
+        set(value) {
+            setOptStringProperty(PROFILE_ALIASES, encodeMap(value))
+        }
+
     override val createComparisonKey: String get() = "$appId.User.$onesignalId"
     override val modifyComparisonKey: String = ""
     override val groupComparisonType: GroupComparisonType = GroupComparisonType.CREATE
     override val canStartExecute: Boolean get() = existingOnesignalId == null || !IDManager.isLocalId(existingOnesignalId!!)
     override val applyToRecordId: String get() = existingOnesignalId ?: onesignalId
 
-    constructor(appId: String, onesignalId: String, externalId: String?, existingOneSignalId: String? = null) : this() {
+    constructor(
+        appId: String,
+        onesignalId: String,
+        externalId: String?,
+        existingOneSignalId: String? = null,
+        profile: OneSignalUserProfile? = null,
+    ) : this() {
         this.appId = appId
         this.onesignalId = onesignalId
         this.externalId = externalId
         this.existingOnesignalId = existingOneSignalId
+        if (profile != null) {
+            this.email = profile.email
+            this.phoneNumber = profile.phoneNumber
+            this.tags = profile.tags
+            this.aliases = profile.aliases
+        }
+    }
+
+    internal fun hasProfileFields(): Boolean =
+        !email.isNullOrBlank() || !phoneNumber.isNullOrBlank() || tags.isNotEmpty() || aliases.isNotEmpty()
+
+    internal fun mergeProfileFrom(other: LoginUserOperation) {
+        if (email.isNullOrEmpty()) email = other.email
+        if (phoneNumber.isNullOrEmpty()) phoneNumber = other.phoneNumber
+        if (other.tags.isNotEmpty()) tags = tags + other.tags
+        if (other.aliases.isNotEmpty()) aliases = aliases + other.aliases
     }
 
     override fun translateIds(map: Map<String, String>) {
@@ -61,4 +111,29 @@ class LoginUserOperation() : Operation(LoginUserOperationExecutor.LOGIN_USER) {
             existingOnesignalId = map[existingOnesignalId]!!
         }
     }
+}
+
+internal fun reservedLoginAliasLabel(label: String): Boolean =
+    label.isEmpty() || label == IdentityConstants.ONESIGNAL_ID || label == IdentityConstants.EXTERNAL_ID
+
+private const val PROFILE_EMAIL = "profileEmail"
+private const val PROFILE_PHONE = "profilePhoneNumber"
+private const val PROFILE_TAGS = "profileTags"
+private const val PROFILE_ALIASES = "profileAliases"
+
+private fun encodeMap(map: Map<String, String>): String? {
+    if (map.isEmpty()) return null
+    return JSONObject().putMap(map).toString()
+}
+
+private fun decodeMap(json: String?): Map<String, String> {
+    if (json.isNullOrEmpty()) return emptyMap()
+    val obj = JSONObject(json)
+    val result = mutableMapOf<String, String>()
+    val keys = obj.keys()
+    while (keys.hasNext()) {
+        val key = keys.next()
+        result[key] = obj.optString(key)
+    }
+    return result
 }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/LoginUserOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/LoginUserOperationExecutor.kt
@@ -35,10 +35,12 @@ import com.onesignal.user.internal.operations.RefreshUserOperation
 import com.onesignal.user.internal.operations.SetAliasOperation
 import com.onesignal.user.internal.operations.TransferSubscriptionOperation
 import com.onesignal.user.internal.operations.UpdateSubscriptionOperation
+import com.onesignal.user.internal.operations.reservedLoginAliasLabel
 import com.onesignal.user.internal.properties.PropertiesModel
 import com.onesignal.user.internal.properties.PropertiesModelStore
 import com.onesignal.user.internal.subscriptions.SubscriptionModel
 import com.onesignal.user.internal.subscriptions.SubscriptionModelStore
+import com.onesignal.user.internal.subscriptions.SubscriptionStatus
 import com.onesignal.user.internal.subscriptions.SubscriptionType
 
 internal class LoginUserOperationExecutor(
@@ -81,9 +83,7 @@ internal class LoginUserOperationExecutor(
         if (!containsSubscriptionOperation && loginUserOp.externalId == null) {
             return ExecutionResponse(ExecutionResult.FAIL_NORETRY)
         }
-        if (loginUserOp.existingOnesignalId == null || loginUserOp.externalId == null ||
-            _identityVerificationService.ivBehaviorActive
-        ) {
+        if (shouldCreateUserDirectly(loginUserOp)) {
             // When there is no existing user to attempt to associate with the externalId provided, we go right to
             // createUser.  If there is no externalId provided this is an insert, if there is this will be an
             // "upsert with retrieval" as the user may already exist.
@@ -159,16 +159,22 @@ internal class LoginUserOperationExecutor(
         createUserOperation: LoginUserOperation,
         operations: List<Operation>,
     ): ExecutionResponse {
-        var identities = mapOf<String, String>()
+        val identities = mutableMapOf<String, String>()
         var subscriptions = mapOf<String, SubscriptionObject>()
-        val properties = mutableMapOf<String, String>()
+        val properties = mutableMapOf<String, Any?>()
         properties["timezone_id"] = TimeUtils.getTimeZoneId()
         properties["language"] = _languageContext.language
+        if (createUserOperation.tags.isNotEmpty()) {
+            properties["tags"] = createUserOperation.tags
+        }
 
         if (createUserOperation.externalId != null) {
-            val mutableIdentities = identities.toMutableMap()
-            mutableIdentities[IdentityConstants.EXTERNAL_ID] = createUserOperation.externalId!!
-            identities = mutableIdentities
+            identities[IdentityConstants.EXTERNAL_ID] = createUserOperation.externalId!!
+        }
+        for ((label, id) in createUserOperation.aliases) {
+            if (!reservedLoginAliasLabel(label)) {
+                identities[label] = id
+            }
         }
 
         // go through the operations grouped with this create user and apply them to the appropriate objects.
@@ -181,6 +187,7 @@ internal class LoginUserOperationExecutor(
                 else -> throw Exception("Unrecognized operation: $operation")
             }
         }
+        subscriptions = addProfileSubscriptions(createUserOperation, subscriptions)
 
         try {
             val subscriptionList = subscriptions.toList()
@@ -222,14 +229,24 @@ internal class LoginUserOperationExecutor(
                 }
 
                 if (backendSubscription != null) {
-                    idTranslations[pair.first] = backendSubscription.id!!
+                    if (!isProfileSubscriptionKey(pair.first)) {
+                        idTranslations[pair.first] = backendSubscription.id!!
+                    }
 
                     if (_configModelStore.model.pushSubscriptionId == pair.first) {
                         _configModelStore.model.pushSubscriptionId = backendSubscription.id
                     }
 
                     val subscriptionModel = _subscriptionsModelStore.get(pair.first)
-                    subscriptionModel?.setStringProperty(SubscriptionModel::id.name, backendSubscription.id!!, ModelChangeTags.HYDRATE)
+                    if (subscriptionModel != null) {
+                        subscriptionModel.setStringProperty(SubscriptionModel::id.name, backendSubscription.id!!, ModelChangeTags.HYDRATE)
+                    } else if (isProfileSubscriptionKey(pair.first)) {
+                        if (_identityModelStore.model.onesignalId == backendOneSignalId) {
+                            persistProfileSubscription(backendSubscription)
+                        }
+                    } else {
+                        Logging.error("LoginUserOperationExecutor.createUser response is missing a local subscription model for ${pair.first}")
+                    }
                 } else {
                     Logging.error("LoginUserOperationExecutor.createUser response is missing subscription data for ${pair.first}")
                 }
@@ -248,6 +265,10 @@ internal class LoginUserOperationExecutor(
                 }
             }
 
+            if (_identityModelStore.model.onesignalId == backendOneSignalId) {
+                hydrateProfile(createUserOperation)
+            }
+
             val wasPossiblyAnUpsert = identities.isNotEmpty()
             val followUpOperations =
                 if (wasPossiblyAnUpsert) {
@@ -258,15 +279,24 @@ internal class LoginUserOperationExecutor(
 
             return ExecutionResponse(ExecutionResult.SUCCESS, idTranslations, followUpOperations)
         } catch (ex: BackendException) {
+            Logging.error("LoginUserOperationExecutor.createUser failed: HTTP ${ex.statusCode} ${ex.response}")
             val responseType = NetworkUtils.getResponseStatusType(ex.statusCode)
 
             return when (responseType) {
                 NetworkUtils.ResponseStatusType.RETRYABLE ->
-                    ExecutionResponse(ExecutionResult.FAIL_RETRY, retryAfterSeconds = ex.retryAfterSeconds)
+                    backendExecutionResponse(ExecutionResult.FAIL_RETRY, ex)
                 NetworkUtils.ResponseStatusType.UNAUTHORIZED ->
-                    ExecutionResponse(ExecutionResult.FAIL_UNAUTHORIZED, retryAfterSeconds = ex.retryAfterSeconds)
+                    backendExecutionResponse(ExecutionResult.FAIL_UNAUTHORIZED, ex)
+                NetworkUtils.ResponseStatusType.INVALID,
+                NetworkUtils.ResponseStatusType.CONFLICT,
+                ->
+                    if (createUserOperation.hasProfileFields()) {
+                        backendExecutionResponse(ExecutionResult.FAIL_NORETRY, ex)
+                    } else {
+                        backendExecutionResponse(ExecutionResult.FAIL_PAUSE_OPREPO, ex)
+                    }
                 else ->
-                    ExecutionResponse(ExecutionResult.FAIL_PAUSE_OPREPO)
+                    backendExecutionResponse(ExecutionResult.FAIL_PAUSE_OPREPO, ex)
             }
         }
     }
@@ -371,7 +401,90 @@ internal class LoginUserOperationExecutor(
         return mutableSubscriptions
     }
 
+    private fun addProfileSubscriptions(
+        op: LoginUserOperation,
+        subscriptions: Map<String, SubscriptionObject>,
+    ): Map<String, SubscriptionObject> {
+        val mutable = subscriptions.toMutableMap()
+        val email = op.email?.takeIf { it.isNotBlank() }
+        if (email != null && mutable.values.none { it.type == SubscriptionObjectType.EMAIL && it.token == email }) {
+            mutable[PROFILE_EMAIL_KEY] =
+                SubscriptionObject(
+                    type = SubscriptionObjectType.EMAIL,
+                    token = email,
+                )
+        }
+        val phone = op.phoneNumber?.takeIf { it.isNotBlank() }
+        if (phone != null && mutable.values.none { it.type == SubscriptionObjectType.SMS && it.token == phone }) {
+            mutable[PROFILE_SMS_KEY] =
+                SubscriptionObject(
+                    type = SubscriptionObjectType.SMS,
+                    token = phone,
+                )
+        }
+        return mutable
+    }
+
+    private fun hydrateProfile(op: LoginUserOperation) {
+        val identityModel = _identityModelStore.model
+        for ((label, id) in op.aliases) {
+            if (!reservedLoginAliasLabel(label)) {
+                identityModel.setStringProperty(label, id, ModelChangeTags.HYDRATE)
+            }
+        }
+        val tagsModel = _propertiesModelStore.model.tags
+        for ((key, value) in op.tags) {
+            tagsModel.setStringProperty(key, value, ModelChangeTags.HYDRATE)
+        }
+    }
+
+    private fun persistProfileSubscription(backend: SubscriptionObject) {
+        val id = backend.id
+        val token = backend.token
+        val type = profileSubscriptionType(backend.type)
+        if (id == null || token == null || type == null) return
+
+        val existing = _subscriptionsModelStore.list().firstOrNull { it.type == type && it.address == token }
+        if (existing != null) {
+            existing.setStringProperty(SubscriptionModel::id.name, id, ModelChangeTags.HYDRATE)
+            return
+        }
+        val model = SubscriptionModel()
+        model.id = id
+        model.type = type
+        model.address = token
+        model.status = SubscriptionStatus.SUBSCRIBED
+        model.optedIn = true
+        _subscriptionsModelStore.add(model, ModelChangeTags.HYDRATE)
+    }
+
+    private fun shouldCreateUserDirectly(op: LoginUserOperation): Boolean {
+        if (op.hasProfileFields() || _identityVerificationService.ivBehaviorActive) return true
+        return op.existingOnesignalId == null || op.externalId == null
+    }
+
+    private fun profileSubscriptionType(type: SubscriptionObjectType?): SubscriptionType? =
+        when (type) {
+            SubscriptionObjectType.EMAIL -> SubscriptionType.EMAIL
+            SubscriptionObjectType.SMS -> SubscriptionType.SMS
+            else -> null
+        }
+
+    private fun backendExecutionResponse(
+        result: ExecutionResult,
+        ex: BackendException,
+    ) = ExecutionResponse(
+        result,
+        retryAfterSeconds = ex.retryAfterSeconds,
+        httpStatusCode = ex.statusCode,
+        httpResponse = ex.response,
+    )
+
     companion object {
         const val LOGIN_USER = "login-user"
+        private const val PROFILE_EMAIL_KEY = "__profile_email"
+        private const val PROFILE_SMS_KEY = "__profile_sms"
+
+        private fun isProfileSubscriptionKey(key: String): Boolean = key == PROFILE_EMAIL_KEY || key == PROFILE_SMS_KEY
     }
 }

--- a/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/LoginUserOperationExecutor.kt
+++ b/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/LoginUserOperationExecutor.kt
@@ -168,9 +168,7 @@ internal class LoginUserOperationExecutor(
             properties["tags"] = createUserOperation.tags
         }
 
-        if (createUserOperation.externalId != null) {
-            identities[IdentityConstants.EXTERNAL_ID] = createUserOperation.externalId!!
-        }
+        createUserOperation.externalId?.let { identities[IdentityConstants.EXTERNAL_ID] = it }
         for ((label, id) in createUserOperation.aliases) {
             if (!reservedLoginAliasLabel(label)) {
                 identities[label] = id

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/OneSignalResultTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/OneSignalResultTests.kt
@@ -528,6 +528,63 @@ class OneSignalResultTests : FunSpec({
         restored.error.shouldBeNull()
     }
 
+    test("LoginData subscription IDs round-trip when present and stay absent when omitted") {
+        val withIds =
+            LoginData(
+                "os-1",
+                "ext-1",
+                emailSubscriptionId = "email-sub",
+                smsSubscriptionId = "sms-sub",
+            )
+        val restoredWithIds = OneSignalResult.fromMap(OneSignalResult.success(withIds).toMap(), LoginData::fromMap)
+
+        restoredWithIds.isSuccess.shouldBeTrue()
+        restoredWithIds.data!!.emailSubscriptionId shouldBe "email-sub"
+        restoredWithIds.data!!.smsSubscriptionId shouldBe "sms-sub"
+        restoredWithIds.toMap() shouldBe
+            mapOf(
+                "success" to true,
+                "data" to
+                    mapOf(
+                        "onesignalId" to "os-1",
+                        "externalId" to "ext-1",
+                        "emailSubscriptionId" to "email-sub",
+                        "smsSubscriptionId" to "sms-sub",
+                    ),
+                "error" to null,
+            )
+
+        val restoredWithoutIds =
+            OneSignalResult.fromMap(
+                mapOf("success" to true, "data" to mapOf("onesignalId" to "os-1", "externalId" to "ext-1")),
+                LoginData::fromMap,
+            )
+        restoredWithoutIds.data!!.emailSubscriptionId.shouldBeNull()
+        restoredWithoutIds.data!!.smsSubscriptionId.shouldBeNull()
+        restoredWithoutIds.toMap()["data"] shouldBe mapOf("onesignalId" to "os-1", "externalId" to "ext-1")
+    }
+
+    test("LoginData ignores empty or wrongly typed subscription IDs rather than failing the payload") {
+        val restored =
+            OneSignalResult.fromMap(
+                mapOf(
+                    "success" to true,
+                    "data" to
+                        mapOf(
+                            "onesignalId" to "os-1",
+                            "externalId" to "ext-1",
+                            "emailSubscriptionId" to "",
+                            "smsSubscriptionId" to 1,
+                        ),
+                ),
+                LoginData::fromMap,
+            )
+
+        restored.isSuccess.shouldBeTrue()
+        restored.data!!.emailSubscriptionId.shouldBeNull()
+        restored.data!!.smsSubscriptionId.shouldBeNull()
+    }
+
     test("JSONObject.NULL under data is treated as an absent payload") {
         val restored =
             OneSignalResult.fromMap(

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/OneSignalSuspendMethodsExistTest.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/OneSignalSuspendMethodsExistTest.kt
@@ -148,6 +148,30 @@ class OneSignalSuspendMethodsExistTest : FunSpec({
         assert(kFunction.parameters.size >= 2) { "loginSuspend should have at least 2 parameters (receiver + externalId)" }
     }
 
+    test("identity-only login still exists and is not suspend") {
+        val blocking =
+            OneSignal::class.memberFunctions
+                .filter { it.name == "login" && !it.isSuspend }
+
+        assert(blocking.any { it.parameters.size == 2 }) { "login(externalId) is missing" }
+        assert(blocking.any { it.parameters.size == 3 }) { "login(externalId, jwtBearerToken) is missing" }
+    }
+
+    test("suspend login with profile exists and returns OneSignalResult") {
+        val kFunction =
+            OneSignal::class.memberFunctions
+                .firstOrNull { fn ->
+                    fn.name == "login" &&
+                        fn.isSuspend &&
+                        fn.parameters.any { it.type.classifier == OneSignalUserProfile::class }
+                }
+
+        assert(kFunction != null) { "suspend login(externalId, profile) not found" }
+        assert(kFunction!!.returnType.classifier == OneSignalResult::class) {
+            "suspend login(externalId, profile) should return OneSignalResult"
+        }
+    }
+
     test("logoutSuspend exists with no parameters") {
         val method: suspend () -> Unit = OneSignal::logoutSuspend
 

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/OneSignalUserProfileTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/OneSignalUserProfileTests.kt
@@ -1,0 +1,65 @@
+package com.onesignal
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+
+class OneSignalUserProfileTests : FunSpec({
+
+    test("Kotlin defaults are all empty") {
+        val profile = OneSignalUserProfile()
+
+        profile.email.shouldBeNull()
+        profile.phoneNumber.shouldBeNull()
+        profile.tags shouldBe emptyMap()
+        profile.aliases shouldBe emptyMap()
+    }
+
+    test("Kotlin named args set only the fields that were passed") {
+        val profile =
+            OneSignalUserProfile(
+                email = "bob@example.com",
+                tags = mapOf("plan" to "pro"),
+            )
+
+        profile.email shouldBe "bob@example.com"
+        profile.phoneNumber.shouldBeNull()
+        profile.tags shouldBe mapOf("plan" to "pro")
+        profile.aliases shouldBe emptyMap()
+    }
+
+    test("Java builder can set email without a phone number") {
+        val profile =
+            OneSignalUserProfile.builder()
+                .setEmail("bob@example.com")
+                .build()
+
+        profile.email shouldBe "bob@example.com"
+        profile.phoneNumber.shouldBeNull()
+        profile.tags shouldBe emptyMap()
+        profile.aliases shouldBe emptyMap()
+    }
+
+    test("Java builder can set a phone number without an email") {
+        val profile =
+            OneSignalUserProfile.Builder()
+                .setPhoneNumber("+15555550100")
+                .setTags(mapOf("plan" to "pro"))
+                .setAliases(mapOf("facebook" to "bob"))
+                .build()
+
+        profile.email.shouldBeNull()
+        profile.phoneNumber shouldBe "+15555550100"
+        profile.tags shouldBe mapOf("plan" to "pro")
+        profile.aliases shouldBe mapOf("facebook" to "bob")
+    }
+
+    test("builder copies tags so later mutation of the caller's map is not visible") {
+        val tags = mutableMapOf("plan" to "pro")
+        val profile = OneSignalUserProfile.builder().setTags(tags).build()
+
+        tags["plan"] = "changed"
+
+        profile.tags shouldBe mapOf("plan" to "pro")
+    }
+})

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/OneSignalUserProfileTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/OneSignalUserProfileTests.kt
@@ -13,6 +13,7 @@ class OneSignalUserProfileTests : FunSpec({
         profile.phoneNumber.shouldBeNull()
         profile.tags shouldBe emptyMap()
         profile.aliases shouldBe emptyMap()
+        profile.hasFields shouldBe false
     }
 
     test("Kotlin named args set only the fields that were passed") {
@@ -26,6 +27,7 @@ class OneSignalUserProfileTests : FunSpec({
         profile.phoneNumber.shouldBeNull()
         profile.tags shouldBe mapOf("plan" to "pro")
         profile.aliases shouldBe emptyMap()
+        profile.hasFields shouldBe true
     }
 
     test("Java builder can set email without a phone number") {
@@ -61,5 +63,9 @@ class OneSignalUserProfileTests : FunSpec({
         tags["plan"] = "changed"
 
         profile.tags shouldBe mapOf("plan" to "pro")
+    }
+
+    test("blank email and phone do not count as fields") {
+        OneSignalUserProfile(email = "  ", phoneNumber = "").hasFields shouldBe false
     }
 })

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/application/SDKInitSuspendTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/application/SDKInitSuspendTests.kt
@@ -3,6 +3,7 @@ package com.onesignal.core.internal.application
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider.getApplicationContext
 import br.com.colman.kotest.android.extensions.robolectric.RobolectricTest
+import com.onesignal.OneSignalUserProfile
 import com.onesignal.debug.LogLevel
 import com.onesignal.debug.internal.logging.Logging
 import com.onesignal.internal.OneSignalImp
@@ -287,6 +288,19 @@ class SDKInitSuspendTests : FunSpec({
                 }
 
             // Should throw immediately because isInitialized is false
+            exception.message shouldBe "Must call 'initWithContext' before 'login'"
+        }
+    }
+
+    test("composite login should throw exception when initWithContext is never called") {
+        val oneSignalImp = OneSignalImp()
+
+        runBlocking {
+            val exception =
+                shouldThrow<IllegalStateException> {
+                    oneSignalImp.login("testUser", OneSignalUserProfile())
+                }
+
             exception.message shouldBe "Must call 'initWithContext' before 'login'"
         }
     }

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/operations/OperationRepoTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/core/internal/operations/OperationRepoTests.kt
@@ -1,5 +1,6 @@
 package com.onesignal.core.internal.operations
 
+import com.onesignal.OneSignalUserProfile
 import com.onesignal.common.threading.Waiter
 import com.onesignal.common.threading.WaiterWithValue
 import com.onesignal.core.internal.operations.impl.OperationModelStore
@@ -186,6 +187,37 @@ class OperationRepoTests : FunSpec({
         val merged = operationRepo.queue.first().operation as LoginUserOperation
         merged.onesignalId shouldBe "local-new"
         merged.existingOnesignalId shouldBe "anon-uuid"
+    }
+
+    test("enqueue dedupes LoginUserOperation for same onesignalId and merges profile fields") {
+        val mocks = Mocks()
+        val operationRepo = mocks.operationRepo
+
+        val queuedOp = LoginUserOperation("appId", "local-new", "alice", null)
+        queuedOp.id = UUID.randomUUID().toString()
+        synchronized(operationRepo.queue) {
+            operationRepo.queue.add(OperationQueueItem(queuedOp, bucket = 0))
+        }
+
+        val incomingOp =
+            LoginUserOperation(
+                "appId",
+                "local-new",
+                "alice",
+                null,
+                OneSignalUserProfile(
+                    email = "a@b.com",
+                    tags = mapOf("plan" to "pro"),
+                ),
+            )
+
+        operationRepo.enqueue(incomingOp)
+        mocks.waitForInternalEnqueue()
+
+        operationRepo.queue.size shouldBe 1
+        val merged = operationRepo.queue.first().operation as LoginUserOperation
+        merged.email shouldBe "a@b.com"
+        merged.tags shouldBe mapOf("plan" to "pro")
     }
 
     test("enqueue dedupe does not merge a local existingOnesignalId onto the queued op") {
@@ -1132,6 +1164,28 @@ class OperationRepoTests : FunSpec({
         verify(exactly = 0) { mocks.operationModelStore.remove(opId) }
     }
 
+    test("FAIL_NORETRY wakes enqueueAndAwaitResult with HTTP status and body") {
+        val mocks = Mocks()
+        coEvery { mocks.executor.execute(any()) } returns
+            ExecutionResponse(
+                ExecutionResult.FAIL_NORETRY,
+                httpStatusCode = 400,
+                httpResponse = """{"errors":["invalid phone"]}""",
+            )
+
+        mocks.operationRepo.start()
+        val result =
+            runBlocking {
+                withTimeout(2_000) {
+                    mocks.operationRepo.enqueueAndAwaitResult(mockOperation())
+                }
+            }
+
+        result.success shouldBe false
+        result.httpStatusCode shouldBe 400
+        result.httpResponse shouldBe """{"errors":["invalid phone"]}"""
+    }
+
     test("FAIL_UNAUTHORIZED with IV inactive falls back to default drop-on-fail") {
         val mocks = Mocks()
         mocks.identityVerificationService = CoreInternalMocks.identityVerificationService(
@@ -1197,7 +1251,9 @@ class OperationRepoTests : FunSpec({
             val executeWaiter = WaiterWithValue<Boolean>()
             coEvery { opRepo.executeOperations(any()) } coAnswers {
                 executeWaiter.wake(true)
-                firstArg<List<OperationRepo.OperationQueueItem>>().forEach { it.waiter?.wake(true) }
+                firstArg<List<OperationRepo.OperationQueueItem>>().forEach {
+                    it.waiter?.wake(OperationWaitResult(true))
+                }
             }
             return executeWaiter
         }

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/LoginHelperTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/LoginHelperTests.kt
@@ -13,6 +13,9 @@ import com.onesignal.user.internal.jwt.JwtRequirement
 import com.onesignal.user.internal.jwt.JwtTokenStore
 import com.onesignal.user.internal.operations.LoginUserOperation
 import com.onesignal.user.internal.properties.PropertiesModel
+import com.onesignal.user.internal.subscriptions.SubscriptionModel
+import com.onesignal.user.internal.subscriptions.SubscriptionModelStore
+import com.onesignal.user.internal.subscriptions.SubscriptionType
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
@@ -64,6 +67,7 @@ class LoginHelperTests : FunSpec({
                 configModel = mockConfigModel,
                 jwtTokenStore = JwtTokenStore(MockPreferencesService()),
                 lock = loginLock,
+                subscriptionModelStore = mockk(relaxed = true),
             )
 
         // When
@@ -119,6 +123,7 @@ class LoginHelperTests : FunSpec({
                 configModel = mockConfigModel,
                 jwtTokenStore = JwtTokenStore(MockPreferencesService()),
                 lock = loginLock,
+                subscriptionModelStore = mockk(relaxed = true),
             )
 
         // When
@@ -187,6 +192,7 @@ class LoginHelperTests : FunSpec({
                 configModel = mockConfigModel,
                 jwtTokenStore = JwtTokenStore(MockPreferencesService()),
                 lock = loginLock,
+                subscriptionModelStore = mockk(relaxed = true),
             )
 
         // When
@@ -251,6 +257,7 @@ class LoginHelperTests : FunSpec({
                 configModel = mockConfigModel,
                 jwtTokenStore = JwtTokenStore(MockPreferencesService()),
                 lock = Any(),
+                subscriptionModelStore = mockk(relaxed = true),
             )
 
         // When
@@ -314,6 +321,7 @@ class LoginHelperTests : FunSpec({
                 configModel = mockConfigModel,
                 jwtTokenStore = JwtTokenStore(MockPreferencesService()),
                 lock = loginLock,
+                subscriptionModelStore = mockk(relaxed = true),
             )
 
         // When
@@ -364,6 +372,7 @@ class LoginHelperTests : FunSpec({
                 configModel = mockConfigModel,
                 jwtTokenStore = jwtTokenStore,
                 lock = Any(),
+                subscriptionModelStore = mockk(relaxed = true),
             )
 
         // When
@@ -399,6 +408,7 @@ class LoginHelperTests : FunSpec({
                 configModel = mockConfigModel,
                 jwtTokenStore = jwtTokenStore,
                 lock = Any(),
+                subscriptionModelStore = mockk(relaxed = true),
             )
 
         // When: login with same externalId but new JWT
@@ -450,6 +460,7 @@ class LoginHelperTests : FunSpec({
                 configModel = mockConfigModel,
                 jwtTokenStore = JwtTokenStore(MockPreferencesService()),
                 lock = Any(),
+                subscriptionModelStore = mockk(relaxed = true),
             )
 
         runBlocking {
@@ -489,6 +500,7 @@ class LoginHelperTests : FunSpec({
                 configModel = mockConfigModel,
                 jwtTokenStore = JwtTokenStore(MockPreferencesService()),
                 lock = Any(),
+                subscriptionModelStore = mockk(relaxed = true),
             )
 
         runBlocking {
@@ -509,5 +521,50 @@ class LoginHelperTests : FunSpec({
                 },
             )
         }
+    }
+
+    test("loginDataFromStores fills email and SMS ids from matching addresses") {
+        val identityStore =
+            MockHelper.identityModelStore { model ->
+                model.externalId = currentExternalId
+                model.onesignalId = currentOneSignalId
+            }
+        val subscriptions = SubscriptionModelStore(MockPreferencesService())
+        subscriptions.add(
+            SubscriptionModel().apply {
+                id = "email-id"
+                type = SubscriptionType.EMAIL
+                address = "a@b.com"
+            },
+        )
+        subscriptions.add(
+            SubscriptionModel().apply {
+                id = "sms-id"
+                type = SubscriptionType.SMS
+                address = "+15555550100"
+            },
+        )
+        val loginHelper =
+            LoginHelper(
+                identityModelStore = identityStore,
+                userSwitcher = mockk(relaxed = true),
+                operationRepo = mockk(relaxed = true),
+                configModel = mockk(relaxed = true),
+                jwtTokenStore = JwtTokenStore(MockPreferencesService()),
+                lock = Any(),
+                subscriptionModelStore = subscriptions,
+            )
+
+        val data =
+            loginHelper.loginDataFromStores(
+                currentExternalId,
+                OneSignalUserProfile(email = "a@b.com", phoneNumber = "+15555550100"),
+            )
+
+        data.onesignalId shouldBe currentOneSignalId
+        data.externalId shouldBe currentExternalId
+        data.emailSubscriptionId shouldBe "email-id"
+        data.smsSubscriptionId shouldBe "sms-id"
+        loginHelper.loginDataFromStores(currentExternalId, OneSignalUserProfile()).emailSubscriptionId shouldBe null
     }
 })

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/LoginHelperTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/LoginHelperTests.kt
@@ -1,7 +1,9 @@
 package com.onesignal.user.internal
 
+import com.onesignal.OneSignalUserProfile
 import com.onesignal.core.internal.config.ConfigModel
 import com.onesignal.core.internal.operations.IOperationRepo
+import com.onesignal.core.internal.operations.OperationWaitResult
 import com.onesignal.debug.LogLevel
 import com.onesignal.debug.internal.logging.Logging
 import com.onesignal.mocks.MockHelper
@@ -72,7 +74,7 @@ class LoginHelperTests : FunSpec({
 
         // Then - should return early without any operations
         verify(exactly = 0) { mockUserSwitcher.createAndSwitchToNewUser(suppressBackendOperation = any(), modify = any()) }
-        coVerify(exactly = 0) { mockOperationRepo.enqueueAndWait(any()) }
+        coVerify(exactly = 0) { mockOperationRepo.enqueueAndAwaitResult(any()) }
     }
 
     test("login with different external id creates and switches to new user") {
@@ -107,7 +109,7 @@ class LoginHelperTests : FunSpec({
             every { mockIdentityModelStore.model } returns newIdentityModel
         }
 
-        coEvery { mockOperationRepo.enqueueAndWait(any()) } returns true
+        coEvery { mockOperationRepo.enqueueAndAwaitResult(any()) } returns OperationWaitResult(true)
 
         val loginHelper =
             LoginHelper(
@@ -132,7 +134,7 @@ class LoginHelperTests : FunSpec({
         newIdentityModel.externalId shouldBe newExternalId
 
         coVerify(exactly = 1) {
-            mockOperationRepo.enqueueAndWait(
+            mockOperationRepo.enqueueAndAwaitResult(
                 withArg<LoginUserOperation> { operation ->
                     operation.appId shouldBe appId
                     operation.onesignalId shouldBe newOneSignalId
@@ -175,7 +177,7 @@ class LoginHelperTests : FunSpec({
             every { mockIdentityModelStore.model } returns newIdentityModel
         }
 
-        coEvery { mockOperationRepo.enqueueAndWait(any()) } returns true
+        coEvery { mockOperationRepo.enqueueAndAwaitResult(any()) } returns OperationWaitResult(true)
 
         val loginHelper =
             LoginHelper(
@@ -195,7 +197,7 @@ class LoginHelperTests : FunSpec({
 
         // Then - should provide existing OneSignal ID for anonymous user conversion
         coVerify(exactly = 1) {
-            mockOperationRepo.enqueueAndWait(
+            mockOperationRepo.enqueueAndAwaitResult(
                 withArg<LoginUserOperation> { operation ->
                     operation.appId shouldBe appId
                     operation.onesignalId shouldBe newOneSignalId
@@ -239,7 +241,7 @@ class LoginHelperTests : FunSpec({
             every { mockIdentityModelStore.model } returns newIdentityModel
         }
 
-        coEvery { mockOperationRepo.enqueueAndWait(any()) } returns true
+        coEvery { mockOperationRepo.enqueueAndAwaitResult(any()) } returns OperationWaitResult(true)
 
         val loginHelper =
             LoginHelper(
@@ -259,7 +261,7 @@ class LoginHelperTests : FunSpec({
 
         // Then — under IV, the executor must take the createUser (upsert) path; no merge link.
         coVerify(exactly = 1) {
-            mockOperationRepo.enqueueAndWait(
+            mockOperationRepo.enqueueAndAwaitResult(
                 withArg<LoginUserOperation> { operation ->
                     operation.externalId shouldBe newExternalId
                     operation.existingOnesignalId shouldBe null
@@ -301,7 +303,8 @@ class LoginHelperTests : FunSpec({
         }
 
         // Mock operation failure
-        coEvery { mockOperationRepo.enqueueAndWait(any()) } returns false
+        coEvery { mockOperationRepo.enqueueAndAwaitResult(any()) } returns
+            OperationWaitResult(false, httpStatusCode = 400, httpResponse = """{"errors":["invalid phone"]}""")
 
         val loginHelper =
             LoginHelper(
@@ -314,14 +317,18 @@ class LoginHelperTests : FunSpec({
             )
 
         // When
-        runBlocking {
-            val context = loginHelper.switchUser(newExternalId)
-            if (context != null) loginHelper.enqueueLogin(context)
-        }
+        val waitResult =
+            runBlocking {
+                val context = loginHelper.switchUser(newExternalId)
+                loginHelper.enqueueLogin(context!!)
+            }
 
-        // Then - should still switch users but operation fails
+        // Then - should still switch users but operation fails with the backend body
+        waitResult.success shouldBe false
+        waitResult.httpStatusCode shouldBe 400
+        waitResult.httpResponse shouldBe """{"errors":["invalid phone"]}"""
         verify(exactly = 1) { mockUserSwitcher.createAndSwitchToNewUser(suppressBackendOperation = any(), modify = any()) }
-        coVerify(exactly = 1) { mockOperationRepo.enqueueAndWait(any()) }
+        coVerify(exactly = 1) { mockOperationRepo.enqueueAndAwaitResult(any()) }
     }
 
     test("login with JWT stores token in JwtTokenStore before enqueueing op") {
@@ -343,7 +350,7 @@ class LoginHelperTests : FunSpec({
             mockIdentityModelStore.model.externalId = newExternalId
         }
         val mockOperationRepo = mockk<IOperationRepo>(relaxed = true)
-        coEvery { mockOperationRepo.enqueueAndWait(any()) } returns true
+        coEvery { mockOperationRepo.enqueueAndAwaitResult(any()) } returns OperationWaitResult(true)
         val mockConfigModel = mockk<ConfigModel>()
         every { mockConfigModel.appId } returns appId
         every { mockConfigModel.useIdentityVerification } returns JwtRequirement.NOT_REQUIRED
@@ -405,5 +412,102 @@ class LoginHelperTests : FunSpec({
         verify(exactly = 0) { mockUserSwitcher.createAndSwitchToNewUser(suppressBackendOperation = any(), modify = any()) }
         jwtTokenStore.getJwt(currentExternalId) shouldBe "new-jwt"
         verify(exactly = 1) { mockOperationRepo.forceExecuteOperations() }
+    }
+
+    test("enqueueLogin copies profile fields onto LoginUserOperation") {
+        val mockIdentityModelStore =
+            MockHelper.identityModelStore { model ->
+                model.externalId = currentExternalId
+                model.onesignalId = currentOneSignalId
+            }
+        val newIdentityModel =
+            IdentityModel().apply {
+                externalId = newExternalId
+                onesignalId = newOneSignalId
+            }
+        val mockUserSwitcher = mockk<UserSwitcher>()
+        val mockOperationRepo = mockk<IOperationRepo>()
+        val mockConfigModel = mockk<ConfigModel>()
+        every { mockConfigModel.appId } returns appId
+        every { mockConfigModel.useIdentityVerification } returns JwtRequirement.NOT_REQUIRED
+        val userSwitcherSlot = slot<(IdentityModel, PropertiesModel) -> Unit>()
+        every {
+            mockUserSwitcher.createAndSwitchToNewUser(
+                suppressBackendOperation = any(),
+                modify = capture(userSwitcherSlot),
+            )
+        } answers {
+            userSwitcherSlot.captured(newIdentityModel, PropertiesModel())
+            every { mockIdentityModelStore.model } returns newIdentityModel
+        }
+        coEvery { mockOperationRepo.enqueueAndAwaitResult(any()) } returns OperationWaitResult(true)
+
+        val loginHelper =
+            LoginHelper(
+                identityModelStore = mockIdentityModelStore,
+                userSwitcher = mockUserSwitcher,
+                operationRepo = mockOperationRepo,
+                configModel = mockConfigModel,
+                jwtTokenStore = JwtTokenStore(MockPreferencesService()),
+                lock = Any(),
+            )
+
+        runBlocking {
+            val context = loginHelper.switchUser(newExternalId)!!
+            loginHelper.enqueueLogin(context, OneSignalUserProfile(email = "a@b.com", tags = mapOf("plan" to "pro")))
+        }
+
+        coVerify(exactly = 1) {
+            mockOperationRepo.enqueueAndAwaitResult(
+                withArg<LoginUserOperation> { operation ->
+                    operation.email shouldBe "a@b.com"
+                    operation.tags shouldBe mapOf("plan" to "pro")
+                    operation.externalId shouldBe newExternalId
+                },
+            )
+        }
+    }
+
+    test("same external id with a profile still enqueues login") {
+        val mockIdentityModelStore =
+            MockHelper.identityModelStore { model ->
+                model.externalId = currentExternalId
+                model.onesignalId = currentOneSignalId
+            }
+        val mockUserSwitcher = mockk<UserSwitcher>(relaxed = true)
+        val mockOperationRepo = mockk<IOperationRepo>()
+        val mockConfigModel = mockk<ConfigModel>()
+        every { mockConfigModel.appId } returns appId
+        every { mockConfigModel.useIdentityVerification } returns JwtRequirement.NOT_REQUIRED
+        coEvery { mockOperationRepo.enqueueAndAwaitResult(any()) } returns OperationWaitResult(true)
+
+        val loginHelper =
+            LoginHelper(
+                identityModelStore = mockIdentityModelStore,
+                userSwitcher = mockUserSwitcher,
+                operationRepo = mockOperationRepo,
+                configModel = mockConfigModel,
+                jwtTokenStore = JwtTokenStore(MockPreferencesService()),
+                lock = Any(),
+            )
+
+        runBlocking {
+            val context =
+                loginHelper.switchUser(currentExternalId)
+                    ?: loginHelper.contextForCurrentUser(currentExternalId)
+            loginHelper.enqueueLogin(context, OneSignalUserProfile(email = "a@b.com"))
+        }
+
+        verify(exactly = 0) { mockUserSwitcher.createAndSwitchToNewUser(suppressBackendOperation = any(), modify = any()) }
+        coVerify(exactly = 1) {
+            mockOperationRepo.enqueueAndAwaitResult(
+                withArg<LoginUserOperation> { operation ->
+                    operation.onesignalId shouldBe currentOneSignalId
+                    operation.externalId shouldBe currentExternalId
+                    operation.existingOnesignalId shouldBe null
+                    operation.email shouldBe "a@b.com"
+                },
+            )
+        }
     }
 })

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/backend/UserBackendServiceTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/backend/UserBackendServiceTests.kt
@@ -68,7 +68,35 @@ class UserBackendServiceTests : FunSpec({
                     it.getJSONObject("identity").has("aliasLabel1") shouldBe true
                     it.getJSONObject("identity").getString("aliasLabel1") shouldBe "aliasValue1"
                     it.has("properties") shouldBe true
+                    it.getJSONObject("properties").has("tags") shouldBe false
                     it.has("subscriptions") shouldBe false
+                },
+                any(),
+            )
+        }
+    }
+
+    test("create user with tags nests them under properties") {
+        val osId = "11111111-1111-1111-1111-111111111111"
+        val spyHttpClient = mockk<IHttpClient>()
+        coEvery {
+            spyHttpClient.post(any(), any(), any())
+        } returns HttpResponse(202, "{identity:{onesignal_id: \"$osId\"}, properties:{timezone_id: \"testTimeZone\"}}")
+        val userBackendService = UserBackendService(spyHttpClient)
+
+        userBackendService.createUser(
+            "appId",
+            mapOf("external_id" to "user-1"),
+            listOf(),
+            mapOf("timezone_id" to "testTimeZone", "tags" to mapOf("plan" to "pro")),
+        )
+
+        coVerify {
+            spyHttpClient.post(
+                "apps/appId/users",
+                withArg {
+                    it.getJSONObject("identity").getString("external_id") shouldBe "user-1"
+                    it.getJSONObject("properties").getJSONObject("tags").getString("plan") shouldBe "pro"
                 },
                 any(),
             )

--- a/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/LoginUserOperationExecutorTests.kt
+++ b/OneSignalSDK/onesignal/core/src/test/java/com/onesignal/user/internal/operations/LoginUserOperationExecutorTests.kt
@@ -1,12 +1,14 @@
 package com.onesignal.user.internal.operations
 
 import br.com.colman.kotest.android.extensions.robolectric.RobolectricTest
+import com.onesignal.OneSignalUserProfile
 import com.onesignal.common.exceptions.BackendException
 import com.onesignal.core.internal.operations.ExecutionResponse
 import com.onesignal.core.internal.operations.ExecutionResult
 import com.onesignal.core.internal.operations.Operation
 import com.onesignal.mocks.AndroidMockHelper
 import com.onesignal.mocks.MockHelper
+import com.onesignal.mocks.MockPreferencesService
 import com.onesignal.user.internal.backend.CreateUserResponse
 import com.onesignal.user.internal.backend.IUserBackendService
 import com.onesignal.user.internal.backend.IdentityConstants
@@ -14,11 +16,13 @@ import com.onesignal.user.internal.backend.PropertiesObject
 import com.onesignal.user.internal.backend.SubscriptionObject
 import com.onesignal.user.internal.backend.SubscriptionObjectType
 import com.onesignal.user.internal.identity.IdentityModel
+import com.onesignal.user.internal.identity.IdentityModelStore
 import com.onesignal.user.internal.operations.ExecutorMocks.Companion.getIdentityVerificationService
 import com.onesignal.user.internal.operations.ExecutorMocks.Companion.getJwtTokenStore
 import com.onesignal.user.internal.operations.impl.executors.IdentityOperationExecutor
 import com.onesignal.user.internal.operations.impl.executors.LoginUserOperationExecutor
 import com.onesignal.user.internal.properties.PropertiesModel
+import com.onesignal.user.internal.properties.PropertiesModelStore
 import com.onesignal.user.internal.subscriptions.SubscriptionModel
 import com.onesignal.user.internal.subscriptions.SubscriptionModelStore
 import com.onesignal.user.internal.subscriptions.SubscriptionStatus
@@ -942,5 +946,286 @@ class LoginUserOperationExecutorTests : FunSpec({
         // IdentityOperationExecutor must NOT be invoked (strict mock enforces this via kotest's
         // unstubbed-call failure; coVerify(exactly = 0) makes the expectation explicit).
         coVerify(exactly = 0) { mockIdentityOperationExecutor.execute(any()) }
+    }
+
+    fun profileExecutor(
+        backend: IUserBackendService,
+        subscriptions: SubscriptionModelStore = SubscriptionModelStore(MockPreferencesService()),
+        identityStore: IdentityModelStore = MockHelper.identityModelStore { it.onesignalId = localOneSignalId },
+        propertiesStore: PropertiesModelStore = MockHelper.propertiesModelStore { it.onesignalId = localOneSignalId },
+        identityExecutor: IdentityOperationExecutor = mockk(relaxed = true),
+        ivActive: Boolean = false,
+    ) = LoginUserOperationExecutor(
+        identityExecutor,
+        AndroidMockHelper.applicationService(),
+        MockHelper.deviceService(),
+        backend,
+        identityStore,
+        propertiesStore,
+        subscriptions,
+        MockHelper.configModelStore(),
+        MockHelper.languageContext(),
+        getJwtTokenStore(),
+        getIdentityVerificationService(newCodePathsRun = ivActive, ivBehaviorActive = ivActive),
+        mockk(relaxed = true),
+    )
+
+    test("composite login with email only sends an Email subscription") {
+        val mockUserBackendService = mockk<IUserBackendService>()
+        coEvery { mockUserBackendService.createUser(any(), any(), any(), any()) } returns
+            CreateUserResponse(
+                mapOf(IdentityConstants.ONESIGNAL_ID to remoteOneSignalId),
+                PropertiesObject(),
+                listOf(SubscriptionObject(id = "email-sub", type = SubscriptionObjectType.EMAIL, token = "a@b.com")),
+            )
+
+        val response =
+            profileExecutor(mockUserBackendService).execute(
+                listOf(LoginUserOperation(appId, localOneSignalId, "externalId", null, OneSignalUserProfile(email = "a@b.com"))),
+            )
+
+        response.result shouldBe ExecutionResult.SUCCESS
+        coVerify(exactly = 1) {
+            mockUserBackendService.createUser(
+                appId,
+                mapOf(IdentityConstants.EXTERNAL_ID to "externalId"),
+                withArg { subs ->
+                    subs.single { it.type == SubscriptionObjectType.EMAIL }.token shouldBe "a@b.com"
+                    subs.none { it.type == SubscriptionObjectType.SMS } shouldBe true
+                },
+                any(),
+            )
+        }
+    }
+
+    test("composite login with phone only sends an SMS subscription") {
+        val mockUserBackendService = mockk<IUserBackendService>()
+        coEvery { mockUserBackendService.createUser(any(), any(), any(), any()) } returns
+            CreateUserResponse(
+                mapOf(IdentityConstants.ONESIGNAL_ID to remoteOneSignalId),
+                PropertiesObject(),
+                listOf(SubscriptionObject(id = "sms-sub", type = SubscriptionObjectType.SMS, token = "+15555550100")),
+            )
+
+        val response =
+            profileExecutor(mockUserBackendService).execute(
+                listOf(LoginUserOperation(appId, localOneSignalId, "externalId", null, OneSignalUserProfile(phoneNumber = "+15555550100"))),
+            )
+
+        response.result shouldBe ExecutionResult.SUCCESS
+        coVerify(exactly = 1) {
+            mockUserBackendService.createUser(
+                appId,
+                mapOf(IdentityConstants.EXTERNAL_ID to "externalId"),
+                withArg { subs ->
+                    subs.single { it.type == SubscriptionObjectType.SMS }.token shouldBe "+15555550100"
+                    subs.none { it.type == SubscriptionObjectType.EMAIL } shouldBe true
+                },
+                any(),
+            )
+        }
+    }
+
+    test("composite login with tags only forwards them on createUser") {
+        val mockUserBackendService = mockk<IUserBackendService>()
+        coEvery { mockUserBackendService.createUser(any(), any(), any(), any()) } returns
+            CreateUserResponse(mapOf(IdentityConstants.ONESIGNAL_ID to remoteOneSignalId), PropertiesObject(), listOf())
+
+        val response =
+            profileExecutor(mockUserBackendService).execute(
+                listOf(LoginUserOperation(appId, localOneSignalId, "externalId", null, OneSignalUserProfile(tags = mapOf("plan" to "pro")))),
+            )
+
+        response.result shouldBe ExecutionResult.SUCCESS
+        coVerify(exactly = 1) {
+            mockUserBackendService.createUser(
+                appId,
+                mapOf(IdentityConstants.EXTERNAL_ID to "externalId"),
+                any(),
+                withArg { props ->
+                    props["tags"] shouldBe mapOf("plan" to "pro")
+                },
+            )
+        }
+    }
+
+    test("composite login with aliases includes them on identity and skips reserved labels") {
+        val mockUserBackendService = mockk<IUserBackendService>()
+        coEvery { mockUserBackendService.createUser(any(), any(), any(), any()) } returns
+            CreateUserResponse(mapOf(IdentityConstants.ONESIGNAL_ID to remoteOneSignalId), PropertiesObject(), listOf())
+
+        val response =
+            profileExecutor(mockUserBackendService).execute(
+                listOf(
+                    LoginUserOperation(
+                        appId,
+                        localOneSignalId,
+                        "externalId",
+                        null,
+                        OneSignalUserProfile(
+                            aliases =
+                            mapOf(
+                                "facebook" to "bob",
+                                IdentityConstants.ONESIGNAL_ID to "should-skip",
+                                IdentityConstants.EXTERNAL_ID to "should-skip",
+                            ),
+                        ),
+                    ),
+                ),
+            )
+
+        response.result shouldBe ExecutionResult.SUCCESS
+        coVerify(exactly = 1) {
+            mockUserBackendService.createUser(
+                appId,
+                mapOf(
+                    IdentityConstants.EXTERNAL_ID to "externalId",
+                    "facebook" to "bob",
+                ),
+                any(),
+                any(),
+            )
+        }
+    }
+
+    test("composite login alias conflict drops the login op") {
+        val mockUserBackendService = mockk<IUserBackendService>()
+        coEvery { mockUserBackendService.createUser(any(), any(), any(), any()) } throws BackendException(409, "CONFLICT")
+
+        val response =
+            profileExecutor(mockUserBackendService).execute(
+                listOf(LoginUserOperation(appId, localOneSignalId, "externalId", null, OneSignalUserProfile(aliases = mapOf("facebook" to "bob")))),
+            )
+
+        response.result shouldBe ExecutionResult.FAIL_NORETRY
+        response.httpStatusCode shouldBe 409
+        response.httpResponse shouldBe "CONFLICT"
+    }
+
+    test("composite login malformed email drops the login op") {
+        val mockUserBackendService = mockk<IUserBackendService>()
+        coEvery { mockUserBackendService.createUser(any(), any(), any(), any()) } throws BackendException(400, "INVALID EMAIL")
+
+        val response =
+            profileExecutor(mockUserBackendService).execute(
+                listOf(LoginUserOperation(appId, localOneSignalId, "externalId", null, OneSignalUserProfile(email = "not-an-email"))),
+            )
+
+        response.result shouldBe ExecutionResult.FAIL_NORETRY
+        response.httpStatusCode shouldBe 400
+        response.httpResponse shouldBe "INVALID EMAIL"
+    }
+
+    test("IV composite login missing the claimed email is unauthorized") {
+        val mockUserBackendService = mockk<IUserBackendService>()
+        coEvery { mockUserBackendService.createUser(any(), any(), any(), any(), any()) } throws BackendException(401, "UNAUTHORIZED")
+
+        val response =
+            profileExecutor(mockUserBackendService, ivActive = true).execute(
+                listOf(LoginUserOperation(appId, localOneSignalId, "externalId", null, OneSignalUserProfile(email = "a@b.com"))),
+            )
+
+        response.result shouldBe ExecutionResult.FAIL_UNAUTHORIZED
+        response.httpStatusCode shouldBe 401
+        response.httpResponse shouldBe "UNAUTHORIZED"
+    }
+
+    test("composite login hydrates aliases tags and email subscription on success") {
+        val mockUserBackendService = mockk<IUserBackendService>()
+        coEvery { mockUserBackendService.createUser(any(), any(), any(), any()) } returns
+            CreateUserResponse(
+                mapOf(IdentityConstants.ONESIGNAL_ID to remoteOneSignalId),
+                PropertiesObject(),
+                listOf(SubscriptionObject(id = "email-sub", type = SubscriptionObjectType.EMAIL, token = "a@b.com")),
+            )
+        val identityStore = MockHelper.identityModelStore { it.onesignalId = localOneSignalId }
+        val propertiesStore = MockHelper.propertiesModelStore { it.onesignalId = localOneSignalId }
+        val subscriptions = SubscriptionModelStore(MockPreferencesService())
+
+        val response =
+            profileExecutor(mockUserBackendService, subscriptions, identityStore, propertiesStore).execute(
+                listOf(
+                    LoginUserOperation(
+                        appId,
+                        localOneSignalId,
+                        "externalId",
+                        null,
+                        OneSignalUserProfile(
+                            email = "a@b.com",
+                            tags = mapOf("plan" to "pro"),
+                            aliases = mapOf("facebook" to "bob"),
+                        ),
+                    ),
+                ),
+            )
+
+        response.result shouldBe ExecutionResult.SUCCESS
+        identityStore.model.onesignalId shouldBe remoteOneSignalId
+        identityStore.model["facebook"] shouldBe "bob"
+        propertiesStore.model.tags["plan"] shouldBe "pro"
+        subscriptions.list().single { it.type == SubscriptionType.EMAIL }.let {
+            it.id shouldBe "email-sub"
+            it.address shouldBe "a@b.com"
+        }
+    }
+
+    test("composite login with existingOnesignalId still createUsers so the profile is sent") {
+        val mockUserBackendService = mockk<IUserBackendService>()
+        coEvery { mockUserBackendService.createUser(any(), any(), any(), any()) } returns
+            CreateUserResponse(
+                mapOf(IdentityConstants.ONESIGNAL_ID to remoteOneSignalId),
+                PropertiesObject(),
+                listOf(SubscriptionObject(id = "email-sub", type = SubscriptionObjectType.EMAIL, token = "a@b.com")),
+            )
+        val identityExecutor = mockk<IdentityOperationExecutor>()
+
+        val response =
+            profileExecutor(mockUserBackendService, identityExecutor = identityExecutor).execute(
+                listOf(LoginUserOperation(appId, localOneSignalId, "externalId", "existing-osid", OneSignalUserProfile(email = "a@b.com"))),
+            )
+
+        response.result shouldBe ExecutionResult.SUCCESS
+        coVerify(exactly = 1) { mockUserBackendService.createUser(any(), any(), any(), any()) }
+        coVerify(exactly = 0) { identityExecutor.execute(any()) }
+    }
+
+    test("identity-only login still associates via SetAlias when existingOnesignalId is set") {
+        val mockUserBackendService = mockk<IUserBackendService>()
+        val identityExecutor = mockk<IdentityOperationExecutor>()
+        coEvery { identityExecutor.execute(any()) } returns ExecutionResponse(ExecutionResult.SUCCESS)
+
+        val response =
+            profileExecutor(mockUserBackendService, identityExecutor = identityExecutor).execute(
+                listOf(LoginUserOperation(appId, localOneSignalId, "externalId", "existing-osid")),
+            )
+
+        response.result shouldBe ExecutionResult.SUCCESS_STARTING_ONLY
+        coVerify(exactly = 0) { mockUserBackendService.createUser(any(), any(), any(), any()) }
+        coVerify(exactly = 1) { identityExecutor.execute(any()) }
+    }
+
+    test("LoginUserOperation profile fields survive JSON round trip") {
+        val original =
+            LoginUserOperation(
+                appId,
+                localOneSignalId,
+                "externalId",
+                "existing-osid",
+                OneSignalUserProfile(
+                    email = "a@b.com",
+                    phoneNumber = "+15555550100",
+                    tags = mapOf("plan" to "pro"),
+                    aliases = mapOf("facebook" to "bob"),
+                ),
+            )
+
+        val restored = LoginUserOperation()
+        restored.initializeFromJson(original.toJSON())
+
+        restored.email shouldBe "a@b.com"
+        restored.phoneNumber shouldBe "+15555550100"
+        restored.tags shouldBe mapOf("plan" to "pro")
+        restored.aliases shouldBe mapOf("facebook" to "bob")
+        restored.existingOnesignalId shouldBe "existing-osid"
     }
 })

--- a/examples/demo/app/src/main/java/com/onesignal/example/CompositeLoginExample.java
+++ b/examples/demo/app/src/main/java/com/onesignal/example/CompositeLoginExample.java
@@ -1,0 +1,27 @@
+package com.onesignal.example;
+
+import com.onesignal.OneSignalUserProfile;
+import java.util.Collections;
+import java.util.Map;
+
+/** Java example of building a composite-login profile with OneSignalUserProfile.Builder. */
+public final class CompositeLoginExample {
+    private CompositeLoginExample() {}
+
+    public static OneSignalUserProfile profile(String email, String phoneNumber) {
+        return profile(email, phoneNumber, Collections.emptyMap(), Collections.emptyMap());
+    }
+
+    public static OneSignalUserProfile profile(
+            String email,
+            String phoneNumber,
+            Map<String, String> tags,
+            Map<String, String> aliases) {
+        return new OneSignalUserProfile.Builder()
+                .setEmail(email)
+                .setPhoneNumber(phoneNumber)
+                .setTags(tags)
+                .setAliases(aliases)
+                .build();
+    }
+}

--- a/examples/demo/app/src/main/java/com/onesignal/example/data/model/CompositeLoginExample.java
+++ b/examples/demo/app/src/main/java/com/onesignal/example/data/model/CompositeLoginExample.java
@@ -1,0 +1,27 @@
+package com.onesignal.example;
+
+import com.onesignal.OneSignalUserProfile;
+import java.util.Collections;
+import java.util.Map;
+
+/** Java example of building a composite-login profile with OneSignalUserProfile.Builder. */
+public final class CompositeLoginExample {
+    private CompositeLoginExample() {}
+
+    public static OneSignalUserProfile profile(String email, String phoneNumber) {
+        return profile(email, phoneNumber, Collections.emptyMap(), Collections.emptyMap());
+    }
+
+    public static OneSignalUserProfile profile(
+            String email,
+            String phoneNumber,
+            Map<String, String> tags,
+            Map<String, String> aliases) {
+        return new OneSignalUserProfile.Builder()
+                .setEmail(email)
+                .setPhoneNumber(phoneNumber)
+                .setTags(tags)
+                .setAliases(aliases)
+                .build();
+    }
+}

--- a/examples/demo/app/src/main/java/com/onesignal/example/data/repository/OneSignalRepository.kt
+++ b/examples/demo/app/src/main/java/com/onesignal/example/data/repository/OneSignalRepository.kt
@@ -2,6 +2,7 @@ package com.onesignal.example.data.repository
 
 import android.util.Log
 import com.onesignal.OneSignal
+import com.onesignal.example.CompositeLoginExample
 import com.onesignal.example.data.model.NotificationType
 import com.onesignal.example.data.network.OneSignalService
 import com.onesignal.example.data.network.UserData
@@ -23,6 +24,18 @@ class OneSignalRepository {
         Log.d(TAG, "Logging in user with externalUserId: $externalUserId, jwt: ${if (jwtToken != null) "provided" else "none"}")
         OneSignal.login(externalUserId, jwtToken)
         Log.d(TAG, "Logged in user with onesignalId: ${OneSignal.User.onesignalId}")
+    }
+
+    suspend fun loginUserWithProfile(
+        externalUserId: String,
+        email: String?,
+        phoneNumber: String?,
+        jwtToken: String? = null,
+    ) = withContext(Dispatchers.IO) {
+        Log.d(TAG, "Composite login externalUserId: $externalUserId email=$email phone=$phoneNumber")
+        val profile = CompositeLoginExample.profile(email, phoneNumber)
+        val result = OneSignal.login(externalUserId, profile, jwtToken)
+        Log.d(TAG, "Composite login result: $result")
     }
 
     suspend fun updateUserJwt(externalUserId: String, jwtToken: String) = withContext(Dispatchers.IO) {

--- a/examples/demo/app/src/main/java/com/onesignal/example/ui/components/Dialogs.kt
+++ b/examples/demo/app/src/main/java/com/onesignal/example/ui/components/Dialogs.kt
@@ -465,6 +465,102 @@ fun LoginDialog(
     )
 }
 
+@Composable
+fun CompositeLoginDialog(
+    onDismiss: () -> Unit,
+    onConfirm: (externalId: String, email: String?, phoneNumber: String?, jwt: String?) -> Unit,
+) {
+    var externalId by remember { mutableStateOf("") }
+    var email by remember { mutableStateOf("") }
+    var phoneNumber by remember { mutableStateOf("") }
+    var jwtToken by remember { mutableStateOf("") }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        modifier = Modifier.fillMaxWidth().padding(horizontal = DemoLayout.pagePadding).exposeTestTagsAsResourceId(),
+        properties = DialogProperties(usePlatformDefaultWidth = false),
+        title = {
+            DialogTitle("Login With Profile")
+        },
+        text = {
+            Column {
+                OutlinedTextField(
+                    value = externalId,
+                    onValueChange = { externalId = it },
+                    label = { Text("External User Id") },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag("composite_login_user_id_input"),
+                    singleLine = true,
+                    shape = TextFieldShape,
+                    colors = dialogTextFieldColors()
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+                OutlinedTextField(
+                    value = email,
+                    onValueChange = { email = it },
+                    label = { Text("Email (optional)") },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag("composite_login_email_input"),
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email),
+                    shape = TextFieldShape,
+                    colors = dialogTextFieldColors()
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+                OutlinedTextField(
+                    value = phoneNumber,
+                    onValueChange = { phoneNumber = it },
+                    label = { Text("Phone (optional)") },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag("composite_login_phone_input"),
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Phone),
+                    shape = TextFieldShape,
+                    colors = dialogTextFieldColors()
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+                OutlinedTextField(
+                    value = jwtToken,
+                    onValueChange = { jwtToken = it },
+                    label = { Text("JWT Token (optional)") },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag("composite_login_jwt_input"),
+                    singleLine = true,
+                    shape = TextFieldShape,
+                    colors = dialogTextFieldColors()
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    onConfirm(
+                        externalId,
+                        email.ifBlank { null },
+                        phoneNumber.ifBlank { null },
+                        jwtToken.ifBlank { null },
+                    )
+                },
+                enabled = externalId.isNotBlank(),
+                modifier = Modifier.testTag("composite_login_confirm_button"),
+                colors = dialogTextButtonColors(),
+            ) {
+                DialogActionLabel("Login")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss, colors = dialogTextButtonColors()) {
+                DialogActionLabel("Cancel")
+            }
+        },
+        shape = DialogShape
+    )
+}
+
 /**
  * Dialog for outcome selection and input.
  */

--- a/examples/demo/app/src/main/java/com/onesignal/example/ui/main/MainScreen.kt
+++ b/examples/demo/app/src/main/java/com/onesignal/example/ui/main/MainScreen.kt
@@ -138,6 +138,9 @@ fun MainScreen(viewModel: MainViewModel) {
                     useIdentityVerification = useIdentityVerification,
                     onUseIdentityVerificationChange = { viewModel.setUseIdentityVerification(it) },
                     onLogin = { userId, jwt -> viewModel.loginUser(userId, jwt) },
+                    onLoginWithProfile = { userId, email, phone, jwt ->
+                        viewModel.loginUserWithProfile(userId, email, phone, jwt)
+                    },
                     onLogout = { viewModel.logoutUser() },
                     onUpdateJwt = { externalId, token -> viewModel.updateUserJwt(externalId, token) },
                     isLoading = isLoading

--- a/examples/demo/app/src/main/java/com/onesignal/example/ui/main/MainViewModel.kt
+++ b/examples/demo/app/src/main/java/com/onesignal/example/ui/main/MainViewModel.kt
@@ -287,6 +287,34 @@ class MainViewModel(application: Application) : AndroidViewModel(application), I
         }
     }
 
+    fun loginUserWithProfile(
+        externalUserId: String,
+        email: String?,
+        phoneNumber: String?,
+        jwtToken: String? = null,
+    ) {
+        _isLoading.value = true
+        viewModelScope.launch(Dispatchers.IO) {
+            repository.loginUserWithProfile(externalUserId, email, phoneNumber, jwtToken)
+            withContext(Dispatchers.Main) {
+                SharedPreferenceUtil.cacheUserExternalUserId(getApplication(), externalUserId)
+                SharedPreferenceUtil.cacheJwtToken(getApplication(), jwtToken)
+                _externalUserId.value = externalUserId
+                aliasesList.clear()
+                emailsList.clear()
+                smsNumbersList.clear()
+                triggersList.clear()
+                refreshAliases()
+                refreshEmails()
+                refreshSmsNumbers()
+                refreshTriggers()
+                loadExistingTags()
+                refreshPushSubscription()
+                _isLoading.value = false
+            }
+        }
+    }
+
     fun updateUserJwt(externalUserId: String, jwtToken: String) {
         viewModelScope.launch(Dispatchers.IO) {
             repository.updateUserJwt(externalUserId, jwtToken)

--- a/examples/demo/app/src/main/java/com/onesignal/example/ui/main/Sections.kt
+++ b/examples/demo/app/src/main/java/com/onesignal/example/ui/main/Sections.kt
@@ -29,6 +29,7 @@ import com.onesignal.example.ui.components.CustomNotificationDialog
 import com.onesignal.example.ui.components.DemoSection
 import com.onesignal.example.ui.components.DestructiveButton
 import com.onesignal.example.ui.components.LocalSnackbarController
+import com.onesignal.example.ui.components.CompositeLoginDialog
 import com.onesignal.example.ui.components.LoginDialog
 import com.onesignal.example.ui.components.MultiPairInputDialog
 import com.onesignal.example.ui.components.MultiSelectRemoveDialog
@@ -133,12 +134,14 @@ fun UserSection(
     useIdentityVerification: Boolean,
     onUseIdentityVerificationChange: (Boolean) -> Unit,
     onLogin: (String, String?) -> Unit,
+    onLoginWithProfile: (String, String?, String?, String?) -> Unit,
     onLogout: () -> Unit,
     onUpdateJwt: (String, String) -> Unit,
     isLoading: Boolean = false,
 ) {
     val isLoggedIn = !externalUserId.isNullOrEmpty()
     var loginOpen by remember { mutableStateOf(false) }
+    var compositeLoginOpen by remember { mutableStateOf(false) }
     var updateJwtOpen by remember { mutableStateOf(false) }
 
     DemoSection {
@@ -176,6 +179,13 @@ fun UserSection(
             testTag = "login_user_button",
         )
 
+        OutlineButton(
+            text = "LOGIN WITH PROFILE",
+            onClick = { compositeLoginOpen = true },
+            enabled = !isLoading,
+            testTag = "composite_login_button",
+        )
+
         if (isLoggedIn) {
             OutlineButton(
                 text = "LOGOUT USER",
@@ -198,6 +208,16 @@ fun UserSection(
             onConfirm = { userId, jwt ->
                 onLogin(userId, jwt)
                 loginOpen = false
+            },
+        )
+    }
+
+    if (compositeLoginOpen) {
+        CompositeLoginDialog(
+            onDismiss = { compositeLoginOpen = false },
+            onConfirm = { userId, email, phone, jwt ->
+                onLoginWithProfile(userId, email, phone, jwt)
+                compositeLoginOpen = false
             },
         )
     }


### PR DESCRIPTION
# Description
## One Line Summary
Add `login(externalId, profile)` so email, SMS, tags, and aliases go out on a single Create User upsert, and return HTTP 4xx on the waiting `OneSignalResult`.

## Details

### Motivation
Identity-only `login(externalId)` cannot attach profile fields. Composite login needs those fields on one Create User POST (upsert by `external_id`) so a bad SMS/email cannot freeze the op repo, and the suspend caller gets the backend body instead of a generic "did not complete".

Stacked on #2710 (`ar/sdk-4988`). Parent: [SDK-5023](https://linear.app/onesignal/issue/SDK-5023). Types/signature: [SDK-5024](https://linear.app/onesignal/issue/SDK-5024). One POST: [SDK-5025](https://linear.app/onesignal/issue/SDK-5025).

### Scope
- New `OneSignalUserProfile` (`email`, `phoneNumber` in E.164, `tags`, `aliases`) plus Java `Builder`. JWT stays a separate argument. `externalId` stays the login key.
- Identity-only `login` / `loginSuspend` are unchanged.
- Same `externalId` with no profile fields is still a no-op. Same `externalId` with profile fields upserts.
- Composite 400/409 drop the op (`FAIL_NORETRY`) instead of pausing the repo. Identity-only 4xx still pause.
- `enqueueAndAwaitResult` carries HTTP status/body so composite `login` returns `OneSignalResult.failure(BACKEND_ERROR, message=body, backendCode=HTTP status)`. Catalog codes are not parsed yet.
- Demo: LOGIN WITH PROFILE dialog.

Not in this PR: persistence ([SDK-5026](https://linear.app/onesignal/issue/SDK-5026)), telemetry ([SDK-5027](https://linear.app/onesignal/issue/SDK-5027)), a login callback, catalog `backendCode`.

# Testing
## Unit testing
Executor tests cover identity-only payload unchanged, profile aliases/email/SMS/tags on Create User, reserved alias skip, 400/409 `FAIL_NORETRY` with HTTP fields, 401, and hydration. OperationRepo wakes `enqueueAndAwaitResult` with status/body. LoginHelper, UserBackendService nested tags, and profile builder tests added.

## Manual testing
Demo app on a physical device. Composite login with a non-E.164 SMS (`4129089471`) returns HTTP 400 `Invalid token format for device type SMS`, logs the body, returns `OneSignalResult.failure`, and does not pause the op repo. Retry with `+14129089471` succeeds.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [x] REST API requests
   - [x] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

Made with [Cursor](https://cursor.com)