### PR TITLE
fix: [SDK-5171] improve Firebase Installation ID configuration errors

### DIFF
--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/pushtoken/PushTokenManager.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/pushtoken/PushTokenManager.kt
@@ -30,17 +30,18 @@ internal class PushTokenManager(
             else -> {
                 val registerResult = _pushRegistrator.registerForPush()
 
-                if (registerResult.status.value == SubscriptionStatus.SUBSCRIBED.value) {
-                    pushTokenStatus = registerResult.status
-                } else if (registerResult.status.value < SubscriptionStatus.SUBSCRIBED.value) {
-                    if (shouldUpdateErrorStatus(registerResult.status)) {
-                        pushTokenStatus = registerResult.status
+                val shouldUpdate =
+                    when {
+                        registerResult.status.value == SubscriptionStatus.SUBSCRIBED.value -> true
+                        registerResult.status.value < SubscriptionStatus.SUBSCRIBED.value ->
+                            shouldUpdateErrorStatus(registerResult.status)
+                        else -> pushTokenStatus.isRetryableTokenError
                     }
-                } else if (pushTokenStatus.isRetryableTokenError) {
-                    pushTokenStatus = registerResult.status
-                }
 
-                pushToken = registerResult.id
+                if (shouldUpdate) {
+                    pushTokenStatus = registerResult.status
+                    pushToken = registerResult.id
+                }
             }
         }
 
@@ -49,8 +50,9 @@ internal class PushTokenManager(
 
     private fun shouldUpdateErrorStatus(newStatus: SubscriptionStatus): Boolean =
         when {
-            !newStatus.isRetryableTokenError -> true
+            newStatus == SubscriptionStatus.INVALID_FCM_SENDER_ID -> true
             pushToken != null -> false
+            !newStatus.isRetryableTokenError -> true
             else -> pushTokenStatus == SubscriptionStatus.NO_PERMISSION || pushTokenStatus.isRetryableTokenError
         }
 }

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/pushtoken/PushTokenManager.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/pushtoken/PushTokenManager.kt
@@ -34,7 +34,7 @@ internal class PushTokenManager(
                     when {
                         registerResult.status.value == SubscriptionStatus.SUBSCRIBED.value -> true
                         registerResult.status.value < SubscriptionStatus.SUBSCRIBED.value ->
-                            shouldUpdateErrorStatus(registerResult.status)
+                            shouldUpdateErrorStatus(registerResult)
                         else -> pushTokenStatus.isRetryableTokenError
                     }
 
@@ -48,11 +48,11 @@ internal class PushTokenManager(
         return PushTokenResponse(pushToken, pushTokenStatus)
     }
 
-    private fun shouldUpdateErrorStatus(newStatus: SubscriptionStatus): Boolean =
+    private fun shouldUpdateErrorStatus(registerResult: IPushRegistrator.RegisterResult): Boolean =
         when {
-            newStatus == SubscriptionStatus.INVALID_FCM_SENDER_ID -> true
+            registerResult.isExistingTokenInvalid -> true
             pushToken != null -> false
-            !newStatus.isRetryableTokenError -> true
+            !registerResult.status.isRetryableTokenError -> true
             else -> pushTokenStatus == SubscriptionStatus.NO_PERMISSION || pushTokenStatus.isRetryableTokenError
         }
 }

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/registration/IPushRegistrator.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/registration/IPushRegistrator.kt
@@ -3,7 +3,11 @@ package com.onesignal.notifications.internal.registration
 import com.onesignal.user.internal.subscriptions.SubscriptionStatus
 
 internal interface IPushRegistrator {
-    class RegisterResult(val id: String?, val status: SubscriptionStatus)
+    class RegisterResult(
+        val id: String?,
+        val status: SubscriptionStatus,
+        val isExistingTokenInvalid: Boolean = false,
+    )
 
     /**
      * Register the provided context for push notifications.

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorAbstractGoogle.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorAbstractGoogle.kt
@@ -123,6 +123,7 @@ internal abstract class PushRegistratorAbstractGoogle(
         )
     }
 
+    @Suppress("LongMethod", "NestedBlockDepth", "ReturnCount")
     private suspend fun attemptRegistration(
         senderId: String,
         currentRetry: Int,
@@ -136,6 +137,8 @@ internal abstract class PushRegistratorAbstractGoogle(
             )
         } catch (e: FCMSenderIdMismatchException) {
             return invalidSenderIdResult(e)
+        } catch (e: FCMInstallationIdException) {
+            return installationIdErrorResult(e)
         } catch (e: IOException) {
             val pushStatus: SubscriptionStatus = pushStatusFromThrowable(e)
             val exceptionMessage: String? = AndroidUtils.getRootCauseMessage(e)
@@ -199,4 +202,12 @@ internal abstract class PushRegistratorAbstractGoogle(
         private const val REGISTRATION_RETRY_COUNT = 5
         private const val REGISTRATION_RETRY_BACKOFF_MS = 10000
     }
+}
+
+private fun installationIdErrorResult(exception: FCMInstallationIdException): IPushRegistrator.RegisterResult {
+    Logging.warn(exception.message ?: "Firebase Installation ID registration failed", exception)
+    return IPushRegistrator.RegisterResult(
+        null,
+        SubscriptionStatus.FIREBASE_FCM_ERROR_MISC_EXCEPTION,
+    )
 }

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorAbstractGoogle.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorAbstractGoogle.kt
@@ -176,10 +176,11 @@ internal abstract class PushRegistratorAbstractGoogle(
     }
 
     private fun invalidSenderIdResult(exception: FCMSenderIdMismatchException): IPushRegistrator.RegisterResult {
-        Logging.warn("FCM sender ID mismatch", exception)
+        Logging.warn(exception.message ?: "FCM sender ID mismatch", exception)
         return IPushRegistrator.RegisterResult(
             null,
             SubscriptionStatus.INVALID_FCM_SENDER_ID,
+            isExistingTokenInvalid = true,
         )
     }
 

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorFCM.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorFCM.kt
@@ -135,6 +135,56 @@ internal class PushRegistratorFCM(
 
 internal class FCMSenderIdMismatchException(message: String) : IllegalStateException(message)
 
+internal enum class FCMInstallationIdFailureReason {
+    NO_DEFAULT_FIREBASE_APP,
+    REGISTER_API_UNAVAILABLE,
+    REGISTRATION_FAILED,
+}
+
+internal class FCMInstallationIdException(
+    val reason: FCMInstallationIdFailureReason,
+    message: String,
+    cause: Throwable? = null,
+) : IllegalStateException(message, cause)
+
+private class FCMInstallationIdDiagnostics(
+    val flagValue: String,
+    val registration: FCMTokenProvider.InstallationIdRegistration?,
+    val registerApiAvailable: Boolean,
+) {
+    fun summary(): String =
+        "firebase_messaging_installation_id_enabled=$flagValue, " +
+            "defaultFirebaseApp=${registration != null}, " +
+            "registerApi=$registerApiAvailable"
+}
+
+private fun requireInstallationIdRegistration(
+    diagnostics: FCMInstallationIdDiagnostics,
+): FCMTokenProvider.InstallationIdRegistration =
+    diagnostics.registration
+        ?: throw FCMInstallationIdException(
+            FCMInstallationIdFailureReason.NO_DEFAULT_FIREBASE_APP,
+            "Firebase Installation ID registration cannot start because this app has no " +
+                "default FirebaseApp (${diagnostics.summary()}). Add google-services.json and " +
+                "apply the com.google.gms.google-services Gradle plugin. If another dependency " +
+                "enabled firebase_messaging_installation_id_enabled through manifest merging, " +
+                "override it to false in your application manifest to use the legacy FCM token API.",
+        )
+
+private fun requireInstallationIdRegisterApi(diagnostics: FCMInstallationIdDiagnostics) {
+    if (!diagnostics.registerApiAvailable) {
+        throw FCMInstallationIdException(
+            FCMInstallationIdFailureReason.REGISTER_API_UNAVAILABLE,
+            "Firebase Installation ID registration cannot start because " +
+                "FirebaseMessaging.register() is unavailable (${diagnostics.summary()}). " +
+                "Use firebase-messaging 25.1.0 or newer and ensure OneSignal's consumer " +
+                "ProGuard rules are applied. If another dependency enabled " +
+                "firebase_messaging_installation_id_enabled through manifest merging, " +
+                "override it to false in your application manifest to use the legacy FCM token API.",
+        )
+    }
+}
+
 internal object FCMTokenProvider {
     fun firebaseAppSenderId(
         senderId: String?,
@@ -169,8 +219,16 @@ internal object FCMTokenProvider {
         installationIdRegistration: () -> InstallationIdRegistration?,
     ): String {
         val installationIdEnabledValue = installationIdEnabled()
-        if (installationIdEnabledValue.equals("true", ignoreCase = true) && installationIdApiAvailable()) {
-            return registerInstallationId(senderId, installationIdEnabledValue, installationIdRegistration())
+        val registerApiAvailable = installationIdApiAvailable()
+        if (installationIdEnabledValue.equals("true", ignoreCase = true) && registerApiAvailable) {
+            return registerInstallationId(
+                senderId,
+                FCMInstallationIdDiagnostics(
+                    installationIdEnabledValue,
+                    installationIdRegistration(),
+                    registerApiAvailable,
+                ),
+            )
         }
 
         return try {
@@ -178,31 +236,48 @@ internal object FCMTokenProvider {
         } catch (e: IllegalStateException) {
             if (!isLegacyTokenApiDisabled(e)) throw e
 
-            registerInstallationId(senderId, installationIdEnabledValue, installationIdRegistration())
+            val registration = installationIdRegistration()
+            registerInstallationId(
+                senderId,
+                FCMInstallationIdDiagnostics(
+                    installationIdEnabledValue,
+                    registration,
+                    registerApiAvailable,
+                ),
+            )
         }
     }
 
     private fun registerInstallationId(
         senderId: String,
-        installationIdEnabled: String,
-        registration: InstallationIdRegistration?,
+        diagnostics: FCMInstallationIdDiagnostics,
     ): String {
-        val optedIn = "firebase_messaging_installation_id_enabled=$installationIdEnabled"
-
-        if (registration == null) {
-            throw IllegalStateException(
-                "Firebase Installation ID registration is enabled ($optedIn) but this app has no " +
-                    "default FirebaseApp to register with. Add your Firebase configuration " +
-                    "(google-services.json), or set firebase_messaging_installation_id_enabled to " +
-                    "false in your manifest to keep using the legacy FCM token API.",
-            )
-        }
+        val registration = requireInstallationIdRegistration(diagnostics)
 
         validateSenderId(senderId, registration.senderId)
-
-        await(registration.register())
-        return await(registration.installationId())
+        requireInstallationIdRegisterApi(diagnostics)
+        return retrieveInstallationId(registration, diagnostics)
     }
+
+    @Suppress("TooGenericExceptionCaught")
+    private fun retrieveInstallationId(
+        registration: InstallationIdRegistration,
+        diagnostics: FCMInstallationIdDiagnostics,
+    ): String =
+        try {
+            await(registration.register())
+            await(registration.installationId())
+        } catch (e: FCMInstallationIdException) {
+            throw e
+        } catch (e: Exception) {
+            throw FCMInstallationIdException(
+                FCMInstallationIdFailureReason.REGISTRATION_FAILED,
+                "Firebase Installation ID registration failed (${diagnostics.summary()}). Verify " +
+                    "google-services.json, the com.google.gms.google-services Gradle plugin, and " +
+                    "that the default Firebase project matches the OneSignal Android configuration.",
+                e,
+            )
+        }
 
     fun validateSenderId(
         senderId: String,
@@ -234,7 +309,8 @@ internal object FCMTokenProvider {
             try {
                 target.javaClass.getMethod("register")
             } catch (e: NoSuchMethodException) {
-                throw IllegalStateException(
+                throw FCMInstallationIdException(
+                    FCMInstallationIdFailureReason.REGISTER_API_UNAVAILABLE,
                     "Firebase Installation ID registration is enabled but " +
                         "FirebaseMessaging.register() was not found. It requires firebase-messaging " +
                         "25.1.0 or newer, and has to survive minification, so check that OneSignal's " +

--- a/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorFCM.kt
+++ b/OneSignalSDK/onesignal/notifications/src/main/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorFCM.kt
@@ -11,6 +11,7 @@ import com.onesignal.common.AndroidUtils
 import com.onesignal.core.internal.application.IApplicationService
 import com.onesignal.core.internal.config.ConfigModelStore
 import com.onesignal.core.internal.device.IDeviceService
+import java.io.IOException
 import java.lang.reflect.InvocationTargetException
 import java.util.concurrent.ExecutionException
 
@@ -58,7 +59,7 @@ internal class PushRegistratorFCM(
         val hostApp = hostFirebaseApp()
         return FCMTokenProvider.getToken(
             senderId = senderId,
-            installationIdEnabled = ::installationIdEnabled,
+            installationIdFlag = ::installationIdFlag,
             legacyToken = { getLegacyToken(senderId) },
             installationIdApiAvailable = { FCMTokenProvider.hasRegisterMethod(FirebaseMessaging::class.java) },
             installationIdRegistration = { hostApp?.let(::installationIdRegistration) },
@@ -76,12 +77,12 @@ internal class PushRegistratorFCM(
         return app.get(FirebaseMessaging::class.java).token
     }
 
-    // Manifest merging means the flag can arrive from a dependency instead of the app's own
-    //   manifest, so report what the app actually resolved to. Read as a raw value because a
-    //   string "true" reads as false when asked for a boolean.
-    private fun installationIdEnabled(): String {
+    private fun installationIdFlag(): FCMTokenProvider.InstallationIdFlag {
         val metaData = AndroidUtils.getManifestMetaBundle(_applicationService.appContext)
-        return metaData?.get(INSTALLATION_ID_ENABLED_METADATA)?.toString() ?: "not set"
+        return FCMTokenProvider.InstallationIdFlag(
+            enabled = metaData?.getBoolean(INSTALLATION_ID_ENABLED_METADATA) ?: false,
+            value = metaData?.get(INSTALLATION_ID_ENABLED_METADATA)?.toString() ?: "not set",
+        )
     }
 
     // Installation ID registration is rejected unless the sender id, app id, and api key all belong
@@ -206,6 +207,11 @@ internal object FCMTokenProvider {
         val installationId: () -> Task<String>,
     )
 
+    class InstallationIdFlag(
+        val enabled: Boolean,
+        val value: String,
+    )
+
     /**
      * Retrieves an FCM token for [senderId]. When the host app has opted into Firebase Installation
      * ID registration and that API is available, it is used directly because opting in disables the
@@ -213,18 +219,18 @@ internal object FCMTokenProvider {
      */
     fun getToken(
         senderId: String,
-        installationIdEnabled: () -> String,
+        installationIdFlag: () -> InstallationIdFlag,
         legacyToken: () -> Task<String>,
         installationIdApiAvailable: () -> Boolean = { false },
         installationIdRegistration: () -> InstallationIdRegistration?,
     ): String {
-        val installationIdEnabledValue = installationIdEnabled()
+        val flag = installationIdFlag()
         val registerApiAvailable = installationIdApiAvailable()
-        if (installationIdEnabledValue.equals("true", ignoreCase = true) && registerApiAvailable) {
+        if (flag.enabled && registerApiAvailable) {
             return registerInstallationId(
                 senderId,
                 FCMInstallationIdDiagnostics(
-                    installationIdEnabledValue,
+                    flag.value,
                     installationIdRegistration(),
                     registerApiAvailable,
                 ),
@@ -240,7 +246,7 @@ internal object FCMTokenProvider {
             registerInstallationId(
                 senderId,
                 FCMInstallationIdDiagnostics(
-                    installationIdEnabledValue,
+                    flag.value,
                     registration,
                     registerApiAvailable,
                 ),
@@ -268,6 +274,8 @@ internal object FCMTokenProvider {
             await(registration.register())
             await(registration.installationId())
         } catch (e: FCMInstallationIdException) {
+            throw e
+        } catch (e: IOException) {
             throw e
         } catch (e: Exception) {
             throw FCMInstallationIdException(

--- a/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/pushtoken/PushTokenManagerTests.kt
+++ b/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/pushtoken/PushTokenManagerTests.kt
@@ -86,7 +86,11 @@ class PushTokenManagerTests : FunSpec({
         val mockPushRegistrator = mockk<IPushRegistrator>()
         coEvery { mockPushRegistrator.registerForPush() } returns
             IPushRegistrator.RegisterResult("host-fid", SubscriptionStatus.SUBSCRIBED) andThen
-            IPushRegistrator.RegisterResult(null, SubscriptionStatus.INVALID_FCM_SENDER_ID)
+            IPushRegistrator.RegisterResult(
+                null,
+                SubscriptionStatus.INVALID_FCM_SENDER_ID,
+                isExistingTokenInvalid = true,
+            )
         val mockDeviceService = MockHelper.deviceService()
         every { mockDeviceService.jetpackLibraryStatus } returns IDeviceService.JetpackLibraryStatus.OK
         val pushTokenManager = PushTokenManager(mockPushRegistrator, mockDeviceService)
@@ -98,6 +102,24 @@ class PushTokenManagerTests : FunSpec({
         response.status shouldBe SubscriptionStatus.INVALID_FCM_SENDER_ID
         pushTokenManager.pushToken shouldBe null
         pushTokenManager.pushTokenStatus shouldBe SubscriptionStatus.INVALID_FCM_SENDER_ID
+    }
+
+    test("missing sender id preserves a previously successful token") {
+        val mockPushRegistrator = mockk<IPushRegistrator>()
+        coEvery { mockPushRegistrator.registerForPush() } returns
+            IPushRegistrator.RegisterResult("push-token", SubscriptionStatus.SUBSCRIBED) andThen
+            IPushRegistrator.RegisterResult(null, SubscriptionStatus.INVALID_FCM_SENDER_ID)
+        val mockDeviceService = MockHelper.deviceService()
+        every { mockDeviceService.jetpackLibraryStatus } returns IDeviceService.JetpackLibraryStatus.OK
+        val pushTokenManager = PushTokenManager(mockPushRegistrator, mockDeviceService)
+
+        pushTokenManager.retrievePushToken()
+        val response = pushTokenManager.retrievePushToken()
+
+        response.token shouldBe "push-token"
+        response.status shouldBe SubscriptionStatus.SUBSCRIBED
+        pushTokenManager.pushToken shouldBe "push-token"
+        pushTokenManager.pushTokenStatus shouldBe SubscriptionStatus.SUBSCRIBED
     }
 
     test("unrelated permanent errors preserve a previously successful token") {

--- a/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/pushtoken/PushTokenManagerTests.kt
+++ b/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/pushtoken/PushTokenManagerTests.kt
@@ -82,7 +82,7 @@ class PushTokenManagerTests : FunSpec({
         pushTokenStatus shouldBe SubscriptionStatus.SUBSCRIBED
     }
 
-    test("permanent configuration errors replace a previously successful token status") {
+    test("sender mismatch replaces a previously successful token status") {
         val mockPushRegistrator = mockk<IPushRegistrator>()
         coEvery { mockPushRegistrator.registerForPush() } returns
             IPushRegistrator.RegisterResult("host-fid", SubscriptionStatus.SUBSCRIBED) andThen
@@ -98,6 +98,42 @@ class PushTokenManagerTests : FunSpec({
         response.status shouldBe SubscriptionStatus.INVALID_FCM_SENDER_ID
         pushTokenManager.pushToken shouldBe null
         pushTokenManager.pushTokenStatus shouldBe SubscriptionStatus.INVALID_FCM_SENDER_ID
+    }
+
+    test("unrelated permanent errors preserve a previously successful token") {
+        val mockPushRegistrator = mockk<IPushRegistrator>()
+        coEvery { mockPushRegistrator.registerForPush() } returns
+            IPushRegistrator.RegisterResult("push-token", SubscriptionStatus.SUBSCRIBED) andThen
+            IPushRegistrator.RegisterResult(null, SubscriptionStatus.MISSING_FIREBASE_FCM_LIBRARY)
+        val mockDeviceService = MockHelper.deviceService()
+        every { mockDeviceService.jetpackLibraryStatus } returns IDeviceService.JetpackLibraryStatus.OK
+        val pushTokenManager = PushTokenManager(mockPushRegistrator, mockDeviceService)
+
+        pushTokenManager.retrievePushToken()
+        val response = pushTokenManager.retrievePushToken()
+
+        response.token shouldBe "push-token"
+        response.status shouldBe SubscriptionStatus.SUBSCRIBED
+        pushTokenManager.pushToken shouldBe "push-token"
+        pushTokenManager.pushTokenStatus shouldBe SubscriptionStatus.SUBSCRIBED
+    }
+
+    test("retryable errors preserve a previously successful token") {
+        val mockPushRegistrator = mockk<IPushRegistrator>()
+        coEvery { mockPushRegistrator.registerForPush() } returns
+            IPushRegistrator.RegisterResult("push-token", SubscriptionStatus.SUBSCRIBED) andThen
+            IPushRegistrator.RegisterResult(null, SubscriptionStatus.FIREBASE_FCM_ERROR_MISC_EXCEPTION)
+        val mockDeviceService = MockHelper.deviceService()
+        every { mockDeviceService.jetpackLibraryStatus } returns IDeviceService.JetpackLibraryStatus.OK
+        val pushTokenManager = PushTokenManager(mockPushRegistrator, mockDeviceService)
+
+        pushTokenManager.retrievePushToken()
+        val response = pushTokenManager.retrievePushToken()
+
+        response.token shouldBe "push-token"
+        response.status shouldBe SubscriptionStatus.SUBSCRIBED
+        pushTokenManager.pushToken shouldBe "push-token"
+        pushTokenManager.pushTokenStatus shouldBe SubscriptionStatus.SUBSCRIBED
     }
 
     test("retrievePushToken should fail with failure status from push registrator with config-type error") {

--- a/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/registration/impl/FCMTokenProviderTests.kt
+++ b/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/registration/impl/FCMTokenProviderTests.kt
@@ -80,12 +80,20 @@ class FCMTokenProviderTests : FunSpec({
         var registered = false
         val token =
             withContext(Dispatchers.IO) {
-                FCMTokenProvider.getToken(SENDER_ID, { "true" }, { Tasks.forException(disabledLegacyApi) }) {
-                    registration(register = {
-                        registered = true
-                        completedTask()
-                    })
-                }
+                FCMTokenProvider.getToken(
+                    SENDER_ID,
+                    { "true" },
+                    { Tasks.forException(disabledLegacyApi) },
+                    installationIdApiAvailable = { true },
+                    installationIdRegistration = {
+                        registration(
+                            register = {
+                                registered = true
+                                completedTask()
+                            },
+                        )
+                    },
+                )
             }
 
         token shouldBe "installation-id"
@@ -110,19 +118,36 @@ class FCMTokenProviderTests : FunSpec({
     test("explains the problem when there is no default FirebaseApp to register with") {
         val thrown =
             withContext(Dispatchers.IO) {
-                shouldThrow<IllegalStateException> {
-                    FCMTokenProvider.getToken(SENDER_ID, { "true" }, { Tasks.forException(disabledLegacyApi) }) { null }
+                shouldThrow<FCMInstallationIdException> {
+                    FCMTokenProvider.getToken(
+                        SENDER_ID,
+                        { "true" },
+                        { Tasks.forException(disabledLegacyApi) },
+                        installationIdApiAvailable = { true },
+                        installationIdRegistration = { null },
+                    )
                 }
             }
 
         thrown.message!! shouldContain "no default FirebaseApp"
+        thrown.message!! shouldContain "google-services.json"
+        thrown.message!! shouldContain "com.google.gms.google-services"
+        thrown.message!! shouldContain "manifest merging"
+        thrown.message!! shouldContain "defaultFirebaseApp=false"
+        thrown.reason shouldBe FCMInstallationIdFailureReason.NO_DEFAULT_FIREBASE_APP
     }
 
     test("reports the manifest flag value it resolved, including when the app never set it") {
         val thrown =
             withContext(Dispatchers.IO) {
-                shouldThrow<IllegalStateException> {
-                    FCMTokenProvider.getToken(SENDER_ID, { "not set" }, { Tasks.forException(disabledLegacyApi) }) { null }
+                shouldThrow<FCMInstallationIdException> {
+                    FCMTokenProvider.getToken(
+                        SENDER_ID,
+                        { "not set" },
+                        { Tasks.forException(disabledLegacyApi) },
+                        installationIdApiAvailable = { true },
+                        installationIdRegistration = { null },
+                    )
                 }
             }
 
@@ -150,17 +175,69 @@ class FCMTokenProviderTests : FunSpec({
 
         val thrown =
             withContext(Dispatchers.IO) {
-                shouldThrow<IllegalStateException> {
-                    FCMTokenProvider.getToken(SENDER_ID, { "true" }, { Tasks.forException(disabledLegacyApi) }) {
-                        registration(
-                            register = { failedTask(registrationFailure) },
-                            installationId = { throw AssertionError("should not run after registration fails") },
-                        )
-                    }
+                shouldThrow<FCMInstallationIdException> {
+                    FCMTokenProvider.getToken(
+                        SENDER_ID,
+                        { "true" },
+                        { Tasks.forException(disabledLegacyApi) },
+                        installationIdApiAvailable = { true },
+                        installationIdRegistration = {
+                            registration(
+                                register = { failedTask(registrationFailure) },
+                                installationId = { throw AssertionError("should not run after registration fails") },
+                            )
+                        },
+                    )
                 }
             }
 
-        thrown shouldBe registrationFailure
+        thrown.reason shouldBe FCMInstallationIdFailureReason.REGISTRATION_FAILED
+        thrown.cause shouldBe registrationFailure
+        thrown.message!! shouldContain "google-services.json"
+    }
+
+    test("explains installation id retrieval failures") {
+        val retrievalFailure = IllegalStateException("Installation ID failed")
+
+        val thrown =
+            withContext(Dispatchers.IO) {
+                shouldThrow<FCMInstallationIdException> {
+                    FCMTokenProvider.getToken(
+                        SENDER_ID,
+                        { "true" },
+                        { Tasks.forException(disabledLegacyApi) },
+                        installationIdApiAvailable = { true },
+                        installationIdRegistration = {
+                            registration(installationId = { Tasks.forException(retrievalFailure) })
+                        },
+                    )
+                }
+            }
+
+        thrown.reason shouldBe FCMInstallationIdFailureReason.REGISTRATION_FAILED
+        thrown.cause shouldBe retrievalFailure
+        thrown.message!! shouldContain "default Firebase project"
+    }
+
+    test("explains when the register API is unavailable") {
+        val thrown =
+            withContext(Dispatchers.IO) {
+                shouldThrow<FCMInstallationIdException> {
+                    FCMTokenProvider.getToken(
+                        SENDER_ID,
+                        { "true" },
+                        { Tasks.forException(disabledLegacyApi) },
+                        installationIdApiAvailable = { false },
+                        installationIdRegistration = { registration() },
+                    )
+                }
+            }
+
+        thrown.reason shouldBe FCMInstallationIdFailureReason.REGISTER_API_UNAVAILABLE
+        thrown.message!! shouldContain "25.1.0 or newer"
+        thrown.message!! shouldContain "ProGuard"
+        thrown.message!! shouldContain "manifest merging"
+        thrown.message!! shouldContain "registerApi=false"
     }
 
     test("invokes register reflectively") {

--- a/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/registration/impl/FCMTokenProviderTests.kt
+++ b/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/registration/impl/FCMTokenProviderTests.kt
@@ -11,6 +11,7 @@ import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import java.io.IOException
 
 private const val SENDER_ID = "123456789012"
 
@@ -24,6 +25,11 @@ private fun registration(
     register: () -> Task<*> = { completedTask() },
     installationId: () -> Task<String> = { Tasks.forResult("installation-id") },
 ) = FCMTokenProvider.InstallationIdRegistration(senderId, register, installationId)
+
+private fun installationIdFlag(
+    value: String = "true",
+    enabled: Boolean = value == "true",
+) = FCMTokenProvider.InstallationIdFlag(enabled, value)
 
 private class Registrar(private val exception: Exception? = null) {
     fun register(): Task<Void> {
@@ -48,9 +54,26 @@ class FCMTokenProviderTests : FunSpec({
     test("returns the legacy FCM token when installation id registration is unavailable") {
         val token =
             withContext(Dispatchers.IO) {
-                FCMTokenProvider.getToken(SENDER_ID, { "true" }, { Tasks.forResult("fcm-token") }) {
+                FCMTokenProvider.getToken(SENDER_ID, { installationIdFlag() }, { Tasks.forResult("fcm-token") }) {
                     throw AssertionError("should not fall back to installation id registration")
                 }
+            }
+
+        token shouldBe "fcm-token"
+    }
+
+    test("uses Firebase boolean semantics when the raw manifest flag is a string") {
+        val token =
+            withContext(Dispatchers.IO) {
+                FCMTokenProvider.getToken(
+                    SENDER_ID,
+                    { installationIdFlag(value = "true", enabled = false) },
+                    { Tasks.forResult("fcm-token") },
+                    installationIdApiAvailable = { true },
+                    installationIdRegistration = {
+                        throw AssertionError("Firebase does not enable installation id registration for a string value")
+                    },
+                )
             }
 
         token shouldBe "fcm-token"
@@ -62,7 +85,7 @@ class FCMTokenProviderTests : FunSpec({
             withContext(Dispatchers.IO) {
                 FCMTokenProvider.getToken(
                     senderId = SENDER_ID,
-                    installationIdEnabled = { "true" },
+                    installationIdFlag = { installationIdFlag() },
                     legacyToken = {
                         legacyTokenRequested = true
                         Tasks.forResult("fcm-token")
@@ -82,7 +105,7 @@ class FCMTokenProviderTests : FunSpec({
             withContext(Dispatchers.IO) {
                 FCMTokenProvider.getToken(
                     SENDER_ID,
-                    { "true" },
+                    { installationIdFlag() },
                     { Tasks.forException(disabledLegacyApi) },
                     installationIdApiAvailable = { true },
                     installationIdRegistration = {
@@ -106,7 +129,7 @@ class FCMTokenProviderTests : FunSpec({
         val thrown =
             withContext(Dispatchers.IO) {
                 shouldThrow<IllegalStateException> {
-                    FCMTokenProvider.getToken(SENDER_ID, { "true" }, { Tasks.forException(unrelated) }) {
+                    FCMTokenProvider.getToken(SENDER_ID, { installationIdFlag() }, { Tasks.forException(unrelated) }) {
                         throw AssertionError("should not fall back to installation id registration")
                     }
                 }
@@ -121,7 +144,7 @@ class FCMTokenProviderTests : FunSpec({
                 shouldThrow<FCMInstallationIdException> {
                     FCMTokenProvider.getToken(
                         SENDER_ID,
-                        { "true" },
+                        { installationIdFlag() },
                         { Tasks.forException(disabledLegacyApi) },
                         installationIdApiAvailable = { true },
                         installationIdRegistration = { null },
@@ -143,7 +166,7 @@ class FCMTokenProviderTests : FunSpec({
                 shouldThrow<FCMInstallationIdException> {
                     FCMTokenProvider.getToken(
                         SENDER_ID,
-                        { "not set" },
+                        { installationIdFlag("not set") },
                         { Tasks.forException(disabledLegacyApi) },
                         installationIdApiAvailable = { true },
                         installationIdRegistration = { null },
@@ -158,7 +181,7 @@ class FCMTokenProviderTests : FunSpec({
         val thrown =
             withContext(Dispatchers.IO) {
                 shouldThrow<IllegalStateException> {
-                    FCMTokenProvider.getToken(SENDER_ID, { "true" }, { Tasks.forException(disabledLegacyApi) }) {
+                    FCMTokenProvider.getToken(SENDER_ID, { installationIdFlag() }, { Tasks.forException(disabledLegacyApi) }) {
                         registration(
                             senderId = "999999999999",
                             register = { throw AssertionError("should not register on a sender id mismatch") },
@@ -178,7 +201,7 @@ class FCMTokenProviderTests : FunSpec({
                 shouldThrow<FCMInstallationIdException> {
                     FCMTokenProvider.getToken(
                         SENDER_ID,
-                        { "true" },
+                        { installationIdFlag() },
                         { Tasks.forException(disabledLegacyApi) },
                         installationIdApiAvailable = { true },
                         installationIdRegistration = {
@@ -204,7 +227,7 @@ class FCMTokenProviderTests : FunSpec({
                 shouldThrow<FCMInstallationIdException> {
                     FCMTokenProvider.getToken(
                         SENDER_ID,
-                        { "true" },
+                        { installationIdFlag() },
                         { Tasks.forException(disabledLegacyApi) },
                         installationIdApiAvailable = { true },
                         installationIdRegistration = {
@@ -219,13 +242,34 @@ class FCMTokenProviderTests : FunSpec({
         thrown.message!! shouldContain "default Firebase project"
     }
 
+    test("preserves IOExceptions for the existing FCM retry handling") {
+        val registrationFailure = IOException("SERVICE_NOT_AVAILABLE")
+
+        val thrown =
+            withContext(Dispatchers.IO) {
+                shouldThrow<IOException> {
+                    FCMTokenProvider.getToken(
+                        SENDER_ID,
+                        { installationIdFlag() },
+                        { Tasks.forException(disabledLegacyApi) },
+                        installationIdApiAvailable = { true },
+                        installationIdRegistration = {
+                            registration(register = { failedTask(registrationFailure) })
+                        },
+                    )
+                }
+            }
+
+        thrown shouldBe registrationFailure
+    }
+
     test("explains when the register API is unavailable") {
         val thrown =
             withContext(Dispatchers.IO) {
                 shouldThrow<FCMInstallationIdException> {
                     FCMTokenProvider.getToken(
                         SENDER_ID,
-                        { "true" },
+                        { installationIdFlag() },
                         { Tasks.forException(disabledLegacyApi) },
                         installationIdApiAvailable = { false },
                         installationIdRegistration = { registration() },

--- a/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorFCMTests.kt
+++ b/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorFCMTests.kt
@@ -164,6 +164,20 @@ class PushRegistratorFCMTests : FunSpec({
         verify(exactly = 0) { FirebaseApp.initializeApp(any(), any<FirebaseOptions>(), any()) }
     }
 
+    test("uses the legacy token when the manifest flag is a string true") {
+        val metaData = Bundle().apply { putString("firebase_messaging_installation_id_enabled", "true") }
+        mockkObject(AndroidUtils)
+        every { AndroidUtils.getManifestMetaBundle(any()) } returns metaData
+        mockkObject(FCMTokenProvider)
+        every { FCMTokenProvider.hasRegisterMethod(FirebaseMessaging::class.java) } returns true
+        val registrator = registrator(legacyToken = Tasks.forResult("fcm-token"))
+
+        val token = withContext(Dispatchers.IO) { registrator.getToken(SENDER_ID) }
+
+        token shouldBe "fcm-token"
+        verify(exactly = 1) { FirebaseApp.initializeApp(any(), any<FirebaseOptions>(), any()) }
+    }
+
     test("registers an installation id before the dashboard has a sender id") {
         val metaData = Bundle().apply { putBoolean("firebase_messaging_installation_id_enabled", true) }
         mockkObject(AndroidUtils)
@@ -256,6 +270,7 @@ class PushRegistratorFCMTests : FunSpec({
 
         result.id shouldBe null
         result.status shouldBe SubscriptionStatus.INVALID_FCM_SENDER_ID
+        result.isExistingTokenInvalid shouldBe true
     }
 
     test("uses OneSignal's FirebaseApp for a legacy token when the default app has a different sender id") {

--- a/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorFCMTests.kt
+++ b/OneSignalSDK/onesignal/notifications/src/test/java/com/onesignal/notifications/internal/registration/impl/PushRegistratorFCMTests.kt
@@ -204,11 +204,35 @@ class PushRegistratorFCMTests : FunSpec({
 
         val thrown =
             withContext(Dispatchers.IO) {
-                shouldThrow<IllegalStateException> { registrator.getToken(SENDER_ID) }
+                shouldThrow<FCMInstallationIdException> { registrator.getToken(SENDER_ID) }
             }
 
         thrown.message!! shouldContain "no default FirebaseApp"
         thrown.message!! shouldContain "firebase_messaging_installation_id_enabled=not set"
+        thrown.message!! shouldContain "com.google.gms.google-services"
+        thrown.message!! shouldContain "manifest merging"
+    }
+
+    test("reports FID configuration failures through the push registration status") {
+        val configModelStore =
+            MockHelper.configModelStore {
+                it.isInitializedWithRemote = true
+                it.googleProjectNumber = SENDER_ID
+            }
+        val deviceService = mockk<IDeviceService>()
+        every { deviceService.hasFCMLibrary } returns true
+        every { deviceService.isGMSInstalledAndEnabled } returns true
+        val registrator =
+            registrator(
+                legacyToken = Tasks.forException(disabledLegacyApi),
+                configModelStore = configModelStore,
+                deviceService = deviceService,
+            )
+
+        val result = withContext(Dispatchers.IO) { registrator.registerForPush() }
+
+        result.id shouldBe null
+        result.status shouldBe SubscriptionStatus.FIREBASE_FCM_ERROR_MISC_EXCEPTION
     }
 
     test("reports an invalid sender id when FID registration would use a different Firebase project") {

--- a/examples/build.md
+++ b/examples/build.md
@@ -43,10 +43,46 @@ Two flavors are declared on the `default` dimension:
 
 | Flavor | Use case |
 |--------|----------|
-| `gms`  | Google Play Services / FCM — pulls `play-services-location`. OneSignal initializes its own Firebase app, so no Google Services plugin or `google-services.json` is needed. |
+| `gms`  | Google Play Services / FCM — pulls `play-services-location`. The legacy FCM token path uses OneSignal's Firebase app and does not require the Google Services plugin. Firebase Installation ID registration requires the host app configuration described below. |
 | `huawei` | Huawei HMS — applies `com.huawei.agconnect`, excludes the GMS transitive deps from the OneSignal artifact, and pulls `com.huawei.hms:push` + `com.huawei.hms:location`. |
 
 The Huawei plugin is selected at configuration time by inspecting `gradle.startParameter.taskRequests` so a clean `./gradlew tasks` doesn't require Huawei configuration.
+
+### Firebase Installation ID registration
+
+Firebase Messaging can enable Installation ID registration through the merged
+`firebase_messaging_installation_id_enabled` manifest value. The value may come from another
+dependency even when the application does not declare it.
+
+When the resolved value is `true`, the application must:
+
+- Use `com.google.firebase:firebase-messaging:25.1.0` or newer. Firebase Messaging 25.x requires
+  `minSdk` 23; apps that must support API 21 or 22 should keep using the legacy token path.
+- Use `compileSdk` 34 or newer.
+- Add the Firebase project's `google-services.json` to the app module and apply the
+  `com.google.gms.google-services` Gradle plugin so Firebase creates the default `FirebaseApp`.
+- Configure that Firebase project with the same sender ID as the OneSignal Android app.
+- Preserve `FirebaseMessaging.register()` during minification. OneSignal publishes the required
+  consumer ProGuard rules, so ensure dependency consumer rules are not disabled or discarded.
+
+To keep using the legacy FCM token path when a dependency enables the flag, override the merged
+value in the application manifest:
+
+```xml
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+    <application>
+        <meta-data
+            android:name="firebase_messaging_installation_id_enabled"
+            android:value="false"
+            tools:replace="android:value" />
+    </application>
+</manifest>
+```
+
+The merged manifest in Android Studio shows which dependency contributed the value. Missing
+Firebase configuration, incompatible `minSdk`, and dependency-version errors occur during the
+Gradle build and cannot be reported by OneSignal at runtime.
 
 ### `build.gradle.kts` essentials
 

--- a/examples/build.md
+++ b/examples/build.md
@@ -80,9 +80,10 @@ value in the application manifest:
 </manifest>
 ```
 
-The merged manifest in Android Studio shows which dependency contributed the value. Missing
-Firebase configuration, incompatible `minSdk`, and dependency-version errors occur during the
-Gradle build and cannot be reported by OneSignal at runtime.
+The merged manifest in Android Studio shows which dependency contributed the value. Gradle
+dependency-resolution and incompatible `minSdk` errors occur before the app runs and cannot be
+reported by OneSignal. If the app builds without a default Firebase configuration, OneSignal
+reports the missing `FirebaseApp` when Installation ID registration runs.
 
 ### `build.gradle.kts` essentials
 

--- a/examples/demo/app/src/gms/AndroidManifest.xml
+++ b/examples/demo/app/src/gms/AndroidManifest.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <application>
         <meta-data
             android:name="firebase_messaging_installation_id_enabled"
-            android:value="false" />
+            android:value="false"
+            tools:replace="android:value" />
     </application>
 
 </manifest>


### PR DESCRIPTION
# Description
## One Line Summary
Improves Firebase Installation ID configuration diagnostics, tests, and integration documentation.

## Details

### Motivation
Firebase Installation ID setup failures were reduced to a generic FCM error, leaving developers without actionable remediation and an empty push token.

### Scope
- Adds typed FID failure reasons and actionable runtime messages for missing Firebase configuration, unavailable `register()`, sender mismatch, minification, and registration failures.
- Includes safe detected state in diagnostics.
- Matches Firebase boolean manifest parsing and preserves existing retries for transient FID IO failures.
- Documents Firebase Messaging, minSdk, Google Services, ProGuard, and manifest-merge requirements.
- Updates the demo-only manifest override for transitively enabled FID registration.
- Keeps existing backend notification status compatibility.

# Testing
## Unit testing
Added coverage for missing default FirebaseApp, unavailable register API, sender mismatch, registration and Installation ID retrieval failures, Firebase manifest-flag semantics, preserved IOExceptions, remediation messages, and push registration status handling.

## Manual testing
Validated the demo merged manifest. Device testing was not performed.

# Affected code checklist
   - [x] Notifications
      - [ ] Display
      - [ ] Open
      - [x] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item